### PR TITLE
Open canonical test case for extension

### DIFF
--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -5,12 +5,6 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 
 	protected $options;
 
-	public static function wpTearDownAfterClass() {
-		$options = PLL_Install::get_default_options();
-		self::$polylang->model = new PLL_Admin_Model( $options ); // Needed for {@see PLL_UnitTest_Trait::delete_all_languages()}.
-		parent::wpTearDownAfterClass();
-	}
-
 	public function setUp() {
 		parent::setUp();
 
@@ -35,7 +29,6 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		// $wp_rewrite->flush_rules() is called in self::assertCanonical()
 	}
 
-
 	/**
 	 * Set up the Polylang environment before testing canonical redirects.
 	 *
@@ -54,7 +47,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		// Needed by {@see pll_requested_url()}.
 		$_SERVER['REQUEST_URI'] = $test_url;
 
-		$model = new PLL_Model( $this->options );
+		$model = new PLL_Admin_Model( $this->options );
 
 		// register post types and taxonomies
 		$model->post->register_taxonomy(); // needs this for 'lang' query var

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -17,17 +17,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.
 		add_filter( 'wp_doing_ajax', '__return_false' );
 
-		$this->options = array_merge(
-			PLL_Install::get_default_options(),
-			array(
-				'default_lang' => 'en',
-				'hide_default' => 0,
-				'post_types'   => array(
-					'cpt' => 'pllcanonical',
-					// translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
-				),
-			)
-		);
+		$this->options = PLL_Install::get_default_options();
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -3,6 +3,18 @@
 class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	use PLL_UnitTestCase_Trait;
 
+	/**
+	 * Set in [@see PLL_Canonical_UnitTestCase::assertCanonical()}.
+	 *
+	 * @var PLL_Frontend
+	 */
+	protected $pll_env = null;
+
+	/**
+	 * Default to {@see PLL_Install::get_default_options()}.
+	 *
+	 * @var array
+	 */
 	protected $options;
 
 	public function setUp() {
@@ -47,7 +59,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		// Needed by {@see pll_requested_url()}.
 		$_SERVER['REQUEST_URI'] = $test_url;
 
-		$model = new PLL_Admin_Model( $this->options );
+		$model = new PLL_Model( $this->options );
 
 		// register post types and taxonomies
 		$model->post->register_taxonomy(); // needs this for 'lang' query var
@@ -55,9 +67,9 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 
 		// reset the links model according to the permalink structure
 		$links_model    = $model->get_links_model();
-		self::$polylang = new PLL_Frontend( $links_model );
-		self::$polylang->init();
-		do_action_ref_array( 'pll_init', array( &self::$polylang ) );
+		$this->pll_env = new PLL_Frontend( $links_model );
+		$this->pll_env->init();
+		do_action_ref_array( 'pll_init', array( &$this->pll_env ) );
 
 		// flush rules
 		$wp_rewrite->flush_rules();
@@ -75,7 +87,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	 * @return string Either the canonical url, if redirected, or the inputted $test_url.
 	 */
 	public function get_canonical( $test_url ) {
-		$pll_redirected_url = self::$polylang->filters_links->check_canonical_url( home_url( $test_url ), false );
+		$pll_redirected_url = $this->pll_env->filters_links->check_canonical_url( home_url( $test_url ), false );
 		$wp_redirected_url  = redirect_canonical( $pll_redirected_url, false );
 		if ( ! $wp_redirected_url ) {
 			return $pll_redirected_url;

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -3,7 +3,7 @@
 class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	use PLL_UnitTestCase_Trait;
 
-	private $options;
+	protected $options;
 
 	public function setUp() {
 		parent::setUp();
@@ -56,7 +56,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		$links_model    = $model->get_links_model();
 		self::$polylang = new PLL_Frontend( $links_model );
 		self::$polylang->init();
-		do_action_ref_array( 'pll_init', array( self::$polylang ) );
+		do_action_ref_array( 'pll_init', array( &self::$polylang ) );
 
 		// flush rules
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -78,21 +78,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-		self::delete_shared_fixtures();
+		_unregister_post_type( 'pllcanonical' );
 
 		parent::wpTearDownAfterClass();
-	}
-
-	public static function delete_shared_fixtures() {
-		self::$post_en           = null;
-		self::$page_id           = null;
-		self::$custom_post_id    = null;
-		self::$term_en           = null;
-		self::$page_for_posts_en = null;
-		self::$page_for_posts_fr = null;
-		self::$page_on_front_en  = null;
-
-		_unregister_post_type( 'pllcanonical' );
 	}
 
 	public function setUp() {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -21,7 +21,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::create_language( 'fr_FR' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
 
 		self::generate_shared_fixtures( $factory );
 	}
@@ -85,6 +84,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
+
+		$GLOBALS['polylang'] = &$this->pll_env;
 
 		$this->options = array_merge(
 			PLL_Install::get_default_options(),

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -23,6 +23,13 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 		$GLOBALS['polylang'] = &self::$polylang;
 
+		self::generate_shared_fixtures( $factory );
+	}
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function generate_shared_fixtures( $factory ) {
 		self::$post_en = $factory->post->create( array( 'post_title' => 'post-format-test-audio' ) );
 		self::$polylang->model->post->set_language( self::$post_en, 'en' );
 
@@ -37,8 +44,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				}
 			}
 		);
-
-		self::$custom_post_id = $factory->post->create( array( 'import_id' => 416, 'post_type' => 'pllcanonical', 'post_title' => 'custom-post' ) );
+		self::$custom_post_id = $factory->post->create( array( 'import_id'  => 416,
+		                                                       'post_type'  => 'pllcanonical',
+		                                                       'post_title' => 'custom-post'
+		) );
 		self::$polylang->model->post->set_language( self::$custom_post_id, 'en' );
 
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
@@ -57,7 +66,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 
-		self::$page_on_front_en = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
+		self::$page_on_front_en = $factory->post->create( array( 'post_type'  => 'page',
+		                                                         'post_title' => 'parent-page'
+		) );
 		self::$polylang->model->post->set_language( self::$page_on_front_en, 'en' );
 
 		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
@@ -65,13 +76,19 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-		self::$post_en = null;
-		self::$page_id = null;
-		self::$custom_post_id = null;
-		self::$term_en = null;
+		self::delete_shared_fixtures();
+
+		parent::wpTearDownAfterClass();
+	}
+
+	public static function delete_shared_fixtures() {
+		self::$post_en           = null;
+		self::$page_id           = null;
+		self::$custom_post_id    = null;
+		self::$term_en           = null;
 		self::$page_for_posts_en = null;
 		self::$page_for_posts_fr = null;
-		self::$page_on_front_en = null;
+		self::$page_on_front_en  = null;
 
 		_unregister_post_type( 'pllcanonical' );
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -44,10 +44,13 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				}
 			}
 		);
