### PR TITLE
Fix home url in sitemaps for subdomains and multiple domains

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -63,9 +63,10 @@ class PLL_Sitemaps {
 	 * @since 2.8
 	 */
 	public function init() {
+		add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
+
 		if ( $this->options['force_lang'] < 2 ) {
 			add_filter( 'pll_set_language_from_query', array( $this, 'set_language_from_query' ), 10, 2 );
-			add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
 			add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
 			add_filter( 'wp_sitemaps_add_provider', array( $this, 'replace_provider' ) );
 		} else {

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -233,6 +233,28 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
 
+	function test_subdomains_home_url() {
+		self::$polylang->options['force_lang'] = 2;
+		$this->init();
+
+		$_SERVER['HTTP_HOST'] = 'fr.example.org';
+		$_SERVER['REQUEST_URI'] = '/wp-sitemap-posts-page-1.xml';
+
+		// For the home_url filter.
+		self::$polylang->links = new PLL_Frontend_Links( self::$polylang );
+		$GLOBALS['wp_actions']['template_redirect'] = 1;
+
+		$providers = wp_get_sitemap_providers();
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$expected = array(
+			'http://fr.example.org/',
+		);
+		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
+
+		unset( $GLOBALS['wp_actions']['template_redirect'] );
+	}
+
 	function test_domains() {
 		self::$polylang->options['force_lang'] = 3;
 		self::$polylang->options['domains'] = array(


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/627

The `home_url` filter was wrongly not added for subdomains and multiple domains in sitemaps. This PR fixes this and adds a dedicated phpunit test (only for subdomains).