### PR TITLE
Improve how WP functions are checked

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -22,12 +22,13 @@ if ( ! defined( 'DIR_TESTROOT' ) ) {
 if ( ! defined( 'PLL_TEST_DATA_DIR' ) ) {
 	define( 'PLL_TEST_DATA_DIR', dirname( __FILE__ ) . '/../data/' );
 }
-require_once dirname( __FILE__ ) . '/testcase-trait.php';
-require_once dirname( __FILE__ ) . '/testcase.php';
-require_once dirname( __FILE__ ) . '/testcase-ajax.php';
-require_once dirname( __FILE__ ) . '/testcase-canonical.php';
-require_once dirname( __FILE__ ) . '/testcase-domain.php';
-require_once dirname( __FILE__ ) . '/wp-screen-mock.php';
+require_once __DIR__ . '/testcase-trait.php';
+require_once __DIR__ . '/testcase.php';
+require_once __DIR__ . '/testcase-ajax.php';
+require_once __DIR__ . '/testcase-canonical.php';
+require_once __DIR__ . '/testcase-domain.php';
+require_once __DIR__ . '/wp-screen-mock.php';
+require_once __DIR__ . '/check-wp-functions-trait.php';
 
 printf(
 	'Testing Polylang%1$s %2$s with WordPress %3$s...' . PHP_EOL,

--- a/tests/phpunit/includes/check-wp-functions-trait.php
+++ b/tests/phpunit/includes/check-wp-functions-trait.php
@@ -1,0 +1,34 @@
+<?php
+
+Trait PLL_Check_WP_Functions_Trait {
+	protected function md5( ...$args ) {
+		if ( empty( $args[1] ) ) {
+			// We got a function.
+			$reflection = new ReflectionFunction( $args[0] );
+		} else {
+			$reflection = new ReflectionMethod( $args[0], $args[1] );
+		}
+		$filename = $reflection->getFileName();
+		$start_line = $reflection->getStartLine() - 1; // It's actually - 1, otherwise you wont get the function() block.
+		$end_line = $reflection->getEndLine();
+		$length = $end_line - $start_line;
+
+		$source = file( $filename );
+		$body = implode( '', array_slice( $source, $start_line, $length ) );
+		return md5( $body );
+	}
+
+	/**
+	 * Checks if a WordPress function has been modified.
+	 *
+	 * @param string $md5     Expected method md5.
+	 * @param string $version Minimum WordPress function to pass the test.
+	 * @param string ...$args Function name or class and method name.
+	 */
+	protected function check_method( $md5, $version, ...$args ) {
+		if ( version_compare( $GLOBALS['wp_version'], $version, '<' ) ) {
+			$this->markTestSkipped( "This test requires WordPress version {$version} or higher" );
+		}
+		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
+	}
+}

--- a/tests/phpunit/includes/check-wp-functions-trait.php
+++ b/tests/phpunit/includes/check-wp-functions-trait.php
@@ -26,7 +26,11 @@ Trait PLL_Check_WP_Functions_Trait {
 	 * @param string ...$args Function name or class and method name.
 	 */
 	protected function check_method( $md5, $version, ...$args ) {
-		if ( version_compare( $GLOBALS['wp_version'], $version, '<' ) ) {
+		// Keep only the main part of the WP version (removing alpha, beta or rc).
+		$parts = explode( '-', $GLOBALS['wp_version'] );
+		$wp_version = $parts[0];
+
+		if ( version_compare( $wp_version, $version, '<' ) ) {
 			$this->markTestSkipped( "This test requires WordPress version {$version} or higher" );
 		}
 		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );

--- a/tests/phpunit/includes/check-wp-functions-trait.php
+++ b/tests/phpunit/includes/check-wp-functions-trait.php
@@ -1,6 +1,6 @@
 <?php
 
-Trait PLL_Check_WP_Functions_Trait {
+trait PLL_Check_WP_Functions_Trait {
 	protected function md5( ...$args ) {
 		if ( empty( $args[1] ) ) {
 			// We got a function.

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -1,37 +1,7 @@
 <?php
 
 class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
-
-	protected function md5( ...$args ) {
-		if ( empty( $args[1] ) ) {
-			// We got a function.
-			$reflection = new ReflectionFunction( $args[0] );
-		} else {
-			$reflection = new ReflectionMethod( $args[0], $args[1] );
-		}
-		$filename = $reflection->getFileName();
-		$start_line = $reflection->getStartLine() - 1; // It's actually - 1, otherwise you wont get the function() block.
-		$end_line = $reflection->getEndLine();
-		$length = $end_line - $start_line;
-
-		$source = file( $filename );
-		$body = implode( '', array_slice( $source, $start_line, $length ) );
-		return md5( $body );
-	}
-
-	/**
-	 * Checks if a WordPress function has been modified.
-	 *
-	 * @param string $md5     Expected method md5.
-	 * @param string $version Minimum WordPress function to pass the test.
-	 * @param string ...$args Function name or class and method name.
-	 */
-	protected function check_method( $md5, $version, ...$args ) {
-		if ( version_compare( $GLOBALS['wp_version'], $version, '<' ) ) {
-			$this->markTestSkipped( "This test requires WordPress version {$version} or higher" );
-		}
-		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
-	}
+	use PLL_Check_WP_Functions_Trait;
 
 	public function test_calendar_widget() {
 		$this->check_method( 'f75a2c70d28b1d2c4e3e8fd86a8bb7d3', '5.4', 'WP_Widget_Calendar', 'widget' );


### PR DESCRIPTION
This PR adds two improvements for our phpunit tests:
1. It moves the methods to check if WP functions have been modified to a trait, to allow re-usability (with Polylang Pro in mind).
2. It allows to check functions during the WP development without including `alpha`, `beta` in the version passed to `check_method()`. 
For example, it allows to call:
```php
$this->check_method( '824f95fb45ff39f0a42556f93c259d3d', '5.6', 'get_comment_delimited_block_content' );
``` 
if the function has been modified during the development of WP 5.6 while we must currently use:
```php
$this->check_method( '824f95fb45ff39f0a42556f93c259d3d', '5.6-alpha', 'get_comment_delimited_block_content' );`
```