### PR TITLE
Fix custom flag size in the admin bar

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -230,8 +230,10 @@ class PLL_Language {
 	 */
 	public static function get_flag_html( $flag, $title = '', $alt = '' ) {
 		return empty( $flag['src'] ) ? '' : sprintf(
-			'<img src="%s"%s%s%s%s />',
+			'<img src="%s" style="%s%s"%s%s%s%s />',
 			$flag['src'],
+			empty( $flag['width'] ) ? '' : sprintf( 'width: %spx;', (int) $flag['width'] ),
+			empty( $flag['height'] ) ? '' : sprintf( ' height: %spx;', (int) $flag['height'] ),
 			empty( $title ) ? '' : sprintf( ' title="%s"', esc_attr( $title ) ),
 			empty( $alt ) ? '' : sprintf( ' alt="%s"', esc_attr( $alt ) ),
 			empty( $flag['width'] ) ? '' : sprintf( ' width="%s"', (int) $flag['width'] ),


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/635

We offer the possibility to specify the flag width and height on admin side with filter `pll_flag`. The width and height are specified with html img attributes. The issue is that for the admin bar, WordPress adds CSS rules for the widthd and height which override our img attributes. See https://github.com/WordPress/WordPress/blob/5.5/wp-includes/css/admin-bar.css#L2-L3

This PR also specifies the width and height as CSS inline style, in addition to the img attributes.