### PR TITLE
Fixes the links and strings stored in the indexable table since Yoast SEO 14.0

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -44,6 +44,7 @@ class PLL_WPSEO {
 				add_filter( 'wpseo_frontend_presenters', array( $this, 'wpseo_frontend_presenters' ) );
 			}
 			add_filter( 'wpseo_canonical', array( $this, 'wpseo_canonical' ) );
+			add_filter( 'wpseo_frontend_presentation', array( $this, 'frontend_presentation' ) );
 		} else {
 			add_action( 'admin_init', array( $this, 'wpseo_register_strings' ) );
 
@@ -391,6 +392,37 @@ class PLL_WPSEO {
 	public function wpseo_canonical( $url ) {
 		return is_front_page( $url ) && get_option( 'permalink_structure' ) ? trailingslashit( $url ) : $url;
 	}
+
+	/**
+	 * Fixes the links and strings stored in the indexable table since Yoast SEO 14.0
+	 *
+	 * @since 2.8.2
+	 *
+	 * @param object $presentation The indexable presentation.
+	 * @return object
+	 */
+	public function frontend_presentation( $presentation ) {
+		if ( is_front_page() ) {
+			$presentation->model->permalink = pll_home_url();
+		}
+
+		if ( is_post_type_archive() ) {
+			$presentation->model->permalink = get_post_type_archive_link( get_post_type() );
+		}
+
+		$strings = array(
+			'title',
+			'description',
+			'breadcrumb_title',
+		);
+
+		foreach ( $strings as $string ) {
+			$presentation->model->$string = pll__( $presentation->model->$string );
+		}
+
+		return $presentation;
+	}
+
 
 	/**
 	 * Helper function to register strings for custom post types and custom taxonomies titles and meta descriptions


### PR DESCRIPTION
For reference: https://github.com/Yoast/wordpress-seo/issues/14994
Fixes #503 
Fixes #505

Also fixes #65 which was fixed earlier by Yoast SEO and re-introduced by Yoast 14.0.

Since the version 14.0, Yoast SEO:
1. sometimes uses `home_url()` and sometimes gets the home url directly from the `yoast_indexable` table, thus bypassing all WP core filters, including the `home_url` filter.
2. always gets the post type archive links from the `yoast_indexable` table instead of evaluating them dynamically, thus bypassing all WP core filters, including the `post_type_archive_link` filter.
3. duplicates some options from the `options` table into the `yoast_indexable` and directly gets them from the `yoast_indexable` table instead of getting them from the `options` table, thus bypassing all WP core filters, including the `option_{option_name}` filters. As a consequence, this prevents the `wpml-config.xml` included in Yoast SEO to work as expected on frontend.

This PR uses the filter `wpseo_frontend_presentation` introduced in Yoast SEO 14.0.3 which somewhat allows to replace the filters now bypassed by Yoast SEO.

The PR doesn't fix another known issue introduced by the usage of `yoast_indexable` table related to data that must be invalidated for example when the url options are modified in Polylang settings. See also https://github.com/Yoast/wordpress-seo/issues/14994#issuecomment-622383946