### PR TITLE
Fix duplicate post compatibility

### DIFF
--- a/integrations/duplicate-post/duplicate-post.php
+++ b/integrations/duplicate-post/duplicate-post.php
@@ -27,7 +27,7 @@ class PLL_Duplicate_Post {
 	 * @param array|string $taxonomies
 	 * @return array
 	 */
-	public function duplicate_post_taxonomies_blacklist( $taxonomies ) {
+	public function taxonomies_blacklist( $taxonomies ) {
 		if ( empty( $taxonomies ) ) {
 			$taxonomies = array(); // As we get an empty string when there is no taxonomy
 		}

--- a/tests/bin/install-plugins.sh
+++ b/tests/bin/install-plugins.sh
@@ -40,3 +40,9 @@ unzip -q $TMPDIR/downloads/wordpress-seo.zip -d  $TMPDIR/downloads/
 mkdir -p $TMPDIR/wordpress-seo
 mv $TMPDIR/downloads/wordpress-seo/* $TMPDIR/wordpress-seo/
 
+#Install Duplicate Post
+download https://downloads.wordpress.org/plugin/duplicate_post.zip $TMPDIR/downloads/duplicate_post.zip
+unzip -q $TMPDIR/downloads/duplicate_post.zip -d  $TMPDIR/downloads/
+mkdir -p $TMPDIR/duplicate_post
+mv $TMPDIR/downloads/duplicate_post/* $TMPDIR/duplicate_post/
+

--- a/tests/bin/install-plugins.sh
+++ b/tests/bin/install-plugins.sh
@@ -41,8 +41,8 @@ mkdir -p $TMPDIR/wordpress-seo
 mv $TMPDIR/downloads/wordpress-seo/* $TMPDIR/wordpress-seo/
 
 #Install Duplicate Post
-download https://downloads.wordpress.org/plugin/duplicate_post.zip $TMPDIR/downloads/duplicate_post.zip
-unzip -q $TMPDIR/downloads/duplicate_post.zip -d  $TMPDIR/downloads/
-mkdir -p $TMPDIR/duplicate_post
-mv $TMPDIR/downloads/duplicate_post/* $TMPDIR/duplicate_post/
+download https://downloads.wordpress.org/plugin/duplicate-post.zip $TMPDIR/downloads/duplicate-post.zip
+unzip -q $TMPDIR/downloads/duplicate-post.zip -d  $TMPDIR/downloads/
+mkdir -p $TMPDIR/duplicate-post
+mv $TMPDIR/downloads/duplicate-post/* $TMPDIR/duplicate-post/
 

--- a/tests/phpunit/tests/plugins/test-duplicate-post.php
+++ b/tests/phpunit/tests/plugins/test-duplicate-post.php
@@ -1,0 +1,43 @@
+<?php
+
+if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
+	require_once DIR_TESTROOT . '/../duplicate-post/duplicate-post.php';
+	require_once DIR_TESTROOT . '/../duplicate-post/duplicate-post-admin.php';
+
+	class Duplicate_Post_Test extends PLL_UnitTestCase {
+
+		static function wpSetUpBeforeClass() {
+			parent::wpSetUpBeforeClass();
+
+			self::$polylang->model->post->registered_post_type( 'post' ); // Important.
+
+			self::create_language( 'en_US' );
+			self::create_language( 'fr_FR' );
+
+			PLL_Integrations::instance()->duplicate_post = new PLL_Duplicate_Post();
+			PLL_Integrations::instance()->duplicate_post->init();
+		}
+
+		function test_exclude_post_translations() {
+			$en = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $en, 'en' );
+
+			$fr = $this->factory->post->create();
+			self::$polylang->model->post->set_language( $fr, 'fr' );
+
+			self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
+
+			$post = get_post( $en );
+			duplicate_post_admin_init();
+			$new_id = duplicate_post_create_duplicate( $post, 'draft' );
+
+			// Check our code.
+			$this->assertContains( 'post_translations', get_object_taxonomies( $post->post_type ) );
+			$this->assertContains( 'post_translations', get_option( 'duplicate_post_taxonomies_blacklist' ) );
+
+			// Check the integration.
+			$this->assertEquals( $fr, self::$polylang->model->post->get( $en, 'fr' ) );
+			$this->assertFalse( self::$polylang->model->post->get( $new_id, 'fr' ) );
+		}
+	}
+}


### PR DESCRIPTION
Since version 2.8, we receive a warning when the plugin Duplicate Post is active. 
```
Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'PLL_Duplicate_Post' does not have a method 'taxonomies_blacklist' in /wp-includes/class-wp-hook.php on line 289
```
It's due to a mistake made during the integration refactor.
This PR fixes the issue.