### PR TITLE
Fix a fatal error with InfiniteWP

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -190,7 +190,8 @@ class PLL_Admin extends PLL_Admin_Base {
 	/**
 	 * Load the post synchronization object, depending on the editor in use.
 	 *
-	 * We must make sure to instantiate the class only once, as the function may be called from a filter and that the synchronization model has been instantiated (due to InfiniteWP messing the actions wp_loaded and admin_init).
+	 * We must make sure to instantiate the class only once, as the function may be called from a filter,
+	 * and that the synchronization model has been instantiated (due to InfiniteWP messing the actions wp_loaded and admin_init).
 	 *
 	 * @since 2.6
 	 *

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -190,16 +190,14 @@ class PLL_Admin extends PLL_Admin_Base {
 	/**
 	 * Load the post synchronization object, depending on the editor in use.
 	 *
+	 * We must make sure to instantiate the class only once, as the function may be called from a filter and that the synchronization model has been instantiated (due to InfiniteWP messing the actions wp_loaded and admin_init).
+	 *
 	 * @since 2.6
 	 *
 	 * @param bool $is_block_editor Whether to use the block editor or not.
 	 * @return bool
 	 */
 	public function _maybe_load_sync_post( $is_block_editor ) {
-		/*
-		 * We must make sure to instantiate the class only once, as the function may be called from a filter.
-		 * and that the synchronization model has been instantiated (due to InfiniteWP messing the actions wp_loaded and admin_init).
-		 */
 		if ( ! isset( $this->sync_post ) && isset( $this->sync_post_model ) ) {
 			if ( class_exists( 'PLL_Sync_Post_REST' ) && pll_use_block_editor_plugin() && $is_block_editor ) {
 				$this->sync_post = new PLL_Sync_Post_REST( $this );

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -196,7 +196,11 @@ class PLL_Admin extends PLL_Admin_Base {
 	 * @return bool
 	 */
 	public function _maybe_load_sync_post( $is_block_editor ) {
-		if ( ! isset( $this->sync_post ) ) { // Make sure to instantiate the class only once, as the function may be called from a filter.
+		/*
+		 * We must kake sure to instantiate the class only once, as the function may be called from a filter.
+		 * and that the synchronization model has been instantiated (due to InfiniteWP messing the actions wp_loaded and admin_init).
+		 */
+		if ( ! isset( $this->sync_post ) && isset( $this->sync_post_model ) ) {
 			if ( class_exists( 'PLL_Sync_Post_REST' ) && pll_use_block_editor_plugin() && $is_block_editor ) {
 				$this->sync_post = new PLL_Sync_Post_REST( $this );
 			} elseif ( class_exists( 'PLL_Sync_Post' ) ) {

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -197,7 +197,7 @@ class PLL_Admin extends PLL_Admin_Base {
 	 */
 	public function _maybe_load_sync_post( $is_block_editor ) {
 		/*
-		 * We must kake sure to instantiate the class only once, as the function may be called from a filter.
+		 * We must make sure to instantiate the class only once, as the function may be called from a filter.
 		 * and that the synchronization model has been instantiated (due to InfiniteWP messing the actions wp_loaded and admin_init).
 		 */
 		if ( ! isset( $this->sync_post ) && isset( $this->sync_post_model ) ) {


### PR DESCRIPTION
I don't understand how it's possible, but it looks like under some circumstances, InfiniteWP is messing with the actions `wp_loaded` and `admin_init` causing objects used by `PLL_Sync_Post` (mainly `PLL_Sync_Post_Model` and `PLL_Bulk_Translate` not to be instantiated). The symptom seen by customers is a fatal error in the `PLL_Sync_Post` constructor.

Adding a check for `$polylang->bulk_translate` in the constructor would solve the fatal error woudl fix it but would leave other notices. I found out it was better to prevent the instantiation of `PLL_Sync_Post` if `PLL_Sync_Post_Model` hasn't been instantaited first (knowing that PLL_Bulk_translate is instatiated in the same `add_filters` method.

To reproduce the issue, I am only guessing as the customers did not provide the steps. Thus I used this:
```php
add_action( 'wp_loaded', function() {
	do_action('admin_init');
}, 1);
```
Although it is *not* the code of InfiniteWP, I hope it reproduces the same behavior. 

Fix https://github.com/polylang/polylang-pro/issues/488