### PR TITLE
Set cookie with "httponly" set to true

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -102,7 +102,8 @@ abstract class PLL_Choose_Lang {
 				time() + $expiration,
 				COOKIEPATH,
 				2 == $this->options['force_lang'] ? wp_parse_url( $this->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN,
-				is_ssl()
+				is_ssl(),
+				true
 			);
 		}
 	}


### PR DESCRIPTION
Safari has started to automatically expire cookies after one week unless they are only accessible over the HTTP protocol.
See https://webkit.org/blog/8613/intelligent-tracking-prevention-2-1/
This means Safari users will have to choose their preferred language each week.

The change proposed here will prevent this from happening. The downside is however, that the cookie is no longer accessible via JavaScript.