### PR TITLE
Always filter WP_Query by the current language

### DIFF
--- a/include/query.php
+++ b/include/query.php
@@ -9,30 +9,6 @@
  * @since 2.2
  */
 class PLL_Query {
-
-	protected static $excludes = array(
-		'p',
-		'post_parent',
-		'attachment',
-		'attachment_id',
-		'name',
-		'pagename',
-		'page_id',
-		'category_name',
-		'tag',
-		'tag_id',
-		'cat',
-		'category__in',
-		'category__and',
-		'post__in',
-		'post_name__in',
-		'tag__in',
-		'tag__and',
-		'tag_slug__in',
-		'tag_slug__and',
-		'post_parent__in',
-	);
-
 	/**
 	 * Constructor
 	 *
@@ -132,33 +108,6 @@ class PLL_Query {
 		$qvars = &$this->query->query_vars;
 
 		if ( ! isset( $qvars['lang'] ) ) {
-			/**
-			 * Filter the query vars which disable the language filter in a query
-			 *
-			 * @since 2.3.5
-			 *
-			 * @param array  $excludes Query vars excluded from the language filter
-			 * @param object $query    WP Query
-			 * @param object $lang     Language
-			 */
-			$excludes = apply_filters( 'pll_filter_query_excluded_query_vars', self::$excludes, $this->query, $lang );
-
-			// Do not filter the query if the language is already specified in another way
-			foreach ( $excludes as $k ) {
-				if ( ! empty( $qvars[ $k ] ) ) {
-					// Specific case for 'cat' as it can contain negative values
-					if ( 'cat' === $k ) {
-						foreach ( explode( ',', $qvars['cat'] ) as $cat ) {
-							if ( $cat > 0 ) {
-								return;
-							}
-						}
-					} else {
-						return;
-					}
-				}
-			}
-
 			$taxonomies = array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( array( '_builtin' => false ) ) );
 
 			foreach ( $taxonomies as $tax ) {

--- a/integrations/jetpack/featured-content.php
+++ b/integrations/jetpack/featured-content.php
@@ -16,7 +16,6 @@ class PLL_Featured_Content {
 	 */
 	public function init() {
 		add_filter( 'transient_featured_content_ids', array( $this, 'featured_content_ids' ) );
-		add_filter( 'pll_filter_query_excluded_query_vars', array( $this, 'fix_featured_posts' ) );
 		add_filter( 'option_featured-content', array( $this, 'option_featured_content' ) );
 	}
 
@@ -100,21 +99,6 @@ class PLL_Featured_Content {
 		set_transient( 'featured_content_ids', $ids );
 
 		return $ids;
-	}
-
-	/**
-	 * Allow to filter the featured posts query per language
-	 *
-	 * @since 2.4
-	 *
-	 * @param array $excludes Query vars excluded from the language filter
-	 * @return array
-	 */
-	public function fix_featured_posts( $excludes ) {
-		if ( $this->is_active() && PLL() instanceof PLL_Frontend && doing_filter( $this->get_featured_posts_filter() ) ) {
-			$excludes = array_diff( $excludes, array( 'post__in' ) );
-		}
-		return $excludes;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -402,10 +402,13 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $en, reset( $posts ) );
 
 		$posts = get_posts( array( 'fields' => 'ids', 'post__in' => array( $fr ) ) );
-		$this->assertEquals( $fr, reset( $posts ) );
+		$this->assertEmpty( $posts );
+
+		$posts = get_posts( array( 'fields' => 'ids', 'post__in' => array( $en, $fr ) ) );
+		$this->assertEquals( array( $en ), $posts );
 
 		$posts = get_posts( array( 'fields' => 'ids', 'tag__in' => array( $tag ) ) );
-		$this->assertEquals( $fr, reset( $posts ) );
+		$this->assertEmpty( $posts );
 
 		$tax_query[] = array(
 			'taxonomy' => 'post_tag',

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -514,10 +514,11 @@ class Query_Test extends PLL_UnitTestCase {
 		$query = new WP_Query( array( 'cat' => -$cat_en ) );
 		$this->assertEmpty( $query->posts );
 
-		// The test was broken by WP 4.9 and fixed in 2.2.7
-		// See also https://core.trac.wordpress.org/ticket/42104
 		$query = new WP_Query( array( 'cat' => $cat_fr ) );
-		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
+		$this->assertEmpty( $query->posts );
+
+		$query = new WP_Query( array( 'cat' => "{$cat_en},{$cat_fr}" ) );
+		$this->assertEquals( array( get_post( $en ) ), $query->posts );
 	}
 
 	// Bug introduced in 2.2 and fixed in 2.2.4


### PR DESCRIPTION
Fixes #469 
Closes https://github.com/polylang/polylang-pro/issues/434

On admin siide, `WP_Query` wasn't filtered by the current language when the query included query vars which specify objects with their language, typically, `p', `page_id`, 'cat'...

This caused several conflicts that we used to fix by removing these exclusions with the filter  `pll_filter_query_excluded_query_vars`. This also caused troubles with the REST API. So it the end, it looks like the idea was bad from the start.

This PR removes completely these exclusions and fixes or adds phpunit tests accordingly.

We will be able to remove the usage of the filter `pll_filter_query_excluded_query_vars` in `PLL_Featured_Content` once this PR and #524 are merged.