### PR TITLE
Fixing ambiguous column SQL error

### DIFF
--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -79,7 +79,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 */
 	public function join_clause() {
 		global $wpdb;
-		return " INNER JOIN $wpdb->term_relationships AS pll_tr ON pll_tr.object_id = ID";
+		return " INNER JOIN $wpdb->term_relationships AS pll_tr ON pll_tr.object_id = $wpdb->posts.ID";
 	}
 
 	/**


### PR DESCRIPTION
Lack of a table name was throwing a SQL error.

> Column 'ID' in on clause is ambiguous

This should technically make things clearer and fixes the error.