### PR TITLE
Delay load_plugin_textdomain after plugin initialization

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -22,9 +22,6 @@ class PLL_Admin_Base extends PLL_Base {
 	public function __construct( &$links_model ) {
 		parent::__construct( $links_model );
 
-		// Plugin i18n, only needed for backend
-		load_plugin_textdomain( 'polylang' );
-
 		// Adds the link to the languages panel in the WordPress admin menu
 		add_action( 'admin_menu', array( $this, 'add_menus' ) );
 
@@ -326,6 +323,9 @@ class PLL_Admin_Base extends PLL_Base {
 			/** This action is documented in include/class-polylang.php */
 			do_action( 'pll_no_language_defined' ); // to load overridden textdomains
 		}
+
+		// Plugin i18n, only needed for backend.
+		load_plugin_textdomain( 'polylang' );
 	}
 
 	/**


### PR DESCRIPTION
The best practice is to load the translation after all plugins are loaded to allow 3rd party plugins to optionnaly change the translation file loaded. This is already what we do and that's ok. However, during the developement of https://github.com/polylang/polylang-pro/pull/668, I noticed that our modules are loaded after the translation file is loaded. This means that it's impossible for our modules to modify the translation file for our own translations. 

This PR delays the call to `load_plugin_textdomain` after the modules are loaded, allowing them to filter the translation file loaded.