### PR TITLE
Improve performance to register WPML strings

### DIFF
--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -89,7 +89,7 @@ class PLL_Upgrade {
 	 * @since 1.2
 	 */
 	public function _upgrade() {
-		foreach ( array( '0.9', '1.0', '1.1', '1.2', '1.2.1', '1.2.3', '1.3', '1.4', '1.4.1', '1.4.4', '1.5', '1.6', '1.7.4', '1.8', '2.0.8', '2.1', '2.3' ) as $version ) {
+		foreach ( array( '0.9', '1.0', '1.1', '1.2', '1.2.1', '1.2.3', '1.3', '1.4', '1.4.1', '1.4.4', '1.5', '1.6', '1.7.4', '1.8', '2.0.8', '2.1', '2.3', '2.7' ) as $version ) {
 			if ( version_compare( $this->options['version'], $version, '<' ) ) {
 				call_user_func( array( $this, 'upgrade_' . str_replace( '.', '_', $version ) ) );
 			}
@@ -608,4 +608,25 @@ class PLL_Upgrade {
 	protected function upgrade_2_3() {
 		delete_transient( 'pll_languages_list' );
 	}
+
+	/**
+	 * Upgrades if the previous version is < 2.7
+	 * Replace numeric keys by hashes in WPML registered strings
+	 *
+	 * @since 2.7
+	 */
+	protected function upgrade_2_7() {
+		$strings = get_option( 'polylang_wpml_strings' );
+		if ( is_array( $strings ) ) {
+			foreach ( $strings as $string ) {
+				$context = $string['context'];
+				$name    = $string['name'];
+
+				$key = md5( "$context | $name" );
+				$new_strings[ $key ] = $string;
+			}
+			update_option( 'polylang_wpml_strings', $new_strings );
+		}
+	}
+
 }

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -100,7 +100,8 @@ class PLL_WPML_Compat {
 		// Registers the string if it does not exist yet (multiline as in WPML).
 		$to_register = array( 'context' => $context, 'name' => $name, 'string' => $string, 'multiline' => true, 'icl' => true );
 		if ( ! in_array( $to_register, self::$strings ) && $to_register['string'] ) {
-			self::$strings[] = $to_register;
+			$key = md5( "$context | $name" );
+			self::$strings[ $key ] = $to_register;
 			update_option( 'polylang_wpml_strings', self::$strings );
 		}
 	}
@@ -110,15 +111,14 @@ class PLL_WPML_Compat {
 	 *
 	 * @since 1.0.2
 	 *
-	 * @param string $context the group in which the string is registered, defaults to 'polylang'
-	 * @param string $name    a unique name for the string
+	 * @param string $context The group in which the string is registered.
+	 * @param string $name    A unique name for the string.
 	 */
 	public function unregister_string( $context, $name ) {
-		foreach ( self::$strings as $key => $string ) {
-			if ( $string['context'] == $context && $string['name'] == $name ) {
-				unset( self::$strings[ $key ] );
-				update_option( 'polylang_wpml_strings', self::$strings );
-			}
+		$key = md5( "$context | $name" );
+		if ( isset( self::$strings[ $key ] ) ) {
+			unset( self::$strings[ $key ] );
+			update_option( 'polylang_wpml_strings', self::$strings );
 		}
 	}
 
@@ -139,16 +139,12 @@ class PLL_WPML_Compat {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $context the group in which the string is registered
-	 * @param string $name    a unique name for the string
-	 * @return bool|string the registered string, false if none was found
+	 * @param string $context The group in which the string is registered.
+	 * @param string $name    A unique name for the string.
+	 * @return bool|string The registered string, false if none was found.
 	 */
 	public function get_string_by_context_and_name( $context, $name ) {
-		foreach ( self::$strings as $string ) {
-			if ( $string['context'] == $context && $string['name'] == $name ) {
-				return $string['string'];
-			}
-		}
-		return false;
+		$key = md5( "$context | $name" );
+		return isset( self::$strings[ $key ] ) ? self::$strings[ $key ]['string'] : false;
 	}
 }


### PR DESCRIPTION
Since https://github.com/polylang/polylang-pro/pull/274, registering WPML strings uses the method `get_string_by_context_and_name()` which loops through all registered strings.

This PR improves the performance by using a hash as key, thus avoiding to loop through all strings to make searches.