### PR TITLE
Decrease the number of queries on pages list

### DIFF
--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -76,7 +76,9 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 
 		// Hierarchical post types
 		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
-			$pages          = get_pages();
+			$pages = get_pages( array( 'sort_column' => 'menu_order, post_title' ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
+			update_post_caches( $pages, $screen->post_type );
+
 			$page_languages = array();
 
 			foreach ( $pages as $page ) {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/562

On the pages list table, we query all pages to be able to filter the pages parent dropdown by language. However the `get_pages()` doesn't query the terms or metas. As a consequence, they are then queried individually each time we need a term or meta associated to the queried pages, instead of being queried all at once, causing a performance decrease.

This PR makes sure to query all terms and meta by calling `update_post_caches()` after `get_pages()`.

Additonnally, I changed the parameters of the `get_pages()` call to use the same as the query made by WordPress to build the page parent dropdown. This saves us an extra db query.

This PR must **not** be tested against the current WP 5.5 alpha because of this regression that I detected during my work on the topic: https://core.trac.wordpress.org/ticket/50352#comment:7