### PR TITLE
Fix canonical redirect for taxonomy terms

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -383,10 +383,14 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( is_category() || is_tag() || is_tax() ) {
-			$obj = $wp_query->get_queried_object();
-			if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
-				$language = $this->model->term->get_language( (int) $obj->term_id );
+		elseif ( is_category() || is_tag() || is_tax() || ( is_404() && ! empty( $wp_query->tax_query ) ) ) {
+			$queried_terms = $wp_query->tax_query->queried_terms;
+			unset( $queried_terms['language'] );
+			$taxonomy = key( $queried_terms );
+			if ( $this->model->is_translated_taxonomy( $taxonomy ) ) {
+				$term_id = $this->get_queried_term_id( $taxonomy, $queried_terms[ $taxonomy ] );
+				$language = $this->model->term->get_language( $term_id );
+				$redirect_url = get_term_link( $term_id );
 			}
 		}
 
@@ -444,5 +448,39 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		return $redirect_url;
+	}
+
+	/**
+	 * Returns the term_id of the requested term.
+	 *
+	 * @since 2.8.4
+	 *
+	 * @param string $taxonomy     Taxonomy name
+	 * @param array  $queried_term {
+	 *   Information about the queried term
+	 *   @type string $field The field used to query the term(s).
+	 *   @type mixed  $term  Taxonomy term(s).
+	 * }
+	 * @return int
+	 */
+	protected function get_queried_term_id( $taxonomy, $queried_term ) {
+		$field = $queried_term['field'];
+		$term  = reset( $queried_term['terms'] );
+
+		// We can get a term_id when requesting a plain permalink, eg /?cat=1.
+		if ( 'term_id' === $field ) {
+			return $term;
+		}
+
+		// We get a slug when requeting a pretty peramlin with the wrong language.
+		$args = array(
+			'lang' => '',
+			'taxonomy' => $taxonomy,
+			$field => $term,
+			'hide_empty' => false,
+			'fields' => 'ids',
+		);
+		$terms = get_terms( $args );
+		return reset( $terms );
 	}
 }

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -469,6 +469,11 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			return $term;
 		}
 
