### PR TITLE
Fix sitemaps always redirected to the default language

### DIFF
--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -36,15 +36,6 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 */
 	protected $model;
 
-	/**
-	 * A reference to the current language.
-	 *
-	 * @since 2.8
-	 *
-	 * @var PLL_Language
-	 */
-	protected $curlang;
-
 
 	/**
 	 * Language used to filter queries for the sitemap index.
@@ -60,18 +51,16 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 *
 	 * @since 2.8
 	 *
-	 * @param WP_Sitemaps_Provider $provider An instance of a WP_Sitemaps_Provider child class.
-	 * @param object               $polylang Main Polylang object.
+	 * @param WP_Sitemaps_Provider $provider    An instance of a WP_Sitemaps_Provider child class.
+	 * @param PLL_Links_Model      $links_model The PLL_Links_Model instance.
 	 */
-	public function __construct( $provider, &$polylang ) {
+	public function __construct( $provider, &$links_model ) {
 		$this->name = $provider->name;
 		$this->object_type = $provider->object_type;
 
 		$this->provider = $provider;
-
-		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->links_model->model;
-		$this->curlang = &$polylang->curlang;
+		$this->links_model = &$links_model;
+		$this->model = &$links_model->model;
 	}
 
 	/**
@@ -200,11 +189,13 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );
-		} elseif ( $this->curlang ) {
-			$lang = $this->curlang;
+		} elseif ( get_query_var( 'lang' ) ) {
+			// Set url when $name doesn't have a lang to avoid the canonical redirection.
+			$lang = $this->model->get_language( get_query_var( 'lang' ) );
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );
-		} else {
+		}
+		else {
 			// Untranslated post types and taxonomies.
 			$url = $this->provider->get_sitemap_url( $name, $page );
 		}

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -72,9 +72,6 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$this->links_model = &$polylang->links_model;
 		$this->model = &$polylang->links_model->model;
 		$this->curlang = &$polylang->curlang;
-
-//		$this->links_model = &$links_model;
-//		$this->model = &$links_model->model;
 	}
 
 	/**

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -200,7 +200,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );
-		} else if ( $this->curlang ) {
+		} elseif ( $this->curlang ) {
 			$lang = $this->curlang;
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -183,24 +183,23 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @return string The composed URL for a sitemap entry.
 	 */
 	public function get_sitemap_url( $name, $page ) {
+		// Check if a language was added in $name.
 		$pattern = '#(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')$#';
 		if ( preg_match( $pattern, $name, $matches ) ) {
 			$lang = $this->model->get_language( $matches[1] );
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
 			$url = $this->provider->get_sitemap_url( $name, $page );
-			$url = $this->links_model->add_language_to_link( $url, $lang );
-		} elseif ( get_query_var( 'lang' ) ) {
-			// Set url when $name doesn't have a lang to avoid the canonical redirection.
-			$lang = $this->model->get_language( get_query_var( 'lang' ) );
-			$url = $this->provider->get_sitemap_url( $name, $page );
-			$url = $this->links_model->add_language_to_link( $url, $lang );
-		}
-		else {
-			// Untranslated post types and taxonomies.
-			$url = $this->provider->get_sitemap_url( $name, $page );
+			return $this->links_model->add_language_to_link( $url, $lang );
 		}
 
-		return $url;
+		// If no language is present in $name, we may attempt to get the current sitemap url (e.g. in redirect_canonical() ).
+		if ( get_query_var( 'lang' ) ) {
+			$lang = $this->model->get_language( get_query_var( 'lang' ) );
+			$url = $this->provider->get_sitemap_url( $name, $page );
+			return $this->links_model->add_language_to_link( $url, $lang );
+		}
+
+		return $this->provider->get_sitemap_url( $name, $page );
 	}
 
 	/**

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -36,6 +36,15 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 */
 	protected $model;
 
+	/**
+	 * A reference to the current language.
+	 *
+	 * @since 2.8
+	 *
+	 * @var PLL_Language
+	 */
+	protected $curlang;
+
 
 	/**
 	 * Language used to filter queries for the sitemap index.
@@ -51,16 +60,21 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 *
 	 * @since 2.8
 	 *
-	 * @param WP_Sitemaps_Provider $provider    An instance of a WP_Sitemaps_Provider child class.
-	 * @param PLL_Links_Model      $links_model The PLL_Links_Model instance.
+	 * @param WP_Sitemaps_Provider $provider An instance of a WP_Sitemaps_Provider child class.
+	 * @param object               $polylang Main Polylang object.
 	 */
