### PR TITLE
Decrease the number of Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,29 @@ branches:
   only:
     - master
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-
-env:
-  - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=4.9 WP_MULTISITE=0
-
 matrix:
   include:
   - name: PHPCS
-    php: 7.3
+    php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 PHPCS=1
-  - php: 7.3
+  - name: WP 4.9
+    php: 7.2
+    env: WP_VERSION=4.9 WP_MULTISITE=0
+  - name: PHP 5.6
+    php: 5.6
     env: WP_VERSION=latest WP_MULTISITE=0
-  - php: 7.3
+  - name: PHP 7.4
+    php: 7.4
+    env: WP_VERSION=latest WP_MULTISITE=0
+  - name: Multisite
+    php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=1
-  - php: 7.4
-    env: WP_VERSION=latest WP_MULTISITE=0
-  - php: 7.3
+  - name: WP Nightly
+    php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
   allow_failures:
-  - php: 7.3
+  - name: WP Nightly
+    php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
 
 before_script:


### PR DESCRIPTION
The new proposal differs from what we discussed together. It decreases the number of jobs from 13 to 6.

1. PHPCS done separately as discussed (I replaced PHP 7.3 by 7.2 to use a pre-installed version which should save a few seconds, as the PHP version doesn't matter here).
2. WP 4.9 (oldest version supported) is tested only once with PHP 7.2 (most recent PHP version supported by this WP version).
3. The latest WP version is tested with PHP 5.6 (oldest version supported)
4. ...and PHP 7.4 (most recent version supported).
5. Multiste is tested with the latest version of WP + PHP 7.3 (used to change compared to other jobs)
6. The developement version of WP is tested with PHP 7.4 (we could use the development version of PHP in the future). This test is allowed to fail as currently.