### PR TITLE
Fix sticky posts appearing 2 times in WP 5.5

### DIFF
--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -101,7 +101,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				$relations = $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM {$wpdb->term_relationships} WHERE object_id IN ({$posts}) AND term_taxonomy_id IN ({$languages})" );
 
 				foreach ( $relations as $relation ) {
-					$_posts[ $relation->term_taxonomy_id ][] = $relation->object_id;
+					$_posts[ $relation->term_taxonomy_id ][] = (int) $relation->object_id;
 				}
 				wp_cache_add( 'sticky_posts', $_posts, 'options' );
 			}

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -654,4 +654,19 @@ class Query_Test extends PLL_UnitTestCase {
 		$query = new WP_Query( array( 'lang' => 'fr', 'cat' => $cat_id ) );
 		$this->assertEquals( array( get_post( $cpt_id ) ), $query->posts );
 	}
+
+	/**
+	 * Bug introduced by WP 5.5 and fixed in Polylang 2.8.
+	 * The sticky posts should appear only once.
+	 */
+	function test_sticky_posts() {
+		$fr = $this->factory->post->create();
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+		stick_post( $fr );
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+		$this->go_to( home_url( '/fr/' ) );
+		$this->assertEquals( 1, $GLOBALS['wp_query']->post_count );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/626

Since WP 5.5, `in_array` comparisons are strict. As mysql queries return strings even for integers, we must cast the returned values to pass this test: https://github.com/WordPress/WordPress/blame/c5ef3b79767f4df5cb4ddb9212a1eefd4cdd51f9/wp-includes/class-wp-query.php#L3138