### PR TITLE
Fix valid license test

### DIFF
--- a/tests/phpunit/tests/test-license.php
+++ b/tests/phpunit/tests/test-license.php
@@ -30,7 +30,7 @@ class License_Test extends PLL_UnitTestCase {
 	function test_valid() {
 		$this->license->license_data = (object) array(
 			'success' => 1,
-			'expires' => gmdate( 'Y-m-d H:i:s', strtotime( 'last day of next month' ) ),
+			'expires' => gmdate( 'Y-m-d H:i:s', strtotime( '+60 days' ) ),
 		);
 
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Your license key expires on' ) );


### PR DESCRIPTION
When testing the valid license message, we set the expiration time to the last day of the next month. However 30 days before the license expires, the message is changed to `Your license key will expire soon`. If the test runs on January, 31, the expiration date is set to February, 28 or 29 which and the license key is valid for less than 30 days. The code works but the test fails. 