### PR TITLE
Fix lang-item-first class in language switcher

### DIFF
--- a/include/switcher.php
+++ b/include/switcher.php
@@ -53,16 +53,10 @@ class PLL_Switcher {
 			$classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
 			$url = null; // Avoids potential notice
 
-			if ( $first ) {
-				$classes[] = 'lang-item-first';
-				$first = false;
-			}
-
 			if ( $current_lang = $links->curlang->slug == $slug ) {
 				if ( $args['hide_current'] && ! ( $args['dropdown'] && ! $args['raw'] ) ) {
 					continue; // Hide current language except for dropdown
-				}
-				else {
+				} else {
 					$classes[] = 'current-lang';
 				}
 			}
@@ -97,6 +91,11 @@ class PLL_Switcher {
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
 			$flag = $args['raw'] && ! $args['show_flags'] ? $language->flag_url : ( $args['show_flags'] ? $language->flag : '' );
+
+			if ( $first ) {
+				$classes[] = 'lang-item-first';
+				$first = false;
+			}
 
 			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
 		}

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -138,7 +138,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 
 		$this->assertEquals( 'English', $xpath->query( '//li/a[@lang="en-US"]/span' )->item( 0 )->nodeValue );
 
-		// Bug fixed in 2.9.10
+		// Bug fixed in 2.6.10.
 		$args = array( 'hide_current' => 1, 'echo' => 0 );
 		$switcher = $this->switcher->the_languages( self::$polylang->links, $args );
 		$doc = new DomDocument();

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -137,6 +137,15 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$xpath = new DOMXpath( $doc );
 
 		$this->assertEquals( 'English', $xpath->query( '//li/a[@lang="en-US"]/span' )->item( 0 )->nodeValue );
+
+		// Bug fixed in 2.9.10
+		$args = array( 'hide_current' => 1, 'echo' => 0 );
+		$switcher = $this->switcher->the_languages( self::$polylang->links, $args );
+		$doc = new DomDocument();
+		$doc->loadHTML( $switcher );
+		$xpath = new DOMXpath( $doc );
+
+		$this->assertNotFalse( strpos( $xpath->query( '//li' )->item( 0 )->getAttribute( 'class' ), 'lang-item-first' ) );
 	}
 
 	/**


### PR DESCRIPTION
The `lang-item-first` class is usually added to the first item of the menu language switcher. 
![lang-item-first](https://user-images.githubusercontent.com/3238583/73348756-3f1ce600-428a-11ea-8e43-58fc28833e1f.png)
This PR aims to fix a bug where this `lang-item-first` is sometimes missing.
**How to reproduce?**
1. Create 2 languages, English first, French second.
2. Creat a menu with a language switcher.
3. Select the option to hide the current language in the language switcher
4. Asign this menu to an English location
5. Visit an English page and examine the html code of the first item of the language switcher in the menu: the `lang-item-first` is missing. 
