### PR TITLE
Make jQuery UI 1.12.1 compatible and keep backward compatibility with jQuery UI 1.11.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1495,16 +1495,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.9.0",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01"
+                "reference": "00b4fa3130faa26762c929989e3d958086c627f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
-                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/00b4fa3130faa26762c929989e3d958086c627f1",
+                "reference": "00b4fa3130faa26762c929989e3d958086c627f1",
                 "shasum": ""
             },
             "require": {
@@ -1539,20 +1539,20 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
-            "time": "2020-10-07T23:32:29+00:00"
+            "time": "2020-07-11T23:32:06+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -1590,7 +1590,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/composer.lock
+++ b/composer.lock
@@ -1495,16 +1495,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.8.3",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "00b4fa3130faa26762c929989e3d958086c627f1"
+                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/00b4fa3130faa26762c929989e3d958086c627f1",
-                "reference": "00b4fa3130faa26762c929989e3d958086c627f1",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
+                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
                 "shasum": ""
             },
             "require": {
@@ -1539,20 +1539,20 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
-            "time": "2020-07-11T23:32:06+00:00"
+            "time": "2020-10-07T23:32:29+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -1590,7 +1590,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -30,20 +30,29 @@
 	list-style-image: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
 }
 
+/* for jQuery UI 1.12 which introduces a wrapper */
+.ui-menu .ui-menu-item:not([role]) {
+	padding: 0;
+}
+
+.ui-menu-item-wrapper {
+	padding: 3px 1em 3px 2em;
+}
 .rtl .ui-menu .ui-menu-item {
 	text-align: right;
 }
-
 
 /* icon support */
 .ui-menu-icons {
 	position: relative;
 }
 
