### PR TITLE
Make flag tests independent from other tests

### DIFF
--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -2,6 +2,8 @@
 
 class Flags_Test extends PLL_UnitTestCase {
 
+	private $pll_env;
+
 	/**
 	 * @param WP_UnitTest_Factory $factory
 	 */
@@ -20,6 +22,15 @@ class Flags_Test extends PLL_UnitTestCase {
 
 		unlink( WP_CONTENT_DIR . '/polylang/fr_FR.png' );
 		rmdir( WP_CONTENT_DIR . '/polylang' );
+	}
+
+	function setUp() {
+		$options       = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
+		$model         = new PLL_Model( $options );
+		$links_model   = new PLL_Links_Default( $model );
+		$this->pll_env = new PLL_Frontend( $links_model );
+		$this->pll_env->init();
+		$this->pll_env->model->cache->clean();
 	}
 
 	function test_default_flag() {

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -35,12 +35,6 @@ class Flags_Test extends PLL_UnitTestCase {
 		$this->pll_env->model->cache->clean();
 	}
 
-	function tearDown() {
-		remove_filter( 'pll_custom_flag', array( $this, 'override_custom_flag' ) );
-
-		parent::tearDown();
-	}
-
 	function test_default_flag() {
 		$lang = self::$model->get_language( 'en' );
 		$this->assertEquals( plugins_url( '/flags/us.png', POLYLANG_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -25,12 +25,20 @@ class Flags_Test extends PLL_UnitTestCase {
 	}
 
 	function setUp() {
+		parent::setUp();
+
 		$options       = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
 		$model         = new PLL_Model( $options );
 		$links_model   = new PLL_Links_Default( $model );
 		$this->pll_env = new PLL_Frontend( $links_model );
 		$this->pll_env->init();
 		$this->pll_env->model->cache->clean();
+	}
+
+	function tearDown() {
+		remove_filter( 'pll_custom_flag', array( $this, 'override_custom_flag' ) );
+
+		parent::tearDown();
 	}
 
 	function test_default_flag() {

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -22,7 +22,7 @@ class Flags_Test extends PLL_UnitTestCase {
 
 		$options       = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
 		$this->model         = new PLL_Model( $options );
-		$links_model = new PLL_Links_Default( $model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
+		$links_model = new PLL_Links_Default( $this->model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
 	}
 
 	public function tearDown() {

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -8,6 +8,8 @@ class Flags_Test extends PLL_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		global $wp_filter;
+
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
@@ -21,8 +23,8 @@ class Flags_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		$options       = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
-		$this->model         = new PLL_Model( $options );
-		$links_model = new PLL_Links_Default( $this->model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
+		$model         = new PLL_Model( $options );
+		$links_model   = new PLL_Links_Default( $model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
 	}
 
 	public function tearDown() {
@@ -38,9 +40,9 @@ class Flags_Test extends PLL_UnitTestCase {
 	}
 
 	function test_default_flag() {
-		$lang = self::$model->get_language( 'en' );
-		$this->assertEquals( plugins_url( '/flags/us.png', POLYLANG_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.
-		$this->assertEquals( 1, preg_match( '#<img src="data:image\/png;base64,(.+)" alt="English" width="16" height="11" style="(.+)" \/>#', $lang->get_display_flag() ) );
+		$lang = self::$model->get_language( 'fr' );
+		$this->assertEquals( plugins_url( '/flags/fr.png', POLYLANG_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.
+		$this->assertEquals( 1, preg_match( '#<img src="data:image\/png;base64,(.+)" alt="Français" width="16" height="11" style="(.+)" \/>#', $lang->get_display_flag() ) );
 	}
 
 	function test_custom_flag() {
@@ -58,7 +60,7 @@ class Flags_Test extends PLL_UnitTestCase {
 	function test_default_flag_ssl() {
 		$_SERVER['HTTPS'] = 'on';
 
-		$lang = self::$model->get_language( 'en' );
+		$lang = self::$model->get_language( 'fr' );
 		$this->assertContains( 'https', $lang->get_display_flag_url() );
 	}
 


### PR DESCRIPTION
## The issue

By running the `Flags_Test` before the `Switcher_Test`, with no other tests, a fatal error would arise at the `PLL_Frontend_Filters::get_locale()` method, triggered by the [get_locale() call](https://github.com/polylang/polylang/blob/bb5e7f55ab90277363d4077586bb9eaabe12f752/include/olt-manager.php#L75) in the global instance of `PLL_OLT_Manager` (which is shared between tests because instantiated in the bootstrap and being a Singleton).

For some reasons, the filters set in the `Flags_Test` **where not removed** when running the `Switcher_Test`, and where triggered by the `PLL_Frontend::init()` calls in the `Switcher_Test::setUp()`, while some of the values needed for this filter have been cleaned after the `Flag_Test`...

## How has it been fixed?

By calling the `PLL_Frontend::init()` method in the `Flag_Test::setUp()`, it seems that the filters instantiated are resolved and then not shared with other test classes.

## Other issues

Setting a new `PLL_Model` instance to replace the shared `PLL_Admin_Model` instance in the `PLL_Frontend` instance, two more issues have been outlined:

- It appeared that `Flags_Test::test_default_flag_ssl()` and `Flags_Test::test_custom_flag_ssl()` used cached values (coming from the shared `PLL_Admin_Model::cache` shared instance). Setting a new `PLL_Model` has reset these cached values, which would then not be set for SSL protocol. Resetting the cache **before** each test would solve the issue.
- Because our `PLL_UnitTestCaseTrait::wpTearDownAfterTest()` relies on the `self::$polylang->model->delete_language()` method to clean the environment, we cannot substitute the static `self::$polylang->model` instance for another class than `PLL_Admin_Model`. This was solved by using a different instance in the test methods.