### PR TITLE
Add abbr wrapper

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -66,7 +66,7 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[ 'language_' . $language->slug ] = $language->flag ? $language->flag . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>' : esc_html( $language->slug );
+			$columns[ 'language_' . $language->slug ] = ( $language->flag ? $language->flag : sprintf('<abbr title="%1$s">%2$s</abbr>', esc_attr( $language->name ), esc_html( $language->slug ) ) ) . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -66,7 +66,7 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[ 'language_' . $language->slug ] = $language->flag ? $language->flag : '<abbr>' . esc_html( $language->slug ) . '</abbr>' . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
+			$columns[ 'language_' . $language->slug ] = $language->flag ? $language->flag : '<abbr>' . esc_html( $language->slug ) . '</abbr><span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -66,7 +66,7 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[ 'language_' . $language->slug ] = ( $language->flag ? $language->flag : sprintf('<abbr title="%1$s">%2$s</abbr>', esc_attr( $language->name ), esc_html( $language->slug ) ) ) . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
+			$columns[ 'language_' . $language->slug ] = ( $language->flag ? $language->flag : sprintf( '<abbr title="%1$s">%2$s</abbr>', esc_attr( $language->name ), esc_html( $language->slug ) ) ) . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -66,7 +66,7 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[ 'language_' . $language->slug ] = ( $language->flag ? $language->flag : sprintf( '<abbr title="%1$s">%2$s</abbr>', esc_attr( $language->name ), esc_html( $language->slug ) ) ) . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
+			$columns[ 'language_' . $language->slug ] = $language->flag ? $language->flag : '<abbr>' . esc_html( $language->slug ) . '</abbr>' . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -34,7 +34,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		?>
 		<tr>
-			<th class = "pll-language-column"><?php echo $language->flag ? $language->flag : esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></th>
+			<th class = "pll-language-column">
+			<?php
+			if ( $language->flag ) {
+					printf(
+						'<span class="pll-translation-flag">%s</span>',
+						$language->flag // phpcs:ignore WordPress.Security.EscapeOutput
+					);
+			} else {
+				printf(
+					'<abbr title="%1$s">%2$s</abbr>',
+					esc_attr( $language->name ),
+					esc_html( $language->slug )
+				);
+			}
+			printf(
+				'<span class="pll-language-name%1$s">%2$s</span>',
+				isset( $term_id ) ? '' : ' screen-reader-text',
+				esc_html( $language->name )
+			);
+			?>
+			</th>
 			<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<td class = "pll-edit-column pll-column-icon"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<?php

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		?>
 		<tr>
-			<th class = "pll-language-column"><?php echo $language->flag ? $language->flag : '<abbr>' . esc_html( $language->slug ) . '</abbr>' . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>'; ?></th>
+			<th class = "pll-language-column"><?php echo $language->flag ? $language->flag : '<abbr>' . esc_html( $language->slug ) . '</abbr><span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';  // phpcs:ignore WordPress.Security.EscapeOutput ?></th>
 			<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<td class = "pll-edit-column pll-column-icon"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<?php

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -34,27 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		?>
 		<tr>
-			<th class = "pll-language-column">
-			<?php
-			if ( $language->flag ) {
-					printf(
-						'<span class="pll-translation-flag">%s</span>',
-						$language->flag // phpcs:ignore WordPress.Security.EscapeOutput
-					);
-			} else {
-				printf(
-					'<abbr title="%1$s">%2$s</abbr>',
-					esc_attr( $language->name ),
-					esc_html( $language->slug )
-				);
-			}
-			printf(
-				'<span class="pll-language-name%1$s">%2$s</span>',
-				isset( $term_id ) ? '' : ' screen-reader-text',
-				esc_html( $language->name )
-			);
-			?>
-			</th>
+			<th class = "pll-language-column"><?php echo $language->flag ? $language->flag : '<abbr>' . esc_html( $language->slug ) . '</abbr>' . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>'; ?></th>
 			<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<td class = "pll-edit-column pll-column-icon"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<?php

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -49,8 +49,19 @@ else {
 		?>
 		<tr>
 			<th class = "pll-language-column">
-				<span class = "pll-translation-flag"><?php echo $language->flag ? $language->flag : esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span>
 				<?php
+				if ( $language->flag ) {
+					printf(
+						'<span class="pll-translation-flag">%s</span>',
+						$language->flag // phpcs:ignore WordPress.Security.EscapeOutput
+					);
+				} else {
+					printf(
+						'<abbr class="pll-translation-flag" title="%1$s">%2$s</abbr>',
+						esc_attr( $language->name ),
+						esc_html( $language->slug )
+					);
+				}
 				printf(
 					'<span class="pll-language-name%1$s">%2$s</span>',
 					isset( $term_id ) ? '' : ' screen-reader-text',

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -49,19 +49,8 @@ else {
 		?>
 		<tr>
 			<th class = "pll-language-column">
+				<?php echo $language->flag ? '<span class="pll-translation-flag">' . $language->flag . '</span>' : '<abbr class="pll-translation-flag">' . esc_html( $language->slug ) . '</abbr>'; // phpcs:ignore WordPress.Security.EscapeOutput ?>
 				<?php
-				if ( $language->flag ) {
-					printf(
-						'<span class="pll-translation-flag">%s</span>',
-						$language->flag // phpcs:ignore WordPress.Security.EscapeOutput
-					);
-				} else {
-					printf(
-						'<abbr class="pll-translation-flag" title="%1$s">%2$s</abbr>',
-						esc_attr( $language->name ),
-						esc_html( $language->slug )
-					);
-				}
 				printf(
 					'<span class="pll-language-name%1$s">%2$s</span>',
 					isset( $term_id ) ? '' : ' screen-reader-text',


### PR DESCRIPTION
After the correction of https://github.com/polylang/polylang-pro/issues/526 in this PR https://github.com/polylang/polylang-pro/pull/531 where I decided to wrap the language slug (when a language has no flag) in a `abbr` tag, this PR propose to do the same on legacy metaboxes (post and term) and on colums on WordPress lists (posts and taxonomies) for consistency.

### Post
![image](https://user-images.githubusercontent.com/1003778/84116957-18896b80-aa31-11ea-932a-dee10b0a66fa.png)

![image](https://user-images.githubusercontent.com/1003778/84117103-4a023700-aa31-11ea-8488-a2b7c52f9c70.png)

### Term and Taxonomy
![image](https://user-images.githubusercontent.com/1003778/84117239-7e75f300-aa31-11ea-801b-e0f0ea71eefd.png)

![image](https://user-images.githubusercontent.com/1003778/84117319-a1a0a280-aa31-11ea-82e5-a3d739a0c6d4.png)

![image](https://user-images.githubusercontent.com/1003778/84117877-7d919100-aa32-11ea-9111-71ce29b1199c.png)


**Edit**: we decided no to use title attribute for accessibilty reasons https://trello.com/c/PFmIHrC7/115-what-will-we-do-for-accessibility 
It's the goal of the last commit to remove the title attribute https://github.com/polylang/polylang/pull/517/commits/d955521396bbd60b115c937e454236cac11d3213
I decided to keep the `abbr` tag if we will decide to add a tooltip in the future.
