### PR TITLE
Support wildcards in parent keys of the wpml-config.xml

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -83,11 +83,16 @@ class PLL_WPML_Config {
 				foreach ( $xml->xpath( 'admin-texts/key' ) as $key ) {
 					$attributes = $key->attributes();
 					$name = (string) $attributes['name'];
-					if ( PLL() instanceof PLL_Frontend ) {
-						$this->options[ $name ] = $key;
-						add_filter( 'option_' . $name, array( $this, 'translate_strings' ) );
+
+					if ( false !== strpos( $name, '*' ) ) {
+						$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
+						$names = preg_grep( $pattern, array_keys( wp_load_alloptions() ) );
+
+						foreach ( $names as $_name ) {
+							$this->register_or_translate_option( $context, $_name, $key );
+						}
 					} else {
-						$this->register_string_recursive( $context, $name, get_option( $name ), $key );
+						$this->register_or_translate_option( $context, $name, $key );
 					}
 				}
 			}
@@ -184,6 +189,24 @@ class PLL_WPML_Config {
 			}
 		}
 		return $taxonomies;
+	}
+
+	/**
+	 * Registers or translates the strings for an option
+	 *
+	 * @since 2.8
+	 *
+	 * @param string $context The group in which the strings will be registered.
+	 * @param string $option  Option name.
+	 * @param object $key     XML node.
+	 */
+	protected function register_or_translate_option( $context, $name, $key ) {
+		if ( PLL() instanceof PLL_Frontend ) {
+			$this->options[ $name ] = $key;
+			add_filter( 'option_' . $name, array( $this, 'translate_strings' ) );
+		} else {
+			$this->register_string_recursive( $context, $name, get_option( $name ), $key );
+		}
 	}
 
 	/**

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -197,7 +197,7 @@ class PLL_WPML_Config {
 	 * @since 2.8
 	 *
 	 * @param string $context The group in which the strings will be registered.
-	 * @param string $option  Option name.
+	 * @param string $name    Option name.
 	 * @param object $key     XML node.
 	 */
 	protected function register_or_translate_option( $context, $name, $key ) {

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -49,6 +49,7 @@
 					</key>
 				</key>
 				<key name="simple_string_option" />
+				<key name="generic_option_*" />
 		</admin-texts>
 		<language-switcher-settings>
 				<key name="icl_lang_sel_config">

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -65,6 +65,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 
 		update_option( 'my_plugins_options', $my_plugins_options );
 		update_option( 'simple_string_option', 'val' );
+		update_option( 'generic_option_1', 'generic_val_1' );
+		update_option( 'generic_option_2', 'generic_val_2' );
 	}
 
 	function translate_options( $slug ) {
@@ -88,6 +90,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$mo->add_entry( $mo->make_entry( 'val41', "val41_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val42', "val42_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val43', "val43_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'generic_val_1', "generic_val_1_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'generic_val_2', "generic_val_2_$slug" ) );
 		$mo->export_to_db( $language );
 	}
 
@@ -259,6 +263,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'val42_fr', $options['options_group_4']['sub_option_name_42'] );
 		$this->assertEquals( 'val43', $options['options_group_4']['sub_option_diff_43'] ); // This one must not be translated.
 		$this->assertEquals( 'val_fr', get_option( 'simple_string_option' ) );
+		$this->assertEquals( 'generic_val_1_fr', get_option( 'generic_option_1' ) );
+		$this->assertEquals( 'generic_val_2_fr', get_option( 'generic_option_2' ) );
 	}
 
 	function test_translate_strings_object() {
@@ -309,6 +315,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertContains( 'val42', $strings );
 		$this->assertNotContains( 'val43', $strings ); // This one must not be registered.
 		$this->assertContains( 'val', $strings );
+		$this->assertContains( 'generic_val_1', $strings );
+		$this->assertContains( 'generic_val_2', $strings );
 	}
 
 	function test_register_string() {


### PR DESCRIPTION
This PR allows to support wildcards in the parent keys of the admin-texts section of the wpml-config.xml. Includes PPHPUnit tests.
Fix https://github.com/polylang/polylang-pro/issues/485