### PR TITLE
Move dismissed notices from user metas to site options

### DIFF
--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -621,6 +621,7 @@ class PLL_Upgrade {
 	/**
 	 * Upgrades if the previous version is < 2.7
 	 * Replace numeric keys by hashes in WPML registered strings
+	 * Dismiss the wizard notice for existing sites
 	 *
 	 * @since 2.7
 	 */
@@ -638,6 +639,7 @@ class PLL_Upgrade {
 			}
 			update_option( 'polylang_wpml_strings', $new_strings );
 		}
-	}
 
+		PLL_Admin_Notices::dismiss( 'wizard' );
+	}
 }

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -148,4 +148,18 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 			$this->assertNotFalse( strpos( $out, 'lingotek' ) );
 		}
 	}
+
+	function test_legacy_user_meta() {
+		wp_set_current_user( 1 );
+		update_user_meta( 1, 'pll_dismissed_notices', array( 'test_notice' ) );
+
+		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->assertTrue( self::$polylang->admin_notices->is_dismissed( 'test_notice' ) );
+		$this->assertEquals( array( 'test_notice' ), get_option( 'pll_dismissed_notices' ) );
+		if ( is_multisite() ) {
+			$this->assertEquals( array( 'test_notice' ), get_user_meta( 1, 'pll_dismissed_notices', true ) );
+		} else {
+			$this->assertEmpty( get_user_meta( 1, 'pll_dismissed_notices', true ) );
+		}
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -83,6 +83,7 @@ class PLL_Uninstall {
 		// Delete users options
 		foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
 			delete_user_meta( $user_id, 'pll_filter_content' );
+			delete_user_meta( $user_id, 'pll_dismissed_notices' ); // Legacy meta.
 			foreach ( $languages as $lang ) {
 				delete_user_meta( $user_id, 'description_' . $lang->slug );
 			}
@@ -149,6 +150,7 @@ class PLL_Uninstall {
 		delete_option( 'widget_polylang' ); // Automatically created by WP
 		delete_option( 'polylang_wpml_strings' ); // Strings registered with icl_register_string
 		delete_option( 'polylang_licenses' );
+		delete_option( 'pll_dismissed_notices' );
 
 		// Delete transients
 		delete_transient( 'pll_languages_list' );


### PR DESCRIPTION
This PR stores the dismissed notices in an option instead of a user meta, to avoid displaying the wizard notice to all admin users once the site is setup.

To avoid querying all users at plugin update, the migration is done each time we check that a notice has been dismissed. The user meta is not deleted on multisite to allow the migration on all sites that the user can administrate.

Also the relevant option and metas are deleted at plugin uninstall (this step was previously missing).

Aside, but important, the wizard notice is dismissed at update to avoid displaying it on existing sites which are already installed. 

Closes https://github.com/polylang/polylang-pro/issues/461
Closes https://github.com/polylang/polylang-pro/issues/473