### PR TITLE
Work around a WP issue which localizes the plugins pages hooks

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -115,7 +115,7 @@ class PLL_Admin_Base extends PLL_Base {
 			if ( empty( $parent ) ) {
 				$parent = $page;
 				add_menu_page( $title, __( 'Languages', 'polylang' ), 'manage_options', $page, null, 'dashicons-translation' );
-				$admin_page_hooks[ $page ] = 'languages'; // Hack to avoid th localization of the hook name. See: https://core.trac.wordpress.org/ticket/18857
+				$admin_page_hooks[ $page ] = 'languages'; // Hack to avoid the localization of the hook name. See: https://core.trac.wordpress.org/ticket/18857
 			}
 
 			add_submenu_page( $parent, $title, $title, 'manage_options', $page, array( $this, 'languages_page' ) );

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -87,6 +87,8 @@ class PLL_Admin_Base extends PLL_Base {
 	 * @since 0.1
 	 */
 	public function add_menus() {
+		global $admin_page_hooks;
+
 		// Prepare the list of tabs
 		$tabs = array( 'lang' => __( 'Languages', 'polylang' ) );
 
@@ -113,6 +115,7 @@ class PLL_Admin_Base extends PLL_Base {
 			if ( empty( $parent ) ) {
 				$parent = $page;
 				add_menu_page( $title, __( 'Languages', 'polylang' ), 'manage_options', $page, null, 'dashicons-translation' );
+				$admin_page_hooks[ $page ] = 'languages'; // Hack to avoid th localization of the hook name. See: https://core.trac.wordpress.org/ticket/18857
 			}
 
 			add_submenu_page( $parent, $title, $title, 'manage_options', $page, array( $this, 'languages_page' ) );


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/18857

This prevents to display the screen options in the strings translations panel when the admin language is not in English. This also prevents to display the metaboxes that we will introduce in Polylang Pro 2.7.

The proposed fix is rather hacky but the other solution would be to use the hook `'load-' . sanitize_title( __( 'Languages', 'polylang' ) ) . '_page_mlang_strings'` instead of `'load-languages_page_mlang_strings'` everywhere we need it. Having a unique fix looks better to me. This could also break in the future if some day, the issue is fixed in WP. 

Fix #465
Fix https://github.com/polylang/polylang-pro/issues/422