### PR TITLE
Added PLL_SET_COOKIE_IN_JS helping varnish based caches

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -74,15 +74,23 @@ abstract class PLL_Choose_Lang {
 	}
 
 	/**
-	 * set a cookie to remember the language.
-	 * possibility to set PLL_COOKIE to false will disable cookie although it will break some functionalities
+	 * Set a cookie to remember the language.
+	 * Possibility to set PLL_COOKIE to false will disable cookie although it will break some functionalities
+	 *
+	 * Defining PLL_SET_COOKIE_IN_JS will disable cookie setting via Set-Cookie response,
+	 * but instead language cookie can be set with JS in `add_cookie_script` of `modules/plugins/cache-compat.php`.
+	 * This helps `varnish` based caches (cannot cache if `Set-Cookie` present)
+	 * so that these can also cache the first-ever response where normally cookie would be set.
 	 *
 	 * @since 1.5
 	 */
 	public function maybe_setcookie() {
+		// Avoid setting cookie in response, see above function description
+		$setCookieInJs = ( defined( 'WP_CACHE' ) && WP_CACHE ) && ( defined( 'PLL_SET_COOKIE_IN_JS') && PLL_SET_COOKIE_IN_JS );
+
 		// check headers have not been sent to avoid ugly error
 		// cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
-		if ( ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] != $this->curlang->slug ) && ! is_404() ) {
+		if ( ! $setCookieInJs && ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] != $this->curlang->slug ) && ! is_404() ) {
 
 			/**
 			 * Filter the Polylang cookie duration

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -86,7 +86,7 @@ abstract class PLL_Choose_Lang {
 	 */
 	public function maybe_setcookie() {
 		// Avoid setting cookie in response, see above function description
-		$setCookieInJs = ( defined( 'WP_CACHE' ) && WP_CACHE ) && ( defined( 'PLL_SET_COOKIE_IN_JS') && PLL_SET_COOKIE_IN_JS );
+		$setCookieInJs = ( defined( 'WP_CACHE' ) && WP_CACHE ) && ( defined( 'PLL_SET_COOKIE_IN_JS' ) && PLL_SET_COOKIE_IN_JS );
 
 		// check headers have not been sent to avoid ugly error
 		// cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.

--- a/modules/plugins/cache-compat.php
+++ b/modules/plugins/cache-compat.php
@@ -25,6 +25,11 @@ class PLL_Cache_Compat {
 
 	/**
 	 * Currently all tested cache plugins don't send cookies with cached pages
+	 *
+	 * Also `varnish` based caches cannot cache responses with Set-Cookie.
+	 * So it is sometimes preferrable to define PLL_SET_COOKIE_IN_JS and use
+	 * this JS based cookie setting instead of `maybe_setcookie` function.
+	 *
 	 * This makes us impossible know the language of the last browsed page
 	 * This functions allows to create the cookie in javascript as a workaround
 	 *


### PR DESCRIPTION
Some hosters (mine included) offer a [varnish](https://varnish-cache.org/) based caching solution. For instance, [Pantheon](https://pantheon.io/docs/caching-advanced-topics/#using-styxkey) and [gandi.net Simple Hosting](https://doc.gandi.net/en/simple/cache#cookies) offer such a cache. It is great! 

Unfortunately, like most varnish setups these do not cache if there's a `Set-Cookie` in the response.

This patch allows to define a `PLL_SET_COOKIE_IN_JS` to be set in `wp-config.php` and if this is set together with `WP_CACHE` then JS is used for cookie setting instead of the HTTP response. Hence the cookie is not set a-priori in the response but when the page got loaded using JavaScript. So there should be not side effects (as far as I can see, or course)

This means that also the *first-time* visitor response can be cached and delivered be delivered from varnish cache, not just every response *after* the first one. 

This helps:
* in case of a [hug of death](https://en.wikipedia.org/wiki/Slashdot_effect) if you have some media coverage where all the many visitors get to your page the first time
* deliver fast to crawlers like Bingbot or GoogleBot (usually do not keep cookies in between sessions)
* deliver fast to anyone else getting to your website first time

With "fast" I mean 50ms instead of 1500ms as in our case for First Byte Time (backend processing), so approx. 30 times faster and also much better scaled and load balanced since it's a full-fledged cache and not php-fpm processes.

I think the bug surface / side effects of this PR are minimal, but let me know what you think?