### PR TITLE
Add tests to detect the modification of WordPress functions

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -73,8 +73,8 @@ class PLL_Frontend_Filters_Search {
 	}
 
 	/**
-	 * Rewrites the admin bar search form to pass our get_search form filter. See #21342
-	 * Code base last checked with WP 4.9.7
+	 * Rewrites the admin bar search form to pass our get_search_form filter. See #21342.
+	 * Code last checked: WP 5.4.1.
 	 *
 	 * @since 0.9
 	 *
@@ -87,11 +87,11 @@ class PLL_Frontend_Filters_Search {
 		$form .= '<input type="submit" class="adminbar-button" value="' . esc_attr__( 'Search', 'polylang' ) . '"/>';
 		$form .= '</form>';
 
-		$wp_admin_bar->add_menu(
+		$wp_admin_bar->add_node(
 			array(
 				'parent' => 'top-secondary',
 				'id'     => 'search',
-				'title'  => $this->get_search_form( $form ), // Pass the get_search_form filter
+				'title'  => $this->get_search_form( $form ), // Pass the get_search_form filter.
 				'meta'   => array(
 					'class'    => 'admin-bar-search',
 					'tabindex' => -1,

--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -8,24 +8,26 @@ if ( ! class_exists( 'WP_Widget_Calendar' ) ) {
 }
 
 /**
- * Obliged to rewrite the whole functionality as there is no filter on sql queries and only a filter on final output
- * Code base last checked with WP 4.9.7
- * A request for making a filter on sql queries exists: http://core.trac.wordpress.org/ticket/15202
- * Method used in 0.4.x: use of the get_calendar filter and overwrite the output of get_calendar function -> not very efficient (add 4 to 5 sql queries)
- * Method used since 0.5: remove the WP widget and replace it by our own -> our language filter will not work if get_calendar is called directly by a theme
+ * This classes rewrite the whole Calendar widget functionality as there is no filter on sql queries and only a filter on final output.
+ * Code last checked: WP 5.4.1.
+ *
+ * A request to add filters on sql queries exists: http://core.trac.wordpress.org/ticket/15202.
+ * Method used in 0.4.x: use of the get_calendar filter and overwrite the output of get_calendar function -> not very efficient (add 4 to 5 sql queries).
+ * Method used since 0.5: remove the WP widget and replace it by our own -> our language filter will not work if get_calendar is called directly by a theme.
  *
  * @since 0.5
  */
 class PLL_Widget_Calendar extends WP_Widget_Calendar {
-	protected static $pll_instance = 0; // Can't use $instance of WP_Widget_Calendar as it's private :/
+	protected static $pll_instance = 0; // Can't use $instance of WP_Widget_Calendar as it's private :/.
 
 	/**
 	 * Outputs the content for the current Calendar widget instance.
-	 * Modified version of the parent function to call our own get_calendar function.
+	 * Modified version of the parent function to call our own get_calendar() method.
 	 *
 	 * @since 0.5
 	 *
-	 * @param array $args Display arguments including before_title, after_title, before_widget, and after_widget.
+	 * @param array $args     Display arguments including 'before_title', 'after_title',
+	 *                        'before_widget', and 'after_widget'.
 	 * @param array $instance The settings for the particular instance of the widget.
 	 */
 	public function widget( $args, $instance ) {
@@ -51,21 +53,21 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 	}
 
 	/**
-	 * Modified version of WP get_calendar function to filter the query
+	 * Modified version of the WP get_calendar() function to filter the queries.
 	 *
 	 * @since 0.5
 	 *
 	 * @param bool $initial Optional, default is true. Use initial calendar names.
-	 * @param bool $echo Optional, default is true. Set to false for return.
-	 * @return string|null String when retrieving, null when displaying.
+	 * @param bool $echo    Optional, default is true. Set to false for return.
+	 * @return void|string Void if `$echo` argument is true, calendar HTML if `$echo` is false.
  	 */
 	static public function get_calendar( $initial = true, $echo = true ) {
 		global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 
-		$join_clause = PLL()->model->post->join_clause(); #added#
+		$join_clause  = PLL()->model->post->join_clause(); #added#
 		$where_clause = PLL()->model->post->where_clause( PLL()->curlang ); #added#
 
-		$key = md5( PLL()->curlang->slug . $m . $monthnum . $year ); #modified#
+		$key   = md5( PLL()->curlang->slug . $m . $monthnum . $year ); #modified#
 		$cache = wp_cache_get( 'get_calendar', 'calendar' );
 
 		if ( $cache && is_array( $cache ) && isset( $cache[ $key ] ) ) {
@@ -86,7 +88,7 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 
 		// Quick check. If we have no posts at all, abort!
 		if ( ! $posts ) {
-			$gotsome = $wpdb->get_var("SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1");
+			$gotsome = $wpdb->get_var( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1" );
 			if ( ! $gotsome ) {
 				$cache[ $key ] = '';
 				wp_cache_set( 'get_calendar', $cache, 'calendar' );
@@ -97,20 +99,19 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		if ( isset( $_GET['w'] ) ) {
 			$w = (int) $_GET['w'];
 		}
-		// week_begins = 0 stands for Sunday
+		// week_begins = 0 stands for Sunday.
 		$week_begins = (int) get_option( 'start_of_week' );
-		$ts = current_time( 'timestamp' );
 
-		// Let's figure out when we are
+		// Let's figure out when we are.
 		if ( ! empty( $monthnum ) && ! empty( $year ) ) {
 			$thismonth = zeroise( intval( $monthnum ), 2 );
-			$thisyear = (int) $year;
+			$thisyear  = (int) $year;
 		} elseif ( ! empty( $w ) ) {
-			// We need to get the month from MySQL
+			// We need to get the month from MySQL.
 			$thisyear = (int) substr( $m, 0, 4 );
-			//it seems MySQL's weeks disagree with PHP's
-			$d = ( ( $w - 1 ) * 7 ) + 6;
-			$thismonth = $wpdb->get_var("SELECT DATE_FORMAT((DATE_ADD('{$thisyear}0101', INTERVAL $d DAY) ), '%m')");
+			// It seems MySQL's weeks disagree with PHP's.
+			$d         = ( ( $w - 1 ) * 7 ) + 6;
+			$thismonth = $wpdb->get_var( "SELECT DATE_FORMAT((DATE_ADD('{$thisyear}0101', INTERVAL $d DAY) ), '%m')" );
 		} elseif ( ! empty( $m ) ) {
 			$thisyear = (int) substr( $m, 0, 4 );
 			if ( strlen( $m ) < 6 ) {
@@ -119,34 +120,38 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 				$thismonth = zeroise( (int) substr( $m, 4, 2 ), 2 );
 			}
 		} else {
-			$thisyear = gmdate( 'Y', $ts );
-			$thismonth = gmdate( 'm', $ts );
+			$thisyear  = current_time( 'Y' );
+			$thismonth = current_time( 'm' );
 		}
 
-		$unixmonth = mktime( 0, 0 , 0, $thismonth, 1, $thisyear );
-		$last_day = date( 't', $unixmonth );
+		$unixmonth = mktime( 0, 0, 0, $thismonth, 1, $thisyear );
+		$last_day  = gmdate( 't', $unixmonth );
 
-		// Get the next and previous month and year with at least one post
-		$previous = $wpdb->get_row( "SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
+		// Get the next and previous month and year with at least one post.
+		$previous = $wpdb->get_row(
+			"SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
 			FROM $wpdb->posts $join_clause
 			WHERE post_date < '$thisyear-$thismonth-01'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
 				ORDER BY post_date DESC
-				LIMIT 1" ); #modified#
-		$next = $wpdb->get_row( "SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
+				LIMIT 1"
+		);  #modified#
+		$next     = $wpdb->get_row(
+			"SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
 			FROM $wpdb->posts $join_clause
 			WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
 				ORDER BY post_date ASC
-				LIMIT 1" ); #modified#
+				LIMIT 1"
+		);  #modified#
 
-		/* translators: Calendar caption: 1: month name, 2: 4-digit year */
+		/* translators: Calendar caption: 1: Month name, 2: 4-digit year. */
 		$calendar_caption = _x( '%1$s %2$s', 'calendar caption' );
-		$calendar_output = '<table id="wp-calendar">
+		$calendar_output  = '<table id="wp-calendar" class="wp-calendar-table">
 		<caption>' . sprintf(
 			$calendar_caption,
 			$wp_locale->get_month( $thismonth ),
-			date( 'Y', $unixmonth )
+			gmdate( 'Y', $unixmonth )
 		) . '</caption>
 		<thead>
 		<tr>';
@@ -158,85 +163,61 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		}
 
 		foreach ( $myweek as $wd ) {
-			$day_name = $initial ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
-			$wd = esc_attr( $wd );
+			$day_name         = $initial ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
+			$wd               = esc_attr( $wd );
 			$calendar_output .= "\n\t\t<th scope=\"col\" title=\"$wd\">$day_name</th>";
 		}
 
 		$calendar_output .= '
 		</tr>
 		</thead>
-
-		<tfoot>
-		<tr>';
-
-		if ( $previous ) {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '">&laquo; ' .
-				$wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) .
-			'</a></td>';
-		} else {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="prev" class="pad">&nbsp;</td>';
-		}
-
-		$calendar_output .= "\n\t\t".'<td class="pad">&nbsp;</td>';
-
-		if ( $next ) {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '">' .
-				$wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) .
-			' &raquo;</a></td>';
-		} else {
-			$calendar_output .= "\n\t\t".'<td colspan="3" id="next" class="pad">&nbsp;</td>';
-		}
-
-		$calendar_output .= '
-		</tr>
-		</tfoot>
-
 		<tbody>
 		<tr>';
 
 		$daywithpost = array();
 
-		// Get days with posts
-		$dayswithposts = $wpdb->get_results( "SELECT DISTINCT DAYOFMONTH( post_date )
-			FROM $wpdb->posts $join_clause
-			WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00'
-			AND post_type = 'post' AND post_status = 'publish' $where_clause
-			AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59'", ARRAY_N ); #modified#
+		// Get days with posts.
+		$dayswithposts = $wpdb->get_results(
+			"SELECT DISTINCT DAYOFMONTH(post_date)
+			FROM $wpdb->posts $join_clause WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00'
+			AND post_type = 'post' AND post_status = 'publish'
+			AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59' $where_clause",
+			ARRAY_N
+		); #modified#
 		if ( $dayswithposts ) {
 			foreach ( (array) $dayswithposts as $daywith ) {
 				$daywithpost[] = $daywith[0];
 			}
 		}
 
-		// See how much we should pad in the beginning
-		$pad = calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
+		// See how much we should pad in the beginning.
+		$pad = calendar_week_mod( gmdate( 'w', $unixmonth ) - $week_begins );
 		if ( 0 != $pad ) {
-			$calendar_output .= "\n\t\t".'<td colspan="'. esc_attr( $pad ) .'" class="pad">&nbsp;</td>';
+			$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 		}
 
-		$newrow = false;
-		$daysinmonth = (int) date( 't', $unixmonth );
+		$newrow      = false;
+		$daysinmonth = (int) gmdate( 't', $unixmonth );
 
 		for ( $day = 1; $day <= $daysinmonth; ++$day ) {
-			if ( isset($newrow) && $newrow ) {
+			if ( isset( $newrow ) && $newrow ) {
 				$calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
 			}
 			$newrow = false;
 
-			if ( $day == gmdate( 'j', $ts ) &&
-				$thismonth == gmdate( 'm', $ts ) &&
-				$thisyear == gmdate( 'Y', $ts ) ) {
+			if ( current_time( 'j' ) == $day &&
+				current_time( 'm' ) == $thismonth &&
+				current_time( 'Y' ) == $thisyear ) {
 				$calendar_output .= '<td id="today">';
 			} else {
 				$calendar_output .= '<td>';
 			}
 
 			if ( in_array( $day, $daywithpost ) ) {
-				// any posts today?
-				$date_format = date( _x( 'F j, Y', 'daily archives date format' ), strtotime( "{$thisyear}-{$thismonth}-{$day}" ) );
-				/* translators: Post calendar label. 1: Date */
-				$label = sprintf( __( 'Posts published on %s' ), $date_format );
+				// Any posts today?
+				$date_format = gmdate( _x( 'F j, Y', 'daily archives date format' ), strtotime( "{$thisyear}-{$thismonth}-{$day}" ) );
+				/* translators: Post calendar label. %s: Date. */
+				$label            = sprintf( __( 'Posts published on %s' ), $date_format );
 				$calendar_output .= sprintf(
 					'<a href="%s" aria-label="%s">%s</a>',
 					get_day_link( $thisyear, $thismonth, $day ),
@@ -248,28 +229,47 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 			}
 			$calendar_output .= '</td>';
 
-			if ( 6 == calendar_week_mod( date( 'w', mktime(0, 0 , 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+			if ( 6 == calendar_week_mod( gmdate( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
 				$newrow = true;
 			}
 		}
 
-		$pad = 7 - calendar_week_mod( date( 'w', mktime( 0, 0 , 0, $thismonth, $day, $thisyear ) ) - $week_begins );
-		if ( $pad != 0 && $pad != 7 ) {
-			$calendar_output .= "\n\t\t".'<td class="pad" colspan="'. esc_attr( $pad ) .'">&nbsp;</td>';
+		$pad = 7 - calendar_week_mod( gmdate( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+		if ( 0 != $pad && 7 != $pad ) {
+			$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
 		}
-		$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";
+		$calendar_output .= "\n\t</tr>\n\t</tbody>";
+
+		$calendar_output .= "\n\t</table>";
+
+		$calendar_output .= '<nav aria-label="' . __( 'Previous and next months' ) . '" class="wp-calendar-nav">';
+
+		if ( $previous ) {
+			$calendar_output .= "\n\t\t" . '<span class="wp-calendar-nav-prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '">&laquo; ' .
+				$wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) .
+			'</a></span>';
+		} else {
+			$calendar_output .= "\n\t\t" . '<span class="wp-calendar-nav-prev">&nbsp;</span>';
+		}
+
+		$calendar_output .= "\n\t\t" . '<span class="pad">&nbsp;</span>';
+
+		if ( $next ) {
+			$calendar_output .= "\n\t\t" . '<span class="wp-calendar-nav-next"><a href="' . get_month_link( $next->year, $next->month ) . '">' .
+				$wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) .
+			' &raquo;</a></span>';
+		} else {
+			$calendar_output .= "\n\t\t" . '<span class="wp-calendar-nav-next">&nbsp;</span>';
+		}
+
+		$calendar_output .= '
+		</nav>';
 
 		$cache[ $key ] = $calendar_output;
 		wp_cache_set( 'get_calendar', $cache, 'calendar' );
 
 		if ( $echo ) {
-			/**
-			 * Filters the HTML calendar output.
-			 *
-			 * @since 3.0.0
-			 *
-			 * @param string $calendar_output HTML output of the calendar.
-			 */
+			/** This filter is documented in wp-includes/general-template.php */
 			echo apply_filters( 'get_calendar', $calendar_output );
 			return;
 		}

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -23,18 +23,24 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	 * Checks if a WordPress function has been modified.
 	 *
 	 * @param string $md5     Expected method md5.
-	 * @param string $version Minimum WP version to check.
 	 * @param string ...$args Function name or class and method name.
 	 */
-	protected function check_method( $md5, $version, ...$args ) {
-		if ( version_compare( $version, $GLOBALS['wp_version'], '<=' ) ) {
-			$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
-		}
+	protected function check_method( $md5, ...$args ) {
+		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
 	}
 
-	public function test_functions_and_methods() {
-		$this->check_method( 'f75a2c70d28b1d2c4e3e8fd86a8bb7d3', '5.4', 'WP_Widget_Calendar', 'widget' );
-		$this->check_method( '4cb06a3a390e2feaa9d32761d1f3fd00', '5.4', 'get_calendar' );
-		$this->check_method( '0104b0cde635904909a91ab3dafd5129', '5.4', 'wp_admin_bar_search_menu' );
+	public function test_wp_calendar() {
+		if ( ! version_compare( '5.4', $GLOBALS['wp_version'], '<=' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress version 5.4 of higher' );
+		}
+		$this->check_method( 'f75a2c70d28b1d2c4e3e8fd86a8bb7d3', 'WP_Widget_Calendar', 'widget' );
+		$this->check_method( '4cb06a3a390e2feaa9d32761d1f3fd00', 'get_calendar' );
+	}
+
+	public function test_wp_admin_bar() {
+		if ( ! version_compare( '5.4', $GLOBALS['wp_version'], '<=' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress version 5.4 of higher' );
+		}
+		$this->check_method( '0104b0cde635904909a91ab3dafd5129', 'wp_admin_bar_search_menu' );
 	}
 }

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -23,24 +23,25 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	 * Checks if a WordPress function has been modified.
 	 *
 	 * @param string $md5     Expected method md5.
+	 * @param string $version Minimum WordPress function to pass the test.
 	 * @param string ...$args Function name or class and method name.
 	 */
-	protected function check_method( $md5, ...$args ) {
+	protected function check_method( $md5, $version, ...$args ) {
+		if ( version_compare( $GLOBALS['wp_version'], $version, '<' ) ) {
+			$this->markTestSkipped( "This test requires WordPress version {$version} or higher" );
+		}
 		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
 	}
 
-	public function test_wp_calendar() {
-		if ( ! version_compare( '5.4', $GLOBALS['wp_version'], '<=' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress version 5.4 of higher' );
-		}
-		$this->check_method( 'f75a2c70d28b1d2c4e3e8fd86a8bb7d3', 'WP_Widget_Calendar', 'widget' );
-		$this->check_method( '4cb06a3a390e2feaa9d32761d1f3fd00', 'get_calendar' );
+	public function test_calendar_widget() {
+		$this->check_method( 'f75a2c70d28b1d2c4e3e8fd86a8bb7d3', '5.4', 'WP_Widget_Calendar', 'widget' );
+	}
+
+	public function test_get_calendar() {
+		$this->check_method( '4cb06a3a390e2feaa9d32761d1f3fd00', '5.4', 'get_calendar' );
 	}
 
 	public function test_wp_admin_bar() {
-		if ( ! version_compare( '5.4', $GLOBALS['wp_version'], '<=' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress version 5.4 of higher' );
-		}
-		$this->check_method( '0104b0cde635904909a91ab3dafd5129', 'wp_admin_bar_search_menu' );
+		$this->check_method( '0104b0cde635904909a91ab3dafd5129', '5.4', 'wp_admin_bar_search_menu' );
 	}
 }

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -1,0 +1,40 @@
+<?php
+
+class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
+
+	protected function md5( ...$args ) {
+		if ( empty( $args[1] ) ) {
+			// We got a function.
+			$reflection = new ReflectionFunction( $args[0] );
+		} else {
+			$reflection = new ReflectionMethod( $args[0], $args[1] );
+		}
+		$filename = $reflection->getFileName();
+		$start_line = $reflection->getStartLine() - 1; // It's actually - 1, otherwise you wont get the function() block.
+		$end_line = $reflection->getEndLine();
+		$length = $end_line - $start_line;
+
+		$source = file( $filename );
+		$body = implode( '', array_slice( $source, $start_line, $length ) );
+		return md5( $body );
+	}
+
+	/**
+	 * Checks if a WordPress function has been modified.
+	 *
+	 * @param string $md5     Expected method md5.
+	 * @param string $version Minimum WP version to check.
+	 * @param string ...$args Function name or class and method name.
+	 */
+	protected function check_method( $md5, $version, ...$args ) {
+		if ( version_compare( $version, $GLOBALS['wp_version'], '<=' ) ) {
+			$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
+		}
+	}
+
+	public function test_functions_and_methods() {
+		$this->check_method( 'f75a2c70d28b1d2c4e3e8fd86a8bb7d3', '5.4', 'WP_Widget_Calendar', 'widget' );
+		$this->check_method( '4cb06a3a390e2feaa9d32761d1f3fd00', '5.4', 'get_calendar' );
+		$this->check_method( '0104b0cde635904909a91ab3dafd5129', '5.4', 'wp_admin_bar_search_menu' );
+	}
+}


### PR DESCRIPTION
This PR adds phpunit tests to check if WordPress functions that we have copied with or without modifications need to be updated.

This is done by reading the WordPress function or method, evaluating its md5 and comparing it to the last known md5. The test is done only for WordPress versions older than a defined versions to avoid errors when testing the backward compatibility with older versions of WordPress.

The PR also updates the methods get_calendar() and admin_bar_search_menu() with the
code base of WP 5.4.1.