### PR TITLE
Force PLL_Translated_Object::get() $id parameter to be an integer

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -219,7 +219,7 @@ abstract class PLL_Translated_Object {
 	 * @param int|string|object $lang language ( term_id or slug or object )
 	 * @return bool|int the translation post id  or term id if exists, otherwise the post id or term id, false if the post has no language
 	 */
-	public function get( $id, $lang ) {
+	public function get( int $id, $lang ) {
 		$obj_lang = $this->get_language( $id ); // FIXME is this necessary?
 		if ( ! $lang || ! $obj_lang ) {
 			return false;


### PR DESCRIPTION
Otherwise PLL_Translated_Object::get() returns a string if $id is an string. This only happens when the language being queried is that same as the post language.

To test this set the front page to a page in English and run the WP-CLI command.
`wp eval "var_dump(pll_get_post(get_option( 'page_on_front'),'en'));"`

If you query the french post it will return an integer.
`wp eval "var_dump(pll_get_post(get_option( 'page_on_front'),'fr'));"`