### PR TITLE
Add compatibility with sitemaps

### DIFF
--- a/modules/sitemaps/load.php
+++ b/modules/sitemaps/load.php
@@ -7,6 +7,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
+/*
+ * Subdomains and multiple domains work out of the box.
+ * We need to load our compatibility when one unique domain is used.
+ */
 if ( $polylang->options['force_lang'] < 2 && $polylang->model->get_languages_list() ) {
 	$polylang->sitemaps = new PLL_Sitemaps( $polylang );
 	$polylang->sitemaps->init();

--- a/modules/sitemaps/load.php
+++ b/modules/sitemaps/load.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Don't access directly.
+};
+
+if ( $polylang instanceof PLL_Frontend && $polylang->model->get_languages_list() ) {
+	$polylang->sitemaps = new PLL_Sitemaps( $polylang );
+	$polylang->sitemaps->init();
+}

--- a/modules/sitemaps/load.php
+++ b/modules/sitemaps/load.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
-if ( $polylang instanceof PLL_Frontend && $polylang->model->get_languages_list() ) {
+if ( $polylang->options['force_lang'] < 2 && $polylang->model->get_languages_list() ) {
 	$polylang->sitemaps = new PLL_Sitemaps( $polylang );
 	$polylang->sitemaps->init();
 }

--- a/modules/sitemaps/load.php
+++ b/modules/sitemaps/load.php
@@ -7,11 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
-/*
- * Subdomains and multiple domains work out of the box.
- * We need to load our compatibility when one unique domain is used.
- */
-if ( $polylang->options['force_lang'] < 2 && $polylang->model->get_languages_list() ) {
+if ( $polylang->model->get_languages_list() ) {
 	$polylang->sitemaps = new PLL_Sitemaps( $polylang );
 	$polylang->sitemaps->init();
 }

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -4,11 +4,11 @@
  */
 
 /**
- * Sitemaps providers decorator
+ * Decorator to add multilingual capability to sitemaps providers
  *
  * @since 2.8
  */
-class PLL_Sitemaps_Provider_Decorator extends WP_Sitemaps_Provider {
+class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	/**
 	 * The decorated sitemaps provider.
 	 *

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -162,26 +162,24 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 			}
 		}
 
+		switch ( $this->provider->name ) {
+			case 'posts':
+				$func = array( $this->model, 'is_translated_post_type' );
+				break;
+			case 'taxonomies':
+				$func = array( $this->model, 'is_translated_taxonomy' );
+				break;
+			default:
+				return $sitemap_data;
+		}
+
 		foreach ( array_keys( $object_subtypes ) as $object_subtype_name ) {
-			switch ( $this->provider->name ) {
-				case 'posts':
-					if ( $this->model->is_translated_post_type( $object_subtype_name ) ) {
-						foreach ( $this->get_active_languages() as $language ) {
-							$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name, $language );
-						}
-					} else {
-						$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name );
-					}
-					break;
-				case 'taxonomies':
-					if ( $this->model->is_translated_taxonomy( $object_subtype_name ) ) {
-						foreach ( $this->get_active_languages() as $language ) {
-							$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name, $language );
-						}
-					} else {
-						$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name );
-					}
-					break;
+			if ( call_user_func( $func, $object_subtype_name ) ) {
+				foreach ( $this->get_active_languages() as $language ) {
+					$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name, $language );
+				}
+			} else {
+				$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name );
 			}
 		}
 

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -202,6 +202,9 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );
+		} else {
+			// Untranslated post types and taxonomies.
+			$url = $this->provider->get_sitemap_url( $name, $page );
 		}
 
 		return $url;

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -196,11 +196,9 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @return string The composed URL for a sitemap entry.
 	 */
 	public function get_sitemap_url( $name, $page ) {
-		$parts = explode( '-', $name );
-		$lang = end( $parts );
-		$lang = $this->model->get_language( $lang ); // Validates that we got an existing language code.
-
-		if ( $lang ) {
+		$pattern = '#(' . implode( '|', $this->get_active_languages() ) . ')$#';
+		if ( preg_match( $pattern, $name, $matches ) ) {
+			$lang = $this->model->get_language( $matches[1] );
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -44,7 +44,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 *
 	 * @var string
 	 */
-	private $filter_lang;
+	private static $filter_lang = '';
 
 	/**
 	 * Constructor.
@@ -109,9 +109,9 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @param array $args Sitemap provider WP_Query or WP_Term_Query arguments.
 	 * @return array
 	 */
-	public function query_args( $args ) {
-		if ( isset( $this->filter_lang ) ) {
-			$args['lang'] = $this->filter_lang;
+	public static function query_args( $args ) {
+		if ( ! empty( self::$filter_lang ) ) {
+			$args['lang'] = self::$filter_lang;
 		}
 		return $args;
 	}
@@ -129,7 +129,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$object_subtype_name = (string) $object_subtype_name;
 
 		if ( ! empty( $lang ) ) {
-			$this->filter_lang = $lang;
+			self::$filter_lang = $lang;
 		}
 
 		$return = array(
@@ -137,7 +137,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 			'pages' => $this->get_max_num_pages( $object_subtype_name ),
 		);
 
-		unset( $this->filter_lang );
+		self::$filter_lang = '';
 		return $return;
 	}
 
@@ -151,8 +151,8 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	public function get_sitemap_type_data() {
 		$sitemap_data = array();
 
-		add_filter( 'wp_sitemaps_posts_query_args', array( $this, 'query_args' ) );
-		add_filter( 'wp_sitemaps_taxonomies_query_args', array( $this, 'query_args' ) );
+		add_filter( 'wp_sitemaps_posts_query_args', array( __CLASS__, 'query_args' ) );
+		add_filter( 'wp_sitemaps_taxonomies_query_args', array( __CLASS__, 'query_args' ) );
 
 		$object_subtypes = $this->get_object_subtypes();
 

--- a/modules/sitemaps/sitemaps-provider-decorator.php
+++ b/modules/sitemaps/sitemaps-provider-decorator.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package Polylang
+ */
 
 /**
  * Sitemaps providers decorator
@@ -28,6 +31,9 @@ class PLL_Sitemaps_Provider_Decorator extends WP_Sitemaps_Provider {
 	 * Constructor.
 	 *
 	 * @since 2.8
+	 *
+	 * @param WP_Sitemaps_Provider $provider An instance of a WP_Sitemaps_Provider child class.
+	 * @param string               $lang     Language code.
 	 */
 	public function __construct( $provider, $lang ) {
 		$this->name = $provider->name . '-' . $lang;

--- a/modules/sitemaps/sitemaps-provider-decorator.php
+++ b/modules/sitemaps/sitemaps-provider-decorator.php
@@ -59,6 +59,9 @@ class PLL_Sitemaps_Provider_Decorator extends WP_Sitemaps_Provider {
 	/**
 	 * Gets the max number of pages available for the object type.
 	 *
+	 * Returns 0 for all languages but the default language for untranslated post types
+	 * and untranslated taxonomies to avoid to duplicate the corresponding sitemaps.
+	 *
 	 * @since 2.8
 	 *
 	 * @param string $object_subtype Optional. Object subtype. Default empty.

--- a/modules/sitemaps/sitemaps-provider-decorator.php
+++ b/modules/sitemaps/sitemaps-provider-decorator.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Sitemaps providers decorator
+ *
+ * @since 2.8
+ */
+class PLL_Sitemaps_Provider_Decorator extends WP_Sitemaps_Provider {
+	/**
+	 * The decorated sitemaps provider.
+	 *
+	 * @since 2.8
+	 *
+	 * @var WP_Sitemaps_Provider
+	 */
+	protected $provider;
+
+	/**
+	 * Language code.
+	 *
+	 * @since 2.8
+	 *
+	 * @var string
+	 */
+	protected $lang;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.8
+	 */
+	public function __construct( $provider, $lang ) {
+		$this->name = $provider->name . '-' . $lang;
+		$this->object_type = $provider->object_type;
+
+		$this->provider = $provider;
+		$this->lang = $lang;
+	}
+
+	/**
+	 * Gets a URL list for a sitemap.
+	 *
+	 * @since 2.8
+	 *
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Object subtype name. Default empty.
+	 * @return array Array of URLs for a sitemap.
+	 */
+	public function get_url_list( $page_num, $object_subtype = '' ) {
+		return $this->provider->get_url_list( $page_num, $object_subtype );
+	}
+
+	/**
+	 * Gets the max number of pages available for the object type.
+	 *
+	 * @since 2.8
+	 *
+	 * @param string $object_subtype Optional. Object subtype. Default empty.
+	 * @return int Total number of pages.
+	 */
+	public function get_max_num_pages( $object_subtype = '' ) {
+		return $this->provider->get_max_num_pages( $object_subtype );
+	}
+
+	/**
+	 * Gets the URL of a sitemap entry.
+	 *
+	 * @since 2.8
+	 *
+	 * @param string $name The name of the sitemap.
+	 * @param int    $page The page of the sitemap.
+	 * @return string The composed URL for a sitemap entry.
+	 */
+	public function get_sitemap_url( $name, $page ) {
+		$url = $this->provider->get_sitemap_url( $name, $page );
+		return str_replace( $this->provider->name, $this->name, $url );
+	}
+
+	/**
+	 * Returns the list of supported object subtypes exposed by the provider.
+	 *
+	 * @since 2.8
+	 *
+	 * @return array List of object subtypes objects keyed by their name.
+	 */
+	public function get_object_subtypes() {
+		return $this->provider->get_object_subtypes();
+	}
+}

--- a/modules/sitemaps/sitemaps-provider-decorator.php
+++ b/modules/sitemaps/sitemaps-provider-decorator.php
@@ -65,6 +65,19 @@ class PLL_Sitemaps_Provider_Decorator extends WP_Sitemaps_Provider {
 	 * @return int Total number of pages.
 	 */
 	public function get_max_num_pages( $object_subtype = '' ) {
+		switch ( $this->provider->name ) {
+			case 'posts':
+				if ( ! PLL()->model->is_translated_post_type( $object_subtype ) && PLL()->model->options['default_lang'] !== $this->lang ) {
+					return 0;
+				}
+				break;
+			case 'taxonomies':
+				if ( ! PLL()->model->is_translated_taxonomy( $object_subtype ) && PLL()->model->options['default_lang'] !== $this->lang ) {
+					return 0;
+				}
+				break;
+		}
+
 		return $this->provider->get_max_num_pages( $object_subtype );
 	}
 

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -1,14 +1,29 @@
 <?php
-/**
- * @package Polylang
- */
 
 /**
- * Handles the WP sitemaps.
+ * Handles the core sitemaps.
  *
  * @since 2.8
  */
 class PLL_Sitemaps {
+	/**
+	 * A reference to teh PLL_Model instance.
+	 *
+	 * @since 2.8
+	 *
+	 * @var PLL_Model
+	 */
+	protected $model;
+
+	/**
+	 * A reference to the current language.
+	 *
+	 * @since 2.8
+	 *
+	 * @var PLL_Language
+	 */
+	protected $curlang;
+
 	/**
 	 * Constructor.
 	 *
@@ -18,35 +33,86 @@ class PLL_Sitemaps {
 	 */
 	public function __construct( $polylang ) {
 		$this->model = &$polylang->model;
-		$this->links_model = &$polylang->links_model;
+		$this->curlang = &$polylang->curlang;
 	}
 
 	/**
-	 * Setups filters.
+	 * Setups actions and filters.
 	 *
 	 * @since 2.8
 	 */
 	public function init() {
-		if ( $polylang->options['force_lang'] <= 1 ) {
-			add_filter( 'wp_sitemaps_posts_query_args', array( $this, 'query_args' ), 10, 2 );
-			add_filter( 'wp_sitemaps_taxonomies_query_args', array( $this, 'query_args' ), 10, 2 );
+		add_action( 'template_redirect', array( $this, 'set_language' ), 5 ); // Before WP_Sitemaps.
+		add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
+		add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
+		add_filter( 'wp_sitemaps_register_providers', array( $this, 'providers' ), 99 ); // 99 in an attempt to have all sitemaps providers in our filter.
+	}
+
+	/**
+	 * Sets the language for the current sitemap being rendered.
+	 *
+	 * @since 2.8
+	 */
+	public function set_language() {
+		$qv = get_query_var( 'sitemap' );
+		if ( $qv ) {
+			$arr = explode( '-', $qv );
+			$lang = end( $arr );
+			$this->curlang = $this->model->get_language( $lang );
 		}
 	}
 
 	/**
-	 * Adds all active languages to the query.
+	 * Whitelists the home url filter for the sitemaps
 	 *
 	 * @since 2.8
 	 *
-	 * @param array  $args      Array of WP_Query arguments.
-	 * @param string $post_type Post type name.
+	 * @param array $whitelist White list.
+	 * @return array;
+	 */
+	public function home_url_white_list( $whitelist ) {
+		$whitelist[] = array( 'file' => 'sitemaps' );
+		return $whitelist;
+	}
+
+	/**
+	 * Filters the sitemaps rewrite rules to take the languages into account.
+	 *
+	 * @since 2.8
+	 *
+	 * @param array $rules Rewrite rules.
 	 * @return array
 	 */
-	public function query_args( $args, $post_type ) {
-		if ( $this->model->is_translated_post_type( $post_type ) ) {
-			$args['lang'] = implode( ',', $this->get_active_languages() );
+	public function rewrite_rules( $rules ) {
+		$new_rules = array();
+		$languages = '(?:' . implode( '|', $this->get_active_languages() ) . ')';
+
+		foreach ( $rules as $key => $rule ) {
+			if ( false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
+				$new_key = str_replace( 'wp-sitemap-([a-z]+?)', 'wp-sitemap-([a-z]+?-' . $languages . ')', $key );
+				$new_rules[ $new_key ] = $rule;
+			} else {
+				$new_rules[ $key ] = $rule;
+			}
 		}
-		return $args;
+		return $new_rules;
+	}
+
+	/**
+	 * Replaces the list of sitemaps providers by our decorators.
+	 *
+	 * @since 2.8
+	 *
+	 * @param array $providers Array of WP_Sitemaps_Provider objects keyed by their name.
+	 * @return array
+	 */
+	public function providers( $providers ) {
+		foreach ( $providers as $key => $provider ) {
+			foreach ( $this->get_active_languages() as $lang ) {
+				$new_providers[ "$key-$lang" ] = new PLL_Sitemaps_Provider_Decorator( $provider, $lang );
+			}
+		}
+		return $new_providers;
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Handles the WP sitemaps.
+ *
+ * @since 2.8
+ */
+class PLL_Sitemaps {
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.8
+	 *
+	 * @param object $polylang Main Polylang object.
+	 */
+	public function __construct( $polylang ) {
+		$this->model = &$polylang->model;
+		$this->links_model = &$polylang->links_model;
+	}
+
+	/**
+	 * Setups filters.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		if ( $polylang->options['force_lang'] <= 1 ) {
+			add_filter( 'wp_sitemaps_posts_query_args', array( $this, 'query_args' ), 10, 2 );
+			add_filter( 'wp_sitemaps_taxonomies_query_args', array( $this, 'query_args' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Adds all active languages to the query.
+	 *
+	 * @since 2.8
+	 *
+	 * @param array  $args      Array of WP_Query arguments.
+	 * @param string $post_type Post type name.
+	 * @return array
+	 */
+	public function query_args( $args, $post_type ) {
+		if ( $this->model->is_translated_post_type( $post_type ) ) {
+			$args['lang'] = implode( ',', $this->get_active_languages() );
+		}
+		return $args;
+	}
+
+	/**
+	 * Get active languages for the sitemap.
+	 *
+	 * @since 2.8
+	 */
+	protected function get_active_languages() {
+		$languages = $this->model->get_languages_list();
+		if ( wp_list_filter( $languages, array( 'active' => false ) ) ) {
+			return wp_list_pluck( wp_list_filter( $languages, array( 'active' => false ), 'NOT' ), 'slug' );
+		}
+		return wp_list_pluck( $languages, 'slug' );
+	}
+}

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -87,10 +87,7 @@ class PLL_Sitemaps {
 	 * @return array;
 	 */
 	public function home_url_white_list( $whitelist ) {
-		$whitelist[] = array(
-			'file' => 'class-wp-sitemaps-posts',
-			'function' => 'get_url_list',
-		);
+		$whitelist[] = array( 'file' => 'class-wp-sitemaps-posts' );
 		return $whitelist;
 	}
 

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package Polylang
+ */
 
 /**
  * Handles the core sitemaps.
@@ -107,11 +110,14 @@ class PLL_Sitemaps {
 	 * @return array
 	 */
 	public function providers( $providers ) {
+		$new_providers = array();
+
 		foreach ( $providers as $key => $provider ) {
 			foreach ( $this->get_active_languages() as $lang ) {
 				$new_providers[ "$key-$lang" ] = new PLL_Sitemaps_Provider_Decorator( $provider, $lang );
 			}
 		}
+
 		return $new_providers;
 	}
 

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -69,7 +69,10 @@ class PLL_Sitemaps {
 	 * @return array;
 	 */
 	public function home_url_white_list( $whitelist ) {
-		$whitelist[] = array( 'file' => 'sitemaps' );
+		$whitelist[] = array(
+			'file' => 'class-wp-sitemaps-posts',
+			'function' => 'get_url_list',
+		);
 		return $whitelist;
 	}
 

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -100,19 +100,22 @@ class PLL_Sitemaps {
 	}
 
 	/**
-	 * Replaces the list of sitemaps providers by our decorators,
-	 * allowing to have one provider per language.
+	 * Replaces the list of sitemaps providers by our decorators.
 	 *
 	 * @since 2.8
 	 *
-	 * @param array $providers Array of WP_Sitemaps_Provider objects keyed by their name.
+	 * @param array $providers Array of Sitemaps provider objects keyed by their name.
 	 * @return array
 	 */
 	public function providers( $providers ) {
 		$new_providers = array();
 
 		foreach ( $providers as $key => $provider ) {
-			$new_providers[ $key ] = new PLL_Sitemaps_Provider_Decorator( $provider, $this->links_model );
+			if ( $provider instanceof WP_Sitemaps_Provider ) {
+				$new_providers[ $key ] = new PLL_Multilingual_Sitemaps_Provider( $provider, $this->links_model );
+			} else {
+				$new_providers[ $key ] = $provider; // Just in case some 3rd party doesn't extend WP_Sitemaps_Provider.
+			}
 		}
 
 		return $new_providers;

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -55,9 +55,27 @@ class PLL_Sitemaps {
 	 * @since 2.8
 	 */
 	public function init() {
+		add_filter( 'pll_set_language_from_query', array( $this, 'set_language_from_query' ), 10, 2 );
 		add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
 		add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
 		add_filter( 'wp_sitemaps_register_providers', array( $this, 'providers' ), 99 ); // 99 in an attempt to have all sitemaps providers in our filter.
+	}
+
+	/**
+	 * Assigns the current language to the default language when the sitemap url
+	 * doesn't include any language.
+	 *
+	 * @since 2.8
+	 *
+	 * @param string|bool $lang  Current language code, false if not set yet.
+	 * @param object      $query Main WP query object.
+	 * @return string|bool
+	 */
+	public function set_language_from_query( $lang, $query ) {
+		if ( isset( $query->query['sitemap'] ) && empty( $query->query['lang'] ) ) {
+			$lang = $this->model->options['default_lang'];
+		}
+		return $lang;
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -69,7 +69,7 @@ class PLL_Sitemaps {
 			add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
 			add_filter( 'wp_sitemaps_register_providers', array( $this, 'providers' ), 99 ); // 99 in an attempt to have all sitemaps providers in our filter.
 		} else {
-			add_filter( 'wp_sitemaps_index_entry', array( $this->links_model, 'site_url' ) );
+			add_filter( 'wp_sitemaps_index_entry', array( $this, 'index_entry' ) );
 			add_filter( 'wp_sitemaps_stylesheet_url', array( $this->links_model, 'site_url' ) );
 			add_filter( 'wp_sitemaps_stylesheet_index_url', array( $this->links_model, 'site_url' ) );
 		}
@@ -161,5 +161,18 @@ class PLL_Sitemaps {
 		}
 
 		return $new_providers;
+	}
+
+	/**
+	 * Filters the sitemap index entries for subdomains and multiple domains.
+	 *
+	 * @since 2.8
+	 *
+	 * @param array $sitemap_entry Sitemap entry for the post.
+	 * return array
+	 */
+	public function index_entry( $sitemap_entry ) {
+		$sitemap_entry['loc'] = $this->links_model->site_url( $sitemap_entry['loc'] );
+		return $sitemap_entry;
 	}
 }

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -63,10 +63,16 @@ class PLL_Sitemaps {
 	 * @since 2.8
 	 */
 	public function init() {
-		add_filter( 'pll_set_language_from_query', array( $this, 'set_language_from_query' ), 10, 2 );
-		add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
-		add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
-		add_filter( 'wp_sitemaps_register_providers', array( $this, 'providers' ), 99 ); // 99 in an attempt to have all sitemaps providers in our filter.
+		if ( $this->options['force_lang'] < 2 ) {
+			add_filter( 'pll_set_language_from_query', array( $this, 'set_language_from_query' ), 10, 2 );
+			add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
+			add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
+			add_filter( 'wp_sitemaps_register_providers', array( $this, 'providers' ), 99 ); // 99 in an attempt to have all sitemaps providers in our filter.
+		} else {
+			add_filter( 'wp_sitemaps_index_entry', array( $this->links_model, 'site_url' ) );
+			add_filter( 'wp_sitemaps_stylesheet_url', array( $this->links_model, 'site_url' ) );
+			add_filter( 'wp_sitemaps_stylesheet_index_url', array( $this->links_model, 'site_url' ) );
+		}
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -102,7 +102,8 @@ class PLL_Sitemaps {
 	}
 
 	/**
-	 * Replaces the list of sitemaps providers by our decorators.
+	 * Replaces the list of sitemaps providers by our decorators,
+	 * allowing to have one provider per language.
 	 *
 	 * @since 2.8
 	 *


### PR DESCRIPTION
This PR adds compatibility with the WP core sitemaps which are planned to be introduced in WP 5.5. See https://make.wordpress.org/core/tag/sitemaps/

The sitemaps should work out of the box for subdomains and multiple domains. So the compatibility code is loaded only when the language is set from the content or from the directory name in the url. In this case, the index is unique for all languages. However the index lists one sitemap per language for each existing sitemap type.

Fixes #451

**Edit**: for testing after installing and activating `Core Sitemaps` feature plugin, just enter the URL for the default XML sitemap file name `http://mon-site.com/sitemap.xml` which redirects to `http://mon-site.com/wp-sitemap.xml`

Then we should see the sitemap index with URLs for each each existing sitemap type and one per language when Polylang is activated too

![image](https://user-images.githubusercontent.com/1003778/86323196-b3462600-bc3c-11ea-94d9-8883eef40924.png)
