### PR TITLE
A new way to handle options

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -281,6 +281,15 @@ class PLL_Admin_Base extends PLL_Base {
 		if ( wp_doing_ajax() && ! empty( $_REQUEST['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = $this->model->get_language( sanitize_key( $_REQUEST['lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
+
+		// Inform that the admin language has been set.
+		if ( $this->curlang ) {
+			/** This action is documented in frontend/choose-lang.php */
+			do_action( 'pll_language_defined', $this->curlang->slug, $this->curlang );
+		} else {
+			/** This action is documented in include/class-polylang.php */
+			do_action( 'pll_no_language_defined' ); // To load overridden textdomains.
+		}
 	}
 
 	/**
@@ -312,16 +321,6 @@ class PLL_Admin_Base extends PLL_Base {
 		$this->pref_lang = apply_filters( 'pll_admin_preferred_language', $this->pref_lang );
 
 		$this->set_current_language();
-
-		// Inform that the admin language has been set
-		// Only if the admin language is one of the Polylang defined language
-		if ( $curlang = $this->model->get_language( get_user_locale() ) ) {
-			/** This action is documented in frontend/choose-lang.php */
-			do_action( 'pll_language_defined', $curlang->slug, $curlang );
-		} else {
-			/** This action is documented in include/class-polylang.php */
-			do_action( 'pll_no_language_defined' ); // to load overridden textdomains
-		}
 
 		// Plugin i18n, only needed for backend.
 		load_plugin_textdomain( 'polylang' );

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -53,20 +53,9 @@ class PLL_Admin_Strings {
 	 */
 	public static function &get_strings() {
 		self::$default_strings = array(
-			'options' => array(
-				'blogname'        => __( 'Site Title', 'polylang' ),
-				'blogdescription' => __( 'Tagline', 'polylang' ),
-				'date_format'     => __( 'Date Format', 'polylang' ),
-				'time_format'     => __( 'Time Format', 'polylang' ),
-			),
 			'widget_title' => __( 'Widget title', 'polylang' ),
 			'widget_text'  => __( 'Widget text', 'polylang' ),
 		);
-
-		// WP strings
-		foreach ( self::$default_strings['options'] as $option => $string ) {
-			self::register_string( $string, get_option( $option ), 'WordPress' );
-		}
 
 		// Widgets titles
 		global $wp_registered_widgets;
@@ -121,11 +110,6 @@ class PLL_Admin_Strings {
 	 * @return string
 	 */
 	public static function sanitize_string_translation( $translation, $name ) {
-
-		if ( false !== ( $option = array_search( $name, self::$default_strings['options'], true ) ) ) {
-			$translation = sanitize_option( $option, $translation );
-		}
-
 		if ( $name == self::$default_strings['widget_title'] ) {
 			$translation = sanitize_text_field( $translation );
 		}

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -42,19 +42,12 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		}
 
 		// Strings translation ( must be applied before WordPress applies its default formatting filters )
-		foreach ( array( 'widget_text', 'widget_title', 'option_blogname', 'option_blogdescription', 'option_date_format', 'option_time_format' ) as $filter ) {
+		foreach ( array( 'widget_text', 'widget_title' ) as $filter ) {
 			add_filter( $filter, 'pll__', 1 );
 		}
 
 		// Translates biography
 		add_filter( 'get_user_metadata', array( $this, 'get_user_metadata' ), 10, 4 );
-
-		// Support theme customizer
-		// FIXME of course does not work if 'transport' is set to 'postMessage'
-		if ( isset( $_POST['wp_customize'], $_POST['customized'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			add_filter( 'pre_option_blogname', 'pll__', 20 );
-			add_filter( 'pre_option_blogdescription', 'pll__', 20 );
-		}
 
 		// FIXME test get_user_locale for backward compatibility with WP < 4.7
 		if ( Polylang::is_ajax_on_front() && function_exists( 'get_user_locale' ) ) {

--- a/include/base.php
+++ b/include/base.php
@@ -78,6 +78,12 @@ abstract class PLL_Base {
 		if ( $this->model->get_languages_list() ) {
 			$this->posts = new PLL_CRUD_Posts( $this );
 			$this->terms = new PLL_CRUD_Terms( $this );
+
+			// WordPress options.
+			new PLL_Translate_Option( 'blogname', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option(	'blogdescription', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option(	'date_format', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option(	'time_format', 1, array( 'context' => 'WorPress' ) );
 		}
 	}
 

--- a/include/base.php
+++ b/include/base.php
@@ -80,10 +80,10 @@ abstract class PLL_Base {
 			$this->terms = new PLL_CRUD_Terms( $this );
 
 			// WordPress options.
-			new PLL_Translate_Option( 'blogname', 1, array( 'context' => 'WorPress' ) );
-			new PLL_Translate_Option( 'blogdescription', 1, array( 'context' => 'WorPress' ) );
-			new PLL_Translate_Option( 'date_format', 1, array( 'context' => 'WorPress' ) );
-			new PLL_Translate_Option( 'time_format', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'blogname', array(), array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'blogdescription', array(), array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'date_format', array(), array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'time_format', array(), array( 'context' => 'WorPress' ) );
 		}
 	}
 

--- a/include/base.php
+++ b/include/base.php
@@ -81,9 +81,9 @@ abstract class PLL_Base {
 
 			// WordPress options.
 			new PLL_Translate_Option( 'blogname', 1, array( 'context' => 'WorPress' ) );
-			new PLL_Translate_Option(	'blogdescription', 1, array( 'context' => 'WorPress' ) );
-			new PLL_Translate_Option(	'date_format', 1, array( 'context' => 'WorPress' ) );
-			new PLL_Translate_Option(	'time_format', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'blogdescription', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'date_format', 1, array( 'context' => 'WorPress' ) );
+			new PLL_Translate_Option( 'time_format', 1, array( 'context' => 'WorPress' ) );
 		}
 	}
 

--- a/include/mo.php
+++ b/include/mo.php
@@ -105,4 +105,15 @@ class PLL_MO extends MO {
 	public function clean_cache() {
 		wp_cache_delete( 'polylang_mo_ids' );
 	}
+
+	/**
+	 * Deletes a string
+	 *
+	 * @since 2.9
+	 *
+	 * @param string $string The source string to remove from the translations.
+	 */
+	public function delete_entry( $string ) {
+		unset( $this->entries[ $string ] );
+	}
 }

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -255,7 +255,7 @@ class PLL_Translate_Option {
 						continue;
 					}
 
-					if ( is_object( $values ) && is_object( $old_values ) && isset( $values->$name, $values->$name ) ) {
+					if ( is_object( $values ) && is_object( $old_values ) && isset( $old_values->$name, $values->$name ) ) {
 						$values->$name = $this->check_value_recursive( $old_values->$name, $values->$name, $child );
 						continue;
 					}
@@ -269,7 +269,7 @@ class PLL_Translate_Option {
 								$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $values[ $n ], $child );
 							}
 
-							if ( is_object( $values ) && is_object( $old_values ) && isset( $values->$n, $values->$n ) ) {
+							if ( is_object( $values ) && is_object( $old_values ) && isset( $old_values->$n, $values->$n ) ) {
 								$values->$n = $this->check_value_recursive( $old_values->$n, $values->$n, $child );
 							}
 						}
@@ -282,7 +282,7 @@ class PLL_Translate_Option {
 						$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $values[ $n ], $child );
 					}
 
-					if ( is_object( $values ) && is_object( $old_values ) && isset( $values->$n, $values->$n ) ) {
+					if ( is_object( $values ) && is_object( $old_values ) && isset( $old_values->$n, $values->$n ) ) {
 						$values->$n = $this->check_value_recursive( $old_values->$n, $values->$n, $child );
 					}
 				}

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Registers and translates strings in an option.
+ * When a string is updated in an original option, the translations of the old string are assigned to the new original string.
+ *
+ * @since 2.9
+ */
+class PLL_Translate_Option {
+
+	/**
+	 * Array of option keys to translate.
+	 *
+	 * @var array
+	 */
+	private $keys;
+
+	/**
+	 * Array of updated strings.
+	 *
+	 * @var array
+	 */
+	private $udpated_strings = array();
+
+	/**
+	 * Constructor
+	 *
+	 * @since 2.9
+	 *
+	 * @param string $name Option name.
+	 * @param object $keys Recursive array of option keys to translate in the form:
+	 *   array(
+	 *     'option_key_to_translate_1' => 1,
+	 *     'option_key_to_translate_2' => 1,
+	 *     'my_group' => array(
+	 *       'sub_key_to_translate_1' => 1,
+	 *       'sub_key_to_translate_2' => 1,
+	 *     ),
+	 *   )
+	 *   Note: only keys are interpreted. Any scalar can be used as values.
+	 * @param string $args {
+	 *   Optional. Array of arguments for registering the option.
+	 *
+	 *   @type string $context           The group in which the strings will be registered.
+	 *   @type string $sanitize_callback A callback function that sanitizes the option's value.
+	 * }
+	 */
+	public function __construct( $name, $keys = array(), $args = array() ) {
+		// Registers the strings.
+		$context = isset( $args['context'] ) ? $args['context'] : 'Polylang';
+		$this->register_string_recursive( $context, $name, get_option( $name ), $keys );
+
+		// Translates the strings.
+		$this->keys = $keys;
+		add_filter( 'option_' . $name, array( $this, 'translate' ) ); // Make sure to add this filter after options are registered.
+
+		// Filters updated values.
+		add_filter( 'pre_update_option_' . $name, array( $this, 'pre_update_option' ), 10, 3 );
+		add_action( 'update_option_' . $name, array( $this, 'update_option' ) );
+
+		// Sanitizes translated strings.
+		if ( empty( $args['sanitize_callback'] ) ) {
+			add_filter( 'pll_sanitize_string_translation', array( $this, 'sanitize_option' ), 10, 2 );
+		} else {
+			add_filter( 'pll_sanitize_string_translation', $args['sanitize_callback'], 10, 3 );
+		}
+	}
+
+	/**
+	 * Translates the strings for an option.
+	 *
+	 * @since 1.0
+	 *
+	 * @param mixed $value Either a string to translate or a list of strings to translate.
+	 * @return mixed Translated string(s).
+	 */
+	public function translate( $value ) {
+		return $this->translate_string_recursive( $value, $this->keys );
+	}
+
+	/**
+	 * Recursively translates the strings for an option.
+	 *
+	 * @since 1.0
+	 *
+	 * @param array|string $values Either a string to translate or a list of strings to translate.
+	 * @param array|bool   $key    Array of option keys to translate.
+	 * @return array|string Translated string(s)
+	 */
+	protected function translate_string_recursive( $values, $key ) {
+		$children = is_array( $key ) ? $key : array();
+
+		if ( is_array( $values ) || is_object( $values ) ) {
+			if ( count( $children ) ) {
+				foreach ( $children as $name => $child ) {
+					if ( is_array( $values ) && isset( $values[ $name ] ) ) {
+						$values[ $name ] = $this->translate_string_recursive( $values[ $name ], $child );
+						continue;
+					}
+
+					if ( is_object( $values ) && isset( $values->$name ) ) {
+						$values->$name = $this->translate_string_recursive( $values->$name, $child );
+						continue;
+					}
+
+					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
+
+					foreach ( $values as $n => &$value ) {
+						// The first case could be handled by the next one, but we avoid calls to preg_match here.
+						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
+							$value = $this->translate_string_recursive( $value, $child );
+						}
+					}
+				}
+			} else {
+				// Parent key is a wildcard and no sub-key has been whitelisted.
+				foreach ( $values as &$value ) {
+					$value = $this->translate_string_recursive( $value, $key );
+				}
+			}
+		} else {
+			$values = pll__( $values );
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Recursively registers strings for an option.
+	 *
+	 * @since 1.0
+	 * @since 2.7 Signature modified
+	 *
+	 * @param string     $context The group in which the strings will be registered.
+	 * @param string     $option  Option name.
+	 * @param array      $values  Option value.
+	 * @param array|bool $key     Array of option keys to translate.
+	 */
+	protected function register_string_recursive( $context, $option, $values, $key ) {
+		if ( is_object( $values ) ) {
+			$values = (array) $values;
+		}
+
+		if ( is_array( $values ) ) {
+			$children = is_array( $key ) ? $key : array();
+
+			if ( count( $children ) ) {
+				foreach ( $children as $name => $child ) {
+					if ( isset( $values[ $name ] ) ) {
+						$this->register_string_recursive( $context, $name, $values[ $name ], $child );
+						continue;
+					}
+
+					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
+
+					foreach ( $values as $n => $value ) {
+						// The first case could be handled by the next one, but we avoid calls to preg_match here.
+						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
+							$this->register_string_recursive( $context, $n, $value, $child );
+						}
+					}
+				}
+			} else {
+				foreach ( $values as $n => $value ) {
+					// Parent key is a wildcard and no sub-key has been whitelisted.
+					$this->register_string_recursive( $context, $n, $value, $key );
+				}
+			}
+		} else {
+			pll_register_string( $option, $values, $context, true );
+		}
+	}
+
+	/**
+	 * Filters an option before it is updated.
+	 *
+	 * @since 2.9
+	 *
+	 * @param mixed  $value     The new, unserialized option value.
+	 * @param mixed  $old_value The old (filtered) option value.
+	 * @param string $name      Option name.
+	 */
+	public function pre_update_option( $value, $old_value, $name ) {
+		// Stores the unfiltered old option value before it is updated in DB.
+		remove_filter( 'option_' . $name, array( $this, 'translate' ), 10, 2 );
+		$this->old_value = get_option( $name );
+		add_filter( 'option_' . $name, array( $this, 'translate' ), 20, 2 );
+
+		// Load strings translations according to the admin language filter
+		$locale = pll_current_language( 'locale' );
+		if ( empty( $locale ) ) {
+			$locale = pll_default_language( 'locale' );
+		}
+		PLL()->load_strings_translations( $locale );
+
+		$value = $this->check_value_recursive( $this->old_value, $value, $this->keys );
+
+		return $value;
+	}
+
+	/**
+	 * Updates the string translations to keep the same translated value when updating the original option.
+	 *
+	 * @since 2.9
+	 */
+	public function update_option() {
+		$curlang = pll_current_language();
+
+		if ( ! empty( $this->updated_strings ) ) {
+			foreach ( pll_languages_list() as $lang ) {
+
+				$language = PLL()->model->get_language( $lang );
+				$mo = new PLL_MO();
+				$mo->import_from_db( $language );
+
+				foreach ( $this->updated_strings as $old_string => $string ) {
+					$translation = $mo->translate( $old_string );
+					if ( ( empty( $curlang ) && $translation === $old_string ) || $lang === $curlang ) {
+						$translation = $string;
+					}
+
+					// Removes the old entry and replace it by the new one, with the same translation.
+					$mo->delete_entry( $old_string );
+					$mo->add_entry( $mo->make_entry( $string, $translation ) );
+				}
+
+				$mo->export_to_db( $language );
+			}
+		}
+	}
+
+	/**
+	 * Prevents updating the option if we are saving the translation of the original value
+	 * when the admin language filter is active.
+	 * Stores the updated strings to be able to later assign the translations to the new value.
+	 *
+	 * @since 2.9
+	 *
+	 * @param mixed      $old_values The old option value.
+	 * @param mixed      $values     The new option value..
+	 * @param array|bool $key        Array of option keys to translate.
+	 * @return mixed
+	 */
+	protected function check_value_recursive( $old_values, $values, $key ) {
+		$children = is_array( $key ) ? $key : array();
+
+		if ( is_array( $values ) || is_object( $values ) ) {
+			if ( count( $children ) ) {
+				foreach ( $children as $name => $child ) {
+					if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $name ], $values[ $name ] ) ) {
+						$values[ $name ] = $this->check_value_recursive( $old_values[ $name ], $values[ $name ], $child );
+						continue;
+					}
+
+					if ( is_object( $values ) && is_object( $old_values ) && isset( $values->$name, $values->$name ) ) {
+						$values->$name = $this->check_value_recursive( $old_values->$name, $values->$name, $child );
+						continue;
+					}
+
+					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
+
+					foreach ( array_keys( $values ) as $n ) {
+						// The first case could be handled by the next one, but we avoid calls to preg_match here.
+						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
+							if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $n ], $values[ $n ] ) ) {
+								$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $values[ $n ], $child );
+							}
+
+							if ( is_object( $values ) && is_object( $old_values ) && isset( $values->$n, $values->$n ) ) {
+								$values->$n = $this->check_value_recursive( $old_values->$n, $values->$n, $child );
+							}
+						}
+					}
+				}
+			} else {
+				// Parent key is a wildcard and no sub-key has been whitelisted.
+				foreach ( array_keys( $values ) as $n ) {
+					if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $n ], $values[ $n ] ) ) {
+						$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $values[ $n ], $child );
+					}
+
+					if ( is_object( $values ) && is_object( $old_values ) && isset( $values->$n, $values->$n ) ) {
+						$values->$n = $this->check_value_recursive( $old_values->$n, $values->$n, $child );
+					}
+				}
+			}
+		} elseif ( $old_values !== $values ) {
+			if ( pll__( $old_values ) === $values ) {
+				$values = $old_values; // Prevents updating the value to its translation.
+			} else {
+				$this->updated_strings[ $old_values ] = $values; // Stores the updated strings.
+			}
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Sanitizes the option value.
+	 *
+	 * @since 2.9
+	 *
+	 * @param string $value The unsanitised value.
+	 * @param string $name  The name of the option.
+	 * @return string Sanitized value.
+	 */
+	public function sanitize_option( $value, $name ) {
+		return sanitize_option( $name, $value );
+	}
+}

