### PR TITLE
Avoid cross domain issues when linking files via `home_url`.

### DIFF
--- a/include/links-abstract-domain.php
+++ b/include/links-abstract-domain.php
@@ -18,6 +18,7 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 		parent::__construct( $model );
 
 		// Avoid cross domain requests ( mainly for custom fonts )
+		add_filter( 'home_url', array( $this, 'site_url' ) );
 		add_filter( 'content_url', array( $this, 'site_url' ) );
 		add_filter( 'plugins_url', array( $this, 'site_url' ) );
 		add_filter( 'upload_dir', array( $this, 'upload_dir' ) );


### PR DESCRIPTION
Tackling issues in combination with other plugins (for example Jetpack, which uses `home_url` for managing infiniteScroll request).