### PR TITLE
Partial fix for a conflict with Fusion Builder

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -64,7 +64,7 @@ class PLL_Admin extends PLL_Admin_Base {
 		// Priority 5 to make sure filters are there before customize_register is fired
 		if ( $this->model->get_languages_list() ) {
 			add_action( 'wp_loaded', array( $this, 'add_filters' ), 5 );
-			add_action( 'admin_init', array( $this, 'maybe_load_sync_post' ) );
+			add_action( 'admin_init', array( $this, 'maybe_load_sync_post' ), 20 ); // After fusion Builder.
 		}
 	}
 


### PR DESCRIPTION
Fusion Builder deactivates the Block editor, which something that could be summarized by:
```php
		add_action( 'admin_init', [ $this, 'init' ], 10 );

	public function init() {
		add_filter( $this->block_editor_check_function, [ $this, 'replace_gutenberg' ], 99, 2 );
	}

	public function replace_gutenberg( $use_block_editor, $post ) {
		global $post_type;

		if ( isset( $_GET['gutenberg-editor'] ) || ! $this->is_fb_enabled( $post_type ) ) { // phpcs:ignore WordPress.Security.NonceVerification
			return $use_block_editor;
		}
		return false;
	}
```

For existing posts, we call `use_block_editor_for_post` at https://github.com/polylang/polylang/blob/2.6.9/admin/admin.php#L173 in a method also hooked to `admin_init` with priority 10, called before the Fusion Builder hook. That means that the Fusion Builder filter is not ready when we call the function `use_block_editor_for_post`, and thus we don't have the right information to instantiate the correct class for post synchorization: https://github.com/polylang/polylang/blob/2.6.9/admin/admin.php#L187-L196

Delaying the call to the 'maybe_load_sync_post' method fixes this part of the issue. On their side the Fusion Builder authors must also correctly handle the case for post editing by using $post->post_type when available, rather than `global $post_type` which is not defined yet.

Fix https://github.com/polylang/polylang-pro/issues/381