### PR TITLE
Fix PHP notice in sitemap module

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -129,7 +129,7 @@ class PLL_Sitemaps {
 		}
 
 		foreach ( $rules as $key => $rule ) {
-			if ( false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
+			if ( isset( $slug ) &&  false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
 				$newrules[ str_replace( '^wp-sitemap', $slug . 'wp-sitemap', $key ) ] = str_replace(
 					array( '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ),
 					array( '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ),

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -129,7 +129,7 @@ class PLL_Sitemaps {
 		}
 
 		foreach ( $rules as $key => $rule ) {
-			if ( isset( $slug ) &&  false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
+			if ( isset( $slug ) && false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
 				$newrules[ str_replace( '^wp-sitemap', $slug . 'wp-sitemap', $key ) ] = str_replace(
 					array( '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ),
 					array( '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ),


### PR DESCRIPTION
Reported in wp.org forum: https://wordpress.org/support/topic/notice-undefined-variable-slug-in/

```
Notice: Undefined variable: slug in /path/wp-content/plugins/polylang/modules/sitemaps/sitemaps.php on line 133
```
when visiting Settings > Permalinks.
with WP 5.5 and Polylang 2.8.1

I did not test, but my guess is that it occurs when only one language is defined.