### PR TITLE
Twenty Seventeen: Translate header video Youtube url

### DIFF
--- a/modules/plugins/plugins-compat.php
+++ b/modules/plugins/plugins-compat.php
@@ -266,10 +266,18 @@ class PLL_Plugins_Compat {
 	 * @since 2.0.10
 	 */
 	public function twenty_seventeen_init() {
-		if ( 'twentyseventeen' === get_template() && function_exists( 'twentyseventeen_panel_count' ) && did_action( 'pll_init' ) && PLL() instanceof PLL_Frontend ) {
-			$num_sections = twentyseventeen_panel_count();
-			for ( $i = 1; $i < ( 1 + $num_sections ); $i++ ) {
-				add_filter( 'theme_mod_panel_' . $i, 'pll_get_post' );
+		if ( 'twentyseventeen' === get_template() && did_action( 'pll_init' ) ) {
+			if ( function_exists( 'twentyseventeen_panel_count' ) && PLL() instanceof PLL_Frontend ) {
+				$num_sections = twentyseventeen_panel_count();
+				for ( $i = 1; $i < ( 1 + $num_sections ); $i++ ) {
+					add_filter( 'theme_mod_panel_' . $i, 'pll_get_post' );
+				}
+			}
+
+			if ( PLL() instanceof PLL_Frontend ) {
+				add_filter( 'theme_mod_external_header_video', 'pll__' );
+			} else {
+				pll_register_string( __( 'Header video', 'polylang' ), get_theme_mod( 'external_header_video' ), 'Twenty Seventeen', false );
 			}
 		}
 	}


### PR DESCRIPTION
Twenty Seventeen has a specific setting to add a Youtube video as header. This PR allows to use a different url per language by adding the url to the strings translations.
Fix #420   