### PR TITLE
Fix deprecated function usage in WP 5.6

### DIFF
--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -77,7 +77,6 @@ class PLL_OLT_Manager {
 		// Don't try to save time for en_US as some users have theme written in another language
 		// Now we can load all overridden text domains with the right language
 		if ( ! empty( $this->list_textdomains ) ) {
-
 			/*
 			 * FIXME: Backward compatibility with WP < 5.6
 			 * From WP 4.7 to 5.5, we need to reset the internal cache of _get_path_to_translation when switching from any locale to en_US.

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -78,10 +78,12 @@ class PLL_OLT_Manager {
 		// Now we can load all overridden text domains with the right language
 		if ( ! empty( $this->list_textdomains ) ) {
 
-			// Since WP 4.7 we need to reset the internal cache of _get_path_to_translation when switching from any locale to en_US
-			// See WP_Locale_Switcher::change_locale()
-			// FIXME test _get_path_to_translation for backward compatibility with WP < 4.7
-			if ( function_exists( '_get_path_to_translation' ) ) {
+			/*
+			 * FIXME: Backward compatibility with WP < 5.6
+			 * From WP 4.7 to 5.5, we need to reset the internal cache of _get_path_to_translation when switching from any locale to en_US.
+			 * See WP_Locale_Switcher::change_locale()
+			 */
+			if ( ! class_exists( 'WP_Textdomain_Registry' ) && function_exists( '_get_path_to_translation' ) ) {
 				_get_path_to_translation( null, true );
 			}
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/710

This removes the call to `_get_path_to_translation()` in WP 5.6+ as it sends a deprecated notice and is not useful anymore.