### PR TITLE
wp_list_filter doesn't act as array_filter

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -161,7 +161,7 @@ abstract class PLL_Choose_Lang {
 			}
 		}
 
-		$accept_langs = wp_list_filter( $accept_langs, array( '0' ), 'NOT' ); // Remove languages markes as unacceptable (q=0).
+		$accept_langs = array_filter( $accept_langs ); // Remove languages marked as unacceptable (q=0).
 
 		$languages = $this->model->get_languages_list( array( 'hide_empty' => true ) ); // Hides languages with no post
 


### PR DESCRIPTION
Since WordPress 5.5 beta2, this phpunit test fails: https://github.com/polylang/polylang/blob/2.8-beta2/tests/phpunit/tests/test-choose-lang.php#L50

It's due a change in the behaviour of `wp_list_filter()` introduced in WP 5.5 beta2. More specifically, I believe that it's due to the removal of this line.
https://github.com/WordPress/WordPress/commit/35257c2e2d7bcc1ba77b8e876cd5a974bf161880#diff-fd60536be5c5375474e07f76b9a058bdL105

In fact, we had a wrong usage of `wp_list_filter()` which is meant to filter arrays of arrays or arrays of objects and not simple arrays. See https://developer.wordpress.org/reference/functions/wp_list_filter/

For this case, we must use `array_filter()`.