### PR TITLE
Add AMP compatibility for accessing front page

### DIFF
--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -150,7 +150,15 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 * @return bool
 	 */
 	protected function is_front_page( $query ) {
-		$query = array_diff( array_keys( $query->query ), array( 'preview', 'page', 'paged', 'cpage', 'orderby' ) );
+		/**
+		 * Filters list of query vars which do not impact whether the front page is served.
+		 *
+		 * @link https://github.com/WordPress/wordpress-develop/blob/0baa8ae85c670d338e78e408f8d6e301c6410c86/src/wp-includes/class-wp-query.php#L951-L971
+		 *
+		 * @param array $query_vars
+		 */
+		$query_vars = apply_filters( 'pll_front_page_ignored_query_vars', array( 'preview', 'page', 'paged', 'cpage', 'orderby' ) );
+		$query = array_diff( array_keys( $query->query ), $query_vars );
 		return 1 === count( $query ) && in_array( 'lang', $query );
 	}
 

--- a/modules/plugins/plugins-compat.php
+++ b/modules/plugins/plugins-compat.php
@@ -124,6 +124,11 @@ class PLL_Plugins_Compat {
 		if ( function_exists( 'custom_post_widget_plugin_init' ) && class_exists( 'PLL_Content_Blocks' ) ) {
 			add_action( 'pll_init', array( $this->content_blocks = new PLL_Content_Blocks(), 'init' ) );
 		}
+
+		// AMP
+		if ( function_exists( 'amp_get_slug' ) ) {
+			add_filter( 'pll_front_page_ignored_query_vars', array( $this, 'add_amp_to_front_page_ignored_query_vars' ) );
+		}
 	}
 
 	/**
@@ -333,5 +338,16 @@ class PLL_Plugins_Compat {
 			// Otherwise rely on MU Domain Mapping
 			redirect_to_mapped_domain();
 		}
+	}
+
+	/**
+	 * Append the AMP query var to the supplied query vars.
+	 *
+	 * @param array $query_vars Query vars.
+	 * @return array Query vars with AMP added.
+	 */
+	public function add_amp_to_front_page_ignored_query_vars( $query_vars ) {
+		$query_vars[] = amp_get_slug();
+		return $query_vars;
 	}
 }


### PR DESCRIPTION
The AMP plugin uses an `amp` query var to indicate that the AMP version of a page should be served when the plugin is configured with the Transitional or Reader template modes. This query var causes Polylang to think that a request for `/?amp` is not actually the homepage due to the presence of that `amp` query var. So this PR adds compatibility for this scenario: it includes the `amp` query var among the list of query vars that are subtracted from the query vars in the current query which should be ignored for front page queries.

Originally reported at https://wordpress.org/support/topic/static-home-page-with-polylang-2/