### PR TITLE
Apply _wp_specialchars to the name when checking if a term exists

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -428,6 +428,7 @@ class PLL_Model {
 		global $wpdb;
 
 		$term_name = trim( wp_unslash( $term_name ) );
+		$term_name = _wp_specialchars( $term_name );
 
 		$select = "SELECT t.term_id FROM $wpdb->terms AS t";
 		$join = " INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id";

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -39,6 +39,15 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( self::$polylang->model->term_exists( 'child', 'category', $parent, 'fr' ) );
 	}
 
+	/**
+	 * Bug fixed in 2.7
+	 */
+	function test_term_exists_with_special_character() {
+		$term = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'Cook & eat' ) );
+		self::$polylang->model->term->set_language( $term, 'en' );
+		$this->assertEquals( $term, self::$polylang->model->term_exists( 'Cook & eat', 'category', 0, 'en' ) );
+	}
+
 	function test_count_posts() {
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );


### PR DESCRIPTION
When inserting a term, the filter `_wp_specialchars()` is applied to the term name (through the `sanitize_term()` method.
For example, `Cook & eat` is transformed to `Cook &amp; eat`. Thus we also need to apply this filter when comparing term names in our `term_exists()` method.

NB: This is not done in the original `term_exists()` function from WordPress (this probably should). However, the comparison is made first on the term slug, so in most cases, the slug comparison will match, thus bypassing the name comparison. So it's less probable to encounter the issue with the WP function, compared to our function which checks only the term name. To reproduce the bug with the WP function, you would need to change the slug to something not default.

Fix https://github.com/polylang/polylang-wc/issues/218