### PR TITLE
Fix database error when the setup wizard is launched the first time

### DIFF
--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -184,7 +184,7 @@ class PLL_Wizard {
 			exit;
 		}
 
-		if ( ! empty( $this->options['default_lang'] ) && $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
+		if ( count( $languages ) > 0 && $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
 			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
 			exit;
 		}

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -184,7 +184,7 @@ class PLL_Wizard {
 			exit;
 		}
 
-		if (  ! empty( $this->options['default_lang'] ) && $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
+		if ( ! empty( $this->options['default_lang'] ) && $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
 			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
 			exit;
 		}

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -184,7 +184,7 @@ class PLL_Wizard {
 			exit;
 		}
 
-		if ( $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
+		if (  ! empty( $this->options['default_lang'] ) && $this->model->get_objects_with_no_lang( 1 ) && ! in_array( $this->step, array( 'licenses', 'languages', 'media', 'untranslated-contents' ) ) ) {
 			wp_safe_redirect( esc_url_raw( $this->get_step_link( 'untranslated-contents' ) ) );
 			exit;
 		}


### PR DESCRIPTION
Fix by adding the same test as in PLL_Settings::notice_objects_with_no_lang method to ensure at least on language is defined to test if untranslated contents exist.

Closes https://github.com/polylang/polylang-pro/issues/474