### PR TITLE
Fix missed var declaration

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -172,7 +172,7 @@ class PLL_Admin_Base extends PLL_Base {
 								options.url = options.url+'&<?php echo $str; ?>';
 							} else {
 								try {
-									o = $.parseJSON(options.data);
+									var o = $.parseJSON(options.data);
 									o = $.extend(o, <?php echo $arr; ?>);
 									options.data = JSON.stringify(o);
 								}


### PR DESCRIPTION
Add missed var declaration for preventing variable assinging in global scope