### PR TITLE
Add $languages initialization wrongly removed

### DIFF
--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -685,6 +685,8 @@ class PLL_Wizard {
 	public function save_step_home_page() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
+		$languages = $this->model->get_languages_list();
+
 		$default_language = count( $languages ) > 0 ? $this->options['default_lang'] : null;
 		$home_page = isset( $_POST['home_page'] ) ? sanitize_key( $_POST['home_page'] ) : false;
 		$home_page_title = isset( $_POST['home_page_title'] ) ? sanitize_text_field( wp_unslash( $_POST['home_page_title'] ) ) : esc_html__( 'Homepage', 'polylang' );


### PR DESCRIPTION
wrongly removed by this commit https://github.com/polylang/polylang/pull/471/commits/927609795cb8e1792a13a2549d2d39a7fc9cabf8

Closes https://github.com/polylang/polylang-pro/issues/468

and potentially avoid an issue when main homepage has no language yet.

We need to improve this case by enforcing the assignement of a language to all content.
See https://github.com/polylang/polylang-pro/issues/469