-		self::$custom_post_id = $factory->post->create( array( 'import_id'  => 416,
-		                                                       'post_type'  => 'pllcanonical',
-		                                                       'post_title' => 'custom-post'
-		) );
+		self::$custom_post_id = $factory->post->create(
+			array(
+				'import_id'  => 416,
+				'post_type'  => 'pllcanonical',
+				'post_title' => 'custom-post',
+			)
+		);
 		self::$polylang->model->post->set_language( self::$custom_post_id, 'en' );
 
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -76,6 +76,22 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		_unregister_post_type( 'pllcanonical' );
 	}
 
+	public function setUp() {
+		parent::setUp();
+
+		$this->options = array_merge(
+			PLL_Install::get_default_options(),
+			array(
+				'default_lang' => 'en',
+				'hide_default' => 0,
+				'post_types'   => array(
+					'cpt' => 'pllcanonical',
+					// translate the cpt // FIXME /!\ 'after_setup_theme' already fired and the list of translated post types is already cached :(
+				),
+			)
+		);
+	}
+
 	public function test_post_with_name_and_language() {
 		$this->assertCanonical(
 			'/en/post-format-test-audio/',


### PR DESCRIPTION
## Changes

This PR add some flexibility for the `PLL_Canonical_UnitTestCase`:

- Allow child classes to override the `$options` property
- Do not set test case specific options
- Override `WP_Canonical_UnitTestCase::set_permalink_structure()` to insert Polylang specific logic in between