### PR TITLE
Use custom flags on demand

### DIFF
--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -109,7 +109,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 				// parent item for dropdown
 				if ( ! empty( $options['dropdown'] ) ) {
 					$name = isset( $options['display_names_as'] ) && 'slug' === $options['display_names_as'] ? $this->curlang->slug : $this->curlang->name;
-					$item->title = $this->get_item_title( $this->curlang->maybe_get_custom_flag(), $name, $options );
+					$item->title = $this->get_item_title( $this->curlang->get_display_flag(), $name, $options );
 					$item->attr_title = '';
 					$item->classes = array( 'pll-parent-menu-item' );
 					$new_items[] = $item;

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -109,7 +109,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 				// parent item for dropdown
 				if ( ! empty( $options['dropdown'] ) ) {
 					$name = isset( $options['display_names_as'] ) && 'slug' === $options['display_names_as'] ? $this->curlang->slug : $this->curlang->name;
-					$item->title = $this->get_item_title( $this->curlang->flag, $name, $options );
+					$item->title = $this->get_item_title( $this->curlang->maybe_get_custom_flag(), $name, $options );
 					$item->attr_title = '';
 					$item->classes = array( 'pll-parent-menu-item' );
 					$new_items[] = $item;

--- a/include/language.php
+++ b/include/language.php
@@ -240,21 +240,21 @@ class PLL_Language {
 	}
 
 	/**
-	 * Replace flag by custom flag
-	 * Takes care of url scheme
+	 * Returns the html of the custom flag if any, or the default flag otherwise.
 	 *
-	 * @since 1.7
+	 * @since 2.8
 	 */
-	public function set_custom_flag() {
-		// Overwrite with custom flags on frontend only
-		if ( ! empty( $this->custom_flag ) ) {
-			$this->flag = $this->custom_flag;
-			$this->flag_url = $this->custom_flag_url;
-			unset( $this->custom_flag, $this->custom_flag_url ); // hide this
-		}
+	public function maybe_get_custom_flag() {
+		return empty( $this->custom_flag ) ? $this->flag : $this->custom_flag;
+	}
 
-		// Set url scheme, also for default flags
-		$this->flag_url = set_url_scheme( $this->flag_url );
+	/**
+	 * Returns the url of the custom flag if any, or the default flag otherwise.
+	 *
+	 * @since 2.8
+	 */
+	public function maybe_get_custom_flag_url() {
+		return empty( $this->custom_flag_url ) ? $this->flag : $this->custom_flag_url;
 	}
 
 	/**
@@ -281,14 +281,21 @@ class PLL_Language {
 	}
 
 	/**
-	 * Set home_url scheme
-	 * this can't be cached across pages
+	 * Sets the scheme of the home url and the flag urls
 	 *
-	 * @since 1.6.4
+	 * This can't be cached across pages.
+	 *
+	 * @since 2.8
 	 */
-	public function set_home_url_scheme() {
+	public function set_url_scheme() {
 		$this->home_url = set_url_scheme( $this->home_url );
 		$this->search_url = set_url_scheme( $this->search_url );
+
+		// Set url scheme, also for the flags.
+		$this->flag_url = set_url_scheme( $this->flag_url );
+		if ( ! empty( $this->custom_flag_url ) ) {
+			$this->custom_flag_url = set_url_scheme( $this->custom_flag_url );
+		}
 	}
 
 	/**

--- a/include/language.php
+++ b/include/language.php
@@ -244,7 +244,7 @@ class PLL_Language {
 	 *
 	 * @since 2.8
 	 */
-	public function maybe_get_custom_flag() {
+	public function get_display_flag() {
 		return empty( $this->custom_flag ) ? $this->flag : $this->custom_flag;
 	}
 
@@ -253,7 +253,7 @@ class PLL_Language {
 	 *
 	 * @since 2.8
 	 */
-	public function maybe_get_custom_flag_url() {
+	public function get_display_flag_url() {
 		return empty( $this->custom_flag_url ) ? $this->flag : $this->custom_flag_url;
 	}
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -119,8 +119,8 @@ abstract class PLL_Links_Model {
 				$this->set_home_url( $language );
 			}
 
-			// Ensures that the ( possibly cached ) home url uses the right scheme http or https
-			$language->set_home_url_scheme();
+			// Ensures that the ( possibly cached ) home and flag urls use the right scheme http or https.
+			$language->set_url_scheme();
 		}
 		return $languages;
 	}

--- a/include/model.php
+++ b/include/model.php
@@ -105,13 +105,6 @@ class PLL_Model {
 				}
 			}
 
-			// Custom flags
-			if ( ! PLL_ADMIN ) {
-				foreach ( $languages as $language ) {
-					$language->set_custom_flag();
-				}
-			}
-
 			/**
 			 * Filter the list of languages *after* it is stored in the persistent cache
 			 * /!\ this filter is fired *before* the $polylang object is available

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -93,7 +93,7 @@ class PLL_Switcher {
 			$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
-			$flag = $args['raw'] && ! $args['show_flags'] ? $language->flag_url : ( $args['show_flags'] ? $language->flag : '' );
+			$flag = $args['raw'] && ! $args['show_flags'] ? $language->maybe_get_custom_flag_url() : ( $args['show_flags'] ? $language->maybe_get_custom_flag() : '' );
 
 			if ( $first ) {
 				$classes[] = 'lang-item-first';

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -93,7 +93,7 @@ class PLL_Switcher {
 			$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
-			$flag = $args['raw'] && ! $args['show_flags'] ? $language->maybe_get_custom_flag_url() : ( $args['show_flags'] ? $language->maybe_get_custom_flag() : '' );
+			$flag = $args['raw'] && ! $args['show_flags'] ? $language->get_display_flag_url() : ( $args['show_flags'] ? $language->get_display_flag() : '' );
 
 			if ( $first ) {
 				$classes[] = 'lang-item-first';

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -222,7 +222,7 @@ class PLL_Admin_Site_Health {
 	 * @return string
 	 */
 	protected function get_flag( $language ) {
-		$flag = $language->maybe_get_custom_flag();
+		$flag = $language->get_display_flag();
 		return empty( $flag ) ? '<span>' . esc_html__( 'Undefined', 'polylang' ) . '</span>' : $flag;
 	}
 

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -222,15 +222,8 @@ class PLL_Admin_Site_Health {
 	 * @return string
 	 */
 	protected function get_flag( $language ) {
-		if ( ! empty( $language->custom_flag ) ) {
-			return $language->custom_flag;
-		}
-
-		if ( ! empty( $language->flag ) ) {
-			return $language->flag;
-		}
-
-		return '<span>' . esc_html__( 'Undefined', 'polylang' ) . '</span>';
+		$flag = $language->maybe_get_custom_flag();
+		return empty( $flag ) ? '<span>' . esc_html__( 'Undefined', 'polylang' ) . '</span>' : $flag;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-custom-data.php
+++ b/tests/phpunit/tests/test-custom-data.php
@@ -25,8 +25,8 @@ class Custom_Data_Test extends PLL_UnitTestCase {
 
 	function test_custom_flag() {
 		$lang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->maybe_get_custom_flag_url() );
-		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" title="Français" alt="Français" />', $lang->maybe_get_custom_flag() );
+		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->get_display_flag_url() );
+		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" title="Français" alt="Français" />', $lang->get_display_flag() );
 	}
 
 	/*
@@ -41,8 +41,8 @@ class Custom_Data_Test extends PLL_UnitTestCase {
 
 		// custom flags
 		$lang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->maybe_get_custom_flag_url() );
-		$this->assertContains( 'https', $lang->maybe_get_custom_flag_url() );
+		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->get_display_flag_url() );
+		$this->assertContains( 'https', $lang->get_display_flag_url() );
 		unset( $_SERVER['HTTPS'] );
 	}
 

--- a/tests/phpunit/tests/test-custom-data.php
+++ b/tests/phpunit/tests/test-custom-data.php
@@ -25,8 +25,8 @@ class Custom_Data_Test extends PLL_UnitTestCase {
 
 	function test_custom_flag() {
 		$lang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->flag_url );
-		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" title="Français" alt="Français" />', $lang->flag );
+		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->maybe_get_custom_flag_url() );
+		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" title="Français" alt="Français" />', $lang->maybe_get_custom_flag() );
 	}
 
 	/*
@@ -41,8 +41,8 @@ class Custom_Data_Test extends PLL_UnitTestCase {
 
 		// custom flags
 		$lang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->flag_url );
-		$this->assertContains( 'https', $lang->flag_url );
+		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->maybe_get_custom_flag_url() );
+		$this->assertContains( 'https', $lang->maybe_get_custom_flag_url() );
 		unset( $_SERVER['HTTPS'] );
 	}
 


### PR DESCRIPTION
Up to now, and only on frontend, we replaced the default flags by the custom flags (when they exist) into the `PLL_Language` properties. This means that `PLL_Language::$flag` may contain a different flag depending on the context (frontend, backend, rest). This could confuse developpers and create bugs.

I propose to change the logic and to pull custom flags only on demand ( for the language switcher and the site health).
The PR 
* removes `PLL_Language:set_custom_flag()`
* introduces `PLL_Language:maybe_get_custom_flag()` and  `PLL_Language:maybe_get_custom_flag_url()` and uses this functions when needed.

Additionnaly, `PLL_Language:set_custom_flag()` was setting the url scheme for flag urls. This is moved to `PLL_Language:set_url_scheme()` which replaces `PLL_Language:set_home_url_scheme()`.

Fix https://github.com/polylang/polylang-pro/issues/556