### PR TITLE
add order to output of PLL_Switcher::get_elements()

### DIFF
--- a/include/switcher.php
+++ b/include/switcher.php
@@ -45,6 +45,7 @@ class PLL_Switcher {
 	protected function get_elements( $links, $args ) {
 		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			$id = (int) $language->term_id;
+			$order = (int) $language->term_group;
 			$slug = $language->slug;
 			$locale = $language->get_locale( 'display' );
 			$classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
@@ -90,7 +91,7 @@ class PLL_Switcher {
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
 			$flag = $args['raw'] && ! $args['show_flags'] ? $language->flag_url : ( $args['show_flags'] ? $language->flag : '' );
 
-			$out[ $slug ] = compact( 'id', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
 		}
 
 		return empty( $out ) ? array() : $out;


### PR DESCRIPTION
Adds order (`term_group` value) to output of `PLL_Switcher::get_elements()`. Useful, if not essential, for building a custom language switcher using `pll_the_languages()` with `raw` param set to `true`.