### PR TITLE
Allow to load the cache compatibility with a filter

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -74,15 +74,16 @@ abstract class PLL_Choose_Lang {
 	}
 
 	/**
-	 * set a cookie to remember the language.
-	 * possibility to set PLL_COOKIE to false will disable cookie although it will break some functionalities
+	 * Set a cookie to remember the language.
+	 * Setting PLL_COOKIE to false will disable cookie although it will break some functionalities
 	 *
 	 * @since 1.5
 	 */
 	public function maybe_setcookie() {
-		// check headers have not been sent to avoid ugly error
-		// cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
-		if ( ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] != $this->curlang->slug ) && ! is_404() ) {
+		// Don't set cookie in javascript when a cache plugin is active
+		// Check headers have not been sent to avoid ugly error
+		// Cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
+		if ( ! pll_is_cache_active() && ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] != $this->curlang->slug ) && ! is_404() ) {
 
 			/**
 			 * Filter the Polylang cookie duration

--- a/include/functions.php
+++ b/include/functions.php
@@ -2,7 +2,8 @@
 
 /**
  * Define wordpress.com VIP equivalent of uncached functions
- * and WordPress backward compatibility functions
+ * WordPress backward compatibility functions
+ * and miscellaneous utility functions
  */
 
 if ( ! function_exists( 'wpcom_vip_get_page_by_title' ) ) {
@@ -81,4 +82,23 @@ if ( ! function_exists( 'wp_doing_ajax' ) ) {
 		/** This filter is documented in wp-includes/load.php */
 		return apply_filters( 'wp_doing_ajax', defined( 'DOING_AJAX' ) && DOING_AJAX );
 	}
+}
+
+/**
+ * Determines whether we should load the cache compatibility
+ *
+ * @since 2.3.9
+ *
+ * return bool True if the cache compatibility must be loaded
+ */
+function pll_is_cache_active() {
+	/**
+	 * Filters whether we should load the cache compatibility
+	 *
+	 * @since 2.3.9
+	 *
+	 * @bool $is_cache True if a known cache plugin is active
+	 *                 incl. WP Fastest Cache which doesn't use WP_CACHE
+	 */
+	return apply_filters( 'pll_is_cache_active', ( defined( 'WP_CACHE' ) && WP_CACHE ) || defined( 'WPFC_MAIN_PATH' ) );
 }

--- a/include/functions.php
+++ b/include/functions.php
@@ -87,7 +87,7 @@ if ( ! function_exists( 'wp_doing_ajax' ) ) {
 /**
  * Determines whether we should load the cache compatibility
  *
- * @since 2.3.9
+ * @since 2.3.8
  *
  * return bool True if the cache compatibility must be loaded
  */
@@ -95,7 +95,7 @@ function pll_is_cache_active() {
 	/**
 	 * Filters whether we should load the cache compatibility
 	 *
-	 * @since 2.3.9
+	 * @since 2.3.8
 	 *
 	 * @bool $is_cache True if a known cache plugin is active
 	 *                 incl. WP Fastest Cache which doesn't use WP_CACHE

--- a/modules/plugins/plugins-compat.php
+++ b/modules/plugins/plugins-compat.php
@@ -82,8 +82,7 @@ class PLL_Plugins_Compat {
 			add_action( 'pll_language_defined', array( $this->wpseo = new PLL_WPSEO(), 'init' ) );
 		}
 
-		// Cache plugins, with specific test for WP Fastest Cache which doesn't use WP_CACHE
-		if ( ( defined( 'WP_CACHE' ) && WP_CACHE ) || defined( 'WPFC_MAIN_PATH' ) ) {
+		if ( pll_is_cache_active() ) {
 			add_action( 'pll_init', array( $this->cache_compat = new PLL_Cache_Compat(), 'init' ) );
 		}
 


### PR DESCRIPTION
Introduces the filter `pll_is_cache_active` to allow third party developers to load the cache compatibility even when no known plugin is active.