### PR TITLE
Check if language is a valid object before returning

### DIFF
--- a/include/links.php
+++ b/include/links.php
@@ -31,6 +31,10 @@ class PLL_Links {
 	 */
 	public function get_home_url( $language, $is_search = false ) {
 		$language = is_object( $language ) ? $language : $this->model->get_language( $language );
+		if ( ! is_object( $language ) ) {
+			return home_url();
+		}
+
 		return $is_search ? $language->search_url : $language->home_url;
 	}
 


### PR DESCRIPTION
So we get this error pointing to wp-content/plugins/polylang/include/links.php on line 34 with varying degrees of regularity in some of our projects. The function get_language which is called specifies object|bool as return type so it needs to be checked again before trying to use it as an object.