--- a/integrations/twenty-seventeen/twenty-seven-teen.php
+++ b/integrations/twenty-seventeen/twenty-seven-teen.php
@@ -23,11 +23,8 @@ class PLL_Twenty_Seventeen {
 				}
 			}
 
-			if ( PLL() instanceof PLL_Frontend ) {
-				add_filter( 'theme_mod_external_header_video', 'pll__' );
-			} else {
-				pll_register_string( __( 'Header video', 'polylang' ), get_theme_mod( 'external_header_video' ), 'Twenty Seventeen', false );
-			}
+			$theme_slug = get_option( 'stylesheet' ); // In case we are using a child theme.
+			new PLL_Translate_Option( "theme_mods_$theme_slug", array( 'external_header_video' => 1 ), array( 'context' => 'Twenty Seventeen' ) );
 		}
 	}
 }

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -33,9 +33,11 @@ class Strings_Test extends PLL_UnitTestCase {
 	}
 
 	function test_base_strings() {
+		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		self::$polylang->init();
 		$strings = PLL_Admin_Strings::get_strings();
 		$names = wp_list_pluck( $strings, 'name' );
-		$this->assertCount( 4, array_intersect( array( 'Site Title', 'Tagline', 'Date Format', 'Time Format' ), $names ) );
+		$this->assertCount( 4, array_intersect( array( 'blogname', 'blogdescription', 'date_format', 'time_format' ), $names ) );
 	}
 
 	// FIXME: order of nest two tests matters due to static protected strings in PLL_Admin_Strings

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * This class is only for updating options.
+ * Registering and translating options is already tested in WPML_Config_Test
+ */
+class Translate_Option_Test extends PLL_UnitTestCase {
+
+	static function wpSetUpBeforeClass() {
+		parent::wpSetUpBeforeClass();
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+
+		require_once POLYLANG_DIR . '/include/api.php';
+		$GLOBALS['polylang'] = &self::$polylang;
+	}
+
+	protected function add_string_translations( $lang, $translations ) {
+		$language = self::$polylang->model->get_language( $lang );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		foreach ( $translations as $original => $translation ) {
+			$mo->add_entry( $mo->make_entry( $original, $translation ) );
+		}
+		$mo->export_to_db( $language );
+	}
+
+	protected function prepare_option_simple() {
+		add_option( 'my_option', 'val' );
+
+		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		new PLL_Translate_Option( 'my_option' );
+	}
+
+	function test_update_option_simple() {
+		$this->prepare_option_simple();
+
+		$languages = array( 'en', 'fr' );
+		foreach ( $languages as $lang ) {
+			$this->add_string_translations( $lang, array( 'val' => 'val_' . $lang ) );
+		}
+
+		// Quick check.
+		self::$polylang->load_strings_translations( 'en' );
+		$this->assertEquals( 'val_en', get_option( 'my_option' ) );
+		self::$polylang->load_strings_translations( 'fr' );
+		$this->assertEquals( 'val_fr', get_option( 'my_option' ) );
+
+		update_option( 'my_option', 'new_val' );
+
+		self::$polylang->load_strings_translations( 'en' );
+		$this->assertEquals( 'val_en', get_option( 'my_option' ) );
+		self::$polylang->load_strings_translations( 'fr' );
+		$this->assertEquals( 'val_fr', get_option( 'my_option' ) );
+	}
+
+	function test_update_option_simple_with_no_translation() {
+		$this->prepare_option_simple();
+		$this->add_string_translations( 'en', array( 'val' => 'val' ) );
+
+		// Quick check.
+		self::$polylang->load_strings_translations( 'en' );
+		$this->assertEquals( 'val', get_option( 'my_option' ) );
+
+		update_option( 'my_option', 'new_val' );
+
+		self::$polylang->load_strings_translations( 'en' );
+		$this->assertEquals( 'new_val', get_option( 'my_option' ) );
+	}
+
+	function test_update_option_simple_when_filtered() {
+		$this->prepare_option_simple();
+		$this->add_string_translations( 'en', array( 'val' => 'val_en' ) );
+
+		PLL()->curlang = self::$polylang->model->get_language( 'en' );
+		update_option( 'my_option', 'val_en' );
+
+		$language = self::$polylang->model->get_language( 'en' );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$this->assertArrayHasKey( 'val', $mo->entries );
+		$this->assertArrayNotHasKey( 'val_en', $mo->entries );
+	}
+
+	protected function prepare_option_multiple() {
+		$options = array(
+			'option_name_1'   => 'val1',
+			'options_group_1' => array(
+				'sub_option_name_11' => 'val11',
+			),
+		);
+
+		add_option( 'my_options', $options );
+
+		$keys = array(
+			'option_name_1'   => 1,
+			'options_group_1' => array(
+				'sub_option_name_11' => 1,
+			),
+		);
+
+		self::$polylang = new PLL_Admin( self::$polylang->links_model );
+		new PLL_Translate_Option( 'my_options', $keys );
+	}
+
+	function test_update_option_multiple() {
+		$this->prepare_option_multiple();
+
+		$languages = array( 'en', 'fr' );
+
+		foreach ( $languages as $lang ) {
+			$translations = array(
+				'val1'  => 'val1_' . $lang,
+				'val11' => 'val11_' . $lang,
+			);
+			$this->add_string_translations( $lang, $translations );
+		}
+
+		// Quick check.
+		foreach ( $languages as $lang ) {
+			self::$polylang->load_strings_translations( $lang );
+			$options = get_option( 'my_options' );
+			$this->assertEquals( 'val1_' . $lang, $options['option_name_1'] );
+			$this->assertEquals( 'val11_' . $lang, $options['options_group_1']['sub_option_name_11'] );
+		}
+
+		$options = array(
+			'option_name_1'   => 'new_val1',
+			'options_group_1' => array(
+				'sub_option_name_11' => 'new_val11',
+			),
+		);
+
+		update_option( 'my_options', $options );
+
+		foreach ( $languages as $lang ) {
+			self::$polylang->load_strings_translations( $lang );
+			$options = get_option( 'my_options' );
+			$this->assertEquals( 'val1_' . $lang, $options['option_name_1'] );
+			$this->assertEquals( 'val11_' . $lang, $options['options_group_1']['sub_option_name_11'] );
+		}
+	}
+
+	function test_update_option_multiple_with_no_translation() {
+		$this->prepare_option_multiple();
+
+		$translations = array(
+			'val1'  => 'val1',
+			'val11' => 'val11',
+		);
+		$this->add_string_translations( 'en', $translations );
+
+		$options = array(
+			'option_name_1'   => 'new_val1',
+			'options_group_1' => array(
+				'sub_option_name_11' => 'new_val11',
+			),
+		);
+
+		update_option( 'my_options', $options );
+
+		self::$polylang->load_strings_translations( 'en' );
+		$options = get_option( 'my_options' );
+		$this->assertEquals( 'new_val1', $options['option_name_1'] );
+		$this->assertEquals( 'new_val11', $options['options_group_1']['sub_option_name_11'] );
+	}
+
+	function test_update_option_multiple_when_filtered() {
+		$this->prepare_option_multiple();
+
+		$translations = array(
+			'val1'  => 'val1_en',
+			'val11' => 'val11_en',
+		);
+		$this->add_string_translations( 'en', $translations );
+
+		$options = array(
+			'option_name_1'   => 'val1_en',
+			'options_group_1' => array(
+				'sub_option_name_11' => 'val11_en',
+			),
+		);
+
+		PLL()->curlang = self::$polylang->model->get_language( 'en' );
+		update_option( 'my_options', $options );
+
+		$language = self::$polylang->model->get_language( 'en' );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$this->assertArrayHasKey( 'val1', $mo->entries );
+		$this->assertArrayNotHasKey( 'val1_en', $mo->entries );
+		$this->assertArrayHasKey( 'val11', $mo->entries );
+		$this->assertArrayNotHasKey( 'val11_en', $mo->entries );
+	}
+}

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -6,8 +6,8 @@
  */
 class Translate_Option_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass() {
-		parent::wpSetUpBeforeClass();
+	static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-wc/issues/211

Up to now, handling multilingual options was done by using `pll_register_string()`, `pll__()` and the filter `pll_sanitize_string_translation`. We copied this same logic multiple times to handle 3rd party plugin options.

On the other hand, the class `PLL_WPML_Config` was able to register strings and translate them based on a list in a configuration file. The mechanism was able to handle complex nested options with wildcards. There was however a limitation as the `wpml-config.xml` doesn't allow to declare a sanitization callback. 

Also the translation of options was intentionnally limited to the frontend to avoid conflicts when updating options in the backend.

This PR moves the logic to register strings and translate strings in options from `PLL_WPML_Config` to a new class `PLL_Translate_Option`.
Basically a `wpml-config.xml` `admin-texts` section like this:
```
<admin-texts>
		<key name="my_plugins_options">
				<key name="option_name_1" />
				<key name="option_name_2" />
				<key name="options_group_1">
						<key name="sub_option_name_11" />
						<key name="sub_option_name_12" />
				</key>
		</key>
		<key name="simple_string_option" />
</admin-texts>
```
could now be done in PHP like this:
```php
// In this array, only keys matter and are interpreted. The values (here 1) are not used. Any scalar value could be used instead.
$keys = array(
	'option_name_1' => 1,
	'option_name_2' => 1,
	'options_group_1' => array(
		'sub_option_name_11' => 1,
		'sub_option_name_12' => 1,
	),
);
new PLL_Translate_option( 'my_plugins_options', $keys );
new PLL_Translate_option( 'simple_string_option' );
```

The class constructor accepts a 3rd optional argument to add a context and/or a sanitization callback:
```php
$args = array(
	'context' => 'My group',
	'sanitize_callback' => 'my_sanitization_callback',
);
new PLL_Translate_option( 'simple_string_option', 1, $args );
``` 
If no context is provided, it defaults to `Polylang`.
The sanitize callback is just added to the filter `pll_sanitize_string_translation`.

Additional decisions taken:
* The strings translations always display multiline input fields
* The string name is the option key (or sub key)
as it's already the case for options handled with a `wpml-config.xml` file.

Now here are the improvements compared to the current situation:
* Previously, updating an option value causes the loss of its translation. Now if an option is translated, the translations are asigned to the new original value. But, if a translation was the same as the old value, then the translation is updated to the new value. This is handled after the option update in the `update_option` action.
* The translation is no more limited to the frontend and occurs on backend too, for example when the admin language filter is activated. That means that we have to prevent the original value to be updated when attempting to replace it by its translation. This is made possible by the `pre_update_option` filter.  
* Finally, if no sanitization callback is provided, we will use `sanitize_option()` which is used by the WordPress options and the plugins using the WordPress settings API.

No tests are added for the registration and translation part as this part is already covered by the tests for the `wpml-config.xml`. However new tests are added to cover the options update.
 
To complete the PR, the WordPress options, Yoast SEO options and Twenty Seventeen external header video are now using the new class. 