### PR TITLE
Whitelist jQuery methods for VIP WPCS

### DIFF
--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -121,7 +121,7 @@ jQuery( document ).ready(
 										$( '#' + tax + 'checklist' ).html( this.supplemental.all ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
 										// @see wp_popular_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L236
 										$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-										// @see wp_dropdown_categories https://github.com/WordPress/WordPress/blob/5.5-branch/wp-includes/category-template.php#L336
+										// @see wp_dropdown_categories https://github.com/WordPress/WordPress/blob/5.5.1/wp-includes/category-template.php#L336
 										// which is called by PLL_Admin_Classic_Editor::post_lang_choice to generate supplemental.dropdown
 										$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 										$( '#' + tax + '-lang' ).val( $( '.post_lang_choice' ).val() ); // hidden field

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -46,11 +46,13 @@
 
 				// add an if else condition to allow modifying the tags outputed when switching the language
 				if ( v = $( '#tagcloud-' + tax ).css( 'display' ) ) {
-					$( '#tagcloud-' + tax ).replaceWith( r );
+					// See the comment above when r variable is created.
+					$( '#tagcloud-' + tax ).replaceWith( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 					$( '#tagcloud-' + tax ).css( 'display', v );
 				}
 				else {
-					$( '#' + id ).after( r );
+					// See the comment above when r variable is created.
+					$( '#' + id ).after( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
 				}
 			}
 		);
@@ -72,7 +74,8 @@ jQuery( document ).ready(
 
 				// add our hidden field in the new category form - for each hierarchical taxonomy
 				// to set the language when creating a new category
-				$( '#' + taxonomy + '-add-submit' ).before(
+				// html code inserted come from html code itself.
+				$( '#' + taxonomy + '-add-submit' ).before( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.before
 					$( '<input />' ).attr( 'type', 'hidden' )
 						.attr( 'id', taxonomy + '-lang' )
 						.attr( 'name', 'term_lang_choice' )
@@ -118,7 +121,9 @@ jQuery( document ).ready(
 										$( '#' + tax + 'checklist' ).html( this.supplemental.all ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
 										// @see wp_popular_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L236
 										$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-										$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown );
+										// @see wp_dropdown_categories https://github.com/WordPress/WordPress/blob/5.5-branch/wp-includes/category-template.php#L336
+										// which is called by PLL_Admin_Classic_Editor::post_lang_choice to generate supplemental.dropdown
+										$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 										$( '#' + tax + '-lang' ).val( $( '.post_lang_choice' ).val() ); // hidden field
 									break;
 									case 'pages': // parent dropdown list for pages

--- a/js/nav-menu.js
+++ b/js/nav-menu.js
@@ -54,7 +54,8 @@ jQuery( document ).ready(
 							// add the fields
 							for ( var i = 0, idsLength = ids.length; i < idsLength; i++ ) {
 								p = $( '<p>' ).attr( 'class', 'description' );
-								$( this ).prepend( p );
+								// p is hardcoded just above by using attr method which is safe.
+								$( this ).prepend( p ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 								// item is a number part of id of parent menu item built by WordPress
 								// pll_data is built server side with i18n strings without HTML
 								label = $( '<label>' ).attr( 'for', 'edit-menu-item-' + ids[ i ] + '-' + item ).text( ' ' + pll_data.strings[ ids[ i ] ] );
@@ -70,7 +71,8 @@ jQuery( document ).ready(
 								if ( ( typeof( pll_data.val[ item ] ) != 'undefined' && pll_data.val[ item ][ ids[ i ] ] == 1 ) || ( typeof( pll_data.val[ item ] ) == 'undefined' && ids[ i ] == 'show_names' ) ) { // show_names as default value
 									cb.prop( 'checked', true );
 								}
-								label.prepend( cb );
+								// See reasons above. Checkbox are totaly hardcoded here with safe value
+								label.prepend( cb ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 							}
 						}
 					);

--- a/js/post.js
+++ b/js/post.js
@@ -127,7 +127,10 @@
 								res.responses,
 								function() {
 									if ( 'row' == this.what ) {
-										$( "#post-" + this.supplemental.post_id ).replaceWith( this.data );
+										// data is built with a call to WP_Posts_List_Table::single_row method
+										// which uses internally other WordPress methods which escape correctly values.
+										// For Polylang language columns the HTML code is correctly escaped in PLL_Admin_Filters_Columns::post_column method.
+										$( "#post-" + this.supplemental.post_id ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 									}
 								}
 							);

--- a/js/term.js
+++ b/js/term.js
@@ -66,7 +66,10 @@
 								res.responses,
 								function() {
 									if ( 'row' == this.what ) {
-										$( "#tag-" + this.supplemental.term_id ).replaceWith( this.data );
+										// data is built with a call to WP_Terms_List_Table::single_row method
+										// which uses internally other WordPress methods which escape correctly values.
+										// For Polylang language columns the HTML code is correctly escaped in PLL_Admin_Filters_Columns::term_column method.
+										$( "#tag-" + this.supplemental.term_id ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 									}
 								}
 							);
@@ -184,10 +187,12 @@ jQuery( document ).ready(
 										init_translations();
 									break;
 									case 'parent': // parent dropdown list for hierarchical taxonomies
-										$( '#parent' ).replaceWith( this.data );
+										// data correctly escaped in PLL_Admin_Filters_Term::term_lang_choice method which uses wp_dropdown_categories function.
+										$( '#parent' ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 									break;
 									case 'tag_cloud': // popular items
-										$( '.tagcloud' ).replaceWith( this.data );
+										// data correctly escaped in PLL_Admin_Filters_Term::term_lang_choice method which uses wp_tag_cloud and wp_generate_tag_cloud functions.
+										$( '.tagcloud' ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 									break;
 									case 'flag': // flag in front of the select dropdown
 										// Data is built and come from server side and is well escaped when necessary

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -35,7 +35,8 @@ jQuery(
 					current.html( icon ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
 				} else {
 					flag = $( '<span />' ).addClass( 'pll-lang' ).html( icon );  // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-					title.prepend( flag );
+					// See the comment above about the icon which is safe. So it is also safe to prepend flag which uses icon.
+					title.prepend( flag ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 				}
 			} else {
 				$( '.pll-lang', title ).remove();

--- a/modules/wizard/js/languages-step.js
+++ b/modules/wizard/js/languages-step.js
@@ -22,7 +22,8 @@ jQuery( document ).ready(
 		 */
 		function addLanguage( language ) {
 			// language properties come from the select dropdown which is built server side and well escaped.
-			var languageValueHtml = $( '<td />' ).text( language.text ).prepend( language.flagUrl );
+			// see template view-wizard-step-languages.php.
+			var languageValueHtml = $( '<td />' ).text( language.text ).prepend( language.flagUrl ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 			var languageTrashIconHtml = $( '<td />' )
 				.append( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 					$( '<span />' )
@@ -34,7 +35,8 @@ jQuery( document ).ready(
 						.text( pll_wizard_params.i18n_remove_language_icon )
 					)
 				);
-			var languageLineHtml = $( '<tr />' ).prepend( languageTrashIconHtml ).prepend( languageValueHtml );
+			// see the comment and the harcoded code above. languageTrashIconHtml and languageValueHtml are safe.
+			var languageLineHtml = $( '<tr />' ).prepend( languageTrashIconHtml ).prepend( languageValueHtml ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 			var languageFieldHtml = $( '<input />' ).attr(
 				{
 					type: 'hidden',
@@ -82,7 +84,9 @@ jQuery( document ).ready(
 		 */
 		function showError( message ) {
 			messagesContainer.empty();
-			messagesContainer.prepend( $( '<p/>' ).addClass( 'error' ).text( message ) );
+			// html is harcoded and use of jQuery text method which is safe to add message value.
+			// In addition message is i18n value which is initialized server side in PLL_Wizard::add_step_languages and correctly escaped.
+			messagesContainer.prepend( $( '<p/>' ).addClass( 'error' ).text( message ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 		}
 
 		/**
@@ -246,7 +250,7 @@ jQuery( document ).ready(
 			}
 		}
 
-		// Initialize dialog box in the case a langauge is selected but not added in the list.
+		// Initialize dialog box in the case a language is selected but not added in the list.
 		dialog.dialog(
 			{
 				autoOpen: false,
@@ -268,7 +272,9 @@ jQuery( document ).ready(
 					}
 					// Display language name and flag information in dialog box.
 					$( this ).find( '#dialog-language' ).text( $( '#lang_list' ).children( ':selected' )[0].innerText );
-					$( this ).find( '#dialog-language-flag' ).empty().prepend( $( '#lang_list' ).children( ':selected' ).data( 'flag-html' ) );
+					// language properties come from the select dropdown #lang_list which is built server side and well escaped.
+					// see template view-wizard-step-languages.php.
+					$( this ).find( '#dialog-language-flag' ).empty().prepend( $( '#lang_list' ).children( ':selected' ).data( 'flag-html' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 				},
 				buttons: [
 				{

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -26,7 +26,14 @@ class PLL_Wizard {
 	/**
 	 * List of steps
 	 *
-	 * @var array $steps
+	 * @var array $steps {
+	 *     @type string $name      i18n string which names the step.
+	 *     @type callable $view    The callback function use to display the step content.
+	 *     @type callable $handler The callback function use to process the step after it is submitted.
+	 *     @type array $scripts    List of scripts handle needed by the step.
+	 *     @type array $styles     The list of styles handle needed by the step.
+	 *
+	 * }
 	 */
 	protected $steps = array();
 

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -32,7 +32,6 @@ class PLL_Wizard {
 	 *     @type callable $handler The callback function use to process the step after it is submitted.
 	 *     @type array $scripts    List of scripts handle needed by the step.
 	 *     @type array $styles     The list of styles handle needed by the step.
-	 *
 	 * }
 	 */
 	protected $steps = array();

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -116,7 +116,7 @@ class PLL_Wizard {
 	 * @since 2.7
 	 */
 	public function settings_tabs( $tabs ) {
-		$tabs['wizard'] = __( 'Setup', 'polylang' );
+		$tabs['wizard'] = esc_html__( 'Setup', 'polylang' );
 		return $tabs;
 	}
 
@@ -335,7 +335,7 @@ class PLL_Wizard {
 		wp_enqueue_script( 'pll_admin', plugins_url( '/js/admin' . $this->get_suffix() . '.js', POLYLANG_FILE ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
 		if ( $this->is_licenses_step_displayable() ) {
 			$steps['licenses'] = array(
-				'name'    => __( 'Licenses', 'polylang' ),
+				'name'    => esc_html__( 'Licenses', 'polylang' ),
 				'view'    => array( $this, 'display_step_licenses' ),
 				'handler' => array( $this, 'save_step_licenses' ),
 				'scripts' => array( 'pll_admin' ), // Polylang admin script used by deactivate license button.
@@ -427,27 +427,27 @@ class PLL_Wizard {
 			'pll-wizard-languages',
 			'pll_wizard_params',
 			array(
-				'i18n_no_language_selected'   => __( 'You need to select a language to be added.', 'polylang' ),
-				'i18n_language_already_added' => __( 'You already added this language.', 'polylang' ),
-				'i18n_no_language_added'      => __( 'You need to add at least one language.', 'polylang' ),
-				'i18n_add_language_needed'    => __( 'You selected a language, however, to be able to continue, you need to add it.', 'polylang' ),
-				'i18n_pll_add_language'       => __( 'Impossible to add the language.', 'polylang' ),
-				'i18n_pll_invalid_locale'     => __( 'Enter a valid WordPress locale', 'polylang' ),
-				'i18n_pll_invalid_slug'       => __( 'The language code contains invalid characters', 'polylang' ),
-				'i18n_pll_non_unique_slug'    => __( 'The language code must be unique', 'polylang' ),
-				'i18n_pll_invalid_name'       => __( 'The language must have a name', 'polylang' ),
-				'i18n_pll_invalid_flag'       => __( 'The flag does not exist', 'polylang' ),
-				'i18n_dialog_title'           => __( "A language wasn't added.", 'polylang' ),
-				'i18n_dialog_yes_button'      => __( 'Yes', 'polylang' ),
-				'i18n_dialog_no_button'       => __( 'No', 'polylang' ),
-				'i18n_dialog_ignore_button'   => __( 'Ignore', 'polylang' ),
-				'i18n_remove_language_icon'   => __( 'Remove this language', 'polylang' ),
+				'i18n_no_language_selected'   => esc_html__( 'You need to select a language to be added.', 'polylang' ),
+				'i18n_language_already_added' => esc_html__( 'You already added this language.', 'polylang' ),
+				'i18n_no_language_added'      => esc_html__( 'You need to add at least one language.', 'polylang' ),
+				'i18n_add_language_needed'    => esc_html__( 'You selected a language, however, to be able to continue, you need to add it.', 'polylang' ),
+				'i18n_pll_add_language'       => esc_html__( 'Impossible to add the language.', 'polylang' ),
+				'i18n_pll_invalid_locale'     => esc_html__( 'Enter a valid WordPress locale', 'polylang' ),
+				'i18n_pll_invalid_slug'       => esc_html__( 'The language code contains invalid characters', 'polylang' ),
+				'i18n_pll_non_unique_slug'    => esc_html__( 'The language code must be unique', 'polylang' ),
+				'i18n_pll_invalid_name'       => esc_html__( 'The language must have a name', 'polylang' ),
+				'i18n_pll_invalid_flag'       => esc_html__( 'The flag does not exist', 'polylang' ),
+				'i18n_dialog_title'           => esc_html__( "A language wasn't added.", 'polylang' ),
+				'i18n_dialog_yes_button'      => esc_html__( 'Yes', 'polylang' ),
+				'i18n_dialog_no_button'       => esc_html__( 'No', 'polylang' ),
+				'i18n_dialog_ignore_button'   => esc_html__( 'Ignore', 'polylang' ),
+				'i18n_remove_language_icon'   => esc_html__( 'Remove this language', 'polylang' ),
 			)
 		);
 		wp_enqueue_script( 'pll-wizard-languages' );
 		wp_enqueue_style( 'pll-wizard-selectmenu', plugins_url( '/css/selectmenu' . $this->get_suffix() . '.css', POLYLANG_FILE ), array( 'dashicons', 'install', 'common', 'wp-jquery-ui-dialog' ), POLYLANG_VERSION );
 		$steps['languages'] = array(
-			'name'    => __( 'Languages', 'polylang' ),
+			'name'    => esc_html__( 'Languages', 'polylang' ),
 			'view'    => array( $this, 'display_step_languages' ),
 			'handler' => array( $this, 'save_step_languages' ),
 			'scripts' => array( 'pll-wizard-languages', 'pll-wizard-language-choice' ),
@@ -553,7 +553,7 @@ class PLL_Wizard {
 
 		if ( $this->is_media_step_displayable( $languages ) ) {
 			$steps['media'] = array(
-				'name'    => __( 'Media', 'polylang' ),
+				'name'    => esc_html__( 'Media', 'polylang' ),
 				'view'    => array( $this, 'display_step_media' ),
 				'handler' => array( $this, 'save_step_media' ),
 				'scripts' => array(),
@@ -602,7 +602,7 @@ class PLL_Wizard {
 			wp_enqueue_script( 'pll-wizard-language-choice', plugins_url( '/js/admin' . $this->get_suffix() . '.js', POLYLANG_FILE ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
 			wp_enqueue_style( 'pll-wizard-selectmenu', plugins_url( '/css/selectmenu' . $this->get_suffix() . '.css', POLYLANG_FILE ), array( 'dashicons', 'install', 'common' ), POLYLANG_VERSION );
 			$steps['untranslated-contents'] = array(
-				'name'    => __( 'Content', 'polylang' ),
+				'name'    => esc_html__( 'Content', 'polylang' ),
 				'view'    => array( $this, 'display_step_untranslated_contents' ),
 				'handler' => array( $this, 'save_step_untranslated_contents' ),
 				'scripts' => array( 'pll-wizard-language-choice' ),
@@ -665,7 +665,7 @@ class PLL_Wizard {
 
 		if ( $home_page_id > 0 && ( ! $languages || count( $languages ) === 1 || count( $translations ) !== count( $languages ) ) ) {
 			$steps['home-page'] = array(
-				'name'    => __( 'Homepage', 'polylang' ),
+				'name'    => esc_html__( 'Homepage', 'polylang' ),
 				'view'    => array( $this, 'display_step_home_page' ),
 				'handler' => array( $this, 'save_step_home_page' ),
 				'scripts' => array(),
@@ -754,7 +754,7 @@ class PLL_Wizard {
 	 */
 	public function add_step_last( $steps ) {
 		$steps['last'] = array(
-			'name'    => __( 'Ready!', 'polylang' ),
+			'name'    => esc_html__( 'Ready!', 'polylang' ),
 			'view'    => array( $this, 'display_step_last' ),
 			'handler' => array( $this, 'save_step_last' ),
 			'scripts' => array(),


### PR DESCRIPTION
This PR propose after verification to whitelist all the jQuery methods: prepend, replaceWith, before and after.
In addition I noticed that some i18n strings weren't correctly escaped in the wizard which are used in the javascript code. So this PR also fixes this issue.

This is the part of javascript code to close this issue https://github.com/polylang/polylang-pro/issues/596