### PR TITLE
Fix PHP notice in walk() methods since WP 5.3

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -81,6 +81,7 @@ class PLL_Admin_Classic_Editor {
 
 		$dropdown_html = $dropdown->walk(
 			$this->model->get_languages_list(),
+			-1,
 			array(
 				'name'     => $id,
 				'class'    => 'post_lang_choice tags-input',

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -201,7 +201,7 @@ class PLL_Admin_Filters_Columns {
 					</div>
 				</fieldset>',
 				esc_html__( 'Language', 'polylang' ),
-				$dropdown->walk( $elements, array( 'name' => 'inline_lang_choice', 'id' => '' ) ) // phpcs:ignore WordPress.Security.EscapeOutput
+				$dropdown->walk( $elements, -1, array( 'name' => 'inline_lang_choice', 'id' => '' ) ) // phpcs:ignore WordPress.Security.EscapeOutput
 			);
 		}
 		return $column;

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -57,6 +57,7 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 			'input' => 'html',
 			'html'  => $dropdown->walk(
 				$this->model->get_languages_list(),
+				-1,
 				array(
 					'name'     => sprintf( 'attachments[%d][language]', $post_id ),
 					'class'    => 'media_lang_choice',

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -79,6 +79,7 @@ class PLL_Admin_Filters_Term {
 
 		$dropdown_html = $dropdown->walk(
 			$this->model->get_languages_list(),
+			-1,
 			array(
 				'name'     => 'term_lang_choice',
 				'value'    => 'term_id',
@@ -145,6 +146,7 @@ class PLL_Admin_Filters_Term {
 
 		$dropdown_html = $dropdown->walk(
 			$this->model->get_languages_list(),
+			-1,
 			array(
 				'name'     => 'term_lang_choice',
 				'value'    => 'term_id',

--- a/admin/admin-filters.php
+++ b/admin/admin-filters.php
@@ -69,6 +69,7 @@ class PLL_Admin_Filters extends PLL_Filters {
 					array( (object) array( 'slug' => 0, 'name' => __( 'All languages', 'polylang' ) ) ),
 					$this->model->get_languages_list()
 				),
+				-1,
 				array(
 					'name'     => $widget->id . '_lang_choice',
 					'class'    => 'tags-input pll-lang-choice',

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -184,7 +184,7 @@ class PLL_Switcher {
 		 * @param string $html html returned/outputted by the template tag
 		 * @param array  $args arguments passed to the template tag
 		 */
-		$out = apply_filters( 'pll_the_languages', $walker->walk( $elements, $args ), $args );
+		$out = apply_filters( 'pll_the_languages', $walker->walk( $elements, -1, $args ), $args );
 
 		// Javascript to switch the language when using a dropdown list
 		if ( $args['dropdown'] ) {

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -52,6 +52,7 @@ class PLL_Walker_Dropdown extends Walker {
 	 * Starts the output of the dropdown list
 	 *
 	 * @since 1.2
+	 * @since 2.7 Use $max_depth and ...$args parameters to follow the move of WP 5.3
 	 *
 	 * List of parameters accepted in $args:
 	 *
@@ -63,12 +64,30 @@ class PLL_Walker_Dropdown extends Walker {
 	 * class    => the class attribute
 	 * disabled => disables the dropdown if set to 1
 	 *
-	 * @param array $elements elements to display
-	 * @param array $args
-	 * @return string
+	 * @param array $elements  An array of elements.
+	 * @param int   $max_depth The maximum hierarchical depth.
+	 * @param mixed ...$args   Additional arguments.
+	 * @return string The hierarchical item output.
 	 */
-	public function walk( $elements, $args = array() ) {
+	public function walk( $elements, $max_depth, ...$args ) {
 		$output = '';
+
+		if ( is_array( $max_depth ) ) {
+			// Backward compatibility with Polylang < 2.7
+			if ( WP_DEBUG ) {
+				trigger_error(
+					sprintf(
+						'%s was called incorrectly. The method expects an integer as second parameter since Polylang 2.7',
+						__METHOD__
+					)
+				);
+			}
+			$args = $max_depth;
+			$max_depth = -1;
+		} else {
+			$args = isset( $args[0] ) ? $args[0] : array();
+		}
+
 		$args = wp_parse_args( $args, array( 'value' => 'slug', 'name' => 'lang_choice' ) );
 
 		if ( ! empty( $args['flag'] ) ) {
@@ -86,7 +105,7 @@ class PLL_Walker_Dropdown extends Walker {
 			isset( $args['id'] ) && ! $args['id'] ? '' : ' id="' . ( empty( $args['id'] ) ? esc_attr( $args['name'] ) : esc_attr( $args['id'] ) ) . '"',
 			empty( $args['class'] ) ? '' : ' class="' . esc_attr( $args['class'] ) . '"',
 			disabled( empty( $args['disabled'] ), false, false ),
-			parent::walk( $elements, -1, $args )
+			parent::walk( $elements, $max_depth, $args )
 		);
 
 		return $output;

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -54,12 +54,30 @@ class PLL_Walker_List extends Walker {
 	 * Overrides Walker:walk to set depth argument
 	 *
 	 * @since 1.2
+	 * @since 2.7 Use $max_depth and ...$args parameters to follow the move of WP 5.3
 	 *
-	 * @param array $elements elements to display
-	 * @param array $args
-	 * @return string
+	 * @param array $elements  An array of elements.
+	 * @param int   $max_depth The maximum hierarchical depth.
+	 * @param mixed ...$args   Additional arguments.
+	 * @return string The hierarchical item output.
 	 */
-	public function walk( $elements, $args = array() ) {
-		return parent::walk( $elements, -1, $args );
+	public function walk( $elements, $max_depth, ...$args ) {
+		if ( is_array( $max_depth ) ) {
+			// Backward compatibility with Polylang < 2.7
+			if ( WP_DEBUG ) {
+				trigger_error(
+					sprintf(
+						'%s was called incorrectly. The method expects an integer as second parameter since Polylang 2.7',
+						__METHOD__
+					)
+				);
+			}
+			$args = $max_depth;
+			$max_depth = -1;
+		} else {
+			$args = isset( $args[0] ) ? $args[0] : array();
+		}
+
+		return parent::walk( $elements, $max_depth, $args );
 	}
 }


### PR DESCRIPTION
* Adapt the methods signature to WP 5.3 in a backward compatible way (Polylang < 2.7).
* Add a notice if the methods are called using the old way without $max_depth parameter.
* Modify all methods calls.
Fix #414 