### PR TITLE
Honor the filter pll_the_language_link for the dropdown language switcher

### DIFF
--- a/include/switcher.php
+++ b/include/switcher.php
@@ -187,13 +187,6 @@ class PLL_Switcher {
 
 		// Javascript to switch the language when using a dropdown list
 		if ( $args['dropdown'] ) {
-			$urls = array();
-
-			foreach ( $links->model->get_languages_list() as $language ) {
-				$url = $links->get_translation_url( $language );
-				$urls[ $language->slug ] = $args['force_home'] || empty( $url ) ? $links->get_home_url( $language ) : $url;
-			}
-
 			// Accept only few valid characters for the urls_x variable name ( as the widget id includes '-' which is invalid )
 			$out .= sprintf(
 				'<script type="text/javascript">
@@ -205,7 +198,7 @@ class PLL_Switcher {
 					//]]>
 				</script>',
 				'urls_' . preg_replace( '#[^a-zA-Z0-9]#', '', $args['dropdown'] ),
-				wp_json_encode( $urls ),
+				wp_json_encode( wp_list_pluck( $elements, 'url' ) ),
 				esc_js( $args['name'] )
 			);
 		}


### PR DESCRIPTION
The urls used in the javascript of the dropdown language switcher were taken directly from `PLL_Frontend_Links::get_translation_url()` while the urls used in other cases are passed through the filter `pll_the_language_link` in `PLL_Switcher::get_elements()`.

This PR re-uses the urls returned by `PLL_Switcher::get_elements()` to consistently apply the filter in all cases.

Fix https://github.com/polylang/polylang-pro/issues/515