### PR TITLE
Add $languages initialization wrongly removed

### DIFF
--- a/modules/wizard/view-wizard-step-home-page.php
+++ b/modules/wizard/view-wizard-step-home-page.php
@@ -105,15 +105,6 @@ foreach ( $languages as $language ) {
 			<tr>
 				<td><?php esc_html_e( "If you add a new language, don't forget to translate your homepage.", 'polylang' ); ?></td>
 			</tr>
-		<?php else : ?>
-			<tr>
-				<th><span class="dashicons dashicons-warning"></span><?php esc_html_e( 'No language is defined', 'polylang' ); ?></th>
-			</tr>
-			<tr>
-				<td>
-					<?php esc_html_e( "You need to add at least one language. You're going to be redirected to the languages' step.", 'polylang' ); ?>
-				</td>
-			</tr>
 		<?php endif; ?>
 	</thead>
 	<tbody>

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -178,6 +178,14 @@ class PLL_Wizard {
 
 		$this->step = $step && array_key_exists( $step, $this->steps ) ? $step : current( array_keys( $this->steps ) );
 
+		$languages = $this->model->get_languages_list();
+
+		if ( count( $languages ) === 0 && ! in_array( $this->step, array( 'licenses', 'languages' ) ) ) {
+			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'languages' ) ) );
+			exit;
+		}
+
+
 		// Call the handler of the step for going to the next step.
 		// Be careful nonce verification with check_admin_referer must be done in each handler.
 		if ( ! empty( $_POST['save_step'] ) && isset( $this->steps[ $this->step ]['handler'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -684,6 +684,8 @@ class PLL_Wizard {
 	public function save_step_home_page() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
+		$languages = $this->model->get_languages_list();
+
 		$default_language = count( $languages ) > 0 ? $this->options['default_lang'] : null;
 		$home_page = isset( $_POST['home_page'] ) ? sanitize_key( $_POST['home_page'] ) : false;
 		$home_page_title = isset( $_POST['home_page_title'] ) ? sanitize_text_field( wp_unslash( $_POST['home_page_title'] ) ) : esc_html__( 'Homepage', 'polylang' );

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -684,13 +684,6 @@ class PLL_Wizard {
 	public function save_step_home_page() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
-		$languages = $this->model->get_languages_list();
-
-		if ( count( $languages ) === 0 ) {
-			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'languages' ) ) );
-			exit;
-		}
-
 		$default_language = count( $languages ) > 0 ? $this->options['default_lang'] : null;
 		$home_page = isset( $_POST['home_page'] ) ? sanitize_key( $_POST['home_page'] ) : false;
 		$home_page_title = isset( $_POST['home_page_title'] ) ? sanitize_text_field( wp_unslash( $_POST['home_page_title'] ) ) : esc_html__( 'Homepage', 'polylang' );


### PR DESCRIPTION
wrongly removed by this commit https://github.com/polylang/polylang/pull/471/commits/927609795cb8e1792a13a2549d2d39a7fc9cabf8

Closes https://github.com/polylang/polylang-pro/issues/468

and potentially avoid an issue when main homepage has no language yet.

We need to improve this case by enforcing the assignement of a language to all the Content.
See https://github.com/polylang/polylang-pro/issues/469