### PR TITLE
Use WP_TestCase_Factory passed as parameter

### DIFF
--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -5,8 +5,11 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 	protected $hosts;
 	protected static $server;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::$server = $_SERVER; // backup
 

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -13,8 +13,10 @@ trait PLL_UnitTestCase_Trait {
 
 	/**
 	 * Initialization before all tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory
 	 */
-	static function wpSetUpBeforeClass() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	static function wpSetUpBeforeClass( $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		self::$polylang = new StdClass();
 
 		self::$polylang->options = PLL_Install::get_default_options();

--- a/tests/phpunit/tests/plugins/test-duplicate-post.php
+++ b/tests/phpunit/tests/plugins/test-duplicate-post.php
@@ -6,8 +6,11 @@ if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 
 	class Duplicate_Post_Test extends PLL_UnitTestCase {
 
-		static function wpSetUpBeforeClass() {
-			parent::wpSetUpBeforeClass();
+		/**
+		 * @param WP_UnitTest_Factory $factory
+		 */
+		public static function wpSetUpBeforeClass( $factory ) {
+			parent::wpSetUpBeforeClass( $factory );
 
 			self::$polylang->model->post->registered_post_type( 'post' ); // Important.
 

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -6,8 +6,11 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '>=' ) && file_exists( DIR_
 
 	class Jetpack_Test extends PLL_UnitTestCase {
 
-		static function wpSetUpBeforeClass() {
-			parent::wpSetUpBeforeClass();
+		/**
+		 * @param WP_UnitTest_Factory $factory
+		 */
+		public static function wpSetUpBeforeClass( $factory ) {
+			parent::wpSetUpBeforeClass( $factory );
 
 			self::create_language( 'en_US' );
 			self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -3,8 +3,11 @@
 class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::$polylang->model->post->register_taxonomy();
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -16,7 +16,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'es_ES' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	function setUp() {

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -3,8 +3,11 @@
 class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -14,7 +14,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'es_ES' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	function setUp() {

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -2,8 +2,11 @@
 
 class Admin_Filters_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'de_DE_formal' );

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -2,8 +2,11 @@
 
 class Admin_Model_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -2,8 +2,11 @@
 
 class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -2,8 +2,11 @@
 
 class Admin_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -3,8 +3,11 @@
 class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -3,8 +3,11 @@
 class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -13,7 +13,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::create_language( 'fr_FR' );
 		self::create_language( 'es_ES' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	function setUp() {

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -12,7 +12,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	public function setUp() {

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -3,8 +3,11 @@
 class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 	protected static $editor;
 
-	public static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-ajax-on-front.php
+++ b/tests/phpunit/tests/test-ajax-on-front.php
@@ -2,8 +2,11 @@
 
 class Ajax_On_Front_Test extends PLL_Ajax_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -2,8 +2,11 @@
 
 class Auto_Translate_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -11,6 +11,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	private static $page_for_posts_fr;
 	private static $page_on_front_en;
 
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -3,8 +3,11 @@
 class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -3,8 +3,11 @@
 class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -2,8 +2,11 @@
 
 class Choose_Lang_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::$polylang->model->post->register_taxonomy();
 	}

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -3,8 +3,11 @@
 class Columns_Test extends PLL_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-filters-links.php
+++ b/tests/phpunit/tests/test-filters-links.php
@@ -3,8 +3,11 @@
 class Filters_Links_Test extends PLL_UnitTestCase {
 	protected $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -3,8 +3,11 @@
 class Filters_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -2,8 +2,11 @@
 
 class Flags_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-hreflang.php
+++ b/tests/phpunit/tests/test-hreflang.php
@@ -2,8 +2,11 @@
 
 class Hreflang_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_GB', array( 'slug' => 'uk' ) );
 		self::create_language( 'en_US', array( 'slug' => 'us' ) );

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -3,8 +3,11 @@
 class Links_Default_Test extends PLL_UnitTestCase {
 	protected $host = 'http://example.org';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -4,8 +4,11 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 	protected $structure = '/%postname%/';
 	protected $host = 'http://example.org';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -2,8 +2,11 @@
 
 class Media_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -2,8 +2,11 @@
 
 class Model_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -2,8 +2,11 @@
 
 class Nav_Menus_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -3,8 +3,11 @@
 class Query_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -3,8 +3,11 @@
 class Search_Form_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -2,8 +2,11 @@
 
 class Settings_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -1,13 +1,16 @@
 <?php
 
 class Sitemaps_Test extends PLL_UnitTestCase {
-	static function wpSetUpBeforeClass() {
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
 		// Sitemaps were introduced in WP 5.5.
 		if ( ! function_exists( 'wp_get_sitemap_providers' ) ) {
 			self::markTestSkipped( 'These tests require WP 5.5+' );
 		}
 
-		parent::wpSetUpBeforeClass();
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -2,8 +2,11 @@
 
 class Slugs_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -4,8 +4,11 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 	static $home_en, $home_fr, $home_de, $posts_en, $posts_fr;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		add_filter( 'pll_languages_list', array( 'PLL_Static_Pages', 'pll_languages_list' ), 2, 2 );
 

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -2,8 +2,11 @@
 
 class Strings_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -3,8 +3,11 @@
 class Switcher_Test extends PLL_UnitTestCase {
 	private $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -12,8 +12,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
-		self::$author = self::factory()->user->create( array( 'role' => 'author' ) );
+		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$author = $factory->user->create( array( 'role' => 'author' ) );
 	}
 
 	function setUp() {

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -3,8 +3,11 @@
 class Sync_Test extends PLL_UnitTestCase {
 	static $editor, $author;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-terms-list.php
+++ b/tests/phpunit/tests/test-terms-list.php
@@ -3,8 +3,11 @@
 class Terms_List_Test extends PLL_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -2,8 +2,11 @@
 
 class Translated_Post_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -2,8 +2,11 @@
 
 class Translated_Term_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-widgets-calendar.php
+++ b/tests/phpunit/tests/test-widgets-calendar.php
@@ -2,8 +2,11 @@
 
 class Widget_Calendar_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -2,8 +2,11 @@
 
 class Widgets_Filter_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -2,8 +2,11 @@
 
 class WPML_Config_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -3,8 +3,11 @@
 class WPML_Test extends PLL_UnitTestCase {
 	public $structure = '/%postname%/';
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/themes/test-twenty-fourteen.php
+++ b/tests/phpunit/tests/themes/test-twenty-fourteen.php
@@ -5,8 +5,11 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 	class Twenty_Fourteen_Test extends PLL_UnitTestCase {
 		static $stylesheet, $tag_en, $tag_fr;
 
-		static function wpSetUpBeforeClass() {
-			parent::wpSetUpBeforeClass();
+		/**
+		 * @param WP_UnitTest_Factory $factory
+		 */
+		public static function wpSetUpBeforeClass( $factory ) {
+			parent::wpSetUpBeforeClass( $factory );
 
 			self::create_language( 'en_US' );
 			self::create_language( 'fr_FR' );

--- a/tests/phpunit/tests/themes/test-twenty-seventeen.php
+++ b/tests/phpunit/tests/themes/test-twenty-seventeen.php
@@ -5,8 +5,11 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyseventee
 	class Twenty_Seventeen_Test extends PLL_UnitTestCase {
 		static $stylesheet;
 
-		static function wpSetUpBeforeClass() {
-			parent::wpSetUpBeforeClass();
+		/**
+		 * @param WP_UnitTest_Factory $factory
+		 */
+		public static function wpSetUpBeforeClass( $factory ) {
+			parent::wpSetUpBeforeClass( $factory );
 
 			self::create_language( 'en_US' );
 			self::create_language( 'fr_FR' );


### PR DESCRIPTION
## Before

The [WP_UnitTest_Factory](https://github.com/WordPress/wordpress-develop/blob/master/tests/phpunit/includes/factory/class-wp-unittest-factory.php) used to create WordPress related fixtures in the database was retrieved from a call to `WP_UnitTestCase_Base::factory()` method call.

## Changes

- Pass the  `WP_UnitTest_Factory` as a parameter of `PLL_UnitTestCase_Trait::wpSetUpBeforeClass()` to be compatible with [the way it is called in `WP_UnitTestCase::setUpBeforeClass()`](https://github.com/WordPress/wordpress-develop/blob/123a965c70acee04b1cb7ab58599fb6284999835/tests/phpunit/includes/abstract-testcase.php#L76)
- Use the `WP_UnitTest_Factory` passed as parameter in tests

## Details

Calling `PLL_UnitTestCase_Trait::wpSetUpBeforeClass()` raised PHP warnings in #592 CI jobs.
