### PR TITLE
Check type of `$post` before using it as a WP_Post object

### DIFF
--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -126,7 +126,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			add_meta_box( 'ml_box', __( 'Languages','polylang' ), array( $this, 'post_language' ), $post_type, 'side', 'high' );
 		}
 
-		if ( ( $page_for_posts = get_option( 'page_for_posts' ) ) && ( $translations = $this->model->post->get_translations( $page_for_posts ) ) && in_array( $post->ID, $translations ) && empty( $post->post_content ) ) {
+		if ( $post instanceof WP_Post && ( $page_for_posts = get_option( 'page_for_posts' ) ) && ( $translations = $this->model->post->get_translations( $page_for_posts ) ) && in_array( $post->ID, $translations ) && empty( $post->post_content ) ) {
 			add_action( 'edit_form_after_title', '_wp_posts_page_notice' );
 			remove_post_type_support( $post_type, 'editor' );
 		}


### PR DESCRIPTION
Avoids a PHP notice if `$post` is for example a string.

Fixes #175.