### PR TITLE
Save one db query when the object id is < 0

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -46,6 +46,11 @@ abstract class PLL_Translated_Object {
 		}
 
 		$object_id = (int) $object_id;
+
+		if ( $object_id < 0 ) {
+			return false;
+		}
+
 		$term = get_object_term_cache( $object_id, $taxonomy );
 
 		if ( false === $term ) {


### PR DESCRIPTION
In some cases, it could happen that we get a negative object_id. That's the case for example with the returned value of the function `wc_get_page_id()` . See https://github.com/woocommerce/woocommerce/blob/4.2.2/includes/wc-page-functions.php#L55.

In such case we uselessly run a db query to get the language and translations of a post or term which doesn't exist.
This PR fixes the issue.