### PR TITLE
UTF-8 Turkish Language error solved

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -67,7 +67,7 @@ class Polylang {
 			return;
 		}
 
-		$class = str_replace( '_', '-', strtolower( substr( $class, 4 ) ) );
+		$class = str_replace( '_', '-', mb_strtolower( substr( $class, 4 ), "UTF-8" ) );
 		$to_find = array( 'media', 'share', 'slug', 'slugs', 'sync', 'translate', 'wpml', 'xdata' );
 		$dir = implode( '-', array_intersect( explode( '-', $class ), $to_find ) );
 


### PR DESCRIPTION
"[error] 471#0: *67 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Class 'PLL_Install' not found"
If using turkish (or UTF-8) and using Wp ALL import together, packages confict, this change solve the problem.
