### PR TITLE
Replace @link annotation by @see one

### DIFF
--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -6,7 +6,7 @@
 /**
  * Class PLL_Admin_Site_Health to add debug info in WP Site Health.
  *
- * @link https://make.wordpress.org/core/2019/04/25/site-health-check-in-5-2/
+ * @see https://make.wordpress.org/core/2019/04/25/site-health-check-in-5-2/ since WordPress 5.2
  *
  * @since 2.8
  */


### PR DESCRIPTION
As we decided to use `@see` phpdocumentor  annotation in Polylang Pro https://github.com/polylang/polylang-pro/pull/650 we need to do the same in Polylang.

