### PR TITLE
Only append lang to preload paths if the current post has a language.

### DIFF
--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -31,6 +31,9 @@ class PLL_Admin_Block_Editor {
 	 */
 	public function preload_paths( $preload_paths, $post ) {
 		$lang = pll_get_post_language( $post->ID );
+		if ( ! $lang ) {
+			return $preload_paths;
+		}
 
 		foreach ( $preload_paths as $k => $path ) {
 			if ( is_string( $path ) && '/' !== $path ) {

--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -6,6 +6,7 @@
  * @since 2.5
  */
 class PLL_Admin_Block_Editor {
+	public $model;
 
 	/**
 	 * Constructor: setups filters and actions
@@ -15,6 +16,9 @@ class PLL_Admin_Block_Editor {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
+		$this->model     = &$polylang->model;
+		$this->pref_lang = &$polylang->pref_lang;
+
 		add_filter( 'block_editor_preload_paths', array( $this, 'preload_paths' ), 10, 2 );
 	}
 
@@ -30,14 +34,17 @@ class PLL_Admin_Block_Editor {
 	 * @return array
 	 */
 	public function preload_paths( $preload_paths, $post ) {
-		$lang = pll_get_post_language( $post->ID );
-		if ( ! $lang ) {
-			return $preload_paths;
-		}
+		if ( $this->model->is_translated_post_type( $post->post_type ) ) {
+			$lang = $this->model->post->get_language( $post->ID );
 
-		foreach ( $preload_paths as $k => $path ) {
-			if ( is_string( $path ) && '/' !== $path ) {
-				$preload_paths[ $k ] = $path . "&lang={$lang}";
+			if ( ! $lang ) {
+				$lang = $this->pref_lang;
+			}
+
+			foreach ( $preload_paths as $k => $path ) {
+				if ( is_string( $path ) && '/' !== $path ) {
+					$preload_paths[ $k ] = $path . "&lang={$lang->slug}";
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes bug with Pods WYSIWYG meta field (and most likely other plugins that use `wp_editor()`: https://github.com/pods-framework/pods/issues/5365