-	public function __construct( $provider, &$links_model ) {
+	public function __construct( $provider, &$polylang ) {
 		$this->name = $provider->name;
 		$this->object_type = $provider->object_type;
 
 		$this->provider = $provider;
-		$this->links_model = &$links_model;
-		$this->model = &$links_model->model;
+
+		$this->links_model = &$polylang->links_model;
+		$this->model = &$polylang->links_model->model;
+		$this->curlang = &$polylang->curlang;
+
+//		$this->links_model = &$links_model;
+//		$this->model = &$links_model->model;
 	}
 
 	/**
@@ -187,6 +201,10 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		if ( preg_match( $pattern, $name, $matches ) ) {
 			$lang = $this->model->get_language( $matches[1] );
 			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
+			$url = $this->provider->get_sitemap_url( $name, $page );
+			$url = $this->links_model->add_language_to_link( $url, $lang );
+		} else if ( $this->curlang ) {
+			$lang = $this->curlang;
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			$url = $this->links_model->add_language_to_link( $url, $lang );
 		} else {

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -10,6 +10,13 @@
  */
 class PLL_Sitemaps {
 	/**
+	 * Reference to the Polylang object.
+	 *
+	 * @var object
+	 */
+	protected $polylang;
+
+	/**
 	 * A reference to the current language.
 	 *
 	 * @since 2.8
@@ -51,6 +58,7 @@ class PLL_Sitemaps {
 	 * @param object $polylang Main Polylang object.
 	 */
 	public function __construct( &$polylang ) {
+		$this->polylang = &$polylang;
 		$this->curlang = &$polylang->curlang;
 		$this->links_model = &$polylang->links_model;
 		$this->model = &$polylang->model;
@@ -152,7 +160,7 @@ class PLL_Sitemaps {
 	 */
 	public function replace_provider( $provider ) {
 		if ( $provider instanceof WP_Sitemaps_Provider ) {
-			$provider = new PLL_Multilingual_Sitemaps_Provider( $provider, $this->links_model );
+			$provider = new PLL_Multilingual_Sitemaps_Provider( $provider, $this->polylang );
 		}
 		return $provider;
 	}

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -10,13 +10,6 @@
  */
 class PLL_Sitemaps {
 	/**
-	 * Reference to the Polylang object.
-	 *
-	 * @var object
-	 */
-	protected $polylang;
-
-	/**
 	 * A reference to the current language.
 	 *
 	 * @since 2.8
@@ -58,7 +51,6 @@ class PLL_Sitemaps {
 	 * @param object $polylang Main Polylang object.
 	 */
 	public function __construct( &$polylang ) {
-		$this->polylang = &$polylang;
 		$this->curlang = &$polylang->curlang;
 		$this->links_model = &$polylang->links_model;
 		$this->model = &$polylang->model;
@@ -160,7 +152,7 @@ class PLL_Sitemaps {
 	 */
 	public function replace_provider( $provider ) {
 		if ( $provider instanceof WP_Sitemaps_Provider ) {
-			$provider = new PLL_Multilingual_Sitemaps_Provider( $provider, $this->polylang );
+			$provider = new PLL_Multilingual_Sitemaps_Provider( $provider, $this->links_model );
 		}
 		return $provider;
 	}

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -73,6 +73,7 @@ class PLL_Sitemaps {
 			add_filter( 'wp_sitemaps_index_entry', array( $this, 'index_entry' ) );
 			add_filter( 'wp_sitemaps_stylesheet_url', array( $this->links_model, 'site_url' ) );
 			add_filter( 'wp_sitemaps_stylesheet_index_url', array( $this->links_model, 'site_url' ) );
+			add_filter( 'home_url', array( $this, 'sitemap_url' ) );
 		}
 	}
 
@@ -168,5 +169,20 @@ class PLL_Sitemaps {
 	public function index_entry( $sitemap_entry ) {
 		$sitemap_entry['loc'] = $this->links_model->site_url( $sitemap_entry['loc'] );
 		return $sitemap_entry;
+	}
+
+	/**
+	 * Makes sure that the sitemap urls are always evaluated on the current domain.
+	 *
+	 * @since 2.8.4
+	 *
+	 * @param string $url A sitemap url.
+	 * @return string
+	 */
+	public function sitemap_url( $url ) {
+		if ( false !== strpos( $url, '/wp-sitemap' ) ) {
+			$url = $this->links_model->site_url( $url );
+		}
+		return $url;
 	}
 }

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -45,6 +45,9 @@ trait PLL_UnitTestCase_Trait {
 
 		$_REQUEST = array(); // WP Cleans up only $_POST and $_GET.
 
+		$_SERVER['HTTP_HOST']   = WP_TESTS_DOMAIN;
+		$_SERVER['REQUEST_URI'] = '';
+
 		parent::tearDown();
 	}
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -263,7 +263,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 					'lang' => 'en',
 					'sitemap' => 'posts',
 					'sitemap-subtype' => 'post',
-					'paged' => '1'
+					'paged' => '1',
 				),
 			)
 		);
@@ -284,7 +284,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 					'lang' => 'en',
 					'sitemap' => 'posts',
 					'sitemap-subtype' => 'cpt',
-					'paged' => '1'
+					'paged' => '1',
 				),
 			)
 		);
@@ -310,7 +310,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 					'lang' => 'en',
 					'sitemap' => 'taxonomies',
 					'sitemap-subtype' => 'tax',
-					'paged' => '1'
+					'paged' => '1',
 				),
 			)
 		);
@@ -329,7 +329,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				'qv'  => array(
 					'sitemap' => 'posts',
 					'sitemap-subtype' => 'cpt',
-					'paged' => '1'
+					'paged' => '1',
 				),
 			)
 		);
@@ -351,7 +351,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				'qv'  => array(
 					'sitemap' => 'taxonomies',
 					'sitemap-subtype' => 'tax',
-					'paged' => '1'
+					'paged' => '1',
 				),
 			)
 		);

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -77,6 +77,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public function init_for_sitemaps() {
+		if ( ! function_exists( 'wp_get_sitemap_providers' ) ) {
+			self::markTestSkipped( 'This test requires WP 5.5+' );
+		}
+
 		self::$polylang->links_model = self::$polylang->model->get_links_model();
 		if ( method_exists( self::$polylang->links_model, 'init' ) ) {
 			self::$polylang->links_model->init();


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/703

* In the multilingual sitemap provider, add the current language slug in the sitemap url when it is not called from the index.
* Add phpunit tests to test the canonical sitemap url.
* For multiple domains or subdmomains, make sure that sitemap urls are always evalauted on the current domain.
