### PR TITLE
Replace older-style PHP type conversion function with type cast

### DIFF
--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -104,7 +104,7 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 
 		// Let's figure out when we are.
 		if ( ! empty( $monthnum ) && ! empty( $year ) ) {
-			$thismonth = zeroise( intval( $monthnum ), 2 );
+			$thismonth = zeroise( (int) $monthnum, 2 );
 			$thisyear  = (int) $year;
 		} elseif ( ! empty( $w ) ) {
 			// We need to get the month from MySQL.

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -8,7 +8,7 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_calendar() {
-		$this->check_method( '3d122ddd339aaf23fdcbb0d008082c32', '5.5', 'get_calendar' );
+		$this->check_method( '218e132e305bb498f975d340a4503e15', '5.6', 'get_calendar' );
 	}
 
 	public function test_wp_admin_bar() {


### PR DESCRIPTION
The function `get_calendar()` has been impacted by https://core.trac.wordpress.org/ticket/42918.
This PR follows the move and updates the relevant detection test.