### PR TITLE
Better handling of admin-texts wildcards in wpml-config.xml

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -84,7 +84,7 @@ class PLL_WPML_Config {
 						$this->options[ $name ] = $key;
 						add_filter( 'option_' . $name, array( $this, 'translate_strings' ) );
 					} else {
-						$this->register_string_recursive( $context, get_option( $name ), $key );
+						$this->register_string_recursive( $context, $name, get_option( $name ), $key );
 					}
 				}
 			}
@@ -200,47 +200,34 @@ class PLL_WPML_Config {
 	 * Recursively registers strings for a serialized option
 	 *
 	 * @since 1.0
+	 * @since 2.7 Signature modified
 	 *
-	 * @param string $context the group in which the strings will be registered
-	 * @param array  $options
-	 * @param object $key XML node
+	 * @param string $context The group in which the strings will be registered.
+	 * @param string $option  Option name.
+	 * @param array  $values  Option value.
+	 * @param object $key     XML node.
 	 */
-	protected function register_string_recursive( $context, $options, $key ) {
+	protected function register_string_recursive( $context, $option, $values, $key ) {
 		$children = $key->children();
 		if ( count( $children ) ) {
 			foreach ( $children as $child ) {
 				$attributes = $child->attributes();
 				$name = (string) $attributes['name'];
-				if ( '*' === $name && is_array( $options ) ) {
-					foreach ( $options as $n => $option ) {
-						$this->register_wildcard_options_recursive( $context, $option, $n );
+				if ( '*' === $name && is_array( $values ) ) {
+					foreach ( $values as $n => $value ) {
+						$this->register_string_recursive( $context, $n, $value, $child );
 					}
-				} elseif ( isset( $options[ $name ] ) ) {
-					$this->register_string_recursive( $context, $options[ $name ], $child );
+				} elseif ( isset( $values[ $name ] ) ) {
+					$this->register_string_recursive( $context, $name, $values[ $name ], $child );
 				}
 			}
-		} else {
-			$attributes = $key->attributes();
-			pll_register_string( (string) $attributes['name'], $options, $context, true ); // Multiline as in WPML
-		}
-	}
-
-	/**
-	 * Recursively registers strings with a wildcard
-	 *
-	 * @since 2.1
-	 *
-	 * @param string $context the group in which the strings will be registered
-	 * @param array  $options
-	 * @param string $name    Option name
-	 */
-	protected function register_wildcard_options_recursive( $context, $options, $name ) {
-		if ( is_array( $options ) ) {
-			foreach ( $options as $n => $option ) {
-				$this->register_wildcard_options_recursive( $context, $option, $n );
+		} elseif ( is_array( $values ) ) {
+			// Parent key is a wildcard and no sub-key has been whitelisted.
+			foreach ( $values as $n => $value ) {
+				$this->register_string_recursive( $context, $n, $value, $key );
 			}
 		} else {
-			pll_register_string( $name, $options, $context );
+			pll_register_string( $option, $values, $context, true );  // Multiline as in WPML.
 		}
 	}
 
@@ -249,9 +236,9 @@ class PLL_WPML_Config {
 	 *
 	 * @since 1.0
 	 *
-	 * @param array|string $values either a string to translate or a list of strings to translate
-	 * @param object       $key    XML node
-	 * @return array|string translated string(s)
+	 * @param array|string $values Either a string to translate or a list of strings to translate.
+	 * @param object       $key     XML node.
+	 * @return array|string Translated string(s)
 	 */
 	protected function translate_strings_recursive( $values, $key ) {
 		$children = $key->children();
@@ -260,36 +247,21 @@ class PLL_WPML_Config {
 				$attributes = $child->attributes();
 				$name = (string) $attributes['name'];
 				if ( '*' === $name && is_array( $values ) ) {
-					foreach ( $values as $n => $v ) {
-						$values[ $n ] = $this->translate_wildcard_options_recursive( $v, $n );
+					foreach ( $values as $n => $value ) {
+						$values[ $n ] = $this->translate_strings_recursive( $value, $child );
 					}
 				} elseif ( isset( $values[ $name ] ) ) {
 					$values[ $name ] = $this->translate_strings_recursive( $values[ $name ], $child );
 				}
 			}
+		} elseif ( is_array( $values ) ) {
+			// Parent key is a wildcard and no sub-key has been whitelisted.
+			foreach ( $values as $n => $value ) {
+				$values[ $n ] = $this->translate_strings_recursive( $value, $key );
+			}
 		} else {
 			$values = pll__( $values );
 		}
 		return $values;
-	}
-
-	/**
-	 * Recursively translates strings registered by a wildcard
-	 *
-	 * @since 2.1
-	 *
-	 * @param array|string $options Either a string to translate or a list of strings to translate
-	 * @param string       $name    Option name
-	 * @return array|string Translated string(s)
-	 */
-	protected function translate_wildcard_options_recursive( $options, $name ) {
-		if ( is_array( $options ) ) {
-			foreach ( $options as $n => $option ) {
-				$options[ $n ] = $this->translate_wildcard_options_recursive( $option, $n );
-			}
-		} else {
-			$options = pll__( $options );
-		}
-		return $options;
 	}
 }

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -214,8 +214,16 @@ class PLL_WPML_Config {
 				$attributes = $child->attributes();
 				$name = (string) $attributes['name'];
 				if ( '*' === $name && is_array( $values ) ) {
+					// This case could be handled by the next one, but we avoid calls to preg_match here.
 					foreach ( $values as $n => $value ) {
 						$this->register_string_recursive( $context, $n, $value, $child );
+					}
+				} elseif ( false !== strpos( $name, '*' ) ) {
+					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
+					foreach ( $values as $n => $value ) {
+						if ( preg_match( $pattern, $n ) ) {
+							$this->register_string_recursive( $context, $n, $value, $child );
+						}
 					}
 				} elseif ( isset( $values[ $name ] ) ) {
 					$this->register_string_recursive( $context, $name, $values[ $name ], $child );
@@ -247,8 +255,16 @@ class PLL_WPML_Config {
 				$attributes = $child->attributes();
 				$name = (string) $attributes['name'];
 				if ( '*' === $name && is_array( $values ) ) {
+					// This case could be handled by the next one, but we avoid calls to preg_match here.
 					foreach ( $values as $n => $value ) {
 						$values[ $n ] = $this->translate_strings_recursive( $value, $child );
+					}
+				} elseif ( false !== strpos( $name, '*' ) ) {
+					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
+					foreach ( $values as $n => $value ) {
+						if ( preg_match( $pattern, $n ) ) {
+							$values[ $n ] = $this->translate_strings_recursive( $value, $child );
+						}
 					}
 				} elseif ( isset( $values[ $name ] ) ) {
 					$values[ $name ] = $this->translate_strings_recursive( $values[ $name ], $child );

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -33,6 +33,12 @@
 						<key name="options_group_2">
 								<key name="*"/>
 						</key>
+						<key name="options_group_3">
+								<key name="*">
+										<key name="sub_sub_option_name_3x1" />
+										<key name="sub_sub_option_name_3x2" />
+								</key>
+						</key>
 				</key>
 				<key name="simple_string_option" />
 		</admin-texts>

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -39,6 +39,9 @@
 										<key name="sub_sub_option_name_3x2" />
 								</key>
 						</key>
+						<key name="options_group_4">
+								<key name="sub_option_name_*" />
+						</key>
 				</key>
 				<key name="simple_string_option" />
 		</admin-texts>

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -47,6 +47,18 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 					),
 				),
 			),
+			'options_group_3' => array(
+				'sub_key_31' => array(
+					'sub_sub_option_name_3x1' => 'val311',
+					'sub_sub_option_name_3x2' => 'val312',
+					'sub_sub_option_name_3x3' => 'val313',
+				),
+				'sub_key_32' => array(
+					'sub_sub_option_name_3x1' => 'val321',
+					'sub_sub_option_name_3x2' => 'val322',
+					'sub_sub_option_name_3x3' => 'val323',
+				),
+			),
 		);
 		update_option( 'my_plugins_options', $my_plugins_options );
 		update_option( 'simple_string_option', 'val' );
@@ -64,6 +76,12 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$mo->add_entry( $mo->make_entry( 'val21', "val21_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val221', "val221_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val2221', "val2221_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val311', "val311_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val312', "val312_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val313', "val313_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val321', "val321_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val322', "val322_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val323', "val323_$slug" ) );
 		$mo->export_to_db( $language );
 	}
 
@@ -222,6 +240,12 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'val21_fr', $options['options_group_2']['sub_key_21'] );
 		$this->assertEquals( 'val221_fr', $options['options_group_2']['sub_key_22']['sub_sub_221'] );
 		$this->assertEquals( 'val2221_fr', $options['options_group_2']['sub_key_22']['sub_sub_222']['sub_sub_sub_2221'] );
+		$this->assertEquals( 'val311_fr', $options['options_group_3']['sub_key_31']['sub_sub_option_name_3x1'] );
+		$this->assertEquals( 'val312_fr', $options['options_group_3']['sub_key_31']['sub_sub_option_name_3x2'] );
+		$this->assertEquals( 'val313', $options['options_group_3']['sub_key_31']['sub_sub_option_name_3x3'] ); // This one must not be translated.
+		$this->assertEquals( 'val321_fr', $options['options_group_3']['sub_key_32']['sub_sub_option_name_3x1'] );
+		$this->assertEquals( 'val322_fr', $options['options_group_3']['sub_key_32']['sub_sub_option_name_3x2'] );
+		$this->assertEquals( 'val323', $options['options_group_3']['sub_key_32']['sub_sub_option_name_3x3'] ); // This one must not be translated.
 		$this->assertEquals( 'val_fr', get_option( 'simple_string_option' ) );
 	}
 
@@ -235,6 +259,12 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertContains( 'val21', $strings );
 		$this->assertContains( 'val221', $strings );
 		$this->assertContains( 'val2221', $strings );
+		$this->assertContains( 'val311', $strings );
+		$this->assertContains( 'val312', $strings );
+		$this->assertNotContains( 'val313', $strings ); // This one must not be registered.
+		$this->assertContains( 'val321', $strings );
+		$this->assertContains( 'val322', $strings );
+		$this->assertNotContains( 'val323', $strings ); // This one must not be registered.
 		$this->assertContains( 'val', $strings );
 	}
 }

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -15,13 +15,6 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
-	function setUp() {
-		parent::setUp();
-
-		$this->prepare_options(); // before reading the wpml-config.xml file
-		$this->translate_options( 'fr' );
-	}
-
 	static function wpTearDownAfterClass() {
 		parent::wpTearDownAfterClass();
 
@@ -237,6 +230,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translate_strings() {
+		$this->prepare_options(); // Before reading the wpml-config.xml file.
+		$this->translate_options( 'fr' );
+
 		$GLOBALS['polylang'] = self::$polylang = new PLL_Frontend( self::$polylang->links_model );
 		PLL_WPML_Config::instance()->init();
 
@@ -262,6 +258,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 	function test_register_string() {
+		$this->prepare_options(); // Before reading the wpml-config.xml file.
+
 		$GLOBALS['polylang'] = self::$polylang = new PLL_Admin( self::$polylang->links_model );
 		PLL_WPML_Config::instance()->init();
 

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -59,6 +59,12 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 					'sub_sub_option_name_3x3' => 'val323',
 				),
 			),
+			'options_group_4' => array(
+				'sub_option_name_41' => 'val41',
+				'sub_option_name_42' => 'val42',
+				'sub_option_diff_43' => 'val43',
+			),
+
 		);
 		update_option( 'my_plugins_options', $my_plugins_options );
 		update_option( 'simple_string_option', 'val' );
@@ -82,6 +88,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$mo->add_entry( $mo->make_entry( 'val321', "val321_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val322', "val322_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val323', "val323_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val41', "val41_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val42', "val42_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'val43', "val43_$slug" ) );
 		$mo->export_to_db( $language );
 	}
 
@@ -246,6 +255,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'val321_fr', $options['options_group_3']['sub_key_32']['sub_sub_option_name_3x1'] );
 		$this->assertEquals( 'val322_fr', $options['options_group_3']['sub_key_32']['sub_sub_option_name_3x2'] );
 		$this->assertEquals( 'val323', $options['options_group_3']['sub_key_32']['sub_sub_option_name_3x3'] ); // This one must not be translated.
