### PR TITLE
Issue #53 change

### DIFF
--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -48,7 +48,7 @@ class PLL_Widget_Languages extends WP_Widget {
 					if ( $title ) {
 						echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . $title . '</label>';
 					} else {
-						echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . __( 'Language Switcher', 'polylang' ) . '</label>';
+						echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . __( 'Choose a language', 'polylang' ) . '</label>';
 					}
 					echo $list;
 				} else {

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -32,30 +32,28 @@ class PLL_Widget_Languages extends WP_Widget {
 	 * @param array $instance The settings for the particular instance of the widget
 	 */
 	 function widget( $args, $instance ) {
- 		// Sets a unique id for dropdown
- 		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
+		// Sets a unique id for dropdown
+		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
 
- 		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
- 			$title = empty( $instance['title'] ) ? '' : $instance['title'];
- 			/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
- 			$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
+		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
+			$title = empty( $instance['title'] ) ? '' : $instance['title'];
+			/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
+			$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
- 			echo $args['before_widget'];
- 			if ( $instance['dropdown'] ) {
- 					if ( $title ) {
- 							echo $args['before_title'] .
-										'<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' .
- 												$title .
- 										'</label>' .
- 								$args['after_title'];
- 					}
- 					echo $list;
- 			} else {
- 					echo "<ul>\n" . $list . "</ul>\n";
- 			}
- 			echo $args['after_widget'];
- 		}
- 	}
+			echo $args['before_widget'];
+			if ( $title ) {
+				echo $instance['dropdown'] ?
+					$args['before_title'] .
+						'<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' .
+							$title .
+						'</label>' .
+					$args['after_title'] :
+					$args['before_title'] . $title . $args['after_title'];
+			}
+			echo $instance['dropdown'] ? $list : "<ul>\n" . $list . "</ul>\n";
+			echo $args['after_widget'];
+		}
+	}
 
 	/**
 	 * Updates the widget options

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -42,15 +42,18 @@ class PLL_Widget_Languages extends WP_Widget {
 
 			echo $args['before_widget'];
 			if ( $title ) {
-				echo $args['before_title'];
-				echo $instance['dropdown'] ?
-					'<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' .
-						$title .
-					'</label>' :
-					$title;
-				echo $args['after_title'];
+				echo $args['before_title'] . $title . $args['after_title'];
 			}
-			echo $instance['dropdown'] ? $list : "<ul>\n" . $list . "</ul>\n";
+			if ( $instance['dropdown'] ) {
+					if ( $title ) {
+						echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . $title . '</label>';
+					} else {
+						echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . __( 'Language Switcher', 'polylang' ) . '</label>';
+					}
+					echo $list;
+				} else {
+				echo "<ul>\n" . $list . "</ul>\n";
+			}
 			echo $args['after_widget'];
 		}
 	}

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -31,7 +31,7 @@ class PLL_Widget_Languages extends WP_Widget {
 	 * @param array $args     Display arguments including before_title, after_title, before_widget, and after_widget.
 	 * @param array $instance The settings for the particular instance of the widget
 	 */
-	 function widget( $args, $instance ) {
+	function widget( $args, $instance ) {
 		// Sets a unique id for dropdown
 		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
 

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -42,13 +42,13 @@ class PLL_Widget_Languages extends WP_Widget {
 
 			echo $args['before_widget'];
 			if ( $title ) {
+				echo $args['before_title'];
 				echo $instance['dropdown'] ?
-					$args['before_title'] .
-						'<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' .
-							$title .
-						'</label>' .
-					$args['after_title'] :
-					$args['before_title'] . $title . $args['after_title'];
+					'<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' .
+						$title .
+					'</label>' :
+					$title;
+				echo $args['after_title'];
 			}
 			echo $instance['dropdown'] ? $list : "<ul>\n" . $list . "</ul>\n";
 			echo $args['after_widget'];

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -31,23 +31,31 @@ class PLL_Widget_Languages extends WP_Widget {
 	 * @param array $args     Display arguments including before_title, after_title, before_widget, and after_widget.
 	 * @param array $instance The settings for the particular instance of the widget
 	 */
-	function widget( $args, $instance ) {
-		// Sets a unique id for dropdown
-		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
+	 function widget( $args, $instance ) {
+ 		// Sets a unique id for dropdown
+ 		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
 
-		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
-			$title = empty( $instance['title'] ) ? '' : $instance['title'];
-			/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
-			$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
+ 		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
+ 			$title = empty( $instance['title'] ) ? '' : $instance['title'];
+ 			/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
+ 			$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-			echo $args['before_widget'];
-			if ( $title ) {
-				echo $args['before_title'] . $title . $args['after_title'];
-			}
-			echo $instance['dropdown'] ? $list : "<ul>\n" . $list . "</ul>\n";
-			echo $args['after_widget'];
-		}
-	}
+ 			echo $args['before_widget'];
+ 			if ( $instance['dropdown'] ) {
+ 					if ( $title ) {
+ 							echo $args['before_title'] .
+										'<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' .
+ 												$title .
+ 										'</label>' .
+ 								$args['after_title'];
+ 					}
+ 					echo $list;
+ 			} else {
+ 					echo "<ul>\n" . $list . "</ul>\n";
+ 			}
+ 			echo $args['after_widget'];
+ 		}
+ 	}
 
 	/**
 	 * Updates the widget options


### PR DESCRIPTION
If widget set to dropdown, wraps the widget title in Label element; with accessibility improvement done in WP 4.2. Prepends and appends before_title and after_tilte around the Label in case theme supplies a block level parent.