### PR TITLE
Fix tests for canonical redirect

### DIFF
--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -38,22 +38,21 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		// Needed by {@see pll_requested_url()}.
 		$_SERVER['REQUEST_URI'] = $test_url;
 
-		$model             = new PLL_Model( $this->options );
-		$links_model       = new PLL_Links_Directory( $model );
-		self::$polylang    = new PLL_Frontend( $links_model );
-		self::$polylang->init();
+		$model = new PLL_Model( $this->options );
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
 		// register post types and taxonomies
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+		$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 
 		// reset the links model according to the permalink structure
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->links_model->init();
+		$links_model    = $model->get_links_model();
+		self::$polylang = new PLL_Frontend( $links_model );
+		self::$polylang->init();
+		do_action_ref_array( 'pll_init', array( self::$polylang ) );
 
 		// flush rules
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -35,6 +35,10 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	public function assertCanonical( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
 		global $wp_rewrite;
 
+		if ( did_action( 'pll_language_defined' ) ) {
+			$this->fail( 'Canonical tests MUST have only one call to PLL_UnitTestCase_Canonical::assertCanonical() per test.' );
+		}
+
 		// Needed by {@see pll_requested_url()}.
 		$_SERVER['REQUEST_URI'] = $test_url;
 

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -11,6 +11,55 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	}
 
 	/**
+	 * Set up the Polylang environment before testing canonical redirects.
+	 *
+	 * @param string $test_url
+	 * @param string $expected
+	 * @param int    $ticket
+	 * @param array  $expected_doing_it_wrong
+	 */
+	public function assertCanonical( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
+		global $wp_rewrite;
+
+		// Needed by {@see pll_requested_url()}.
+		$_SERVER['REQUEST_URI'] = $test_url;
+
+		$options = array_merge(
+			PLL_Install::get_default_options(),
+			array(
+				'default_lang' => 'en',
+				'hide_default' => 0,
+				'post_types' => array(
+					'cpt' => 'cpt', // translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
+				),
+			)
+		);
+		$model = new PLL_Model( $options );
+		$links_model = new PLL_Links_Directory( $model );
+		self::$polylang = new PLL_Frontend( $links_model );
+		self::$polylang->init();
+
+		// switch to pretty permalinks
+		$wp_rewrite->init();
+		$wp_rewrite->set_permalink_structure( $this->structure );
+
+		// register post types and taxonomies
+		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+		create_initial_taxonomies();
+		register_post_type( 'cpt', array( 'public' => true ) ); // add custom post type
+
+		// reset the links model according to the permalink structure
+		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$polylang->links_model->init();
+
+		// flush rules
+		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->flush_rules();
+
+		return parent::assertCanonical( $test_url, $expected, $ticket, $expected_doing_it_wrong );
+	}
+
+	/**
 	 * Parses the canonical url if redirect, by either Polylang and/or WordPress.
 	 *
 	 * The {@see PLL_Frontend_Filters_Links::check_canonical_url()} method is hooked on {@see https://github.com/WordPress/wordpress-develop/blob/505fe2f0b87bba956d399f657f85a7073c978289/src/wp-includes/template-loader.php#L13 template_redirect}, which is not triggered during automated tests.

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -3,11 +3,25 @@
 class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	use PLL_UnitTestCase_Trait;
 
+	private $options;
+
 	public function setUp() {
 		parent::setUp();
 
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.
 		add_filter( 'wp_doing_ajax', '__return_false' );
+
+		$this->options = array_merge(
+			PLL_Install::get_default_options(),
+			array(
+				'default_lang' => 'en',
+				'hide_default' => 0,
+				'post_types'   => array(
+					'cpt' => 'pllcanonical',
+					// translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
+				),
+			)
+		);
 	}
 
 	/**
@@ -24,19 +38,9 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		// Needed by {@see pll_requested_url()}.
 		$_SERVER['REQUEST_URI'] = $test_url;
 
-		$options = array_merge(
-			PLL_Install::get_default_options(),
-			array(
-				'default_lang' => 'en',
-				'hide_default' => 0,
-				'post_types' => array(
-					'cpt' => 'pllcanonical', // translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
-				),
-			)
-		);
-		$model = new PLL_Model( $options );
-		$links_model = new PLL_Links_Directory( $model );
-		self::$polylang = new PLL_Frontend( $links_model );
+		$model             = new PLL_Model( $this->options );
+		$links_model       = new PLL_Links_Directory( $model );
+		self::$polylang    = new PLL_Frontend( $links_model );
 		self::$polylang->init();
 
 		// switch to pretty permalinks

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -30,7 +30,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 				'default_lang' => 'en',
 				'hide_default' => 0,
 				'post_types' => array(
-					'cpt' => 'cpt', // translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
+					'cpt' => 'pllcanonical', // translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
 				),
 			)
 		);
@@ -46,7 +46,6 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		// register post types and taxonomies
 		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
-		register_post_type( 'cpt', array( 'public' => true ) ); // add custom post type
 
 		// reset the links model according to the permalink structure
 		self::$polylang->links_model = self::$polylang->model->get_links_model();

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -14,7 +14,7 @@ trait PLL_UnitTestCase_Trait {
 	/**
 	 * Initialization before all tests run.
 	 */
