### PR TITLE
Reverse dependency between flags and languages list

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -153,11 +153,14 @@ jQuery( document ).ready(
 		if ( flagListExist ) {
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
 			var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
-			$( '#lang_list' ).on( 'notifyChange', function( event, language ) {
-				// Refresh the flag field
-				selectmenuFlagList.element.val( language.values[3] );
-				selectmenuFlagList._trigger( 'change' );
-			});
+			$( '#lang_list' ).on(
+				'notifyChange',
+				function( event, flag ) {
+					// Refresh the flag field
+					selectmenuFlagList.element.val( flag );
+					selectmenuFlagList._trigger( 'change' );
+				}
+			);
 		}
 
 		/**
@@ -171,21 +174,21 @@ jQuery( document ).ready(
 		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
 		 */
 		function fillLanguageFields( language ) {
-			// All field values is obtained by splitting the selected element value in the language list dropdown.
-			var fieldValues = language.values;
-			// Language name field is obtained by splitting the selected element text in the language list dropdown.
-			var languageName = language.name;
-			$( '#lang_slug' ).val( fieldValues[0] );
-			$( '#lang_locale' ).val( fieldValues[1] );
-			$( 'input[name="rtl"]' ).val( [fieldValues[2]] );
-			$( '#lang_name' ).val( languageName[0] );
+			$( '#lang_slug' ).val( language.slug );
+			$( '#lang_locale' ).val( language.locale );
+			$( 'input[name="rtl"]' ).val( language.rtl ); 
+			$( '#lang_name' ).val( language.name );
 		}
 
 		function parseSelectedLanguage( event ) {
 			var selectedElement = $('option:selected', event.target);
+			var values = selectedElement.val().split(':')
 			return {
-				values: selectedElement.val().split(':'),
-				name: selectedElement.text().split(' - ')
+				slug: values[0],
+				locale: values[1],
+				rtl: values[2],
+				flag: values[3],
+				name: selectedElement.text().split(' - ')[0] // at the moment there is no need of the 2nd part because it corresponding on the locale which is already by splitting the selected element value
 			};
 		}
 
@@ -195,7 +198,7 @@ jQuery( document ).ready(
 
 			fillLanguageFields( language );
 
-			$( event.target ).trigger( 'notifyChange', language );
+			$( event.target ).trigger( 'notifyChange', language.flag );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.

--- a/js/admin.js
+++ b/js/admin.js
@@ -171,15 +171,21 @@ jQuery( document ).ready(
 		/**
 		 * Fill the other language form fields from the language element selected in the language list dropdown.
 		 *
-		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
+		 * @param {Object} language - language object of the selected element in the language list dropdown.
 		 */
 		function fillLanguageFields( language ) {
 			$( '#lang_slug' ).val( language.slug );
 			$( '#lang_locale' ).val( language.locale );
-			$( 'input[name="rtl"]' ).val( language.rtl ); 
+			$( 'input[name="rtl"]' ).val( language.rtl );
 			$( '#lang_name' ).val( language.name );
 		}
 
+		/**
+		 * Parse selected language element in the language list dropdown.
+		 *
+		 * @param {object} event - jQuery triggered event.
+		 * @return {object} The language object with its named properties.
+		 */
 		function parseSelectedLanguage( event ) {
 			var selectedElement = $('option:selected', event.target);
 			var values = selectedElement.val().split(':')
@@ -188,7 +194,7 @@ jQuery( document ).ready(
 				locale: values[1],
 				rtl: values[2],
 				flag: values[3],
-				name: selectedElement.text().split(' - ')[0] // at the moment there is no need of the 2nd part because it corresponding on the locale which is already by splitting the selected element value
+				name: selectedElement.text().split(' - ')[0] // At the moment there is no need of the 2nd part because it corresponds on the locale which is already known by splitting the selected element value
 			};
 		}
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -154,7 +154,7 @@ jQuery( document ).ready(
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
 			var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
 			$( '#lang_list' ).on(
-				'notifyChange',
+				'languageChanged',
 				function( event, flag ) {
 					// Refresh the flag field
 					selectmenuFlagList.element.val( flag );
@@ -198,7 +198,7 @@ jQuery( document ).ready(
 
 			fillLanguageFields( language );
 
-			$( event.target ).trigger( 'notifyChange', language.flag );
+			$( event.target ).trigger( 'languageChanged', language.flag );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.

--- a/js/admin.js
+++ b/js/admin.js
@@ -152,8 +152,12 @@ jQuery( document ).ready(
 		// Create the selectmenu widget only if the field is present.
 		if ( flagListExist ) {
 			// Create the jQuery UI selectmenu widget for flags list dropdown and return its instance.
-			// Need to keep the instance to be able to use it in the managment of the languages list.
-			 var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
+			var selectmenuFlagList = initializeSelectmenuWidget( $( '#flag_list' ), Object.assign( {}, selectmenuOptions, selectmenuFlagListCallbacks ) );
+			$( '#lang_list' ).on( 'notifyChange', function( event, language ) {
+				// Refresh the flag field
+				selectmenuFlagList.element.val( language.values[3] );
+				selectmenuFlagList._trigger( 'change' );
+			});
 		}
 
 		/**
@@ -166,27 +170,32 @@ jQuery( document ).ready(
 		 *
 		 * @param {Object} languageSelected - jQuery object of the selected element in the language list dropdown.
 		 */
-		function fillLanguageFields( languageSelected ) {
+		function fillLanguageFields( language ) {
 			// All field values is obtained by splitting the selected element value in the language list dropdown.
-			var fieldValues = languageSelected.val().split( ':' );
+			var fieldValues = language.values;
 			// Language name field is obtained by splitting the selected element text in the language list dropdown.
-			var languageName = languageSelected.text().split( ' - ' );
+			var languageName = language.name;
 			$( '#lang_slug' ).val( fieldValues[0] );
 			$( '#lang_locale' ).val( fieldValues[1] );
 			$( 'input[name="rtl"]' ).val( [fieldValues[2]] );
 			$( '#lang_name' ).val( languageName[0] );
+		}
 
-			// Refresh the flag field only if it's present.
-			if ( flagListExist ) {
-				$( '#flag_list').val( fieldValues[3] );
-				// Refresh the jQuery UI selectmenu flag list widget by triggerring its change event.
-				selectmenuFlagList._trigger( 'change' );
-			}
-		};
+		function parseSelectedLanguage( event ) {
+			var selectedElement = $('option:selected', event.target);
+			return {
+				values: selectedElement.val().split(':'),
+				name: selectedElement.text().split(' - ')
+			};
+		}
 
 		// Callback when selectmenu widget change event is triggered.
 		var changeCallback = function( event, ui ) {
-			fillLanguageFields( $( 'option:selected', event.target ) );
+			var language = parseSelectedLanguage( event );
+
+			fillLanguageFields( language );
+
+			$( event.target ).trigger( 'notifyChange', language );
 		};
 
 		// Create the jQuery UI selectmenu widget languages list dropdown and return its instance.
@@ -383,3 +392,4 @@ jQuery( document ).ready(
 		}
 	}
 );
+


### PR DESCRIPTION
## Before

Our `selectmenuLangList` widget needed to check whether a `selectmenuFlagList`widget existed or not, because the `selectmenuLangList` is included on:
- The _Languages_ settings page where the `selectmenuFlagList` exists as well
- The _Languages_ Wizard step where the `selectmenuFlagList` doesn't exist

## Changes

We now attach an event handle to the `selectmenuLangList` from the outside, only when we need to set a `selectmenuFlagList` widget.

## Going further

I defined a custom `'notifyChange'` event, but maybe we could listen for the native `'change'` event instead?