### PR TITLE
Fix fatal error when no language is defined

### DIFF
--- a/modules/site-health/load.php
+++ b/modules/site-health/load.php
@@ -9,6 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
-if ( $polylang instanceof PLL_Admin ) {
+if ( $polylang instanceof PLL_Admin && $polylang->model->get_languages_list() ) {
 	$polylang->site_health = new PLL_Admin_Site_Health( $polylang );
 }


### PR DESCRIPTION
**Steps to reproduce the issue:**
1. Activate Polylang and do not create any language.
2. In Settings > Reading, select "Your homepage displays: a static page".
3. Go to Tools > Site Health
This results in a fatal error:
```
PHP Fatal error:  Uncaught Error: Call to a member function get_must_translate_message() on null in /polylang/modules/site-health/admin-site-health.php:271
Stack trace:
#0 /wp-admin/includes/class-wp-site-health.php(127): PLL_Admin_Site_Health->homepage_test()
#1 /wp-includes/class-wp-hook.php(288): WP_Site_Health->enqueue_scripts('site-health.php')
#2 /wp-includes/class-wp-hook.php(312): WP_Hook->apply_filters(NULL, Array)
#3 /wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#4 /wp-admin/admin-header.php(104): do_action('admin_enqueue_s...', 'site-health.php')
#5 /wp-admin/site-health.php(35): require_once('/home/fred/Docu...')
#6 {main}
  thrown in /polylang/modules/site-health/admin-site-health.php on line 271
```
**Causes**
`PLL_Admin_Site_Health` attempts to access to the `PLL_Admin_Static_Pages` object which is not defined if no languages exist: https://github.com/polylang/polylang/blob/2.8.1/admin/admin-base.php#L49-L55
**Fix**
There is no reason to load the site health module when no language are defined.