### PR TITLE
Added new filter for wpml strings in backend which need to be translated

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -79,7 +79,7 @@ class PLL_WPML_Config {
 				foreach ( $xml->xpath( 'admin-texts/key' ) as $key ) {
 					$attributes = $key->attributes();
 					$name = (string) $attributes['name'];
-					if ( PLL() instanceof PLL_Frontend ) {
+					if ( PLL() instanceof PLL_Frontend || apply_filters('pll_always_translate_string', false, 'option_' . $name) ) {
 						$this->options[ $name ] = $key;
 						add_filter( 'option_' . $name, array( $this, 'translate_strings' ) );
 					} else {

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -79,7 +79,7 @@ class PLL_WPML_Config {
 				foreach ( $xml->xpath( 'admin-texts/key' ) as $key ) {
 					$attributes = $key->attributes();
 					$name = (string) $attributes['name'];
-					if ( PLL() instanceof PLL_Frontend || apply_filters('pll_always_translate_string', false, 'option_' . $name) ) {
+					if ( PLL() instanceof PLL_Frontend || apply_filters( 'pll_always_translate_string', false, 'option_' . $name ) ) {
 						$this->options[ $name ] = $key;
 						add_filter( 'option_' . $name, array( $this, 'translate_strings' ) );
 					} else {


### PR DESCRIPTION
Currently compatibility only spans the frontend for strings. However this poses some problems in dealing with e-mails that can be triggered with certain plugins via backend.
Hereby I provide a filter `pll_always_translate_string` which can be used to translate a string even if in backend. This might need some further work in the admin table.

Would love to get feedback whether you consider this for merging.