### PR TITLE
Prevent cookie hijacking

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -102,7 +102,8 @@ abstract class PLL_Choose_Lang {
 				time() + $expiration,
 				COOKIEPATH,
 				2 == $this->options['force_lang'] ? wp_parse_url( $this->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN,
-				is_ssl()
+				is_ssl(),
+				true
 			);
 		}
 	}


### PR DESCRIPTION
Our site gets regularly scanned by a vulnerability scanner. Since we employ Polylang, our CVSS rating has dramatically increased. We found out that Polylang employs cookies without the restriction to HTTP usage (`httpOnly`). This allows [session hijacking](https://www.owasp.org/index.php/HttpOnly).

While it is possible to hack relabeling in configuration for PHP or nginx, this is not a solution for everybody. I am totally aware that the language setting is not super sensible. It is just not a good practice in my option.

I propose to simply set the parameter for `httpOnly` to true when setting the cookie. I added it to the cookie function and the JavaScript cache fallback. This allows us to use Polylang without any manual hacking to receive a good security assessment.

P.S. Thanks a lot for your work, it made translating our page very comfortable!