### PR TITLE
Yoast SEO: Fix indexables

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -405,27 +405,33 @@ class PLL_WPSEO {
 	public function frontend_presentation( $presentation ) {
 		if ( is_front_page() ) {
 			$presentation->model->permalink = pll_home_url();
+			$presentation->model->title = WPSEO_Options::get( 'title-home-wpseo' );
+			$presentation->model->description = WPSEO_Options::get( 'title-home-wpseo' );
 		}
 
-		if ( is_post_type_archive() ) {
-			$presentation->model->permalink = get_post_type_archive_link( get_post_type() );
-		}
+		switch ( $presentation->model->object_type ) {
+			case 'post-type-archive':
+				$presentation->model->permalink = get_post_type_archive_link( $presentation->model->object_sub_type );
+				$presentation->model->title = WPSEO_Options::get( 'title-ptarchive-' . $presentation->model->object_sub_type );
+				$presentation->model->description = WPSEO_Options::get( 'metadesc-ptarchive-' . $presentation->model->object_sub_type );
+				break;
 
-		$strings = array(
-			'title',
-			'description',
-			'breadcrumb_title',
-		);
+			case 'user':
+				$presentation->model->permalink = get_author_posts_url( $presentation->model->object_id );
+				break;
 
-		foreach ( $strings as $string ) {
-			$presentation->model->$string = pll__( $presentation->model->$string );
+			case 'system-page':
+				if ( '404' === $presentation->model->object_sub_type ) {
+					$presentation->model->title = WPSEO_Options::get( 'title-404-wpseo' );
+				}
+				break;
 		}
 
 		return $presentation;
 	}
 
 	/**
-	 * Fixes the breadcrumb homepage link stored in the indexable table since Yoast SEO 14.0
+	 * Fixes the breadcrumb links and strings stored in the indexable table since Yoast SEO 14.0
 	 *
 	 * @since 2.8.3
 	 *
@@ -434,8 +440,16 @@ class PLL_WPSEO {
 	 */
 	public function breadcrumb_indexables( $indexables ) {
 		foreach ( $indexables as &$indexable ) {
-			if ( 'home-page' === $indexable->object_type ) {
-				$indexable->permalink = pll_home_url();
+			switch ( $indexable->object_type ) {
+				case 'home-page':
+					$indexable->permalink = pll_home_url();
+					$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
+					break;
+
+				case 'post-type-archive':
+					$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
+					$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type ) );
+					break;
 			}
 		}
 

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -403,13 +403,13 @@ class PLL_WPSEO {
 	 * @return object
 	 */
 	public function frontend_presentation( $presentation ) {
-		if ( is_front_page() ) {
-			$presentation->model->permalink = pll_home_url();
-			$presentation->model->title = WPSEO_Options::get( 'title-home-wpseo' );
-			$presentation->model->description = WPSEO_Options::get( 'title-home-wpseo' );
-		}
-
 		switch ( $presentation->model->object_type ) {
+			case 'home-page':
+				$presentation->model->permalink = pll_home_url();
+				$presentation->model->title = WPSEO_Options::get( 'title-home-wpseo' );
+				$presentation->model->description = WPSEO_Options::get( 'title-home-wpseo' );
+				break;
+
 			case 'post-type-archive':
 				$presentation->model->permalink = get_post_type_archive_link( $presentation->model->object_sub_type );
 				$presentation->model->title = WPSEO_Options::get( 'title-ptarchive-' . $presentation->model->object_sub_type );

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -45,6 +45,7 @@ class PLL_WPSEO {
 			}
 			add_filter( 'wpseo_canonical', array( $this, 'wpseo_canonical' ) );
 			add_filter( 'wpseo_frontend_presentation', array( $this, 'frontend_presentation' ) );
+			add_filter( 'wpseo_breadcrumb_indexables', array( $this, 'breadcrumb_indexables' ) );
 		} else {
 			add_action( 'admin_init', array( $this, 'wpseo_register_strings' ) );
 
@@ -423,6 +424,23 @@ class PLL_WPSEO {
 		return $presentation;
 	}
 
+	/**
+	 * Fixes the breadcrumb homepage link stored in the indexable table since Yoast SEO 14.0
+	 *
+	 * @since 2.8.3
+	 *
+	 * @param array $indexables An array of Indexable objects.
+	 * @return object
+	 */
+	public function breadcrumb_indexables( $indexables ) {
+		foreach ( $indexables as &$indexable ) {
+			if ( 'home-page' === $indexable->object_type ) {
+				$indexable->permalink = pll_home_url();
+			}
+		}
+
+		return $indexables;
+	}
 
 	/**
 	 * Helper function to register strings for custom post types and custom taxonomies titles and meta descriptions


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/681

Since the version 14.0, Yoast SEO often gets the home url directly from the `yoast_indexable table`, thus bypassing the `home_url` filter. We worked around this in #564. 

However, the filter `wpseo_frontend_presentation` has no effect to the breadcrumbs. This PR uses the filter `wpseo_breadcrumb_indexables` to fix this specific case for the homepage and the post type archive link (visible when viewing a single post).

Also the PR reviews the ways the titles and descriptions are translated. Indeed, the previous method attempted to translate the value passed to the filter `wpseo_frontend_presentation` which could already be a translated string instead of the original string, making the translation mechanism inefficient. So we restart from the source string stored in options instead.

Finally, the PR also fixes the author archive link.