### PR TITLE
throw error if $_SERVER['HTTP_HOST'] is not set correctly

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -314,7 +314,8 @@ class PLL_Admin_Base extends PLL_Base {
 	 * @param object $wp_admin_bar
 	 */
 	public function admin_bar_menu( $wp_admin_bar ) {
-		$url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		//$url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		$url = ( is_ssl() ? 'https://' : 'http://' ) . PLL_UTILS::get_http_host() . $_SERVER['REQUEST_URI'];
 
 		$all_item = (object) array(
 			'slug' => 'all',

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -314,7 +314,6 @@ class PLL_Admin_Base extends PLL_Base {
 	 * @param object $wp_admin_bar
 	 */
 	public function admin_bar_menu( $wp_admin_bar ) {
-		//$url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$url = ( is_ssl() ? 'https://' : 'http://' ) . PLL_UTILS::get_http_host() . $_SERVER['REQUEST_URI'];
 
 		$all_item = (object) array(

--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -34,7 +34,7 @@ class PLL_Choose_Lang_Url extends PLL_Choose_lang {
 		$host = str_replace( 'www.', '', parse_url( $this->links_model->home, PHP_URL_HOST ) );
 		$home_path = parse_url( $this->links_model->home, PHP_URL_PATH );
 
-		$requested_host = str_replace( 'www.', '', $_SERVER['HTTP_HOST'] );
+		$requested_host = str_replace( 'www.', '', PLL_UTILS::get_http_host() );
 		$requested_uri = rtrim( str_replace( $this->index, '', $_SERVER['REQUEST_URI'] ), '/' ); // some PHP setups turn requests for / into /index.php in REQUEST_URI
 
 		// home is resquested

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -365,7 +365,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		if ( empty( $requested_url ) ) {
-			$requested_url  = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+			$requested_url  = ( is_ssl() ? 'https://' : 'http://' ) . PLL_UTILS::get_http_host() . $_SERVER['REQUEST_URI'];
 		}
 
 		if ( is_single() || is_page() ) {

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -154,7 +154,7 @@ class PLL_Frontend_Links extends PLL_Links {
 	 * @return string
 	 */
 	public function get_archive_url( $language ) {
-		$url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		$url = ( is_ssl() ? 'https://' : 'http://' ) . PLL_UTILS::get_http_host() . $_SERVER['REQUEST_URI'];
 		$url = $this->links_model->switch_language_in_link( $url, $language );
 		$url = $this->links_model->remove_paged_from_link( $url );
 

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -99,7 +99,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	 */
 	public function get_language_from_url( $url = '' ) {
 		if ( empty( $url ) ) {
-			$url  = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+			$url  = ( is_ssl() ? 'https://' : 'http://' ) . PLL_UTILS::get_http_host() . $_SERVER['REQUEST_URI'];
 		}
 
 		$pattern = str_replace( '/', '\/', $this->home . '/' . $this->root . ( $this->options['rewrite'] ? '' : 'language/' ) );

--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -70,7 +70,7 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 	 * @return string language slug
 	 */
 	public function get_language_from_url( $url = '' ) {
-		$host = empty( $url ) ? $_SERVER['HTTP_HOST'] : parse_url( $url, PHP_URL_HOST );
+		$host = empty( $url ) ? PLL_UTILS::get_http_host() : parse_url( $url, PHP_URL_HOST );
 		return ( $lang = array_search( $host , $this->hosts ) ) ? $lang : '';
 	}
 

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -73,7 +73,7 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	 * @return string language slug
 	 */
 	public function get_language_from_url( $url = '' ) {
-		$host = empty( $url ) ? $_SERVER['HTTP_HOST'] : parse_url( $url, PHP_URL_HOST );
+		$host = empty( $url ) ? PLL_UTILS::get_http_host() : parse_url( $url, PHP_URL_HOST );
 		$pattern = '#('.implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ).')\.#';
 		return preg_match( $pattern, trailingslashit( $host ), $matches ) ? $matches[1] : ''; // $matches[1] is the slug of the requested language
 	}

--- a/include/utils.php
+++ b/include/utils.php
@@ -21,3 +21,4 @@ class PLL_UTILS {
         }
         return $_SERVER['HTTP_HOST'])
 	}
+}

--- a/include/utils.php
+++ b/include/utils.php
@@ -17,8 +17,8 @@ class PLL_UTILS {
         if (empty( $_SERVER['HTTP_HOST'])) {
             // error is sent to PHP's system logger
             error_log("[polylang] HTTP_HOST is not set", 0);
-            return ''
+            return '';
         }
-        return $_SERVER['HTTP_HOST'])
+        return $_SERVER['HTTP_HOST']);
 	}
 }

--- a/include/utils.php
+++ b/include/utils.php
@@ -19,6 +19,6 @@ class PLL_UTILS {
             error_log("[polylang] HTTP_HOST is not set", 0);
             return '';
         }
-        return $_SERVER['HTTP_HOST']);
+        return $_SERVER['HTTP_HOST'];
 	}
 }

--- a/include/utils.php
+++ b/include/utils.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Base class for both admin
+ *
+ * @since 2.1
+ */
+
+class PLL_UTILS {
+
+    /**
+	 * Returns the http_host
+	 *
+	 * @since 2.1
+	 */
+	public function get_http_host() {
+        if (empty( $_SERVER['HTTP_HOST'])) {
+            // error is sent to PHP's system logger
+            error_log("[polylang] HTTP_HOST is not set", 0);
+            return ''
+        }
+        return $_SERVER['HTTP_HOST'])
+	}


### PR DESCRIPTION
Accordingly to my own fault in https://github.com/polylang/polylang/issues/91 the polylang throws an error into the logs if `$_SERVER['HTTP_HOST']` is not set (if its empty)