### PR TITLE
Enforce content step as next steps depend on it

### DIFF
--- a/modules/wizard/view-wizard-step-home-page.php
+++ b/modules/wizard/view-wizard-step-home-page.php
@@ -43,7 +43,7 @@ foreach ( $languages as $language ) {
 		printf(
 			/* translators: %s is the language of the front page ( flag, native name and locale ) */
 			esc_html__( 'Its language is : %s.', 'polylang' ),
-			false !== $home_page_language ? $home_page_language->flag . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' : '<strong>' . esc_html__( 'no language', 'polylang' ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$home_page_language->flag . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		)
 		?>
 	<br />

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -186,7 +186,7 @@ class PLL_Wizard {
 		$home_page_id = get_option( 'page_on_front' );
 		$home_page_language = $this->model->post->get_language( $home_page_id );
 
-		if ( ! $home_page_language && 'home-page' === $this->step ) {
+		if ( ! $home_page_language && in_array( $this->step, array( 'home-page', 'wc-pages' ) ) ) {
 			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
 			exit;
 		}

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -186,7 +186,7 @@ class PLL_Wizard {
 		$home_page_id = get_option( 'page_on_front' );
 		$home_page_language = $this->model->post->get_language( $home_page_id );
 
-		if ( ! $home_page_language && in_array( $this->step, array( 'home-page', 'wc-pages' ) ) ) {
+		if ( ! $home_page_language && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
 			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
 			exit;
 		}

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -183,10 +183,7 @@ class PLL_Wizard {
 			exit;
 		}
 
-		$home_page_id = get_option( 'page_on_front' );
-		$home_page_language = $this->model->post->get_language( $home_page_id );
-
-		if ( ! $home_page_language && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
+		if ( $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
 			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
 			exit;
 		}

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -692,6 +692,8 @@ class PLL_Wizard {
 	public function save_step_home_page() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
+		$languages = $this->model->get_languages_list();
+
 		$default_language = count( $languages ) > 0 ? $this->options['default_lang'] : null;
 		$home_page = isset( $_POST['home_page'] ) ? sanitize_key( $_POST['home_page'] ) : false;
 		$home_page_title = isset( $_POST['home_page_title'] ) ? sanitize_text_field( wp_unslash( $_POST['home_page_title'] ) ) : esc_html__( 'Homepage', 'polylang' );

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -183,6 +183,13 @@ class PLL_Wizard {
 			exit;
 		}
 
+		$home_page_id = get_option( 'page_on_front' );
+		$home_page_language = $this->model->post->get_language( $home_page_id );
+
+		if ( ! $home_page_language && 'home-page' === $this->step ) {
+			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
+			exit;
+		}
 
 		// Call the handler of the step for going to the next step.
 		// Be careful nonce verification with check_admin_referer must be done in each handler.
@@ -722,20 +729,14 @@ class PLL_Wizard {
 		$translations = $this->model->post->get_translations( $home_page );
 
 		foreach ( $untranslated_languages as $language ) {
-			// In fact this case isn't possible if we come from the untranslated contents step.
-			// And the static home page has already the default language assigned.
-			if ( $default_language === $language && false === $home_page_language && false !== $home_page && $home_page > 0 ) {
-				$id = $home_page;
-			} else {
-				$language_properties = $this->model->get_language( $language );
-				$id = wp_insert_post(
-					array(
-						'post_title'  => $home_page_title . ' - ' . $language_properties->name,
-						'post_type'   => 'page',
-						'post_status' => 'publish',
-					)
-				);
-			}
+			$language_properties = $this->model->get_language( $language );
+			$id = wp_insert_post(
+				array(
+					'post_title'  => $home_page_title . ' - ' . $language_properties->name,
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+				)
+			);
 			$translations[ $language ] = $id;
 			pll_set_post_language( $id, $language );
 		}


### PR DESCRIPTION
In fact unlike I said in the https://github.com/polylang/polylang-pro/issues/469 the message display when there is one language and already assigned to the homepage is necessary to warn the user that I will have to translate the future homepage in each language he will add.

To be sure the homepage has a language we now enforce to pass through the `Content` step before.

Because the homepage will now always have a language assigned, some code is now useless in the `create_home_page_translations` method. Then I removed this useless code.

This modification is also needed in Polylang Pro (wizard-pro.php). Another PR is then made in its repository.

Closes https://github.com/polylang/polylang-pro/issues/469