### PR TITLE
Add navigation markup to the language switcher widget

### DIFF
--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -35,24 +35,47 @@ class PLL_Widget_Languages extends WP_Widget {
 	 * @param array $instance The settings for the particular instance of the widget
 	 */
 	public function widget( $args, $instance ) {
-		// Sets a unique id for dropdown
+		// Sets a unique id for dropdown.
 		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
 
 		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
 			$title = empty( $instance['title'] ) ? '' : $instance['title'];
+
 			/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 			$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 			echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
+
 			if ( $title ) {
 				echo $args['before_title'] . $title . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput
 			}
+
+			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
+			$aria_label = trim( strip_tags( $title ) );
+			if ( ! $aria_label ) {
+				$aria_label = __( 'Select a language', 'polylang' );
+			}
+
 			if ( $instance['dropdown'] ) {
-				echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . esc_html__( 'Choose a language', 'polylang' ) . '</label>';
+				echo '<label class="screen-reader-text" for="' . esc_attr( 'lang_choice_' . $instance['dropdown'] ) . '">' . esc_html( $aria_label ) . '</label>';
 				echo $list; // phpcs:ignore WordPress.Security.EscapeOutput
 			} else {
+				$format = current_theme_supports( 'html5', 'navigation-widgets' ) ? 'html5' : 'xhtml';
+
+				/** This filter is documented in wp-includes/widgets/class-wp-nav-menu-widget.php */
+				$format = apply_filters( 'navigation_widgets_format', $format );
+
+				if ( 'html5' === $format ) {
+					echo '<nav role="navigation" aria-label="' . esc_attr( $aria_label ) . '">';
+				}
+
 				echo "<ul>\n" . $list . "</ul>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+
+				if ( 'html5' === $format ) {
+					echo '</nav>';
+				}
 			}
+
 			echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
 		}
 	}

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -53,7 +53,7 @@ class PLL_Widget_Languages extends WP_Widget {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$aria_label = trim( wp_strip_all_tags( $title ) );
 			if ( ! $aria_label ) {
-				$aria_label = __( 'Select a language', 'polylang' );
+				$aria_label = __( 'Choose a language', 'polylang' );
 			}
 
 			if ( $instance['dropdown'] ) {

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -51,7 +51,7 @@ class PLL_Widget_Languages extends WP_Widget {
 			}
 
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
-			$aria_label = trim( strip_tags( $title ) );
+			$aria_label = trim( wp_strip_all_tags( $title ) );
 			if ( ! $aria_label ) {
 				$aria_label = __( 'Select a language', 'polylang' );
 			}


### PR DESCRIPTION
Lets follow the move initiated by WP 5.5. See https://make.wordpress.org/core/2020/07/09/accessibility-improvements-to-widgets-outputting-lists-of-links-in-5-5/
Closes https://github.com/polylang/polylang-pro/issues/590