### PR TITLE
Add attribute title on pencil icon on legacy metabox

### DIFF
--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -47,12 +47,21 @@ class PLL_Admin_Links extends PLL_Links {
 	 * @return string
 	 */
 	public function edit_translation_link( $link, $language ) {
-		return $link ? sprintf(
-			'<a href="%1$s" class="pll_icon_edit"><span class="screen-reader-text">%2$s</span></a>',
-			esc_url( $link ),
+		$str = '';
+
+		if ( $link ) {
 			/* translators: accessibility text, %s is a native language name */
-			esc_html( sprintf( __( 'Edit the translation in %s', 'polylang' ), $language->name ) )
-		) : '';
+			$hint = sprintf( __( 'Edit the translation in %s', 'polylang' ), $language->name );
+
+			$str = sprintf(
+				'<a href="%1$s" title="%2$s" class="pll_icon_edit"><span class="screen-reader-text">%3$s</span></a>',
+				esc_url( $link ),
+				esc_attr( $hint ),
+				esc_html( $hint )
+			);
+		}
+
+		return $str;
 	}
 
 	/**


### PR DESCRIPTION
During the correction of polylang/polylang-pro#526 in this PR polylang/polylang-pro#531 where I decided to wrap the language slug (when a language has no flag) in a abbr tag, I noticed that no title attribute is set on pencil icon on legacy metabox unlike on plus icon.
This PR propose to add the title attribute as on the plus icon.

### post
![image](https://user-images.githubusercontent.com/1003778/84133818-ee8f7380-aa47-11ea-9500-1cdec93a77fa.png)

### term
![image](https://user-images.githubusercontent.com/1003778/84133890-0b2bab80-aa48-11ea-8555-88ddf2f0b84f.png)

