### PR TITLE
Fix wrong language detected

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -118,7 +118,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 
 		$pattern = wp_parse_url( $root . ( $this->options['rewrite'] ? '' : 'language/' ), PHP_URL_PATH );
 		$pattern = preg_quote( $pattern, '#' );
-		$pattern = '#' . $pattern . '(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')(/|$)#';
+		$pattern = '#^' . $pattern . '(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')(/|$)#';
 		return preg_match( $pattern, trailingslashit( $path ), $matches ) ? $matches[1] : ''; // $matches[1] is the slug of the requested language
 	}
 

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -132,6 +132,10 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$_SERVER['REQUEST_URI'] = '/fr/test/';
 		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
 
+		// Bug fixed in 2.6.10.
+		$_SERVER['REQUEST_URI'] = '/test/fr/';
+		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() );
+
 		self::$polylang->options['rewrite'] = 0;
 		$_SERVER['REQUEST_URI'] = '/language/fr/test/';
 		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );


### PR DESCRIPTION
When languages are defined as sub-directories and the default language is hidden in the url, an url such as: `https://mysite.com/parent-page/fr/` would be detected as French instead of the default language. This PR aims to make sure that the language is detected only if the language code is at the right place. Includes a simple PHPUnit test.

Fix https://github.com/polylang/polylang-pro/issues/376