+		$this->assertEquals( 'val41_fr', $options['options_group_4']['sub_option_name_41'] );
+		$this->assertEquals( 'val42_fr', $options['options_group_4']['sub_option_name_42'] );
+		$this->assertEquals( 'val43', $options['options_group_4']['sub_option_diff_43'] ); // This one must not be translated.
 		$this->assertEquals( 'val_fr', get_option( 'simple_string_option' ) );
 	}
 
@@ -265,6 +277,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertContains( 'val321', $strings );
 		$this->assertContains( 'val322', $strings );
 		$this->assertNotContains( 'val323', $strings ); // This one must not be registered.
+		$this->assertContains( 'val41', $strings );
+		$this->assertContains( 'val42', $strings );
+		$this->assertNotContains( 'val43', $strings ); // This one must not be registered.
 		$this->assertContains( 'val', $strings );
 	}
 }


### PR DESCRIPTION
1. Supports whitelisting of sub-keys of a wildcard as used in Germanized WooCommerce:
```xml
<wpml-config>
    <admin-texts>
        <key name="woocommerce_gzd_legal_checkboxes_settings">
            <key name="*">
                <key name="admin_name" />
                <key name="admin_desc" />
                <key name="label" />
                <key name="error_message" />
                <key name="confirmation" />
            </key>
        </key>
    </admin-texts>
</wpml-config>
```
and thus avoids adding all non whitelisted sub keys in the strings translations table. This fixes https://github.com/polylang/polylang-pro/issues/308
2. Supports keys partially wildcarded such as
```xml
<wpml-config>
    <admin-texts>
        <key name="some_group">
            <key name="some_option_*" />
        </key>
    </admin-texts>
</wpml-config>
```
3. Adds more phpunit tests.