### PR TITLE
Fix page structure/hierarchy list when bulk editing custom post types

### DIFF
--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -543,10 +543,12 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
 		if ( isset( $postarr['bulk_edit'] ) ) {
 			check_admin_referer( 'bulk-posts' );
-			$lang = -1 == $postarr['inline_lang_choice'] ?
+			if (isset($postarr['inline_lang_choice'])) {
+				$lang = -1 == $postarr['inline_lang_choice'] ?
 				$this->model->post->get_language( $post_id ) :
 				$this->model->get_language( $postarr['inline_lang_choice'] );
-			$post_parent = $this->model->post->get_translation( $post_parent, $lang );
+				$post_parent = $this->model->post->get_translation( $post_parent, $lang );
+			}
 		}
 		return $post_parent;
 	}

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -543,10 +543,10 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
 		if ( isset( $postarr['bulk_edit'] ) ) {
 			check_admin_referer( 'bulk-posts' );
-			if (isset($postarr['inline_lang_choice'])) {
+			if ( isset( $postarr['inline_lang_choice'] ) ) {
 				$lang = -1 == $postarr['inline_lang_choice'] ?
-				$this->model->post->get_language( $post_id ) :
-				$this->model->get_language( $postarr['inline_lang_choice'] );
+				  $this->model->post->get_language( $post_id ) :
+				  $this->model->get_language( $postarr['inline_lang_choice'] );
 				$post_parent = $this->model->post->get_translation( $post_parent, $lang );
 			}
 		}

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -545,8 +545,8 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			check_admin_referer( 'bulk-posts' );
 			if ( isset( $postarr['inline_lang_choice'] ) ) {
 				$lang = -1 == $postarr['inline_lang_choice'] ?
-				  $this->model->post->get_language( $post_id ) :
-				  $this->model->get_language( $postarr['inline_lang_choice'] );
+					$this->model->post->get_language( $post_id ) :
+					$this->model->get_language( $postarr['inline_lang_choice'] );
 				$post_parent = $this->model->post->get_translation( $post_parent, $lang );
 			}
 		}


### PR DESCRIPTION
I encountered this problem when I tried to bulk assign a category to a few CPT posts - once I save the changes trough the admin dashboard I get notices for $postarr['inline_lang_choice'] - undefined index.

The end result was that the category was saved to the selected CPT's but the page tree structure was lost (post parent) so every CPT that is edited has no parent post anymore. 

With the plugin  turned off (I am using polylang pro version 2.3.8) and redoing the same steps everything worked as expected. I've looked at the source where the notices were thrown and added this simple check and it worked when i activated the plugin back on - there were no notices thrown, the CPT parent posts were kept as they were before the bulk edit and the selected category was assigned.