### PR TITLE
Cache get_objects_in_language

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -279,7 +279,23 @@ abstract class PLL_Translated_Object {
 	public function get_objects_in_language( $lang ) {
 		global $wpdb;
 		$tt_id = $this->tax_tt;
-		return $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $lang->$tt_id ) );
+
+		$last_changed = wp_cache_get_last_changed( 'terms' );
+		$cache_key    = "polylang:get_objects_in_language:{$lang->$tt_id}:{$last_changed}";
+		$cache        = wp_cache_get( $cache_key, 'terms' );
+
+		if ( false === $cache ) {
+			$object_ids = $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $lang->$tt_id ) );
+			wp_cache_set( $cache_key, $object_ids, 'terms' );
+		} else {
+			$object_ids = (array) $cache;
+		}
+
+		if ( ! $object_ids ) {
+			return array();
+		}
+
+		return $object_ids;
 	}
 
 	/**


### PR DESCRIPTION
Tests made with Redis show  (or rather remind us) that the sql query in `PLL_Model::get_objects_in_language()` is not cached.
This method was created to avoid using `get_object_in_terms()` which does a useless (for us) `JOIN`, in the hope to slightly improve the performance.

Note: The `JOIN` is useless for us because we don't need to transform the `term_id` to a `term_taxonomy_id` as it ailready available in our `PLL_Language` object.

At the time the function was written, `get_object_in_terms()` was not cached either. However, things have evolved and the WordPress function is cached since WP 4.9. See https://core.trac.wordpress.org/ticket/37094#comment:9.

This PR caches our sql query using the same cache group as `get_object_in_terms()` to take profit of the WordPress invalidation system.

Another possibility, slightly less performant when the cache is empty, could be now to simply wrap `get_object_in_terms()`, but this would require to move the function to the child classes or to introduce a new property in child classes to be able to use the `term_id` instead of the `term_taxonomy_id` as today.
