### PR TITLE
Allow featured pages (Jetpack featured content)

### DIFF
--- a/modules/plugins/featured-content.php
+++ b/modules/plugins/featured-content.php
@@ -77,6 +77,7 @@ class PLL_Featured_Content {
 					'lang'        => 0, // avoid language filters
 					'fields'      => 'ids',
 					'numberposts' => Featured_Content::$max_posts,
+					'post_type'   => Featured_Content::$post_types,
 					'tax_query'   => array(
 						array(
 							'taxonomy' => 'post_tag',


### PR DESCRIPTION
Jetpack featured content feature allows theme creators to feature pages. This bug in polylang causes pages not to be displayed even if configured.

`post_type` is now set to `Featured_Content::$post_types` in `get_post` parameters