### PR TITLE
date.setTime() expects ms not s, also make code more robust by closure around vars

### DIFF
--- a/modules/plugins/cache-compat.php
+++ b/modules/plugins/cache-compat.php
@@ -37,13 +37,12 @@ class PLL_Cache_Compat {
 				var expirationDate = new Date();
 				expirationDate.setTime( expirationDate.getTime() + %d );
 				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s";
-			}());
-				',
-				esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) * 1000 ),
-				esc_js( PLL_COOKIE ),
-				esc_js( pll_current_language() ),
-				esc_js( COOKIEPATH ),
-				$domain ? '; domain=' . esc_js( $domain ) : ''
+			}());',
+			esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) * 1000 ),
+			esc_js( PLL_COOKIE ),
+			esc_js( pll_current_language() ),
+			esc_js( COOKIEPATH ),
+			$domain ? '; domain=' . esc_js( $domain ) : ''
 		);
 		echo '<script type="text/javascript">' . $js . '</script>';
 	}

--- a/modules/plugins/cache-compat.php
+++ b/modules/plugins/cache-compat.php
@@ -33,14 +33,17 @@ class PLL_Cache_Compat {
 	public function add_cookie_script() {
 		$domain = ( 2 == PLL()->options['force_lang'] ) ? parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
 		$js = sprintf( '
-			var date = new Date();
-			date.setTime( date.getTime() + %d );
-			document.cookie = "%s=%s; expires=" + date.toUTCString() + "; path=%s%s";',
-			esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) ),
-			esc_js( PLL_COOKIE ),
-			esc_js( pll_current_language() ),
-			esc_js( COOKIEPATH ),
-			$domain ? '; domain=' . esc_js( $domain ) : ''
+			(function() {
+				var expirationDate = new Date();
+				expirationDate.setTime( expirationDate.getTime() + %d );
+				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s";
+			}());
+				',
+				esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) * 1000 ),
+				esc_js( PLL_COOKIE ),
+				esc_js( pll_current_language() ),
+				esc_js( COOKIEPATH ),
+				$domain ? '; domain=' . esc_js( $domain ) : ''
 		);
 		echo '<script type="text/javascript">' . $js . '</script>';
 	}


### PR DESCRIPTION
Fixes two issues with the current code:
1. The setTime() in JS takes *milli*seconds not seconds. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime with `represented by a number of milliseconds` So currently instead of 1 year the expiration time was set to something like 4 hours ;)
2. I think it's not a good idea to have a global variable name `date`, which is a very general name. This can lead to all kind of (really hard to debug) problems if another plugins decides to create the a var by the same name. It is better to scope the variable by using a [self-executing anonymous function](http://markdalgleish.com/2011/03/self-executing-anonymous-functions/). 