### PR TITLE
Check if page_for_post is not false before assign it

### DIFF
--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -75,7 +75,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 */
 	public function translate_page_on_front( $v ) {
 		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache
-		return isset( $this->curlang->page_on_front ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_on_front : $v;
+		return isset( $this->curlang->page_on_front ) && ( $this->curlang->page_on_front ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_on_front : $v;
 	}
 
 	/**

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -103,7 +103,7 @@ class PLL_Static_Pages {
 	 */
 	public function translate_page_for_posts( $v ) {
 		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache
-		return isset( $this->curlang->page_for_posts ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_for_posts : $v;
+		return isset( $this->curlang->page_for_posts ) && ( $this->curlang->page_for_posts ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_for_posts : $v;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -312,6 +312,42 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
 	}
 
+	function test_untranslated_page_for_posts_2() {
+		wp_delete_post( self::$posts_fr, true );
+
+		$en = $this->factory->post->create(
+			array(
+				'post_title' => 'english post',
+				'post_type'  => 'post',
+			)
+		);
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		$page_en = $en = $this->factory->post->create(
+			array(
+				'post_title' => 'page en',
+				'post_type'  => 'page',
+			)
+		);
+		self::$polylang->model->post->set_language( $en, 'en' );
+		$page_fr = $fr = $this->factory->post->create(
+			array(
+				'post_title' => 'page fr',
+				'post_type'  => 'page',
+			)
+		);
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+		wp_delete_post( $page_fr, true );
+
+		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->go_to( home_url( '/en/posts/' ) );
+
+		$this->assertEquals( array(), $GLOBALS['wp_query']->posts );
+	}
+
+
 	function test_paged_page_for_posts() {
 		update_option( 'posts_per_page', 2 ); // to avoid creating too much posts
 

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -312,25 +312,6 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
 	}
 
-	function test_get_option_return() {
-		wp_delete_post( self::$posts_fr, true );
-
-		update_option( 'page_for_posts', self::$posts_en );
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-
-		add_filter( 'option_page_for_posts', array( self::$polylang->static_pages, 'translate_page_for_posts' ) );
-
-		$page_for_posts_fr = self::$polylang->model->post->get( get_option( 'page_for_posts' ), 'fr' );
-		$page_for_posts_en = self::$polylang->model->post->get( get_option( 'page_for_posts' ), 'en' );
-
-		$this->assertEquals( self::$posts_en, $page_for_posts_en );
-		$this->assertFalse( $page_for_posts_fr );
-	}
-
-
 	function test_paged_page_for_posts() {
 		update_option( 'posts_per_page', 2 ); // to avoid creating too much posts
 

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -312,38 +312,22 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
 	}
 
-	function test_untranslated_page_for_posts_2() {
+	function test_get_option_return() {
 		wp_delete_post( self::$posts_fr, true );
 
-		self::$polylang->model->clean_languages_cache();
+		update_option( 'page_for_posts', self::$posts_en );
+		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+		self::$polylang->init();
 
-		$en = $this->factory->post->create(
-			array(
-				'post_title' => 'english post',
-				'post_type'  => 'post',
-			)
-		);
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
-		$page_en = $en = $this->factory->post->create(
-			array(
-				'post_title' => 'page en',
-				'post_type'  => 'page',
-			)
-		);
-		self::$polylang->model->post->set_language( $en, 'en' );
-		$page_fr = $fr = $this->factory->post->create(
-			array(
-				'post_title' => 'page fr',
-				'post_type'  => 'page',
-			)
-		);
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		add_filter( 'option_page_for_posts', array( self::$polylang->static_pages, 'translate_page_for_posts' ) );
 
-		wp_delete_post( $page_fr, true );
+		$page_for_posts_fr = self::$polylang->model->post->get( get_option( 'page_for_posts' ), 'fr' );
+		$page_for_posts_en = self::$polylang->model->post->get( get_option( 'page_for_posts' ), 'en' );
 
-		$this->assertEquals( self::$posts_en, self::$polylang->model->get_language( 'en' )->page_for_posts );
+		$this->assertEquals( self::$posts_en, $page_for_posts_en );
+		$this->assertFalse( $page_for_posts_fr );
 	}
 
 

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -315,6 +315,8 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_untranslated_page_for_posts_2() {
 		wp_delete_post( self::$posts_fr, true );
 
+		self::$polylang->model->clean_languages_cache();
+
 		$en = $this->factory->post->create(
 			array(
 				'post_title' => 'english post',
@@ -341,10 +343,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 
 		wp_delete_post( $page_fr, true );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
-		$this->go_to( home_url( '/en/posts/' ) );
-
-		$this->assertEquals( array(), $GLOBALS['wp_query']->posts );
+		$this->assertEquals( self::$posts_en, self::$polylang->model->get_language( 'en' )->page_for_posts );
 	}
 
 

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -1,72 +1,73 @@
 <?php
 
 class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
-	static $posts_en, $posts_fr;
-	public $structure = '/%postname%/';
-
 
 	static function wpSetUpBeforeClass() {
 		parent::wpSetUpBeforeClass();
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
-
-		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
-
-		// page for posts
-		self::$posts_en = $en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		self::$posts_fr = $fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
 	}
 
 	function setUp() {
 		parent::setUp();
 
-		global $wp_rewrite;
-
-		// switch to pretty permalinks
-		$wp_rewrite->init();
-		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
-		$wp_rewrite->set_permalink_structure( $this->structure );
-
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
-
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_for_posts', self::$posts_en );
 
-		// go to frontend
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
+		self::$polylang->static_pages = new PLL_Static_Pages( self::$polylang );
 	}
 
 	public function test_translate_page_for_posts_on_default_language() {
+		// page for posts
+		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		$fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+
+		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+		update_option( 'page_for_posts', $en );
+
+
 		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
 
 		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
 
-		$this->assertEquals(self::$posts_en, $return );
+		$this->assertEquals( $en, $return );
 	}
 
 	public function test_translate_page_for_posts_on_secondary_language() {
+		// page for posts
+		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		$fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+
+		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+		update_option( 'page_for_posts', $en );
+
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
 		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
 
-		$this->assertEquals(self::$posts_fr, $return );
+		$this->assertEquals( $fr, $return );
 
 	}
 
 	public function test_translate_page_for_posts_when_page_for_posts_has_no_translations() {
-		wp_delete_post( self::$posts_fr, true );
+		// page for posts
+		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		update_option( 'page_for_posts', $en );
+
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 
 		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
 
-		$this->assertEquals(self::$posts_en, $return );
+		$this->assertEquals( $en, $return );
 	}
 }

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -1,0 +1,72 @@
+<?php
+
+class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
+	static $posts_en, $posts_fr;
+	public $structure = '/%postname%/';
+
+
+	static function wpSetUpBeforeClass() {
+		parent::wpSetUpBeforeClass();
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+
+		require_once POLYLANG_DIR . '/include/api.php';
+		$GLOBALS['polylang'] = &self::$polylang;
+
+		// page for posts
+		self::$posts_en = $en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		self::$posts_fr = $fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( $fr, 'fr' );
+
+		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		global $wp_rewrite;
+
+		// switch to pretty permalinks
+		$wp_rewrite->init();
+		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->set_permalink_structure( $this->structure );
+
+		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', self::$posts_en );
+
+		// go to frontend
+		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+		self::$polylang->init();
+	}
+
+	public function test_translate_page_for_posts_on_default_language() {
+		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+
+		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+
+		$this->assertEquals(self::$posts_en, $return );
+	}
+
+	public function test_translate_page_for_posts_on_secondary_language() {
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+
+		$this->assertEquals(self::$posts_fr, $return );
+
+	}
+
+	public function test_translate_page_for_posts_when_page_for_posts_has_no_translations() {
+		wp_delete_post( self::$posts_fr, true );
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+
+		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+
+		$this->assertEquals(self::$posts_en, $return );
+	}
+}

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -2,8 +2,8 @@
 
 class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
@@ -18,7 +18,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_translate_page_for_posts_on_default_language() {
-		// page for posts
+		// Pages for posts.
 		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
@@ -38,7 +38,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_translate_page_for_posts_on_secondary_language() {
-		// page for posts
+		// Pages for posts.
 		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$polylang->model->post->set_language( $en, 'en' );
 
@@ -58,7 +58,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_translate_page_for_posts_when_page_for_posts_has_no_translations() {
-		// page for posts
+		// Only one page for posts.
 		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$polylang->model->post->set_language( $en, 'en' );
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/656

This function checks if we have a data set in the current language `$this->curlang->page_for_posts` and if so, returns it.

In the case tested for the issue, the function did an `isset` on the property `$this->curlang->page_for_posts` which was indeed set, but was `false`.
_(because the secondary language doesn't have a blog page translation, the tested case was to not translate the blog page on the secondary language)._

So now we check that it also has a value different from false before returning it for `page_for_posts`.


Edit (stack trace debug break point PhpStorm) :

```
static-pages.php:108, PLL_Admin_Static_Pages->translate_page_for_posts()
class-wp-hook.php:289, WP_Hook->apply_filters()
plugin.php:206, apply_filters()
option.php:178, get_option()
static-pages.php:90, PLL_Static_Pages::pll_languages_list()
class-wp-hook.php:287, WP_Hook->apply_filters()
plugin.php:206, apply_filters()
model.php:89, PLL_Model->get_languages_list()
model.php:176, PLL_Model->get_language()
model.php:172, PLL_Model->get_language()
translated-post.php:68, PLL_Translated_Post->get_language()
crud-posts.php:82, PLL_CRUD_Posts->save_post()
class-wp-hook.php:289, WP_Hook->apply_filters()
class-wp-hook.php:311, WP_Hook->do_action()
plugin.php:478, do_action()
post.php:4296, wp_insert_post()
post.php:4390, wp_update_post()
post.php:3213, wp_trash_post()
post.php:260, {main}()
```

