### PR TITLE
Fix PHP warning in wpml-config.xml

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -209,6 +209,7 @@ class PLL_WPML_Config {
 	 */
 	protected function register_string_recursive( $context, $option, $values, $key ) {
 		$children = $key->children();
+
 		if ( count( $children ) ) {
 			foreach ( $children as $child ) {
 				$attributes = $child->attributes();
@@ -218,7 +219,7 @@ class PLL_WPML_Config {
 					foreach ( $values as $n => $value ) {
 						$this->register_string_recursive( $context, $n, $value, $child );
 					}
-				} elseif ( false !== strpos( $name, '*' ) ) {
+				} elseif ( false !== strpos( $name, '*' ) && is_array( $values ) ) {
 					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
 					foreach ( $values as $n => $value ) {
 						if ( preg_match( $pattern, $n ) ) {
@@ -259,7 +260,7 @@ class PLL_WPML_Config {
 					foreach ( $values as $n => $value ) {
 						$values[ $n ] = $this->translate_strings_recursive( $value, $child );
 					}
-				} elseif ( false !== strpos( $name, '*' ) ) {
+				} elseif ( false !== strpos( $name, '*' ) && is_array( $values ) ) {
 					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
 					foreach ( $values as $n => $value ) {
 						if ( preg_match( $pattern, $n ) ) {

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -43,6 +43,11 @@
 								<key name="sub_option_name_*" />
 						</key>
 				</key>
+				<key name="empty_option">
+					<key name="*">
+		            	<key name="label"/>
+					</key>
+				</key>
 				<key name="simple_string_option" />
 		</admin-texts>
 		<language-switcher-settings>

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -23,7 +23,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 	function prepare_options() {
-		// mirror options defined in the sample wpml-config.xml
+		// Mirror options defined in the sample wpml-config.xml (except the empty option).
 		$my_plugins_options = array(
 			'option_name_1'   => 'val1',
 			'option_name_2'   => 'val2',


### PR DESCRIPTION
This PR fixes a `PHP warning : Invalid argument supplied for foreach() in /home/fred/Documents/Web/git/polylang-pro/modules/wpml/wpml-config.php on line 223` reported on wordpress.org forum. 

It can be easily reproduced by simply activating this plugin https://wordpress.org/plugins/motopress-hotel-booking-lite (tested at version 3.8.0)., without saving any option.

It occurs when the wpml-config.xml registers an option with a wildcard and this option does not exist in the database. 

I also fixed a similar potential warning on front.

Resgistering an option with a wildcard in our wpml-config.xml, without adding the corresponding option allows to test automatically the warning. 

