### PR TITLE
Initialize options property at the right moment

### DIFF
--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -15,6 +15,7 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
+		$this->options = &$polylang->options;
 		parent::__construct(
 			$polylang,
 			array(

--- a/tests/phpunit/tests/test-settings-browser.php
+++ b/tests/phpunit/tests/test-settings-browser.php
@@ -1,0 +1,16 @@
+<?php
+
+class Settings_Browser_Test extends PLL_UnitTestCase {
+
+	function test_active_true() {
+		self::$polylang->options['browser'] = 1;
+		$module = new PLL_Settings_Browser( self::$polylang );
+		$this->assertTrue( $module->is_active() );
+	}
+
+	function test_active_false() {
+		self::$polylang->options['browser'] = 0;
+		$module = new PLL_Settings_Browser( self::$polylang );
+		$this->assertFalse( $module->is_active() );
+	}
+}


### PR DESCRIPTION
The property options wasn't initialized correctly when the `is_available` method was called

See https://github.com/polylang/polylang/blob/2.6.9/settings/settings-browser.php#L24

because the property is initialized in the PLL_Settings_Module parent constructor after the call of  the `is_available` method
https://github.com/polylang/polylang/blob/2.6.9/settings/settings-browser.php#L24