### PR TITLE
WP 5.4: Fix admin_body_class test failing

### DIFF
--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -53,6 +53,11 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 	}
 
 	function test_admin_body_class() {
+		// Since WP 5.4, remove this filter which requires a WP_Screen that we don't provide and is not relevant for our test.
+		if ( class_exists( 'WP_Site_Health' ) ) {
+			remove_filter( 'admin_body_class', array( WP_Site_Health::get_instance(), 'admin_body_class' ) );
+		}
+
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 		$this->assertEquals( ' pll-dir-ltr', apply_filters( 'admin_body_class', '' ) );
 


### PR DESCRIPTION
Since WP 5.4, the 'admin_body_class' filter of the WP Site health calls `get_current_screen()`. See https://github.com/WordPress/WordPress/commit/2c4480958bc230cbe89978738a26156c5346e785
As we don't set the current screen in our admin body class test, it ends with an error `Trying to get property of non-object`. Rather then providing a current screen object, I propose to remove the WP Site health filter as it's not relevant for our integration test. 