### PR TITLE
Prevent creating 2 terms with the same name and same language

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -405,21 +405,25 @@ class PLL_Admin_Filters_Term {
 		// If the term already exists in another language
 		if ( ! $slug && $this->model->is_translated_taxonomy( $taxonomy ) && term_exists( $name, $taxonomy ) ) {
 			if ( isset( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$slug = $name . '-' . $this->model->get_language( sanitize_key( $_POST['term_lang_choice'] ) )->slug; // phpcs:ignore WordPress.Security.NonceVerification
+				$lang = $this->model->get_language( sanitize_key( $_POST['term_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			}
 
 			elseif ( isset( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$slug = $name . '-' . $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) )->slug; // phpcs:ignore WordPress.Security.NonceVerification
+				$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			}
 
 			// *Post* bulk edit, in case a new term is created
 			elseif ( isset( $_GET['bulk_edit'], $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				// Bulk edit does not modify the language
 				if ( -1 == $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-					$slug = $name . '-' . $this->model->post->get_language( $this->post_id )->slug;
+					$lang = $this->model->post->get_language( $this->post_id );
 				} else {
-					$slug = $name . '-' . $this->model->get_language( sanitize_key( $_GET['inline_lang_choice'] ) )->slug; // phpcs:ignore WordPress.Security.NonceVerification
+					$lang = $this->model->get_language( sanitize_key( $_GET['inline_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 				}
+			}
+
+			if ( ! empty( $lang ) && ! $this->model->term_exists_by_slug( $name, $lang, $taxonomy ) ) {
+				$slug = $name . '-' . $lang->slug;
 			}
 		}
 

--- a/include/model.php
+++ b/include/model.php
@@ -441,6 +441,40 @@ class PLL_Model {
 	}
 
 	/**
+	 * Checks if a term slug exists in a given language, taxonomy, hierarchy
+	 *
+	 * @since 1.9
+	 * @since 2.8 Moved from PLL_Share_Term_Slug::term_exists() to PLL_Model::term_exists_by_slug()
+	 *
+	 * @param string        $slug     The term slug to test.
+	 * @param string|object $language The language slug or object.
+	 * @param string        $taxonomy Optional taxonomy name.
+	 * @param int           $parent   Optional parent term id.
+	 * @return null|int The term_id of the found term.
+	 */
+	public function term_exists_by_slug( $slug, $language, $taxonomy = '', $parent = 0 ) {
+		global $wpdb;
+
+		$select = "SELECT t.term_id FROM {$wpdb->terms} AS t";
+		$join   = " INNER JOIN {$wpdb->term_taxonomy} AS tt ON t.term_id = tt.term_id";
+		$join  .= $this->term->join_clause();
+		$where  = $wpdb->prepare( ' WHERE t.slug = %s', $slug );
+		$where .= $this->term->where_clause( $this->get_language( $language ) );
+
+		if ( ! empty( $taxonomy ) ) {
+			$where .= $wpdb->prepare( ' AND tt.taxonomy = %s', $taxonomy );
+		}
+
+		if ( $parent > 0 ) {
+			$where .= $wpdb->prepare( ' AND tt.parent = %d', $parent );
+		}
+
+		// PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return $wpdb->get_var( $select . $join . $where );
+	}
+
+
+	/**
 	 * Gets the number of posts per language in a date, author or post type archive.
 	 *
 	 * @since 1.2

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -485,4 +485,32 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
 		$this->assertEqualSets( array( $en, $fr ), $terms );
 	}
+
+	function test_create_terms_with_same_name() {
+		$_REQUEST = $_POST = array(
+			'action'           => 'add-tag',
+			'term_lang_choice' => 'en',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+		);
+
+		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en )->slug );
+
+		// Second category in English with the same name.
+		$error = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
+		$this->assertWPError( $error );
+
+		$_POST['term_lang_choice'] = 'fr';
+		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
+		$term = get_term( $fr, 'category' );
+		$this->assertEquals( 'test-fr', $term->slug );
+		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr )->slug );
+
+		// Second category in French with the same name.
+		$error = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
+		$this->assertWPError( $error );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/557

This PR prevents creating a second term with the same name (and the same language) without specifying the slug. This was an inconsistent behaviour compared to WordPress which doesn't allow to this.

The PR introduces a new method `term_exists_by_slug()` which allows to check if a term slug already exists in a given language. This function is then used to check that the term with the default slug doesn't already exist before appending the language code to the evaluated slug.

A phpunit test tests the original bug.