### PR TITLE
Fix fatal in MU Domain Mapping integration

### DIFF
--- a/integrations/domain-mapping/domain-mapping.php
+++ b/integrations/domain-mapping/domain-mapping.php
@@ -39,6 +39,11 @@ class PLL_Domain_Mapping {
 
 		// The language is set from the subdomain or domain name
 		if ( $options['force_lang'] > 1 ) {
+			// Don't go further if we stopped loading the plugin early ( for example when deactivate-polylang=1 ).
+			if ( ! function_exists( 'PLL' ) ) {
+				return;
+			}
+
 			// Don't redirect the main site
 			if ( is_main_site() ) {
 				return;


### PR DESCRIPTION
When using the plugin MU Domain Mapping on a multisite, saving URL modifications for diferent domains produces this notice for all domains:
```
Polylang was unable to access the http://site1.test/?deactivate-polylang=1 URL. Please check that the URL is valid.
```

The reason under the hood is this fatal error:
```
PHP Fatal error:  Uncaught Error: Call to undefined function PLL() in /polylang-pro/vendor/wpsyntex/polylang/integrations/domain-mapping/domain-mapping.php:61
```
It occurs because with the parameter `deactivate-polylang=1`, the execution of Polylang is stopped early (but after plugins integrations are loaded) and thus `PLL()` is never defined. 

This PR adds a test to bail early if `PLL()` is not defined.