### PR TITLE
Fixing security errors highlighted by phpcs

### DIFF
--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -25,7 +25,14 @@
 				r = wpAjax.broken;
 			}
 
-			r = $( '<div id="tagcloud-' + tax + '" class="the-tagcloud">' + r + '</div>' );
+			var tagInnerText = r;
+			var tagCloudId = 'tagcloud-' + tax;
+
+			r = $( '<div></div>' );
+			r.attr( 'id', tagCloudId );
+			r.attr( 'class', 'the-tagcloud' );
+			r.text( tagInnerText );
+
 			$( 'a', r ).click(function(){
 				tagBox.flushTags( $( this ).closest( '.inside' ).children( '.tagsdiv' ), this );
 				return false;

--- a/js/user.js
+++ b/js/user.js
@@ -11,7 +11,9 @@ jQuery( document ).ready(function( $ ) {
 		desc = d.clone();
 		desc.attr( 'name', 'description_' + lang[0] );
 		desc.html( $( this ).val() );
-		td.append( '<div>' + lang[1] + '</div' );
+		var langInner = $( '<div></div>' );
+		langInner.text(lang[1]);
+		td.append( langInner );
 		td.append( desc );
 	});
 

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -76,6 +76,11 @@ class PLL_Sync_Tax {
 			$strings = array_map( 'is_string', $terms );
 			if ( in_array( true, $strings, true ) ) {
 				$terms = get_the_terms( $object_id, $taxonomy );
+
+				if ( ! is_array( $terms ) ) {
+					return $newterms;
+				}
+
 				$terms = wp_list_pluck( $terms, 'term_id' );
 			}
 


### PR DESCRIPTION
Related: https://github.com/polylang/polylang/issues/388

So far fixed:
```
FILE: /home/francois/devel/polylang/modules/sync/sync-tax.php
----------------------------------------------------------------------------------------------------------------
  79 | ERROR   | Type of `$terms` must be checked before calling `wp_list_pluck()` using that variable.

FILE: /home/francois/devel/polylang/js/user.js
----------------------------------------------------------------------------------------------------------------
 14 | ERROR   | [ ] HTML string concatenation detected, this is a security risk, use DOM node construction or a
    |         |     templating language instead: lang+.
 14 | ERROR   | [ ] HTML string concatenation detected, this is a security risk, use DOM node construction or a
    |         |     templating language instead: +'</div'.

FILE: /home/francois/devel/polylang/js/classic-editor.js
----------------------------------------------------------------------------------------------------------------
  28 | ERROR   | [ ] HTML string concatenation detected, this is a security risk, use DOM node construction or
     |         |     a templating language instead: tax+.
  28 | ERROR   | [ ] HTML string concatenation detected, this is a security risk, use DOM node construction or
     |         |     a templating language instead: +'</div>'.
```