### PR TITLE
VIPWPCS 2.2

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -25,7 +25,7 @@ class PLL_Admin_Classic_Editor {
 		$this->pref_lang = &$polylang->pref_lang;
 
 		// Adds the Languages box in the 'Edit Post' and 'Edit Page' panels
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
 
 		// Ajax response for changing the language in the post metabox
 		add_action( 'wp_ajax_post_lang_choice', array( $this, 'post_lang_choice' ) );
@@ -44,9 +44,8 @@ class PLL_Admin_Classic_Editor {
 	 * @since 0.1
 	 *
 	 * @param string $post_type Current post type
-	 * @param object $post      Current post
 	 */
-	public function add_meta_boxes( $post_type, $post ) {
+	public function add_meta_boxes( $post_type ) {
 		if ( $this->model->is_translated_post_type( $post_type ) ) {
 			add_meta_box(
 				'ml_box',
@@ -71,7 +70,7 @@ class PLL_Admin_Classic_Editor {
 		global $post_ID;
 		$post_type = get_post_type( $post_ID );
 
-		// phpcs:ignore WordPress.Security.NonceVerification, WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$from_post_id = isset( $_GET['from_post'] ) ? (int) $_GET['from_post'] : 0;
 
 		$lang = ( $lg = $this->model->post->get_language( $post_ID ) ) ? $lg :

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -36,8 +36,8 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		// Quick edit and bulk edit.
-		add_filter( 'quick_edit_custom_box', array( $this, 'quick_edit_custom_box' ), 10, 2 );
-		add_filter( 'bulk_edit_custom_box', array( $this, 'quick_edit_custom_box' ), 10, 2 );
+		add_filter( 'quick_edit_custom_box', array( $this, 'quick_edit_custom_box' ) );
+		add_filter( 'bulk_edit_custom_box', array( $this, 'quick_edit_custom_box' ) );
 
 		// Adds the language column in the 'Categories' and 'Post Tags' tables.
 		foreach ( $this->model->get_translated_taxonomies() as $tax ) {
@@ -185,10 +185,9 @@ class PLL_Admin_Filters_Columns {
 	 * @since 0.9
 	 *
 	 * @param string $column column name
-	 * @param string $type either 'edit-tags' for terms list table or post type for posts list table
 	 * @return string unmodified $column
 	 */
-	public function quick_edit_custom_box( $column, $type ) {
+	public function quick_edit_custom_box( $column ) {
 		if ( $column == $this->get_first_language_column() ) {
 
 			$elements = $this->model->get_languages_list();

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -137,7 +137,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		$term_id  = $tag->term_id;
-		$taxonomy = $tag->taxonomy; // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		$taxonomy = $tag->taxonomy; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 		$lang = $this->model->term->get_language( $term_id );
 		$lang = empty( $lang ) ? $this->pref_lang : $lang;
@@ -443,8 +443,8 @@ class PLL_Admin_Filters_Term {
 		}
 
 		$lang      = $this->model->get_language( sanitize_key( $_POST['lang'] ) );
-		$term_id   = isset( $_POST['term_id'] ) ? (int) $_POST['term_id'] : null; // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
-		$taxonomy  = sanitize_key( $_POST['taxonomy'] ); // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		$term_id   = isset( $_POST['term_id'] ) ? (int) $_POST['term_id'] : null; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$taxonomy  = sanitize_key( $_POST['taxonomy'] );
 		$post_type = sanitize_key( $_POST['post_type'] );
 
 		if ( ! post_type_exists( $post_type ) || ! taxonomy_exists( $taxonomy ) ) {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"phpunit/phpunit": "^5",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"wp-coding-standards/wpcs": "*",
-		"automattic/vipwpcs": "~2.1.0",
+		"automattic/vipwpcs": "*",
 		"phpcompatibility/phpcompatibility-wp": "*"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15032865f527ea9aceb4d95159e15f0e",
+    "content-hash": "8f3ebd10b0f175c3a830e88b13452e18",
     "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "03e75ddd0261b675dece60fb67fc2e9c6af4ad35"
+                "reference": "4d0612461232b313d06321f1501c3989bd6aecf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/03e75ddd0261b675dece60fb67fc2e9c6af4ad35",
-                "reference": "03e75ddd0261b675dece60fb67fc2e9c6af4ad35",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/4d0612461232b313d06321f1501c3989bd6aecf9",
+                "reference": "4d0612461232b313d06321f1501c3989bd6aecf9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.8.3",
                 "squizlabs/php_codesniffer": "^3.5.5",
                 "wp-coding-standards/wpcs": "^2.3"
             },
@@ -51,7 +52,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2020-07-07T07:48:04+00:00"
+            "time": "2020-09-07T10:45:45+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1493,6 +1494,54 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "00b4fa3130faa26762c929989e3d958086c627f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/00b4fa3130faa26762c929989e3d958086c627f1",
+                "reference": "00b4fa3130faa26762c929989e3d958086c627f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+                "sirbrillig/phpcs-import-detection": "^1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "time": "2020-07-11T23:32:06+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.5.6",
             "source": {
@@ -1621,16 +1670,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.44",
+            "version": "v3.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4152e36b0f305c2a57aa0233dee56ec27bca4f06"
+                "reference": "ec3c2ac4d881a4684c1f0317d2107f1a4152bad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4152e36b0f305c2a57aa0233dee56ec27bca4f06",
-                "reference": "4152e36b0f305c2a57aa0233dee56ec27bca4f06",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ec3c2ac4d881a4684c1f0317d2107f1a4152bad9",
+                "reference": "ec3c2ac4d881a4684c1f0317d2107f1a4152bad9",
                 "shasum": ""
             },
             "require": {
@@ -1690,7 +1739,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-26T06:32:27+00:00"
+            "time": "2020-09-18T15:58:55+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -34,7 +34,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		add_filter( 'getarchives_where', array( $this, 'getarchives_where' ), 10, 2 );
 
 		// Filters the widgets according to the current language
-		add_filter( 'widget_display_callback', array( $this, 'widget_display_callback' ), 10, 2 );
+		add_filter( 'widget_display_callback', array( $this, 'widget_display_callback' ) );
 		add_filter( 'sidebars_widgets', array( $this, 'sidebars_widgets' ) );
 
 		if ( $this->options['media_support'] ) {
@@ -67,10 +67,9 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 *
 	 * @since 0.1
 	 *
-	 * @param string $locale
 	 * @return string
 	 */
-	public function get_locale( $locale ) {
+	public function get_locale() {
 		return $this->curlang->locale;
 	}
 
@@ -144,11 +143,10 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 *
 	 * @since 0.3
 	 *
-	 * @param array  $instance Widget settings
-	 * @param object $widget   WP_Widget object
+	 * @param array $instance Widget settings
 	 * @return bool|array false if we hide the widget, unmodified $instance otherwise
 	 */
-	public function widget_display_callback( $instance, $widget ) {
+	public function widget_display_callback( $instance ) {
 		// FIXME it looks like this filter is useless, now the we use the filter sidebars_widgets
 		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] != $this->curlang->slug ? false : $instance;
 	}

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -27,7 +27,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 		add_action( 'pll_home_requested', array( $this, 'pll_home_requested' ) );
 
 		// Manages the redirection of the homepage
-		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ), 10, 2 );
+		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
 
 		add_filter( 'pll_pre_translation_url', array( $this, 'pll_pre_translation_url' ), 10, 3 );
 		add_filter( 'pll_check_canonical_url', array( $this, 'pll_check_canonical_url' ) );
@@ -84,10 +84,9 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 * @since 0.1
 	 *
 	 * @param string $redirect_url
-	 * @param string $requested_url
 	 * @return bool|string modified url, false if redirection is canceled
 	 */
-	public function redirect_canonical( $redirect_url, $requested_url ) {
+	public function redirect_canonical( $redirect_url ) {
 		global $wp_query;
 		if ( is_page() && ! is_feed() && isset( $wp_query->queried_object ) && $wp_query->queried_object->ID == $this->curlang->page_on_front ) {
 			$url = is_paged() ? $this->links_model->add_paged_to_link( $this->links->get_home_url(), $wp_query->query_vars['page'] ) : $this->links->get_home_url();

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -237,7 +237,7 @@ class Polylang {
 			require_once __DIR__ . '/api.php'; // Loads the API
 
 			// Loads the modules.
-			foreach ( glob( POLYLANG_DIR . '/modules/*/load.php', GLOB_NOSORT ) as $load_script ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+			foreach ( glob( POLYLANG_DIR . '/modules/*/load.php', GLOB_NOSORT ) as $load_script ) {
 				require_once $load_script; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 			}
 

--- a/include/filters-sanitization.php
+++ b/include/filters-sanitization.php
@@ -41,10 +41,9 @@ class PLL_Filters_Sanitization {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $locale
 	 * @return string
 	 */
-	public function get_locale( $locale ) {
+	public function get_locale() {
 		return $this->locale;
 	}
 

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -139,16 +139,14 @@ class PLL_OLT_Manager {
 
 	/**
 	 * FIXME: Backward compatibility with Polylang for WooCommerce < 0.3.4
-	 * To remove in Polylang 2.1
+	 * Was formerly hooked to the filter 'override_load_textdomain'
 	 *
 	 * @since 0.1
 	 *
-	 * @param bool   $bool   not used
-	 * @param string $domain text domain name
-	 * @param string $mofile translation file name
+	 * @param bool $bool Whether to override the .mo file loading.
 	 * @return bool
 	 */
-	public function mofile( $bool, $domain, $mofile ) {
+	public function mofile( $bool ) {
 		return $bool;
 	}
 

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -22,7 +22,7 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @param array  $args              An array of additional arguments.
 	 * @param int    $current_object_id ID of the current item.
 	 */
-	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value = $args['value'];
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -22,7 +22,7 @@ class PLL_Walker_List extends Walker {
 	 * @param array  $args              An array of additional arguments.
 	 * @param int    $current_object_id ID of the current item.
 	 */
-	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$output .= sprintf(
 			'%6$s<li class="%1$s"><a lang="%2$s" hreflang="%2$s" href="%3$s">%4$s%5$s</a></li>%7$s',
 			esc_attr( implode( ' ', $element->classes ) ),

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -66,7 +66,7 @@ class PLL_Widget_Languages extends WP_Widget {
 	 * @param array $old_instance Old settings for this instance
 	 * @return array Settings to save or bool false to cancel saving
 	 */
-	public function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$instance = array( 'title' => sanitize_text_field( $new_instance['title'] ) );
 		foreach ( array_keys( PLL_Switcher::get_switcher_options( 'widget' ) ) as $key ) {
 			$instance[ $key ] = ! empty( $new_instance[ $key ] ) ? 1 : 0;

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -25,7 +25,7 @@ class PLL_Integrations {
 	 */
 	protected function __construct() {
 		// Loads external integrations.
-		foreach ( glob( __DIR__ . '/*/load.php', GLOB_NOSORT ) as $load_script ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		foreach ( glob( __DIR__ . '/*/load.php', GLOB_NOSORT ) as $load_script ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 			require_once $load_script; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		}
 	}

--- a/integrations/jetpack/jetpack.php
+++ b/integrations/jetpack/jetpack.php
@@ -16,8 +16,8 @@ class PLL_Jetpack {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'jetpack_init' ) );
-		add_action( 'jetpack_widget_get_top_posts', array( $this, 'jetpack_widget_get_top_posts' ), 10, 3 );
-		add_filter( 'grunion_contact_form_field_html', array( $this, 'grunion_contact_form_field_html_filter' ), 10, 3 );
+		add_action( 'jetpack_widget_get_top_posts', array( $this, 'jetpack_widget_get_top_posts' ) );
+		add_filter( 'grunion_contact_form_field_html', array( $this, 'grunion_contact_form_field_html_filter' ), 10, 2 );
 		add_filter( 'jetpack_open_graph_tags', array( $this, 'jetpack_ogp' ) );
 		add_filter( 'jetpack_relatedposts_filter_filters', array( $this, 'jetpack_relatedposts_filter_filters' ), 10, 2 );
 
@@ -50,12 +50,10 @@ class PLL_Jetpack {
 	 *
 	 * @since 1.5.4
 	 *
-	 * @param array  $posts    Array of the most popular posts.
-	 * @param array  $post_ids Array of Post IDs.
-	 * @param string $count    Number of Top Posts we want to display.
+	 * @param array $posts Array of the most popular posts.
 	 * @return array
 	 */
-	public function jetpack_widget_get_top_posts( $posts, $post_ids, $count ) {
+	public function jetpack_widget_get_top_posts( $posts ) {
 		foreach ( $posts as $k => $post ) {
 			if ( pll_current_language() !== pll_get_post_language( $post['post_id'] ) ) {
 				unset( $posts[ $k ] );
@@ -72,12 +70,11 @@ class PLL_Jetpack {
 	 *
 	 * @since 1.5.4
 	 *
-	 * @param string   $r           Contact Form HTML output.
-	 * @param string   $field_label Field label.
-	 * @param int|null $id          Post ID.
+	 * @param string $r           Contact Form HTML output.
+	 * @param string $field_label Field label.
 	 * @return string
 	 */
-	public function grunion_contact_form_field_html_filter( $r, $field_label, $id ) {
+	public function grunion_contact_form_field_html_filter( $r, $field_label ) {
 		if ( function_exists( 'icl_translate' ) ) {
 			if ( pll_current_language() !== pll_default_language() ) {
 				$label_translation = icl_translate( 'jetpack ', $field_label . '_label', $field_label );

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -126,18 +126,16 @@ class PLL_WPML_API {
 
 	/**
 	 * In WPML, get a language's native and translated name for display in a custom language switcher
-	 * Since Polylang does not implement the translated name, always returns only the native name
+	 * Since Polylang does not implement the translated name, always returns only the native name,
+	 * so the 3rd, 4th and 5th parameters are not used.
 	 *
 	 * @since 2.2
 	 *
-	 * @param mixed       $null              Not used.
-	 * @param string      $native_name       The language native name.
-	 * @param string|bool $translated_name   The language translated name. Not used.
-	 * @param bool        $native_hidden     Whether to hide the language native name or not. Not used.
-	 * @param bool        $translated_hidden Whether to hide the language translated name or not. Not used.
+	 * @param mixed  $null        Not used.
+	 * @param string $native_name The language native name.
 	 * @return string
 	 */
-	public function wpml_display_language_names( $null, $native_name, $translated_name = false, $native_hidden = false, $translated_hidden = false ) {
+	public function wpml_display_language_names( $null, $native_name ) {
 		return $native_name;
 	}
 
@@ -172,10 +170,9 @@ class PLL_WPML_API {
 	 *
 	 * @since 2.0
 	 *
-	 * @param mixed $null Not used
 	 * @return bool
 	 */
-	public function wpml_is_rtl( $null ) {
+	public function wpml_is_rtl() {
 		return pll_current_language( 'is_rtl' );
 	}
 

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -243,15 +243,15 @@ if ( ! function_exists( 'icl_register_string' ) ) {
 	/**
 	 * Registers a string for translation in the "strings translation" panel
 	 *
+	 * The 4th and 5th parameters $allow_empty_value and $source_lang are not used by Polylang.
+	 *
 	 * @since 0.9.3
 	 *
 	 * @param string $context           the group in which the string is registered, defaults to 'polylang'
 	 * @param string $name              a unique name for the string
 	 * @param string $string            the string to register
-	 * @param bool   $allow_empty_value not used
-	 * @param string $source_lang       not used by Polylang
 	 */
-	function icl_register_string( $context, $name, $string, $allow_empty_value = false, $source_lang = '' ) {
+	function icl_register_string( $context, $name, $string ) {
 		PLL_WPML_Compat::instance()->register_string( $context, $name, $string );
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -73,6 +73,17 @@
 		</properties>
 	</rule>
 
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable" >
+		<exclude-pattern>load.php</exclude-pattern>
+		<exclude-pattern>/view-*</exclude-pattern>
+	</rule>
+
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" >
+		<properties>
+			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
+		</properties>
+	</rule>
+
 	<rule ref="Generic.Commenting.Fixme.CommentFound" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -74,7 +74,7 @@
 	</rule>
 
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable" >
-		<exclude-pattern>load.php</exclude-pattern>
+		<exclude-pattern>/load.php</exclude-pattern>
 		<exclude-pattern>/view-*</exclude-pattern>
 	</rule>
 

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -216,7 +216,7 @@ class PLL_Settings_Module {
 	 * @param array $options Raw options
 	 * @return array Options
 	 */
-	protected function update( $options ) {
+	protected function update( $options ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return array(); // It's responsibility of the child class to decide what is saved
 	}
 

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -305,7 +305,7 @@ class PLL_Settings extends PLL_Admin_Base {
 		// Handle user input
 		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			// phpcs:ignore WordPress.Security.NonceVerification, WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
 		} else {
 			$this->handle_actions( $action );

--- a/settings/table-settings.php
+++ b/settings/table-settings.php
@@ -186,5 +186,5 @@ class PLL_Table_Settings extends WP_List_Table {
 	 *
 	 * @param string $which 'top' or 'bottom'
 	 */
-	protected function display_tablenav( $which ) {}
+	protected function display_tablenav( $which ) {} // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/651 for Polylang.

The goal of this PR is to follow the move of VIPWPCS 2.2 which replaces `WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable` by `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable` and `WordPressVIPMinimum.Variables.VariableAnalysis.UndefinedVariable` by `VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable`.

Thus it restores the latest version of VIPWPCS in composer.json.
In the config file, it excludes the views and loaders for the undefined variables checks and accepts unused variables before require, include, etc... (NB: this property doesn't seem to work in all cases).

The updated sniff detects more cases of unused variables that are fixed in this PR, mainly in function definitions, but some are ignored, mainly to keep the same method signature between parent and child classes. Cases that were previously ignored with the old sniff have been updated.