### PR TITLE
Fix test_upload

### DIFF
--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -26,7 +26,7 @@ class Media_Test extends PLL_UnitTestCase {
 
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
 		$fr = $this->factory->attachment->create_upload_object( $filename );
-		$this->assertEquals( self::$polylang->pref_lang, self::$polylang->model->post->get_language( $fr ) );
+		$this->assertEquals( self::$polylang->pref_lang->slug, self::$polylang->model->post->get_language( $fr )->slug );
 
 		// cleanup
 		wp_delete_attachment( $fr );


### PR DESCRIPTION
The test used to compare 2 languages objects, one evaluated before the media upload, the other evaluated after the media upload. This is wrong as the 2 different objects must differ by the count. In this PR, I now compare the language codes instead.

Note: the test used to pass in WP < 5.6 (with a term count set to 0, for both languages). The different behavior may have been introduced by https://core.trac.wordpress.org/ticket/40351 