### PR TITLE
Don't output our scripts for untranslatable post types and taxonomies

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -135,20 +135,21 @@ class PLL_Admin_Base extends PLL_Base {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		// For each script:
-		// 0 => the pages on which to load the script
-		// 1 => the scripts it needs to work
-		// 2 => 1 if loaded even if languages have not been defined yet, 0 otherwise
-		// 3 => 1 if loaded in footer
-		// FIXME: check if I can load more scripts in footer
+		/*
+		 * For each script:
+		 * 0 => the pages on which to load the script
+		 * 1 => the scripts it needs to work
+		 * 2 => 1 if loaded even if languages have not been defined yet, 0 otherwise
+		 * 3 => 1 if loaded in footer
+		 */
 		$scripts = array(
-			'post'           => array( array( 'edit', 'upload' ), array( 'jquery', 'wp-ajax-response' ), 0, 1 ),
-			'term'           => array( array( 'edit-tags', 'term' ), array( 'jquery', 'wp-ajax-response', 'jquery-ui-autocomplete' ), 0, 1 ),
-			'user'           => array( array( 'profile', 'user-edit' ), array( 'jquery' ), 0, 0 ),
-			'widgets'        => array( array( 'widgets' ), array( 'jquery' ), 0, 0 ),
+			'user'    => array( array( 'profile', 'user-edit' ), array( 'jquery' ), 0, 0 ),
+			'widgets' => array( array( 'widgets' ), array( 'jquery' ), 0, 0 ),
 		);
 
 		if ( ! empty( $screen->post_type ) && $this->model->is_translated_post_type( $screen->post_type ) ) {
+			$scripts['post'] = array( array( 'edit', 'upload' ), array( 'jquery', 'wp-ajax-response' ), 0, 1 );
+
 			// Classic editor.
 			if ( ! method_exists( $screen, 'is_block_editor' ) || ! $screen->is_block_editor() ) {
 				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post' ), 0, 1 );
@@ -158,6 +159,10 @@ class PLL_Admin_Base extends PLL_Base {
 			if ( method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() && ! pll_use_block_editor_plugin() ) {
 				$scripts['block-editor'] = array( array( 'post' ), array( 'jquery', 'wp-ajax-response', 'wp-api-fetch' ), 0, 1 );
 			}
+		}
+
+		if ( ! empty( $screen->taxonomy ) && $this->model->is_translated_taxonomy( $screen->taxonomy ) ) {
+			$scripts['term'] = array( array( 'edit-tags', 'term' ), array( 'jquery', 'wp-ajax-response', 'jquery-ui-autocomplete' ), 0, 1 );
 		}
 
 		foreach ( $scripts as $script => $v ) {

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -68,23 +68,44 @@ class Admin_Test extends PLL_UnitTestCase {
 
 	function test_scripts_in_post_list_table() {
 		$GLOBALS['hook_suffix'] = 'edit.php';
-		set_current_screen( 'edit' );
+		set_current_screen();
 
 		$scripts = array( 'pll_ajax_backend', 'post', 'css' );
 		$this->_test_scripts( $scripts );
 	}
 
+	function test_scripts_in_untranslated_cpt_list_table() {
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type'] = 'cpt';
+		register_post_type( 'cpt' );
+		set_current_screen();
+
+		$scripts = array( 'pll_ajax_backend', 'css' );
+		$this->_test_scripts( $scripts );
+	}
+
 	function test_scripts_in_edit_post() {
 		$GLOBALS['hook_suffix'] = 'post.php';
-		set_current_screen( 'post' );
+		set_current_screen();
 
 		$scripts = array( 'pll_ajax_backend', 'classic-editor', 'metabox', 'css' );
 		$this->_test_scripts( $scripts );
 	}
 
+	function test_scripts_in_edit_untranslated_cpt() {
+		$GLOBALS['hook_suffix'] = 'post.php';
+		$_REQUEST['post_type'] = 'cpt';
+		register_post_type( 'cpt' );
+		set_current_screen();
+
+		$scripts = array( 'pll_ajax_backend', 'css' );
+		$this->_test_scripts( $scripts );
+	}
+
+
 	function test_scripts_in_media_list_table() {
 		$GLOBALS['hook_suffix'] = 'upload.php';
-		set_current_screen( 'upload' );
+		set_current_screen();
 
 		$scripts = array( 'pll_ajax_backend', 'post', 'css' );
 		$this->_test_scripts( $scripts );
@@ -92,23 +113,44 @@ class Admin_Test extends PLL_UnitTestCase {
 
 	function test_scripts_in_terms_list_table() {
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
-		set_current_screen( 'edit-tags' );
+		set_current_screen();
 
 		$scripts = array( 'pll_ajax_backend', 'term', 'css' );
+		$this->_test_scripts( $scripts );
+	}
+
+	function test_scripts_in_untranslated_custom_tax_list_table() {
+		$GLOBALS['hook_suffix'] = 'edit-tags.php';
+		$_REQUEST['taxonomy'] = 'tax';
+		register_taxonomy( 'tax', 'post' );
+		set_current_screen();
+
+		$scripts = array( 'pll_ajax_backend', 'css' );
 		$this->_test_scripts( $scripts );
 	}
 
 	function test_scripts_in_edit_term() {
 		$GLOBALS['hook_suffix'] = 'term.php';
-		set_current_screen( 'term' );
+		set_current_screen();
 
 		$scripts = array( 'pll_ajax_backend', 'term', 'css' );
 		$this->_test_scripts( $scripts );
 	}
 
+	function test_scripts_in_edit_unstranslated_custom_tax() {
+		$GLOBALS['hook_suffix'] = 'term.php';
+		$_REQUEST['taxonomy'] = 'tax';
+		register_taxonomy( 'tax', 'post' );
+		set_current_screen();
+
+		$scripts = array( 'pll_ajax_backend', 'css' );
+		$this->_test_scripts( $scripts );
+	}
+
+
 	function test_scripts_in_user_profile() {
 		$GLOBALS['hook_suffix'] = 'profile.php';
-		set_current_screen( 'profile' );
+		set_current_screen();
 
 		$scripts = array( 'pll_ajax_backend', 'user', 'css' );
 		$this->_test_scripts( $scripts );


### PR DESCRIPTION
The scripts post.js and term.js are outputed in all post types and taxonomies screens. They should not be outputed for untranslatable content types to avoid conflicts as reported in https://github.com/polylang/polylang-pro/issues/517

This PR tests post types and taxonomies before outputing the scripts and adds relevant phpunit tests. 

Fix https://github.com/polylang/polylang-pro/issues/517