### PR TITLE
Ensure correct scheme for flag url on load

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -87,6 +87,9 @@ class PLL_Language {
 				$this->facebook = $languages[ $this->locale ]['facebook'];
 			}
 		}
+
+		// Ensure correct scheme.
+		$this->flag_url = set_url_scheme( $this->flag_url );
 	}
 
 	/**


### PR DESCRIPTION
The language dropdown in #257 is rendering flag url's without a check for the correct scheme because the handlers are not triggered.
This PR sets the correct scheme for flag url's on `__construct()`.

**Enhancement idea:**
Let me know if you want me to change this.

Currently you are using `is_ssl()` and `str_replace()` to change the scheme.
Example: https://github.com/polylang/polylang/blob/master/include/language.php#L169-L175

Why not use WP core `set_url_scheme()` without a second parameter. Less code and it let's users use the filter: `set_url_scheme` from WP core.
https://developer.wordpress.org/reference/functions/set_url_scheme/