### PR TITLE
Modules lazy instantiation

### DIFF
--- a/include/base.php
+++ b/include/base.php
@@ -197,11 +197,17 @@ abstract class PLL_Base {
 	 * @param string $dependency_class A class name.
 	 */
 	public function get( $dependency_class ) {
-		return array_filter(
+		$instances = array_filter(
 			get_object_vars( $this ),
 			function ( $property ) use ( $dependency_class ) {
 				return $property instanceof $dependency_class;
 			}
 		);
+
+		if ( empty( $instances ) ) {
+			return new $dependency_class( $this );
+		} else {
+			return $instances[0];
+		}
 	}
 }

--- a/include/base.php
+++ b/include/base.php
@@ -186,4 +186,22 @@ abstract class PLL_Base {
 			E_USER_ERROR
 		);
 	}
+
+	/**
+	 * Allow classes to find instances of their dependencies.
+	 *
+	 * Since lots of Polylang classes need to be shared instances, this code will require an instance of the said class if it exists, or instantiate a new one.
+	 *
+	 * @since 2.8
+	 *
+	 * @param string $dependency_class A class name.
+	 */
+	public function get( $dependency_class ) {
+		return array_filter(
+			get_object_vars( $this ),
+			function ( $property ) use ( $dependency_class ) {
+				return $property instanceof $dependency_class;
+			}
+		);
+	}
 }

--- a/include/base.php
+++ b/include/base.php
@@ -207,7 +207,7 @@ abstract class PLL_Base {
 		if ( empty( $instances ) ) {
 			return new $dependency_class( $this );
 		} else {
-			return $instances[0];
+			return array_pop( $instances );
 		}
 	}
 }

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -22,6 +22,7 @@ class PLL_CRUD_Posts {
 		$this->model = &$polylang->model;
 		$this->pref_lang = &$polylang->pref_lang;
 		$this->curlang = &$polylang->curlang;
+		$this->sync = $polylang->get( PLL_Sync::class );
 
 		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
 		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 4 );

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -12,4 +12,23 @@ class PLL_UnitTestCase extends WP_UnitTestCase {
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.
 		add_filter( 'wp_doing_ajax', '__return_false' );
 	}
+
+	/**
+	 * Creates a Polylang environment to recreate an administration dashboard context.
+	 *
+	 * @since 2.8
+	 *
+	 * @param $options_overrides
+	 * @return array
+	 */
+	protected function admin_setup($options_overrides)
+	{
+		$options = array_merge(PLL_Install::get_default_options(), $options_overrides);
+		$model = new PLL_Admin_Model($options);
+		$links_model = new PLL_Links_Default($model);
+		$polylang = new PLL_Admin($links_model);
+		$polylang->init();
+		do_action('wp_loaded');
+		return $polylang;
+	}
 }


### PR DESCRIPTION
This brings the possibility for dependencies to be instantiated only when required. This means that their hooks will not register on plugin initialization but latter.