### PR TITLE
bbPress & BuddyPress compatibility fix

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -54,7 +54,7 @@ class PLL_Admin_Base extends PLL_Base {
 
 		// Filter admin language for users
 		// We must not call user info before WordPress defines user roles in wp-settings.php
-		add_filter( 'setup_theme', array( $this, 'init_user' ) );
+		add_filter( 'init', array( $this, 'init_user' ) );
 		add_filter( 'request', array( $this, 'request' ) );
 
 		// Adds the languages in admin bar


### PR DESCRIPTION
Path to fix the warning "The current user is being initialized without
using $wp->init()" after installing bbPress or BuddyPress.