+		// Avoid a useless DB request if the taxonomy is not translatable.
+		if ( ! $this->model->is_translated_taxonomy( $taxonomy ) ) {
+			return $term;
+		}
+
 		// We get a slug when requesting a pretty permalink with the wrong language.
 		$args = array(
 			'lang' => '',

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -384,11 +384,8 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		elseif ( is_category() || is_tag() || is_tax() || ( is_404() && ! empty( $wp_query->tax_query ) ) ) {
-			$queried_terms = $wp_query->tax_query->queried_terms;
-			unset( $queried_terms['language'] );
-			$taxonomy = key( $queried_terms );
-			if ( $this->model->is_translated_taxonomy( $taxonomy ) ) {
-				$term_id = $this->get_queried_term_id( $taxonomy, $queried_terms[ $taxonomy ] );
+			$term_id = $this->get_queried_term_id( $wp_query->tax_query );
+			if ( $term_id ) {
 				$language = $this->model->term->get_language( $term_id );
 				$redirect_url = get_term_link( $term_id );
 			}
@@ -455,24 +452,24 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 *
 	 * @since 2.8.4
 	 *
-	 * @param string $taxonomy     Taxonomy name
-	 * @param array  $queried_term {
-	 *   Information about the queried term
-	 *   @type string $field The field used to query the term(s).
-	 *   @type mixed  $term  Taxonomy term(s).
-	 * }
+	 * @param object $tax_query An instance of WP_Tax_Query.
 	 * @return int
 	 */
-	protected function get_queried_term_id( $taxonomy, $queried_term ) {
-		$field = $queried_term['field'];
-		$term  = reset( $queried_term['terms'] );
+	protected function get_queried_term_id( $tax_query ) {
+		$queried_terms = $tax_query->queried_terms;
+		unset( $queried_terms['language'] );
+
+		$taxonomy = key( $queried_terms );
+
+		$field = $queried_terms[ $taxonomy ]['field'];
+		$term  = reset( $queried_terms[ $taxonomy ]['terms'] );
 
 		// We can get a term_id when requesting a plain permalink, eg /?cat=1.
 		if ( 'term_id' === $field ) {
 			return $term;
 		}
 
-		// We get a slug when requeting a pretty peramlin with the wrong language.
+		// We get a slug when requesting a pretty permalink with the wrong language.
 		$args = array(
 			'lang' => '',
 			'taxonomy' => $taxonomy,

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -453,7 +453,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	/**
 	 * Returns the term_id of the requested term.
 	 *
-	 * @since 2.8.4
+	 * @since 2.9
 	 *
 	 * @param object $tax_query An instance of WP_Tax_Query.
 	 * @return int
@@ -485,8 +485,9 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	/**
 	 * Find the taxonomy being queried.
 	 *
-	 * @param WP_Tax_Query
+	 * @since 2.9
 	 *
+	 * @param object $tax_query An instance of WP_Tax_Query.
 	 * @return string A taxonomy slug
 	 */
 	protected function get_queried_taxonomy( $tax_query ) {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -47,10 +47,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
 		update_option( 'show_on_front', 'page' );
 
-		self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		$en = self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$polylang->model->post->set_language( self::$page_for_posts_en, 'en' );
 
-		self::$page_for_posts_fr = $factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		$fr = self::$page_for_posts_fr = $factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
 		self::$polylang->model->post->set_language( self::$page_for_posts_fr, 'fr' );
 
 		self::$polylang->model->post->save_translations( self::$page_for_posts_en, compact( 'en', 'fr' ) );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -57,7 +57,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 
-		self::$page_on_front_en = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
+		self::$page_on_front_en = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'home' ) );
 		self::$polylang->model->post->set_language( self::$page_on_front_en, 'en' );
 
 		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
@@ -94,6 +94,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '/post-format-test-audio/', '/en/post-format-test-audio/' );
 	}
 
+	public function test_post_from_plain_permalink() {
+		$this->assertCanonical( '?p=' . self::$post_en, '/en/post-format-test-audio/' );
+	}
+
 	public function test_page_with_name_and_language() {
 		$this->assertCanonical(
 			'/en/parent-page/',
@@ -110,6 +114,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_without_language() {
 		$this->assertCanonical( '/parent-page/', '/en/parent-page/' );
+	}
+
+	public function test_page_from_plain_permalink() {
+		$this->assertCanonical( '?page_id=' . self::$page_id, '/en/parent-page/' );
 	}
 
 	public function test_custom_post_type_with_name_and_language() {
@@ -167,8 +175,12 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '/fr/posts/', '/en/posts/' );
 	}
 
-	public function test_page_for_should_match_page_for_post_option_posts_without_language() {
+	public function test_page_for_posts_should_match_page_for_post_option_posts_without_language() {
 		$this->assertCanonical( '/posts/', '/en/posts/' );
+	}
+
+	public function test_page_for_posts_should_match_page_for_post_option_posts_from_plain_permalink() {
+		$this->assertCanonical( '?page_id=' . self::$page_for_posts_en, '/en/posts/' );
 	}
 
 	public function test_page_for_post_option_should_be_translated_when_language_is_incorrect() {
@@ -179,21 +191,29 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '/articles/', '/fr/articles/' );
 	}
 
+	public function test_page_for_post_option_should_be_translated_from_plain_permalink() {
+		$this->assertCanonical( '?page_id=' . self::$page_for_posts_fr, '/fr/articles/' );
+	}
+
 	public function test_static_front_page_with_name_and_language() {
 		$this->assertCanonical(
-			'/en/parent-page/',
+			'/en/home/',
 			array(
-				'url' => '/en/parent-page/',
-				'qv'  => array( 'lang' => 'en', 'pagename' => 'parent-page', 'page' => '' ),
+				'url' => '/en/home/',
+				'qv'  => array( 'lang' => 'en', 'pagename' => 'home', 'page' => '' ),
 			)
 		);
 	}
 
 	public function test_static_front_page_with_incorrect_language() {
-		$this->assertCanonical( '/fr/parent-page/', '/en/parent-page/' );
+		$this->assertCanonical( '/fr/home/', '/en/home/' );
 	}
 
 	public function test_static_front_page_without_language() {
-		$this->assertCanonical( '/parent-page/', '/en/parent-page/' );
+		$this->assertCanonical( '/home/', '/en/home/' );
+	}
+
+	public function test_static_front_page_from_plain_permalink() {
+		$this->assertCanonical( '?page_id=' . self::$page_on_front_en, '/en/home/' );
 	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -149,6 +149,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '/category/parent/', '/en/category/parent/' );
 	}
 
+	public function test_category_from_plain_permalink() {
+		$this->assertCanonical( '?cat=' . self::$term_en, '/en/category/parent/' );
+	}
+
 	public function test_page_for_posts_with_name_and_language() {
 		$this->assertCanonical(
 			'/en/posts/',


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/667
Fixes https://github.com/polylang/polylang-pro/issues/693

Additionnally, the PR also adds more tests for plain permalinks which must be redirected to the canonical redirect and fixes the tests for the home page which were duplicating the tests for a standard page since #596. 
 