### PR TITLE
Fix test_edit_language failing "randomly"

### DIFF
--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -35,6 +35,10 @@ class Settings_Test extends PLL_UnitTestCase {
 		get_admin_page_title();
 		set_current_screen();
 
+		// languages_pages() calls wp_get_available_translations() which triggers a wp.org api request
+		// if the transient 'available_translations' is empty, so let's fill it with a dummy value.
+		set_site_transient( 'available_translations', array( 'fr_FR' => '' ) );
+
 		ob_start();
 		self::$polylang = new PLL_Settings( self::$polylang->links_model );
 		self::$polylang->languages_page();


### PR DESCRIPTION
This PR aims to fix the integration test `Settings_Test::test_edit_language` which randomy triggers the error:
```
An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)
```
To reproduce easily, disconnect from Internet and run the test suite. 

The test in https://github.com/polylang/polylang/blob/a6475b10c4817c19f6a5ce7086e5fdbbe71ebb88/tests/phpunit/tests/test-settings.php#L27 ends up in calling `wp_get_available_translations()` in https://github.com/polylang/polylang/blob/a6475b10c4817c19f6a5ce7086e5fdbbe71ebb88/settings/settings.php#L368. This [WordPress function](https://github.com/WordPress/WordPress/blob/5.3.2/wp-admin/includes/translation-install.php#L121-L148) triggers a wp.org api call unless the result is already cached in a transient.

The PR prefills the transient to avoid the wp.org api call.