### PR TITLE
Outputs secure cookie when using ssl

### DIFF
--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -39,13 +39,14 @@ class PLL_Cache_Compat {
 			'(function() {
 				var expirationDate = new Date();
 				expirationDate.setTime( expirationDate.getTime() + %d * 1000 );
-				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s";
+				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s%s";
 			}());',
 			esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) ),
 			esc_js( PLL_COOKIE ),
 			esc_js( pll_current_language() ),
 			esc_js( COOKIEPATH ),
-			$domain ? '; domain=' . esc_js( $domain ) : ''
+			$domain ? '; domain=' . esc_js( $domain ) : '',
+			is_ssl() ? '; secure' : ''
 		);
 		echo '<script type="text/javascript">' . $js . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput
 	}


### PR DESCRIPTION
Fixes #542

We already send a secure cookie everywhere when using SSL, when using the function `setcookie`. However when a cache plugin is active, the cookie is not sent through http, but outputed directly by javascript. In this case, the cookie is never defined as secure, which causes a warning with Firefox.

To test without cache plugin, just use:
`add_filter( 'pll_is_cache_active', '__return_true' );`
for example in pll-config.php.