### PR TITLE
Enable admin function in WP_CLI

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -123,7 +123,7 @@ class Polylang {
 
 		// Admin
 		if ( ! defined( 'PLL_ADMIN' ) ) {
-			define( 'PLL_ADMIN', defined( 'DOING_CRON' ) || ( is_admin() && ! PLL_AJAX_ON_FRONT ) );
+			define( 'PLL_ADMIN', defined( 'DOING_CRON' ) || ( defined( 'WP_CLI' ) && WP_CLI ) || ( is_admin() && ! PLL_AJAX_ON_FRONT ) );
 		}
 
 		// Settings page whatever the tab


### PR DESCRIPTION
I wanted to do a copy_post as batch through WP_CLI (polylang pro). I wasn't able to do so since these functions only gets loaded in admin and on ajax requests. This simple change makes it possible to use the function in WP_CLI as well.