### PR TITLE
Merge instead of overriding locales for translations updates

### DIFF
--- a/admin/admin-filters.php
+++ b/admin/admin-filters.php
@@ -174,15 +174,15 @@ class PLL_Admin_Filters extends PLL_Filters {
 	}
 
 	/**
-	 * Allows to update translations files for plugins and themes
+	 * Allows to update translations files for plugins and themes.
 	 *
 	 * @since 1.6
 	 *
-	 * @param array $locales Not used
-	 * @return array list of locales to update
+	 * @param array $locales List of locales to update for plugins and themes.
+	 * @return array
 	 */
 	public function update_check_locales( $locales ) {
-		return $this->model->get_languages_list( array( 'fields' => 'locale' ) );
+		return array_merge( $locales, $this->model->get_languages_list( array( 'fields' => 'locale' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
The method `update_check_locales` hooked to `plugins_update_check_locales` and `themes_update_check_locales` completely overrides the locales passed to these filters. There is a risk to loose the locales if they are not in our languages list.

This PR keeps the locales passed and adds our own locales to the list instead of overriding the values.