-.ui-menu-icons .ui-menu-item {
+.ui-menu-icons .ui-menu-item[role] {
 	padding-left: 2em;
 }
-.rtl .ui-menu-icons .ui-menu-item {
+
+.rtl .ui-menu-item-wrapper, /* for jQuery UI 1.12 which introduces a wrapper */
+.rtl .ui-menu-icons .ui-menu-item[role] {
 	padding-left: 1em;
 	padding-right: 2em;
 }

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -139,7 +139,8 @@
 
 .ui-widget-content,
 .ui-state-default,
-.ui-selectmenu-button-closed,  /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
+.ui-selectmenu-button-closed, /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
+.ui-selectmenu-button-open, /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 .ui-widget-content .ui-state-default,
 .ui-widget-header .ui-state-default {
 	background: #fff;
@@ -149,7 +150,8 @@
 }
 /* Override to have same styles as WP form styles since WordPress 5.4 */
 .toplevel_page_mlang .ui-selectmenu-button.ui-state-default,
-.toplevel_page_mlang .ui-selectmenu-button.ui-selectmenu-button-closed{ /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
+.toplevel_page_mlang .ui-selectmenu-button.ui-selectmenu-button-closed, /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
+.toplevel_page_mlang .ui-selectmenu-button.ui-selectmenu-button-open{ /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 	box-shadow: 0 0 0 transparent;
 	border-radius: 4px;
     border: 1px solid #7e8993;

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -164,7 +164,8 @@
 }
 
 .ui-widget-content .ui-state-hover,
-.ui-widget-content .ui-state-focus {
+.ui-widget-content .ui-state-focus,
+.ui-widget-content .ui-state-active { /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 	background: #f5f5f5;
 }
 

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -139,6 +139,7 @@
 
 .ui-widget-content,
 .ui-state-default,
+.ui-selectmenu-button-closed,  /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 .ui-widget-content .ui-state-default,
 .ui-widget-header .ui-state-default {
 	background: #fff;
@@ -147,7 +148,8 @@
 	color: #32373c;
 }
 /* Override to have same styles as WP form styles since WordPress 5.4 */
-.toplevel_page_mlang .ui-selectmenu-button.ui-state-default{
+.toplevel_page_mlang .ui-selectmenu-button.ui-state-default,
+.toplevel_page_mlang .ui-selectmenu-button.ui-selectmenu-button-closed{ /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 	box-shadow: 0 0 0 transparent;
 	border-radius: 4px;
     border: 1px solid #7e8993;

--- a/js/admin.js
+++ b/js/admin.js
@@ -32,75 +32,75 @@ jQuery( document ).ready(
 			'tr'
 		); // acts on the whole tr instead of single td as we have actions links in several columns
 
+		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
 		// Common functions for overriding language and flag dropdown list.
+
+		// Inject flag image when jQuery UI selectmenu is created or an item is selected.
 		var selectmenuRenderItem = function( wrapper, item ) {
 			var li = $( '<li>' ).text( item.label ).prepend( $( item.element ).data( 'flag-html' ) );
 			li.children( 'img' ).addClass( 'ui-icon' );
 			return li.appendTo( wrapper );
 		};
+		// Override selected item to inject flag for jQuery UI less than 1.12.
 		var selectmenuRefreshButtonText = function( selectElement ) {
 			var buttonText = $( selectElement ).selectmenu( 'instance' ).buttonText;
 			buttonText.prepend( $( selectElement ).children( ':selected' ).data( 'flag-html' ) );
 			buttonText.children( 'img' ).addClass( 'ui-icon' );
 		};
-		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
 
-		// Inject flag image when jQuery UI selectmenu is created or an item is selected.
-		$( '#flag_list' ).on(
-			'selectmenucreate selectmenuselect',
-			function(){
-				selectmenuRefreshButtonText( this );
-			}
-		);
-		// Refresh jQuery UI selectmenu when the value is changed programmatically: select another language or edit an existing language.
-		// For putting the focus in the list on the selected item and injecting the right flag on the selected item.
-		$( '#flag_list' ).on(
-			'selectmenuopen',
-			function(){
-				$( this ).selectmenu( 'refresh' ).trigger( 'selectmenuselect' );
-			}
-		);
-		// Create the jQuery UI selectmenu widget
-		$( '#flag_list' ).selectmenu( { width: '97%' } );
+		// Selectmenu widget parameters.
+		// Callbacks when Selectmenu widget create or select event is triggered.
+		var createSelectCallback = function( event, ui ) {
+			selectmenuRefreshButtonText( event.target );
+		}
+		// Callbacks when Selectmenu widget open event is triggered.
+		var openCallback = function( event, ui ){
+			selectmenuRefreshButtonText( $( event.target ).selectmenu( 'refresh' ) );
+		}
+
+		// Selectmenu widget options
+		var selectmenuOptions = { width: '97%'};
+
+		// Create the jQuery UI selectmenu widget for flag list dropdown and return its jQuery object.
+		var selectmenuFlagListCallbacks = {
+			create: createSelectCallback,
+			select: createSelectCallback,
+			open: openCallback,
+		};
+		var selectmenuFlagList = $( '#flag_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
 		// Overrides each item in the jQuery UI selectmenu list by injecting flag image.
-		$( '#flag_list' ).selectmenu( 'instance' )._renderItem = selectmenuRenderItem;
+		selectmenuFlagList.selectmenu('instance')._renderItem = selectmenuRenderItem;
 
 		// Language choice in predefined languages in Polylang Languages settings page and wizard.
 		// Overrides the predefined language dropdown list with our customized jquery ui selectmenu.
 
-		// Inject flag image when jQuery UI selectmenu is created or an item is selected.
-		$( '#lang_list' ).on(
-			'selectmenucreate selectmenuselect',
-			function() {
-				selectmenuRefreshButtonText( this );
-			}
-		);
-		// Create the jQuery UI selectmenu widget
-		$( '#lang_list' ).selectmenu( { width: '97%' } ); // jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
+		// Callback when Selectmenu widget change event is triggered.
+		var changeCallback = function( event, ui ) {
+			var value = $( event.target ).val().split( ':' );
+			var selected = $( "option:selected", event.target ).text().split( ' - ' );
+			$( '#lang_slug' ).val( value[0] );
+			$( '#lang_locale' ).val( value[1] );
+			$( 'input[name="rtl"]' ).val( [value[2]] );
+			$( '#lang_name' ).val( selected[0] );
+			$( '#flag_list').val( value[3] );
+
+			// Refresh the jQuery UI selectmenu flag list.
+			selectmenuRefreshButtonText( selectmenuFlagList.selectmenu( 'refresh' ) );
+		};
+
+		// Create the jQuery UI selectmenu widget language list dropdown and return its jQuery object.
+		var selectmenuLangListCallbacks = {
+			create: createSelectCallback,
+			select: createSelectCallback,
+			change: changeCallback,
+		};
+		var selectmenuLangList = $( '#lang_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuLangListCallbacks ) ); // jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
 		// However for the wizard we need a 100% width.
-		if( $( '#lang_list' ).closest( '.pll-wizard-content' ).length > 0 ) {
-			$( '#lang_list' ).selectmenu( 'option', 'width', '102%' );
-		}
+		// if( $( '#lang_list' ).closest( '.pll-wizard-content' ).length > 0 ) {
+		// 	$( '#lang_list' ).selectmenu( 'option', 'width', '102%' );
+		// }
 		// Overrides each element in the jQuery UI selectmenu list by injecting flag image.
-		$( '#lang_list' ).selectmenu( 'instance' )._renderItem = selectmenuRenderItem;
-
-		// Languages form
-		// Fills the fields based on the language dropdown list choice
-		$( '#add-lang #lang_list' ).on(
-			'selectmenuchange',
-			function() {
-				var value = $( this ).val().split( ':' );
-				var selected = $( "option:selected", this ).text().split( ' - ' );
-				$( '#lang_slug' ).val( value[0] );
-				$( '#lang_locale' ).val( value[1] );
-				$( 'input[name="rtl"]' ).val( [value[2]] );
-				$( '#lang_name' ).val( selected[0] );
-				$( '#flag_list').val( value[3] );
-
-				// Refresh the jQuery UI selectmenu flags list.
-				$( '#flag_list' ).selectmenu( 'refresh' ).trigger( 'selectmenuselect' );
-			}
-		);
+		selectmenuLangList.selectmenu( 'instance' )._renderItem = selectmenuRenderItem;
 
 		// strings translations
 		// save translations when pressing enter

--- a/js/admin.js
+++ b/js/admin.js
@@ -94,14 +94,14 @@ jQuery( document ).ready(
 
 		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
 
-		// Callbacks when Selectmenu widget open event is triggered.
-		// Needed to correctly refresh the selected element in the list when editing an existing language.
+		// Callbacks when Selectmenu widget change or open event is triggered.
+		// Needed to correctly refresh the selected element in the list when editing an existing language or when the value change is triggered by the language choice.
 		// jQuery UI 1.11 callback version.
-		var openCallback = function( event, ui ){
+		var changeOpenCallback = function( event, ui ){
 			selectmenuRefreshButtonText( $( event.target ).selectmenu( 'refresh' ) );
 		}
 		// jQueryUI 1.12 callback version.
-		var openCallbackjQueryUI112 = function( event, ui ){
+		var changeOpenCallbackjQueryUI112 = function( event, ui ){
 			// Just a refresh of the menu is needed with jQuery UI 1.12 because _renderButtonItem is triggered and then inject correctly the flag.
 			$( event.target ).selectmenu( 'refresh' );
 		}
@@ -109,13 +109,15 @@ jQuery( document ).ready(
 		if ( isJqueryUImin112 ) {
 			selectmenuFlagListCallbacks =
 				{
-					open: openCallbackjQueryUI112,
+					change: changeOpenCallbackjQueryUI112,
+					open: changeOpenCallbackjQueryUI112,
 				};
 		} else {
 			selectmenuFlagListCallbacks = {
 				create: createSelectCallback,
 				select: createSelectCallback,
-				open: openCallback,
+				change: changeOpenCallback,
+				open: changeOpenCallback,
 			};
 		}
 
@@ -131,6 +133,7 @@ jQuery( document ).ready(
 				selectmenuFlagList.refresh(); // Need to refresh to take in account the button item rendering method after the selectmenu widget instanciaion.
 			}
 		}
+
 		// Language choice in predefined languages in Polylang Languages settings page and wizard.
 		// Overrides the predefined language dropdown list with our customized jQuery ui selectmenu widget.
 
@@ -146,14 +149,8 @@ jQuery( document ).ready(
 			// Refresh the flag field only if it's present.
 			if ( flagListExist ) {
 				$( '#flag_list').val( value[3] );
-
-				// Refresh the jQuery UI selectmenu flag list.
-				if ( isJqueryUImin112 ) {
-					// Just a refresh of the menu is needed with jQuery UI 1.12 because _renderButtonItem is triggered and then inject correctly the flag.
-					selectmenuFlagList.refresh();
-				} else {
-					selectmenuRefreshButtonText( $( '#flag_list').selectmenu( 'refresh' ) );
-				}
+				// Refresh the jQuery UI selectmenu flag list widget by triggerring its change event.
+				selectmenuFlagList._trigger( 'change' );
 			}
 		};
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -147,21 +147,32 @@ jQuery( document ).ready(
 		 * Overrides the predefined language dropdown list with our customized jQuery ui selectmenu widget.
 		 */
 
-		// Callback when selectmenu widget change event is triggered.
-		var changeCallback = function( event, ui ) {
-			var value = $( event.target ).val().split( ':' );
-			var selected = $( "option:selected", event.target ).text().split( ' - ' );
-			$( '#lang_slug' ).val( value[0] );
-			$( '#lang_locale' ).val( value[1] );
-			$( 'input[name="rtl"]' ).val( [value[2]] );
-			$( '#lang_name' ).val( selected[0] );
+		/**
+		 * Fill the other language form fields from the language element selected in the language list dropdown.
+		 *
+		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
+		 */
+		function fillLanguageFields( languageSelected ) {
+			// All field values is obtained by splitting the selected element value in the language list dropdown.
+			var fieldValues = languageSelected.val().split( ':' );
+			// Language name field is obtained by splitting the selected element text in the language list dropdown.
+			var languageName = languageSelected.text().split( ' - ' );
+			$( '#lang_slug' ).val( fieldValues[0] );
+			$( '#lang_locale' ).val( fieldValues[1] );
+			$( 'input[name="rtl"]' ).val( [fieldValues[2]] );
+			$( '#lang_name' ).val( languageName[0] );
 
 			// Refresh the flag field only if it's present.
 			if ( flagListExist ) {
-				$( '#flag_list').val( value[3] );
+				$( '#flag_list').val( fieldValues[3] );
 				// Refresh the jQuery UI selectmenu flag list widget by triggerring its change event.
 				selectmenuFlagList._trigger( 'change' );
 			}
+		};
+
+		// Callback when selectmenu widget change event is triggered.
+		var changeCallback = function( event, ui ) {
+			fillLanguageFields( $( 'option:selected', event.target ) );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,8 +7,10 @@ jQuery( document ).ready(
 		// Add a boolean variable to be able to check jQuery UI >= 1.12 which is introduced in WP 5.6.
 		// Backward compatibility WP < 5.6
 		var isJqueryUImin112 = $.ui.version >= '1.12.0';
-		// Allow to check if a flag list dropdown is present. Not present in the Wizard steps.
+		// Allow to check if a flag list dropdown is present. Not present in the Wizard steps or other settings page.
 		var flagListExist = $( "#flag_list" ).length;
+		// Allow to check if a language list dropdown is present. Not present in other settings page.
+		var langListExist = $( "#lang_list" ).length;
 
 		// languages list table
 		// accessibility to row actions on focus
@@ -171,13 +173,15 @@ jQuery( document ).ready(
 				change: changeCallback,
 			};
 		}
-		var selectmenuLangList = $( '#lang_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuLangListCallbacks ) ).selectmenu( 'instance' );
-		// Overrides each element in the jQuery UI selectmenu list by injecting flag image.
-		selectmenuLangList._renderItem = selectmenuRenderItem;
-		// Override the selected item rendering for jQuery UI 1.12
-		if ( isJqueryUImin112 ) {
-			selectmenuLangList._renderButtonItem = selectmenuRenderButtonItem;
-			selectmenuLangList.refresh(); // Need to refresh to take in account the button item rendering method after the selectmenu widget instanciaion.
+		if ( langListExist ) {
+			var selectmenuLangList = $( '#lang_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuLangListCallbacks ) ).selectmenu( 'instance' );
+			// Overrides each element in the jQuery UI selectmenu list by injecting flag image.
+			selectmenuLangList._renderItem = selectmenuRenderItem;
+			// Override the selected item rendering for jQuery UI 1.12
+			if ( isJqueryUImin112 ) {
+				selectmenuLangList._renderButtonItem = selectmenuRenderButtonItem;
+				selectmenuLangList.refresh(); // Need to refresh to take in account the button item rendering method after the selectmenu widget instanciaion.
+			}
 		}
 
 		// strings translations

--- a/js/admin.js
+++ b/js/admin.js
@@ -95,20 +95,21 @@ jQuery( document ).ready(
 		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
 
 		// Callbacks when Selectmenu widget open event is triggered.
-		// Needed to correctly refresh the selected element in the list.
+		// Needed to correctly refresh the selected element in the list when editing an existing language.
+		// jQuery UI 1.11 callback version.
 		var openCallback = function( event, ui ){
-			if ( isJqueryUImin112 ) {
-				// Just a refresh of the menu is needed with jQuery UI 1.12 because _renderButtonItem is triggered and then inject correctly the flag.
-				$( event.target ).selectmenu( 'refresh' );
-			} else {
-				selectmenuRefreshButtonText( $( event.target ).selectmenu( 'refresh' ) );
-			}
+			selectmenuRefreshButtonText( $( event.target ).selectmenu( 'refresh' ) );
+		}
+		// jQueryUI 1.12 callback version.
+		var openCallbackjQueryUI112 = function( event, ui ){
+			// Just a refresh of the menu is needed with jQuery UI 1.12 because _renderButtonItem is triggered and then inject correctly the flag.
+			$( event.target ).selectmenu( 'refresh' );
 		}
 		// There is no need of create and select callbacks with jQuery UI 1.12 because overriding _renderButtonItem method do the job.
 		if ( isJqueryUImin112 ) {
 			selectmenuFlagListCallbacks =
 				{
-					open: openCallback,
+					open: openCallbackjQueryUI112,
 				};
 		} else {
 			selectmenuFlagListCallbacks = {

--- a/js/admin.js
+++ b/js/admin.js
@@ -153,11 +153,14 @@ jQuery( document ).ready(
 		if ( flagListExist ) {
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
 			var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
-			$( '#lang_list' ).on( 'notifyChange', function( event, language ) {
-				// Refresh the flag field
-				selectmenuFlagList.element.val( language.values[3] );
-				selectmenuFlagList._trigger( 'change' );
-			});
+			$( '#lang_list' ).on(
+				'notifyChange',
+				function( event, flag ) {
+					// Refresh the flag field
+					selectmenuFlagList.element.val( flag );
+					selectmenuFlagList._trigger( 'change' );
+				}
+			);
 		}
 
 		/**
@@ -171,21 +174,21 @@ jQuery( document ).ready(
 		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
 		 */
 		function fillLanguageFields( language ) {
-			// All field values is obtained by splitting the selected element value in the language list dropdown.
-			var fieldValues = language.values;
-			// Language name field is obtained by splitting the selected element text in the language list dropdown.
-			var languageName = language.name;
-			$( '#lang_slug' ).val( fieldValues[0] );
-			$( '#lang_locale' ).val( fieldValues[1] );
-			$( 'input[name="rtl"]' ).val( [fieldValues[2]] );
-			$( '#lang_name' ).val( languageName[0] );
+			$( '#lang_slug' ).val( language.slug );
+			$( '#lang_locale' ).val( language.locale );
+			$( 'input[name="rtl"]' ).val( language.rtl ); 
+			$( '#lang_name' ).val( language.name );
 		}
 
 		function parseSelectedLanguage( event ) {
 			var selectedElement = $('option:selected', event.target);
+			var values = selectedElement.val().split(':')
 			return {
-				values: selectedElement.val().split(':'),
-				name: selectedElement.text().split(' - ')
+				slug: values[0],
+				locale: values[1],
+				rtl: values[2],
+				flag: values[3],
+				name: selectedElement.text().split(' - ')[0] // at the moment there is no need of the 2nd part because it corresponding on the locale which is already by splitting the selected element value
 			};
 		}
 
@@ -195,7 +198,7 @@ jQuery( document ).ready(
 
 			fillLanguageFields( language );
 
-			$( event.target ).trigger( 'notifyChange', language );
+			$( event.target ).trigger( 'notifyChange', language.flag );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.

--- a/js/admin.js
+++ b/js/admin.js
@@ -20,7 +20,7 @@ jQuery( document ).ready(
 			{ // restricted to languages list table
 				focusin: function() {
 					clearTimeout( transitionTimeout );
-					focusedRowActions = $( this ).find( '.row-actions' );
+					var focusedRowActions = $( this ).find( '.row-actions' );
 					// transitionTimeout is necessary for Firefox, but Chrome won't remove the CSS class without a little help.
 					$( '.row-actions' ).not( this ).removeClass( 'visible' );
 					focusedRowActions.addClass( 'visible' );

--- a/js/admin.js
+++ b/js/admin.js
@@ -171,15 +171,21 @@ jQuery( document ).ready(
 		/**
 		 * Fill the other language form fields from the language element selected in the language list dropdown.
 		 *
-		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
+		 * @param {Object} language - language object of the selected element in the language list dropdown.
 		 */
 		function fillLanguageFields( language ) {
 			$( '#lang_slug' ).val( language.slug );
 			$( '#lang_locale' ).val( language.locale );
-			$( 'input[name="rtl"]' ).val( language.rtl ); 
+			$( 'input[name="rtl"]' ).val( language.rtl );
 			$( '#lang_name' ).val( language.name );
 		}
 
+		/**
+		 * Parse selected language element in the language list dropdown.
+		 *
+		 * @param {object} event - jQuery triggered event.
+		 * @return {object} The language object with its named properties.
+		 */
 		function parseSelectedLanguage( event ) {
 			var selectedElement = $('option:selected', event.target);
 			var values = selectedElement.val().split(':')
@@ -188,7 +194,7 @@ jQuery( document ).ready(
 				locale: values[1],
 				rtl: values[2],
 				flag: values[3],
-				name: selectedElement.text().split(' - ')[0] // at the moment there is no need of the 2nd part because it corresponding on the locale which is already by splitting the selected element value
+				name: selectedElement.text().split(' - ')[0] // At the moment there is no need of the 2nd part because it corresponds on the locale which is already known by splitting the selected element value
 			};
 		}
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -86,8 +86,16 @@ jQuery( document ).ready(
 		var createSelectCallback = function( event, ui ) {
 			selectmenuRefreshButtonText( event.target );
 		}
+
+		// Selectmenu widget options
+		// jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
+		var selectmenuOptions = { width: '97%'};
+		var selectmenuFlagListCallbacks = {};
+
+		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
+
 		// Callbacks when Selectmenu widget open event is triggered.
-		// Needed to corectly refresh the selected element in the list.
+		// Needed to correctly refresh the selected element in the list.
 		var openCallback = function( event, ui ){
 			if ( isJqueryUImin112 ) {
 				// Just a refresh of the menu is needed with jQuery UI 1.12 because _renderButtonItem is triggered and then inject correctly the flag.
@@ -96,15 +104,7 @@ jQuery( document ).ready(
 				selectmenuRefreshButtonText( $( event.target ).selectmenu( 'refresh' ) );
 			}
 		}
-
-		// Selectmenu widget options
-		// jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
-		var selectmenuOptions = { width: '97%'};
-		var selectmenuFlagListCallbacks = {};
-
-		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
-		// Create the jQuery UI selectmenu widget for flag list dropdown and return its instance.
-		// There is no need of create and select callbacks with jQuery UI 1.12 because overrinding _renderButtonItem method do the job.
+		// There is no need of create and select callbacks with jQuery UI 1.12 because overriding _renderButtonItem method do the job.
 		if ( isJqueryUImin112 ) {
 			selectmenuFlagListCallbacks =
 				{
@@ -120,6 +120,7 @@ jQuery( document ).ready(
 
 		// Create the selectmenu widget only if the field is present.
 		if ( flagListExist ) {
+			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
 			var selectmenuFlagList = $( '#flag_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) ).selectmenu( 'instance' );
 			// Overrides each item in the jQuery UI selectmenu list by injecting flag image.
 			selectmenuFlagList._renderItem = selectmenuRenderItem;

--- a/js/admin.js
+++ b/js/admin.js
@@ -4,13 +4,6 @@
 
 jQuery( document ).ready(
 	function( $ ) {
-		// Add a boolean variable to be able to check jQuery UI >= 1.12 which is introduced in WP 5.6.
-		// Backward compatibility WP < 5.6
-		var isJqueryUImin112 = $.ui.version >= '1.12.0';
-		// Allow to check if a flag list dropdown is present. Not present in the Wizard steps or other settings page.
-		var flagListExist = $( "#flag_list" ).length;
-		// Allow to check if a language list dropdown is present. Not present in other settings page.
-		var langListExist = $( "#lang_list" ).length;
 
 		// languages list table
 		// accessibility to row actions on focus
@@ -39,8 +32,15 @@ jQuery( document ).ready(
 			'tr'
 		); // acts on the whole tr instead of single td as we have actions links in several columns
 
-		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
-		// Common functions for overriding language and flag dropdown list.
+		// Common functions and variables for overriding languages and flags dropdown list.
+
+		// Add a boolean variable to be able to check jQuery UI >= 1.12 which is introduced in WP 5.6.
+		// Backward compatibility WP < 5.6
+		var isJqueryUImin112 = $.ui.version >= '1.12.0';
+		// Allow to check if a flag list dropdown is present. Not present in the Wizard steps or other settings page.
+		var flagListExist = $( "#flag_list" ).length;
+		// Allow to check if a language list dropdown is present. Not present in other settings page.
+		var langListExist = $( "#lang_list" ).length;
 
 		// Inject flag image when jQuery UI selectmenu is created or an item is selected.
 		// jQuery UI 1.12 introduce a wrapper inside de li tag which is necessary to selectmenu widget to work correctly.
@@ -102,6 +102,7 @@ jQuery( document ).ready(
 		var selectmenuOptions = { width: '97%'};
 		var selectmenuFlagListCallbacks = {};
 
+		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
 		// Create the jQuery UI selectmenu widget for flag list dropdown and return its instance.
 		// There is no need of create and select callbacks with jQuery UI 1.12 because overrinding _renderButtonItem method do the job.
 		if ( isJqueryUImin112 ) {
@@ -154,7 +155,7 @@ jQuery( document ).ready(
 			}
 		};
 
-		// Create the jQuery UI selectmenu widget language list dropdown and return its instance.
+		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.
 		var selectmenuLangListCallbacks = {};
 		// For the wizard we need a 100% width. So we override the previous defined value of selectmenuOptions. Remind that jQuery UI selectmenu widget substract 2% to this value.
 		if( $( '#lang_list' ).closest( '.pll-wizard-content' ).length > 0 ) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -84,6 +84,26 @@ jQuery( document ).ready(
 		}
 
 		/**
+		 * Initialize a jQuery UI selectmenu widget on a DOM element
+		 *
+		 * @param {*} element - The jQuery object representing the DOM element to attach the widget with.
+		 * @param {*} config  - All the parameters - options and callbacks - necessary to configure the jQuery UI selectmenu widget.
+		 * @return {Object} - The jQuery UI selectmenu widget object instance.
+		 */
+		function initializeSelectmenuWidget( element, config ) {
+			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
+			var selectmenuWidgetInstance = element.selectmenu( config ).selectmenu( 'instance' );
+			// Overrides each item in the jQuery UI selectmenu list by injecting flag image.
+			selectmenuWidgetInstance._renderItem = selectmenuRenderItem;
+			// Override the selected item rendering for jQuery UI 1.12
+			if ( isJqueryUImin112 ) {
+				selectmenuWidgetInstance._renderButtonItem = selectmenuRenderButtonItem;
+				// Need to refresh to take in account the new button item rendering method after the selectmenu widget instanciaion.
+				selectmenuWidgetInstance.refresh();
+			}
+			return selectmenuWidgetInstance
+		}
+		/**
 		 *  Selectmenu widget common parameters for its configuration: options and callbacks.
 		 */
 
@@ -132,14 +152,8 @@ jQuery( document ).ready(
 		// Create the selectmenu widget only if the field is present.
 		if ( flagListExist ) {
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
-			var selectmenuFlagList = $( '#flag_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) ).selectmenu( 'instance' );
-			// Overrides each item in the jQuery UI selectmenu list by injecting flag image.
-			selectmenuFlagList._renderItem = selectmenuRenderItem;
-			// Override the selected item rendering for jQuery UI 1.12
-			if ( isJqueryUImin112 ) {
-				selectmenuFlagList._renderButtonItem = selectmenuRenderButtonItem;
-				selectmenuFlagList.refresh(); // Need to refresh to take in account the button item rendering method after the selectmenu widget instanciaion.
-			}
+			// Need to keep the instance to be able to use it in the managment of the languages list.
+			 var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
 		}
 
 		/**
@@ -195,14 +209,7 @@ jQuery( document ).ready(
 			};
 		}
 		if ( langListExist ) {
-			var selectmenuLangList = $( '#lang_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuLangListCallbacks ) ).selectmenu( 'instance' );
-			// Overrides each element in the jQuery UI selectmenu list by injecting flag image.
-			selectmenuLangList._renderItem = selectmenuRenderItem;
-			// Override the selected item rendering for jQuery UI 1.12
-			if ( isJqueryUImin112 ) {
-				selectmenuLangList._renderButtonItem = selectmenuRenderButtonItem;
-				selectmenuLangList.refresh(); // Need to refresh to take in account the button item rendering method after the selectmenu widget instanciaion.
-			}
+			initializeSelectmenuWidget( $( '#lang_list' ), Object.assign( {}, selectmenuOptions, selectmenuLangListCallbacks ) );
 		}
 
 		// strings translations

--- a/js/admin.js
+++ b/js/admin.js
@@ -59,6 +59,7 @@ jQuery( document ).ready(
 		}
 
 		// Selectmenu widget options
+		// jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
 		var selectmenuOptions = { width: '97%'};
 
 		// Create the jQuery UI selectmenu widget for flag list dropdown and return its jQuery object.
@@ -89,16 +90,16 @@ jQuery( document ).ready(
 		};
 
 		// Create the jQuery UI selectmenu widget language list dropdown and return its jQuery object.
+		// For the wizard we need a 100% width. So we override the previous defined value.
+		if( $( '#lang_list' ).closest( '.pll-wizard-content' ).length > 0 ) {
+			selectmenuOptions = Object.assign( selectmenuOptions, { width: '102%' } );
+		}
 		var selectmenuLangListCallbacks = {
 			create: createSelectCallback,
 			select: createSelectCallback,
 			change: changeCallback,
 		};
 		var selectmenuLangList = $( '#lang_list' ).selectmenu( Object.assign( {}, selectmenuOptions, selectmenuLangListCallbacks ) ); // jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
-		// However for the wizard we need a 100% width.
-		// if( $( '#lang_list' ).closest( '.pll-wizard-content' ).length > 0 ) {
-		// 	$( '#lang_list' ).selectmenu( 'option', 'width', '102%' );
-		// }
 		// Overrides each element in the jQuery UI selectmenu list by injecting flag image.
 		selectmenuLangList.selectmenu( 'instance' )._renderItem = selectmenuRenderItem;
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -154,7 +154,7 @@ jQuery( document ).ready(
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
 			var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
 			$( '#lang_list' ).on(
-				'notifyChange',
+				'languageChanged',
 				function( event, flag ) {
 					// Refresh the flag field
 					selectmenuFlagList.element.val( flag );
@@ -198,7 +198,7 @@ jQuery( document ).ready(
 
 			fillLanguageFields( language );
 
-			$( event.target ).trigger( 'notifyChange', language.flag );
+			$( event.target ).trigger( 'languageChanged', language.flag );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.

--- a/js/admin.js
+++ b/js/admin.js
@@ -152,8 +152,12 @@ jQuery( document ).ready(
 		// Create the selectmenu widget only if the field is present.
 		if ( flagListExist ) {
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
-			// Need to keep the instance to be able to use it in the managment of the languages list.
-			 var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
+			var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
+			$( '#lang_list' ).on( 'notifyChange', function( event, language ) {
+				// Refresh the flag field
+				selectmenuFlagList.element.val( language.values[3] );
+				selectmenuFlagList._trigger( 'change' );
+			});
 		}
 
 		/**
@@ -166,27 +170,32 @@ jQuery( document ).ready(
 		 *
 		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
 		 */
-		function fillLanguageFields( languageSelected ) {
+		function fillLanguageFields( language ) {
 			// All field values is obtained by splitting the selected element value in the language list dropdown.
-			var fieldValues = languageSelected.val().split( ':' );
+			var fieldValues = language.values;
 			// Language name field is obtained by splitting the selected element text in the language list dropdown.
-			var languageName = languageSelected.text().split( ' - ' );
+			var languageName = language.name;
 			$( '#lang_slug' ).val( fieldValues[0] );
 			$( '#lang_locale' ).val( fieldValues[1] );
 			$( 'input[name="rtl"]' ).val( [fieldValues[2]] );
 			$( '#lang_name' ).val( languageName[0] );
+		}
 
-			// Refresh the flag field only if it's present.
-			if ( flagListExist ) {
-				$( '#flag_list').val( fieldValues[3] );
-				// Refresh the jQuery UI selectmenu flag list widget by triggerring its change event.
-				selectmenuFlagList._trigger( 'change' );
-			}
-		};
+		function parseSelectedLanguage( event ) {
+			var selectedElement = $('option:selected', event.target);
+			return {
+				values: selectedElement.val().split(':'),
+				name: selectedElement.text().split(' - ')
+			};
+		}
 
 		// Callback when selectmenu widget change event is triggered.
 		var changeCallback = function( event, ui ) {
-			fillLanguageFields( $( 'option:selected', event.target ) );
+			var language = parseSelectedLanguage( event );
+
+			fillLanguageFields( language );
+
+			$( event.target ).trigger( 'notifyChange', language );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.
@@ -383,3 +392,4 @@ jQuery( document ).ready(
 		}
 	}
 );
+

--- a/js/admin.js
+++ b/js/admin.js
@@ -32,7 +32,9 @@ jQuery( document ).ready(
 			'tr'
 		); // acts on the whole tr instead of single td as we have actions links in several columns
 
-		// Common functions and variables for overriding languages and flags dropdown list.
+		/**
+		 * Common functions and variables for overriding languages and flags dropdown list by a jQuery UI selectmenu widget.
+		*/
 
 		// Add a boolean variable to be able to check jQuery UI >= 1.12 which is introduced in WP 5.6.
 		// Backward compatibility WP < 5.6
@@ -81,18 +83,24 @@ jQuery( document ).ready(
 			return buttonItem;
 		}
 
-		// Selectmenu widget parameters.
+		/**
+		 *  Selectmenu widget common parameters for its configuration: options and callbacks.
+		 */
+
+		// Selectmenu widget options
+		// jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
+		var selectmenuOptions = { width: '97%'};
+
+		// Selectmenu widget callbacks
+		var selectmenuFlagListCallbacks = {};
 		// Callbacks when Selectmenu widget create or select event is triggered.
 		var createSelectCallback = function( event, ui ) {
 			selectmenuRefreshButtonText( event.target );
 		}
 
-		// Selectmenu widget options
-		// jQuery UI selectmenu widget substract 2% and we need 95% for the width matches to the other fields width.
-		var selectmenuOptions = { width: '97%'};
-		var selectmenuFlagListCallbacks = {};
-
-		// Overrides the flag dropdown list with our customized jquery ui selectmenu.
+		/**
+		 *  Overrides the flag dropdown list with our customized jquery ui selectmenu.
+		 */
 
 		// Callbacks when Selectmenu widget change or open event is triggered.
 		// Needed to correctly refresh the selected element in the list when editing an existing language or when the value change is triggered by the language choice.
@@ -134,8 +142,10 @@ jQuery( document ).ready(
 			}
 		}
 
-		// Language choice in predefined languages in Polylang Languages settings page and wizard.
-		// Overrides the predefined language dropdown list with our customized jQuery ui selectmenu widget.
+		/**
+		 * Language choice in predefined languages in Polylang Languages settings page and wizard.
+		 * Overrides the predefined language dropdown list with our customized jQuery ui selectmenu widget.
+		 */
 
 		// Callback when selectmenu widget change event is triggered.
 		var changeCallback = function( event, ui ) {


### PR DESCRIPTION
WordPress 5.6 will introduce new version of jQuery UI: 1.12
This new version introduces breaking changes in our use of jQuery UI selectmenu widget which triggers a javascript error making the use of the languages settings page and the wizard impossible.

So we need to adapt our code to be compatible with this new version but stay compatible with the older version - 1.11.4 - which is used in the older WordPress version.

### Breaking changes
- jQuery UI 1.12 replace the property name of its button in the selectmenu widget instance which triggers the javascript error quoted above.
- jQuery UI 1.12 introduces a wrapper in the menu rendering which produces side effects - wrong selection of the item and then wrong synchronization between language and flag fields - and breaks styles of the selected item in the menu or when we're hovering above the menu items. 

In this PR, I rewrote a lot of the code to be able to test which jQuery version we're using and thus initialize correctly the selectmenu widgets in function of this version.

jQuery UI 1.12 introduces a new extensions point method `_renderButtonItem` to be able to easier customize the selectmenu button than with older jQuery UI.
See https://api.jqueryui.com/1.12/selectmenu/#method-_renderButtonItem
So I decided to use this method which simplifies the management of the behaviours and solve the javascript error triggered because this method uses the new property name of the selectmenu button. The code is also ready for the future.

However we need to keep the older code for jQuery UI older version. It's why I introduce some checks of the jQuery UI version when it's necessary.
For example https://github.com/polylang/polylang/blob/migrate-jquery-35/js/admin.js#L90

For the side effects, I simply introduce the wrapper which is compatible with the two jQuery UI version - 1.11.4 and 1.12.1.
https://github.com/polylang/polylang/blob/migrate-jquery-35/js/admin.js#L60

However this wrapper introduction produces some style breaking changes that I also corrected.

I tested the code with the two versions of jQuery UI - 1.11.4 (WP 5.5) and 1.12.1 (WP5.6) and on the languages settings page and the two wizard steps - languages and untranslated content.

This closes the #https://github.com/polylang/polylang-pro/issues/700

**Note:** this PR doesn't provide for the moment the minified version of the javascript and css files. So it is usable only with the constant SCRIPT_DEBUG defined to true.

**Note:** this PR doesn't make modifications about jQuery depreciations. This will be the subject of another PR.