### PR TITLE
Prevent undefined key error with default_lang

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -92,6 +92,7 @@ class PLL_Install extends PLL_Install_Base {
 			'domains'          => array(),
 			'version'          => POLYLANG_VERSION,
 			'first_activation' => time(),
+			'default_lang'     => '',
 		);
 	}
 


### PR DESCRIPTION
Interacting with a site via WP CLI, if Polylang is activated but not yet configured with the install wizard, a warning can be thrown due to accessing an unset `default_lang` key. E.g. https://github.com/polylang/polylang/blob/master/admin/admin-base.php#L335