### PR TITLE
fixed related posts filter to use slug instead of name

### DIFF
--- a/modules/plugins/plugins-compat.php
+++ b/modules/plugins/plugins-compat.php
@@ -615,7 +615,7 @@ class PLL_Plugins_Compat {
 	 * @return array
 	 */
 	function jetpack_relatedposts_filter_filters( $filters, $post_id ) {
-		$slug = sanitize_title( pll_get_post_language( $post_id, 'name' ) );
+		$slug = sanitize_title( pll_get_post_language( $post_id, 'slug' ) );
 		$filters[] = array( 'term' => array( 'taxonomy.language.slug' => $slug ) );
 		return $filters;
 	}


### PR DESCRIPTION
Related posts aren't showing up because the value being search against `taxonomy.language.slug` is the `name` instead of the `slug`. This PR fixes that issue by requesting the `slug` from `pll_get_post_language()`.