### PR TITLE
Sitemap tests

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -9,7 +9,26 @@
  * @since 1.8
  */
 class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
-	public $cache; // Our internal non persistent cache object
+	/**
+	 * Our internal non persistent cache object
+	 *
+	 * @var PLL_Cache
+	 */
+	public $cache;
+
+	/**
+	 * Stores a list of files and functions that home_url() must not filter.
+	 *
+	 * @var array
+	 */
+	private $black_list = array();
+
+	/**
+	 * Stores a list of files and functions that home_url() must filter.
+	 *
+	 * @var array
+	 */
+	private $white_list = array();
 
 	/**
 	 * Constructor
@@ -240,10 +259,8 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			return $url;
 		}
 
-		static $white_list, $black_list; // Avoid evaluating this at each function call
-
 		// We *want* to filter the home url in these cases
-		if ( empty( $white_list ) ) {
+		if ( empty( $this->white_list ) ) {
 			// On Windows get_theme_root() mixes / and \
 			// We want only \ for the comparison with debug_backtrace
 			$theme_root = get_theme_root();
@@ -259,7 +276,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			 *
 			 * @param array $args
 			 */
-			$white_list = apply_filters(
+			$this->white_list = apply_filters(
 				'pll_home_url_white_list',
 				array(
 					array( 'file' => $theme_root ),
@@ -271,7 +288,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		// We don't want to filter the home url in these cases
-		if ( empty( $black_list ) ) {
+		if ( empty( $this->black_list ) ) {
 
 			/**
 			 * Filter the black list of the Polylang 'home_url' filter
@@ -283,7 +300,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			 *
 			 * @param array $args
 			 */
-			$black_list = apply_filters(
+			$this->black_list = apply_filters(
 				'pll_home_url_black_list',
 				array(
 					array( 'file' => 'searchform.php' ), // Since WP 3.6 searchform.php is passed through get_search_form
@@ -297,13 +314,13 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		foreach ( $traces as $trace ) {
 			// Black list first
-			foreach ( $black_list as $v ) {
+			foreach ( $this->black_list as $v ) {
 				if ( ( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) ) || ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ) {
 					return $url;
 				}
 			}
 
-			foreach ( $white_list as $v ) {
+			foreach ( $this->white_list as $v ) {
 				if ( ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ||
 					( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) && in_array( $trace['function'], array( 'home_url', 'get_home_url', 'bloginfo', 'get_bloginfo' ) ) ) ) {
 					$ok = true;

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -54,13 +54,13 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @param WP_Sitemaps_Provider $provider    An instance of a WP_Sitemaps_Provider child class.
 	 * @param PLL_Links_Model      $links_model The PLL_Links_Model instance.
 	 */
-	public function __construct( $provider, $links_model ) {
+	public function __construct( $provider, &$links_model ) {
 		$this->name = $provider->name;
 		$this->object_type = $provider->object_type;
 
 		$this->provider = $provider;
-		$this->links_model = $links_model;
-		$this->model = $links_model->model;
+		$this->links_model = &$links_model;
+		$this->model = &$links_model->model;
 	}
 
 	/**

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -89,19 +89,6 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	}
 
 	/**
-	 * Get active languages for the sitemap.
-	 *
-	 * @since 2.8
-	 */
-	protected function get_active_languages() {
-		$languages = $this->model->get_languages_list();
-		if ( wp_list_filter( $languages, array( 'active' => false ) ) ) {
-			return wp_list_pluck( wp_list_filter( $languages, array( 'active' => false ), 'NOT' ), 'slug' );
-		}
-		return wp_list_pluck( $languages, 'slug' );
-	}
-
-	/**
 	 * Filters the query arguments to add the language.
 	 *
 	 * @since 2.8
@@ -157,7 +144,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$object_subtypes = $this->get_object_subtypes();
 
 		if ( empty( $object_subtypes ) ) {
-			foreach ( $this->get_active_languages() as $language ) {
+			foreach ( $this->model->get_languages_list( array( 'fields' => 'slug' ) ) as $language ) {
 				$sitemap_data[] = $this->get_sitemap_data( '', $language );
 			}
 		}
@@ -175,7 +162,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 
 		foreach ( array_keys( $object_subtypes ) as $object_subtype_name ) {
 			if ( call_user_func( $func, $object_subtype_name ) ) {
-				foreach ( $this->get_active_languages() as $language ) {
+				foreach ( $this->model->get_languages_list( array( 'fields' => 'slug' ) ) as $language ) {
 					$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name, $language );
 				}
 			} else {
@@ -196,7 +183,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @return string The composed URL for a sitemap entry.
 	 */
 	public function get_sitemap_url( $name, $page ) {
-		$pattern = '#(' . implode( '|', $this->get_active_languages() ) . ')$#';
+		$pattern = '#(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')$#';
 		if ( preg_match( $pattern, $name, $matches ) ) {
 			$lang = $this->model->get_language( $matches[1] );
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -50,7 +50,7 @@ class PLL_Sitemaps {
 	 *
 	 * @param object $polylang Main Polylang object.
 	 */
-	public function __construct( $polylang ) {
+	public function __construct( &$polylang ) {
 		$this->curlang = &$polylang->curlang;
 		$this->links_model = &$polylang->links_model;
 		$this->model = &$polylang->model;

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -1,0 +1,217 @@
+<?php
+
+class Sitemaps_Test extends PLL_UnitTestCase {
+	static function wpSetUpBeforeClass() {
+		// Sitemaps were introduced in WP 5.5.
+		if ( ! function_exists( 'wp_get_sitemap_providers' ) ) {
+			self::markTestSkipped( 'These tests require WP 5.5+' );
+		}
+
+		parent::wpSetUpBeforeClass();
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+
+		require_once POLYLANG_DIR . '/include/api.php';
+		$GLOBALS['polylang'] = &self::$polylang;
+	}
+
+	function init() {
+		global $wp_rewrite, $wp_sitemaps;
+
+		// Initialize sitemaps.
+		$wp_sitemaps = null;
+		self::$polylang->sitemaps = new PLL_Sitemaps( self::$polylang );
+		self::$polylang->sitemaps->init();
+
+		// Switch to pretty permalinks.
+		$wp_rewrite->init();
+		$wp_rewrite->extra_rules_top = array(); // Brute force since WP does not do it :(
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
+
+		self::$polylang->model->post->register_taxonomy(); // Needs this for 'lang' query var.
+		create_initial_taxonomies();
+		register_post_type( 'cpt', array( 'public' => true ) ); // *Untranslated* custom post type.
+		register_taxonomy( 'tax', 'cpt' ); // *Untranslated* custom tax.
+
+		wp_sitemaps_get_server(); // Allows to register sitemaps rewrite rules.
+
+		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model->init();
+
+		// Flush rules.
+		$wp_rewrite->flush_rules();
+
+		// Goto front and setup filters.
+		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
+		self::$polylang->filters_links = new PLL_Frontend_Filters_Links( self::$polylang );
+		self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
+	}
+
+	function tearDown() {
+		parent::tearDown();
+
+		_unregister_post_type( 'cpt' );
+		_unregister_taxonomy( 'tax' );
+	}
+
+	function test_sitemap_providers() {
+		$this->init();
+
+		$providers = wp_get_sitemap_providers();
+		foreach ( $providers as $provider ) {
+			$this->assertTrue( $provider instanceof PLL_Multilingual_Sitemaps_Provider );
+		}
+	}
+
+	// The page sitemaps always include the homepages.
+	function test_sitemaps_page() {
+		$this->init();
+
+		$providers = wp_get_sitemap_providers();
+
+		$expected = array(
+			'http://example.org/en/wp-sitemap-posts-page-1.xml',
+			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+	}
+
+	function test_sitemaps_posts() {
+		$this->init();
+
+		$en = self::factory()->post->create( array( 'post_author' => 1 ) );
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		$fr = self::factory()->post->create( array( 'post_author' => 1 ) );
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+
+		$providers = wp_get_sitemap_providers();
+
+		$expected = array(
+			'http://example.org/en/wp-sitemap-posts-post-1.xml',
+			'http://example.org/fr/wp-sitemap-posts-post-1.xml',
+			'http://example.org/en/wp-sitemap-posts-page-1.xml',
+			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/en/wp-sitemap-users-1.xml',
+			'http://example.org/fr/wp-sitemap-users-1.xml',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['users']->get_sitemap_entries(), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/en/wp-sitemap-taxonomies-category-1.xml',
+			'http://example.org/fr/wp-sitemap-taxonomies-category-1.xml',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
+	}
+
+	function test_sitemaps_untranslated_cpt_and_tax() {
+		$this->init();
+
+		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
+		$post_id = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
+		wp_set_post_terms( $post_id, 'test', 'tax' );
+
+		$providers = wp_get_sitemap_providers();
+
+		$expected = array(
+			'http://example.org/wp-sitemap-posts-cpt-1.xml',
+			'http://example.org/en/wp-sitemap-posts-page-1.xml',
+			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/wp-sitemap-taxonomies-tax-1.xml',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
+	}
+
+	function test_home_urls() {
+		self::$polylang->options['hide_default'] = 1;
+		$this->init();
+
+		// For the home_url filter.
+		self::$polylang->links = new PLL_Frontend_Links( self::$polylang );
+		$GLOBALS['wp_actions']['template_redirect'] = 1;
+
+		$providers = wp_get_sitemap_providers();
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$expected = array(
+			'http://example.org/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$expected = array(
+			'http://example.org/fr/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
+
+		unset( $GLOBALS['wp_actions']['template_redirect'] );
+	}
+
+	function test_url_list_posts() {
+		self::$polylang->options['hide_default'] = 1;
+		$this->init();
+		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
+
+		$tag_en = self::factory()->tag->create( array( 'name' => 'tag-en' ) );
+		self::$polylang->model->term->set_language( $tag_en, 'en' );
+
+		$tag_fr = self::factory()->tag->create( array( 'name' => 'tag-fr' ) );
+		self::$polylang->model->term->set_language( $tag_fr, 'fr' );
+
+		$en = self::factory()->post->create( array( 'post_title' => 'test', 'post_author' => 1 ) );
+		self::$polylang->model->post->set_language( $en, 'en' );
+		wp_set_post_terms( $en, array( $tag_en ), 'post_tag' );
+
+
+		$fr = self::factory()->post->create( array( 'post_title' => 'essai', 'post_author' => 1 ) );
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+		wp_set_post_terms( $fr, array( $tag_fr ), 'post_tag' );
+
+		$providers = wp_get_sitemap_providers();
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+
+		$expected = array(
+			'http://example.org/test/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'post' ), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/author/admin/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['users']->get_url_list( 1 ), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/tag/tag-en/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+		$expected = array(
+			'http://example.org/fr/essai/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'post' ), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/fr/author/admin/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['users']->get_url_list( 1 ), 'loc' ) );
+
+		$expected = array(
+			'http://example.org/fr/tag/tag-fr/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
+	}
+}


### PR DESCRIPTION
This PR adds several phpunit tests for the sitemaps to test the sitemap index (languages per directory, per subdomains and multiple domains), as well as the url lists (only for the languages per directory).

Also the development of these tests as well as the tests for inactive languages on Polylang Pro side show that:
* the static variables in `PLL_Frontend_Filters_Links::home_url()` were preventing to use the filter more than once.
* we need to use a reference to the `PLL_Links_Model` object in the constructor of `PLL_Multilingual_Sitemaps_Provider`.
* it's useless to take care of inactive languages in `PLL_Multilingual_Sitemaps_Provider` as this is correctly handled out of the box.
