### PR TITLE
Move all integrations to their own directory.

### DIFF
--- a/integrations/aqua-resizer/aqua-resizer.php
+++ b/integrations/aqua-resizer/aqua-resizer.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Manages the compatibility with Aqua Resizer when used in themes.
+ *
+ * @since 2.8
+ */
+class PLL_Aqua_Resizer {
+	/**
+	 * Setups filters.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		add_filter( 'pll_home_url_black_list', array( $this, 'home_url_black_list' ) );
+	}
+
+	/**
+	 * Avoids filtering the home url for the function aq_resize().
+	 *
+	 * @since 1.1.5
+	 *
+	 * @param array $arr Home url filter black list.
+	 * @return array
+	 */
+	public function home_url_black_list( $arr ) {
+		return array_merge( $arr, array( array( 'function' => 'aq_resize' ) ) );
+	}
+}

--- a/integrations/aqua-resizer/load.php
+++ b/integrations/aqua-resizer/load.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Loads the integration with Aqua Resizer.
+ *
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+PLL_Integrations::instance()->aq_resizer = new PLL_Aqua_Resizer();
+PLL_Integrations::instance()->aq_resizer->init();

--- a/integrations/custom-field-template/cft.php
+++ b/integrations/custom-field-template/cft.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Manages the compatibility with Custom Field Template.
+ *
+ * @since 2.8
+ */
+class PLL_Cft {
+	/**
+	 * Setups actions.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		add_action( 'add_meta_boxes', array( $this, 'cft_copy' ), 10, 2 );
+	}
+
+	/**
+	 * Custom field template does check $_REQUEST['post'] to populate the custom fields values.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @param string $post_type Unused.
+	 * @param object $post      Current post object.
+	 */
+	public function cft_copy( $post_type, $post ) {
+		global $custom_field_template;
+		if ( isset( $custom_field_template, $_REQUEST['from_post'], $_REQUEST['new_lang'] ) && ! empty( $post ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$_REQUEST['post'] = $post->ID;
+		}
+	}
+}

--- a/integrations/custom-field-template/load.php
+++ b/integrations/custom-field-template/load.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Loads the integration with Custom Field Template.
+ *
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+add_action(
+	'plugins_loaded',
+	function() {
+		if ( class_exists( 'custom_field_template' ) ) {
+			PLL_Integrations::instance()->cft = new PLL_Cft();
+			PLL_Integrations::instance()->cft->init();
+		}
+	},
+	0
+);

--- a/integrations/duplicate-post/duplicate-post.php
+++ b/integrations/duplicate-post/duplicate-post.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Manages the compatibility with Duplicate Post.
+ *
+ * @since 2.8
+ */
+class PLL_Duplicate_Post {
+	/**
+	 * Setups actions.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		add_filter( 'option_duplicate_post_taxonomies_blacklist', array( $this, 'taxonomies_blacklist' ) );
+	}
+
+	/**
+	 * Duplicate Post
+	 * Avoid duplicating the 'post_translations' taxonomy
+	 *
+	 * @since 1.8
+	 *
+	 * @param array|string $taxonomies
+	 * @return array
+	 */
+	public function duplicate_post_taxonomies_blacklist( $taxonomies ) {
+		if ( empty( $taxonomies ) ) {
+			$taxonomies = array(); // As we get an empty string when there is no taxonomy
+		}
+
+		$taxonomies[] = 'post_translations';
+		return $taxonomies;
+	}
+}

--- a/integrations/duplicate-post/load.php
+++ b/integrations/duplicate-post/load.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Loads the integration with Duplicate Post.
+ *
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+add_action(
+	'plugins_loaded',
+	function() {
+		if ( defined( 'DUPLICATE_POST_CURRENT_VERSION' ) ) {
+			PLL_Integrations::instance()->duplicate_post = new PLL_Duplicate_Post();
+			PLL_Integrations::instance()->duplicate_post->init();
+		}
+	},
+	0
+);

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -4,20 +4,22 @@
  */
 
 /**
- * Manages compatibility with 3rd party plugins ( and themes ).
+ * Container for 3rd party plugins ( and themes ) integrations.
  * This class is available as soon as the plugin is loaded.
- *
- * It handles the most simple integrations while more complex inegrations
- * are handled separately in their own classes.
  *
  * @since 1.0
  * @since 2.8 Renamed from PLL_Plugins_Compat to PLL_Integrations.
  */
 class PLL_Integrations {
-	protected static $instance; // for singleton
+	/**
+	 * Singleton instance.
+	 *
+	 * @var PLL_Integrations
+	 */
+	protected static $instance;
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
 	 * @since 1.0
 	 */
@@ -26,28 +28,10 @@ class PLL_Integrations {
 		foreach ( glob( __DIR__ . '/*/load.php', GLOB_NOSORT ) as $load_script ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 			require_once $load_script; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		}
-
-		// YARPP
-		add_action( 'init', array( $this, 'yarpp_init' ) ); // after Polylang has registered its taxonomy in setup_theme
-
-		// Custom field template
-		add_action( 'add_meta_boxes', array( $this, 'cft_copy' ), 10, 2 );
-
-		// Aqua Resizer
-		add_filter( 'pll_home_url_black_list', array( $this, 'aq_home_url_black_list' ) );
-
-		// Duplicate post
-		add_filter( 'option_duplicate_post_taxonomies_blacklist', array( $this, 'duplicate_post_taxonomies_blacklist' ) );
-
-		// WP Sweep
-		add_filter( 'wp_sweep_excluded_taxonomies', array( $this, 'wp_sweep_excluded_taxonomies' ) );
-
-		// No category base (works for Yoast SEO too)
-		add_filter( 'get_terms_args', array( $this, 'no_category_base_get_terms_args' ), 5 ); // Before adding cache domain
 	}
 
 	/**
-	 * Access to the single instance of the class
+	 * Access to the single instance of the class.
 	 *
 	 * @since 1.7
 	 *
@@ -59,90 +43,6 @@ class PLL_Integrations {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * YARPP
-	 * Just makes YARPP aware of the language taxonomy ( after Polylang registered it )
-	 *
-	 * @since 1.0
-	 */
-	public function yarpp_init() {
-		$GLOBALS['wp_taxonomies']['language']->yarpp_support = 1;
-	}
-
-	/**
-	 * Aqua Resizer
-	 *
-	 * @since 1.1.5
-	 *
-	 * @param array $arr
-	 * @return array
-	 */
-	public function aq_home_url_black_list( $arr ) {
-		return array_merge( $arr, array( array( 'function' => 'aq_resize' ) ) );
-	}
-
-	/**
-	 * Custom field template
-	 * Custom field template does check $_REQUEST['post'] to populate the custom fields values
-	 *
-	 * @since 1.0.2
-	 *
-	 * @param string $post_type unused
-	 * @param object $post      current post object
-	 */
-	public function cft_copy( $post_type, $post ) {
-		global $custom_field_template;
-		if ( isset( $custom_field_template, $_REQUEST['from_post'], $_REQUEST['new_lang'] ) && ! empty( $post ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$_REQUEST['post'] = $post->ID;
-		}
-	}
-
-	/**
-	 * Duplicate Post
-	 * Avoid duplicating the 'post_translations' taxonomy
-	 *
-	 * @since 1.8
-	 *
-	 * @param array|string $taxonomies
-	 * @return array
-	 */
-	public function duplicate_post_taxonomies_blacklist( $taxonomies ) {
-		if ( empty( $taxonomies ) ) {
-			$taxonomies = array(); // As we get an empty string when there is no taxonomy
-		}
-
-		$taxonomies[] = 'post_translations';
-		return $taxonomies;
-	}
-
-	/**
-	 * WP Sweep
-	 * Add 'term_language' and 'term_translations' to excluded taxonomies otherwise terms loose their language and translation group
-	 *
-	 * @since 2.0
-	 *
-	 * @param array $excluded_taxonomies list of taxonomies excluded from sweeping
-	 * @return array
-	 */
-	public function wp_sweep_excluded_taxonomies( $excluded_taxonomies ) {
-		return array_merge( $excluded_taxonomies, array( 'term_language', 'term_translations' ) );
-	}
-
-	/**
-	 * Make sure No category base plugins (including Yoast SEO) get all categories when flushing rules
-	 *
-	 * @since 2.1
-	 *
-	 * @param array $args
-	 * @return array
-	 */
-	public function no_category_base_get_terms_args( $args ) {
-		if ( doing_filter( 'category_rewrite_rules' ) ) {
-			$args['lang'] = '';
-		}
-		return $args;
 	}
 }
 

--- a/integrations/no-category-base/load.php
+++ b/integrations/no-category-base/load.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Loads the integration with No Category Base.
+ *
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+PLL_Integrations::instance()->no_category_base = new PLL_No_Category_Base();
+PLL_Integrations::instance()->no_category_base->init();

--- a/integrations/no-category-base/no-category-base.php
+++ b/integrations/no-category-base/no-category-base.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Manages the compatibility with No Category Base.
+ * Works for Yoast SEO too.
+ *
+ * @since 2.8
+ */
+class PLL_No_Category_Base {
+	/**
+	 * Setups actions.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		add_filter( 'get_terms_args', array( $this, 'no_category_base_get_terms_args' ), 5 ); // Before adding our cache domain.
+	}
+
+	/**
+	 * Make sure No category base plugins get all the categories when flushing rules.
+	 *
+	 * @since 2.1
+	 *
+	 * @param array $args WP_Term_Query arguments.
+	 * @return array
+	 */
+	public function no_category_base_get_terms_args( $args ) {
+		if ( doing_filter( 'category_rewrite_rules' ) ) {
+			$args['lang'] = '';
+		}
+		return $args;
+	}
+}

--- a/integrations/wp-sweep/load.php
+++ b/integrations/wp-sweep/load.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Loads the integration with WP Sweep.
+ *
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+add_action(
+	'plugins_loaded',
+	function() {
+		if ( defined( 'WP_SWEEP_VERSION' ) ) {
+			PLL_Integrations::instance()->wp_sweep = new PLL_WP_Sweep();
+			PLL_Integrations::instance()->wp_sweep->init();
+		}
+	},
+	0
+);

--- a/integrations/wp-sweep/wp-sweep.php
+++ b/integrations/wp-sweep/wp-sweep.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Manages the compatibility with WP Sweep.
+ *
+ * @since 2.8
+ */
+class PLL_WP_Sweep {
+	/**
+	 * Setups actions.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		add_filter( 'wp_sweep_excluded_taxonomies', array( $this, 'wp_sweep_excluded_taxonomies' ) );
+	}
+
+	/**
+	 * Add 'term_language' and 'term_translations' to excluded taxonomies otherwise terms loose their language and translation group.
+	 *
+	 * @since 2.0
+	 *
+	 * @param array $excluded_taxonomies List of taxonomies excluded from sweeping.
+	 * @return array
+	 */
+	public function wp_sweep_excluded_taxonomies( $excluded_taxonomies ) {
+		return array_merge( $excluded_taxonomies, array( 'term_language', 'term_translations' ) );
+	}
+}

--- a/integrations/yarpp/load.php
+++ b/integrations/yarpp/load.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Loads the integration with Yet Another Related Posts Plugin.
+ *
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+add_action(
+	'plugins_loaded',
+	function() {
+		if ( defined( 'YARPP_VERSION' ) ) {
+			add_action( 'init', array( PLL_Integrations::instance()->yarpp = new PLL_Yarpp(), 'init' ) );
+		}
+	},
+	0
+);

--- a/integrations/yarpp/yarpp.php
+++ b/integrations/yarpp/yarpp.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Manages the compatibility with Yet Another Related Posts Plugin.
+ *
+ * @since 2.8
+ */
+class PLL_Yarpp {
+	/**
+	 * Just makes YARPP aware of the language taxonomy ( after Polylang registered it ).
+	 *
+	 * @since 1.0
+	 */
+	public function init() {
+		$GLOBALS['wp_taxonomies']['language']->yarpp_support = 1;
+	}
+}

--- a/tests/phpunit/tests/plugins/test-yarpp.php
+++ b/tests/phpunit/tests/plugins/test-yarpp.php
@@ -4,12 +4,13 @@ class YARPP_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		$GLOBALS['polylang'] = &self::$polylang; // avoid conflicts when other tests are executed before
+		$GLOBALS['polylang'] = &self::$polylang; // Avoid conflicts when other tests are executed before.
 	}
 
 	// bug introduced in 1.8 and fixed in 1.8.2
 	function test_yarpp_support() {
-		do_action( 'setup_theme' );
+		define( 'YARPP_VERSION', '1.0' ); // Fake.
+		do_action( 'plugins_loaded' );
 		do_action( 'init' );
 		$this->assertEquals( 1, $GLOBALS['wp_taxonomies']['language']->yarpp_support );
 	}


### PR DESCRIPTION
This PR follows the comments of @raaaahman and @manooweb for the plugins integrations https://github.com/polylang/polylang/pull/524#discussion_r443506907

It of course depends on #524.

* All integrations are moved on their own directory. A `load.php` and a class for each.
* For some plugins I added a test to check if the 3rd party plugin is indeed active (these tests did not exist before for the smallest integrations).
* Adapt phpunit test for YARPP.