### PR TITLE
Allow to translate 0 in string translations

### DIFF
--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -39,7 +39,7 @@ class PLL_Admin_Strings {
 			$context = 'Polylang';
 		}
 
-		if ( $string && is_scalar( $string ) ) {
+		if ( is_scalar( $string ) && '' !== $string ) {
 			self::$strings[ md5( $string ) ] = compact( 'name', 'string', 'context', 'multiline' );
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/712

This PR allows explicitely to register any scalar as string for translation, except empty strings.