-	static function wpSetUpBeforeClass() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	static function wpSetUpBeforeClass( $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		self::$polylang = new StdClass();
 
 		self::$polylang->options = PLL_Install::get_default_options();

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -14,7 +14,7 @@ trait PLL_UnitTestCase_Trait {
 	/**
 	 * Initialization before all tests run.
 	 */
-	static function wpSetUpBeforeClass( $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	static function wpSetUpBeforeClass() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		self::$polylang = new StdClass();
 
 		self::$polylang->options = PLL_Install::get_default_options();

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -13,11 +13,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
-	function tearDown() {
-		parent::tearDown();
-
-	}
-
 	public function post_canonical_url_provider() {
 		return array(
 			'post with name and language'  => array(
@@ -191,7 +186,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	/**
-	 * bug introduced in 1.8.2 and fixed in 1.8.3
+	 * Bug introduced in 1.8.2 and fixed in 1.8.3
 	 *
 	 * @dataProvider static_front_page_canonical_url_provider()
 	 *

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -3,8 +3,8 @@
 class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass( $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
+	static function wpSetUpBeforeClass() {
+		parent::wpSetUpBeforeClass();
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -16,7 +16,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	function tearDown() {
 		parent::tearDown();
 
-		_unregister_post_type( 'cpt' );
 	}
 
 	public function post_canonical_url_provider() {
@@ -76,14 +75,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public function custom_post_type_canonical_url_provider() {
 		return array(
 			'custom post type with name and language' => array(
-				'/en/cpt/custom-post/',
+				'/en/pllcanonical/custom-post/',
 				array(
-					'url' => '/en/cpt/custom-post/',
-					'qv'  => array( 'lang' => 'en', 'cpt' => 'custom-post', 'name' => 'custom-post', 'post_type' => 'cpt', 'page' => '' ),
+					'url' => '/en/pllcanonical/custom-post/',
+					'qv'  => array( 'lang' => 'en', 'pllcanonical' => 'custom-post', 'name' => 'custom-post', 'post_type' => 'pllcanonical', 'page' => '' ),
 				),
 			),
-			'custom post type with incorrect language' => array( '/fr/cpt/custom-post/', '/en/cpt/custom-post/' ),
-			'custom post type without language' => array( '/cpt/custom-post/', '/en/cpt/custom-post/' ),
+			'custom post type with incorrect language' => array( '/fr/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' ),
+			'custom post type without language' => array( '/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' ),
 		);
 	}
 
@@ -94,11 +93,21 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	 * @param string|array $expected_url
 	 */
 	function test_cpt( $test_url, $expected_url ) {
-		// custom post type
-		$post_id = $this->factory->post->create( array( 'import_id' => 416, 'post_type' => 'cpt', 'post_title' => 'custom-post' ) );
+		add_action(
+			'registered_taxonomy',
+			function( $taxonomy ) {
+				if ( 'post_format' === $taxonomy && ! post_type_exists( 'pllcanonical' ) ) { // Last taxonomy registered in {@see https://github.com/WordPress/wordpress-develop/blob/36ef9cbca96fca46e7daf1ee687bb6a20788385c/src/wp-includes/taxonomy.php#L158-L174 create_initial_taxonomies()}.
+					register_post_type( 'pllcanonical', array( 'public' => true ) );
+				}
+			}
+		);
+
+		$post_id = $this->factory->post->create( array( 'import_id' => 416, 'post_type' => 'pllcanonical', 'post_title' => 'custom-post' ) );
 		self::$polylang->model->post->set_language( $post_id, 'en' );
 
 		$this->assertCanonical( $test_url, $expected_url );
+
+		_unregister_post_type( 'pllcanonical' );
 	}
 
 	public function category_canonical_url_provider() {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -3,8 +3,8 @@
 class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -166,6 +166,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	 * @param string|array $expected_url
 	 */
 	function test_category( $test_url, $expected_url ) {
+		$this->markTestSkipped( 'Needs fixing, see: https://github.com/polylang/polylang/issues/589' );
 		$term_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$polylang->model->term->set_language( $term_en, 'en' );
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -3,203 +3,190 @@
 class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	private static $post_en;
+	private static $page_id;
+	private static $custom_post_id;
+	private static $term_en;
+	private static $page_for_posts_en;
+	private static $page_for_posts_fr;
+	private static $page_on_front_en;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
 		$GLOBALS['polylang'] = &self::$polylang;
-	}
 
-	public function post_canonical_url_provider() {
-		return array(
-			'post with name and language'  => array(
-				'/en/post-format-test-audio/',
-				array(
-					'url' => '/en/post-format-test-audio/',
-					'qv'  => array( 'lang' => 'en', 'name' => 'post-format-test-audio', 'page' => '' ),
-				),
-			),
-			'post with incorrect language' => array( '/fr/post-format-test-audio/', '/en/post-format-test-audio/' ),
-			'post without language'        => array( '/post-format-test-audio/', '/en/post-format-test-audio/' ),
-		);
-	}
+		self::$post_en = $factory->post->create( array( 'post_title' => 'post-format-test-audio' ) );
+		self::$polylang->model->post->set_language( self::$post_en, 'en' );
 
-	/**
-	 * @dataProvider post_canonical_url_provider
-	 *
-	 * @param string       $test_url
-	 * @param string|array $expected_url
-	 */
-	function test_post( $test_url, $expected_url ) {
-		$post_en = $this->factory->post->create( array( 'post_title' => 'post-format-test-audio' ) );
-		self::$polylang->model->post->set_language( $post_en, 'en' );
+		self::$page_id = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
+		self::$polylang->model->post->set_language( self::$page_id, 'en' );
 
-		$this->assertCanonical( $test_url, $expected_url );
-	}
-
-	public function page_canonical_url_provider() {
-		return array(
-			'page with name and language'  => array(
-				'/en/parent-page/',
-				array(
-					'url' => '/en/parent-page/',
-					'qv'  => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
-				),
-			),
-			'page with incorrect language' => array( '/fr/parent-page/', '/en/parent-page/' ),
-			'page without language' => array( '/parent-page/', '/en/parent-page/' ),
-		);
-	}
-
-	/**
-	 * @dataProvider page_canonical_url_provider
-	 *
-	 * @param string       $test_url
-	 * @param string|array $expected_url
-	 */
-	function test_page( $test_url, $expected_url ) {
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
-
-		$this->assertCanonical( $test_url, $expected_url );
-	}
-
-	public function custom_post_type_canonical_url_provider() {
-		return array(
-			'custom post type with name and language' => array(
-				'/en/pllcanonical/custom-post/',
-				array(
-					'url' => '/en/pllcanonical/custom-post/',
-					'qv'  => array( 'lang' => 'en', 'pllcanonical' => 'custom-post', 'name' => 'custom-post', 'post_type' => 'pllcanonical', 'page' => '' ),
-				),
-			),
-			'custom post type with incorrect language' => array( '/fr/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' ),
-			'custom post type without language' => array( '/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' ),
-		);
-	}
-
-	/**
-	 * @dataProvider custom_post_type_canonical_url_provider
-	 *
-	 * @param string       $test_url
-	 * @param string|array $expected_url
-	 */
-	function test_cpt( $test_url, $expected_url ) {
 		add_action(
 			'registered_taxonomy',
 			function( $taxonomy ) {
-				if ( 'post_format' === $taxonomy && ! post_type_exists( 'pllcanonical' ) ) { // Last taxonomy registered in {@see https://github.com/WordPress/wordpress-develop/blob/36ef9cbca96fca46e7daf1ee687bb6a20788385c/src/wp-includes/taxonomy.php#L158-L174 create_initial_taxonomies()}.
+				if ( 'post_format' === $taxonomy && ! post_type_exists( 'pllcanonical' ) ) { // Last taxonomy registered in {@see https://github.com/WordPress/wordpress-develop/blob/36ef9cbca96fca46e7daf1ee687bb6a20788385c/src/wp-includes/taxonomy.php#L158-L174 create_initial_taxonomies()}
 					register_post_type( 'pllcanonical', array( 'public' => true ) );
 				}
 			}
 		);
 
-		$post_id = $this->factory->post->create( array( 'import_id' => 416, 'post_type' => 'pllcanonical', 'post_title' => 'custom-post' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$custom_post_id = $factory->post->create( array( 'import_id' => 416, 'post_type' => 'pllcanonical', 'post_title' => 'custom-post' ) );
+		self::$polylang->model->post->set_language( self::$custom_post_id, 'en' );
 
-		$this->assertCanonical( $test_url, $expected_url );
+		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
+		self::$polylang->model->term->set_language( self::$term_en, 'en' );
+
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'page' );
+
+		self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( self::$page_for_posts_en, 'en' );
+
+		self::$page_for_posts_fr = $factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		self::$polylang->model->post->set_language( self::$page_for_posts_fr, 'fr' );
+
+		self::$polylang->model->post->save_translations( self::$page_for_posts_en, compact( 'en', 'fr' ) );
+
+		update_option( 'page_for_posts', self::$page_for_posts_fr );
+
+		self::$page_on_front_en = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
+		self::$polylang->model->post->set_language( self::$page_on_front_en, 'en' );
+
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'posts' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::$post_en = null;
+		self::$page_id = null;
+		self::$custom_post_id = null;
+		self::$term_en = null;
+		self::$page_for_posts_en = null;
+		self::$page_for_posts_fr = null;
+		self::$page_on_front_en = null;
 
 		_unregister_post_type( 'pllcanonical' );
 	}
 
-	public function category_canonical_url_provider() {
-		return array(
-			'category with name and language' => array(
-				'/en/category/parent/',
-				array(
-					'url' => '/en/category/parent/',
-					'qv'  => array( 'lang' => 'en', 'category_name' => 'parent' ),
-				),
-			),
-			'category with incorrect language' => array( '/fr/category/parent/', '/en/category/parent/' ),
-			'category without language' => array( '/category/parent/', '/en/category/parent/' ),
+	public function test_post_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/post-format-test-audio/',
+			array(
+				'url' => '/en/post-format-test-audio/',
+				'qv'  => array( 'lang' => 'en', 'name' => 'post-format-test-audio', 'page' => '' ),
+			)
 		);
 	}
 
-	/**
-	 * @dataProvider category_canonical_url_provider
-	 *
-	 * @param string       $test_url
-	 * @param string|array $expected_url
-	 */
-	function test_category( $test_url, $expected_url ) {
-		$term_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
-		self::$polylang->model->term->set_language( $term_en, 'en' );
-
-		$this->assertCanonical( $test_url, $expected_url );
+	public function test_post_with_incorrect_language() {
+		$this->assertCanonical( '/fr/post-format-test-audio/', '/en/post-format-test-audio/' );
 	}
 
-	public function posts_page_canonical_url_provider() {
-		return array(
-			'page for posts with name and language' => array(
-				'/en/posts/',
-				array(
-					'url' => '/en/posts/',
-					'qv'  => array( 'lang' => 'en', 'pagename' => 'posts', 'page' => '' ),
-				),
-			),
-			'page for posts should match page_for_post option when language is incorrect' => array( '/fr/posts/', '/en/posts/' ),
-			'page for should mathc page_for_post option posts without language' => array( '/posts/', '/en/posts/' ),
-			'page_for_post option should be translated when language is incorrect' => array( '/en/articles/', '/fr/articles/' ),
-			'page_for_post option should be translated when no language is set' => array( '/articles/', '/fr/articles/' ),
+	public function test_post_without_language() {
+		$this->assertCanonical( '/post-format-test-audio/', '/en/post-format-test-audio/' );
+	}
+
+	public function test_page_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/parent-page/',
+			array(
+				'url' => '/en/parent-page/',
+				'qv'  => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
+			)
 		);
 	}
 
-	/**
-	 * @dataProvider posts_page_canonical_url_provider
-	 *
-	 * @param string       $test_url
-	 * @param string|array $expected_url
-	 */
-	function test_posts_page( $test_url, $expected_url ) {
-		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
-		update_option( 'show_on_front', 'page' );
-
-		$this->posts_en = $en = $this->factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
-
-		$this->posts_fr = $fr = $this->factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
-
-		update_option( 'page_for_posts', $fr );
-
-		$this->assertCanonical( $test_url, $expected_url );
+	public function test_page_with_incorrect_language() {
+		$this->assertCanonical( '/fr/parent-page/', '/en/parent-page/' );
 	}
 
-	public function static_front_page_canonical_url_provider() {
-		return array(
-			'static front page with name and language' => array(
-				'/en/parent-page/',
-				array(
-					'url' => '/en/parent-page/',
-					'qv'  => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
-				),
-			),
-			'static front page with incorrect language' => array( '/fr/parent-page/', '/en/parent-page/' ),
-			'static front page without language' => array( '/parent-page/', '/en/parent-page/' ),
+	public function test_page_without_language() {
+		$this->assertCanonical( '/parent-page/', '/en/parent-page/' );
+	}
+
+	public function test_custom_post_type_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/pllcanonical/custom-post/',
+			array(
+				'url' => '/en/pllcanonical/custom-post/',
+				'qv'  => array( 'lang' => 'en', 'pllcanonical' => 'custom-post', 'name' => 'custom-post', 'post_type' => 'pllcanonical', 'page' => '' ),
+			)
 		);
 	}
 
-	/**
-	 * Bug introduced in 1.8.2 and fixed in 1.8.3
-	 *
-	 * @dataProvider static_front_page_canonical_url_provider()
-	 *
-	 * @param string       $test_url
-	 * @param string|array $expected_url
-	 */
-	function test_page_when_static_front_page_displays_posts( $test_url, $expected_url ) {
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+	public function test_custom_post_type_with_incorrect_language() {
+		$this->assertCanonical( '/fr/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' );
+	}
 
-		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
-		update_option( 'show_on_front', 'posts' );
 
-		$this->assertCanonical( $test_url, $expected_url );
+	public function test_custom_post_type_without_language() {
+		$this->assertCanonical( '/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' );
+	}
+
+	public function test_category_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/category/parent/',
+			array(
+				'url' => '/en/category/parent/',
+				'qv'  => array( 'lang' => 'en', 'category_name' => 'parent' ),
+			)
+		);
+	}
+
+	public function test_category_with_incorrect_language() {
+		$this->assertCanonical( '/fr/category/parent/', '/en/category/parent/' );
+	}
+
+	public function test_category_without_language() {
+		$this->assertCanonical( '/category/parent/', '/en/category/parent/' );
+	}
+
+	public function test_page_for_posts_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/posts/',
+			array(
+				'url' => '/en/posts/',
+				'qv'  => array( 'lang' => 'en', 'pagename' => 'posts', 'page' => '' ),
+			)
+		);
+	}
+
+	public function test_page_for_posts_should_match_page_for_post_option_when_language_is_incorrect() {
+		$this->assertCanonical( '/fr/posts/', '/en/posts/' );
+	}
+
+	public function test_page_for_should_match_page_for_post_option_posts_without_language() {
+		$this->assertCanonical( '/posts/', '/en/posts/' );
+	}
+
+	public function test_page_for_post_option_should_be_translated_when_language_is_incorrect() {
+		$this->assertCanonical( '/en/articles/', '/fr/articles/' );
+	}
+
+	public function test_page_for_post_option_should_be_translated_when_no_language_is_set() {
+		$this->assertCanonical( '/articles/', '/fr/articles/' );
+	}
+
+	public function test_static_front_page_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/parent-page/',
+			array(
+				'url' => '/en/parent-page/',
+				'qv'  => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
+			)
+		);
+	}
+
+	public function test_static_front_page_with_incorrect_language() {
+		$this->assertCanonical( '/fr/parent-page/', '/en/parent-page/' );
+	}
+
+	public function test_static_front_page_without_language() {
+		$this->assertCanonical( '/parent-page/', '/en/parent-page/' );
 	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -30,7 +30,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				'hide_default' => 0,
 				'post_types' => array(
 					'cpt' => 'cpt', // translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
-				)
+				),
 			)
 		);
 		$model = new PLL_Model( $options );
@@ -67,11 +67,12 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function post_canonical_url_provider() {
 		return array(
-			'post with name and language'  => array( '/en/post-format-test-audio/',
+			'post with name and language'  => array(
+				'/en/post-format-test-audio/',
 				array(
 					'url' => '/en/post-format-test-audio/',
 					'qv'  => array( 'lang' => 'en', 'name' => 'post-format-test-audio', 'page' => '' ),
-				)
+				),
 			),
 			'post with incorrect language' => array( '/fr/post-format-test-audio/', '/en/post-format-test-audio/' ),
 			'post without language'        => array( '/post-format-test-audio/', '/en/post-format-test-audio/' ),
@@ -81,7 +82,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider post_canonical_url_provider
 	 *
-	 * @param string $test_url
+	 * @param string       $test_url
 	 * @param string|array $expected_url
 	 */
 	function test_post( $test_url, $expected_url ) {
@@ -98,9 +99,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				array(
 					'url' => '/en/parent-page/',
 					'qv'  => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
-				)
+				),
 			),
-			'page with incorrect language' => array( '/fr/parent-page/', '/en/parent-page/'	),
+			'page with incorrect language' => array( '/fr/parent-page/', '/en/parent-page/' ),
 			'page without language' => array( '/parent-page/', '/en/parent-page/' ),
 		);
 	}
@@ -108,7 +109,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider page_canonical_url_provider
 	 *
-	 * @param string $test_url
+	 * @param string       $test_url
 	 * @param string|array $expected_url
 	 */
 	function test_page( $test_url, $expected_url ) {
@@ -120,13 +121,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function custom_post_type_canonical_url_provider() {
 		return array(
-			'custom post type with name and language' => array( '/en/cpt/custom-post/',
+			'custom post type with name and language' => array(
+				'/en/cpt/custom-post/',
 				array(
 					'url' => '/en/cpt/custom-post/',
 					'qv'  => array( 'lang' => 'en', 'cpt' => 'custom-post', 'name' => 'custom-post', 'post_type' => 'cpt', 'page' => '' ),
-				)
+				),
 			),
-			'custom post type with incorrect language' => array( '/fr/cpt/custom-post/', '/en/cpt/custom-post/'	),
+			'custom post type with incorrect language' => array( '/fr/cpt/custom-post/', '/en/cpt/custom-post/' ),
 			'custom post type without language' => array( '/cpt/custom-post/', '/en/cpt/custom-post/' ),
 		);
 	}
@@ -134,7 +136,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider custom_post_type_canonical_url_provider
 	 *
-	 * @param string $test_url
+	 * @param string       $test_url
 	 * @param string|array $expected_url
 	 */
 	function test_cpt( $test_url, $expected_url ) {
@@ -150,8 +152,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 			'category with name and language' => array(
 				'/en/category/parent/',
 				array(
-				'url' => '/en/category/parent/',
-				'qv'  => array( 'lang' => 'en', 'category_name' => 'parent' ),
+					'url' => '/en/category/parent/',
+					'qv'  => array( 'lang' => 'en', 'category_name' => 'parent' ),
 				),
 			),
 			'category with incorrect language' => array( '/fr/category/parent/', '/en/category/parent/' ),
@@ -162,7 +164,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider category_canonical_url_provider
 	 *
-	 * @param string $test_url
+	 * @param string       $test_url
 	 * @param string|array $expected_url
 	 */
 	function test_category( $test_url, $expected_url ) {
@@ -189,7 +191,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider posts_page_canonical_url_provider
 	 *
-	 * @param string $test_url
+	 * @param string       $test_url
 	 * @param string|array $expected_url
 	 */
 	function test_posts_page( $test_url, $expected_url ) {
@@ -228,7 +230,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	 *
 	 * @dataProvider static_front_page_canonical_url_provider()
 	 *
-	 * @param string $test_url
+	 * @param string       $test_url
 	 * @param string|array $expected_url
 	 */
 	function test_page_when_static_front_page_displays_posts( $test_url, $expected_url ) {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -127,20 +127,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '/category/parent-fr/', '/fr/category/parent-fr/' );
 	}
 
-	/**
-	 * @see https://github.com/polylang/polylang-pro/issues/667 Polylang breaks canonical redirect for taxonomies
-	 */
-	function test_redirect_category_from_plain_link() {
-		$term_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
-		self::$polylang->model->term->set_language( $term_en, 'en' );
-
-		$term_fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent-fr' ) );
-		self::$polylang->model->term->set_language( $term_fr, 'fr' );
-
-		$this->assertCanonical( "?cat={$term_en}", '/en/category/parent/' );
-		$this->assertCanonical( "?cat={$term_fr}", '/en/category/parent/' );
-	}
-
 	function test_posts_page() {
 		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
 		update_option( 'show_on_front', 'page' );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -166,7 +166,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	 * @param string|array $expected_url
 	 */
 	function test_category( $test_url, $expected_url ) {
-		$this->markTestSkipped( 'Needs fixing, see: https://github.com/polylang/polylang/issues/589' );
 		$term_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$polylang->model->term->set_language( $term_en, 'en' );
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -146,8 +146,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 					'qv'  => array( 'lang' => 'en', 'pagename' => 'posts', 'page' => '' ),
 				),
 			),
-			'page for posts with incorrect language' => array( '/fr/posts/', '/en/posts/' ),
-			'page for poests without language' => array( '/posts/', '/en/posts/' ),
+			'page for posts should match page_for_post option when language is incorrect' => array( '/fr/posts/', '/en/posts/' ),
+			'page for should mathc page_for_post option posts without language' => array( '/posts/', '/en/posts/' ),
+			'page_for_post option should be translated when language is incorrect' => array( '/en/articles/', '/fr/articles/' ),
+			'page_for_post option should be translated when no language is set' => array( '/articles/', '/fr/articles/' ),
 		);
 	}
 


### PR DESCRIPTION
## Before

The `PLL_Canonical_Test::test_category()` throwed false positives regarding to the following issue: https://github.com/polylang/polylang-pro/issues/693

## Changes 

- All tests are now executed in a PLL_Frontend context
- Fix to avoid `PLL_Choose_Lang_Url::set_language_from_url()` believing we're calling the homepage
- Refresh Polylang between each assertion: Because [PLL_Choose_Lang_Url::init() checks if 'pll_language_defined' has already been triggered](https://github.com/polylang/polylang/blob/0c9fd403caa735875c2a5dad077948f8a03f1103/frontend/choose-lang-url.php#L24), we need to refresh the hooks between each assertion, so there's only one assertion per test.

To enhance tests speed, WordPress chose to [set the fixtures (post, taxonomies, etc.) only once in the wpSetUpBeforeClass() method](https://github.com/WordPress/wordpress-develop/blob/701dee26f19b4bfdcbc1cc636f5fdecd8a753432/tests/phpunit/includes/testcase-canonical.php#L18-L20). These has two drawbacks:

- Because all data set during the `wpSetUpBeforeClass()` is backed up and shared, it needed to [mirror the `generate_shared_fixtures()` method with a `delete_shared_fixtures()`](https://github.com/WordPress/wordpress-develop/blob/701dee26f19b4bfdcbc1cc636f5fdecd8a753432/tests/phpunit/includes/testcase-canonical.php#L22-L24). This introduce a liability when adding new tests, as the developer should not forgot to erase the new fixtures he introduces for these tests.
- The test data is absent from the [test cases where it is tested](https://github.com/WordPress/wordpress-develop/blob/701dee26f19b4bfdcbc1cc636f5fdecd8a753432/tests/phpunit/tests/canonical.php#L21-L33), which makes tests less easy to read.

The solution in this PR then sacrifices performance in favor of readability. Although an optimization could be added in the future.

## Going further

- Optimize performance by generating the database fixtures only once
- As discussed during October 15, 2020 tech meeting, the modification to the test setup could (and should) be used in every test relying on `WP_UnitTest_Case::go_to()` method.

