### PR TITLE
admin.js code modernization

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -231,7 +231,8 @@ jQuery(
 
 		// settings URL modifications
 		// manages visibility of fields
-		$( "input[name='force_lang']" ).change(
+		$( "input[name='force_lang']" ).on(
+			'change',
 			function() {
 				function pll_toggle( a, test ) {
 					test ? a.show() : a.hide();

--- a/js/admin.js
+++ b/js/admin.js
@@ -104,9 +104,10 @@ jQuery(
 
 		// strings translations
 		// save translations when pressing enter
-		$( '.translation input' ).keypress(
+		$( '.translation input' ).on(
+			'keydown',
 			function( event ){
-				if ( 13 === event.keyCode ) {
+				if ( 'Enter' === event.key ) {
 					event.preventDefault();
 					$( '#submit' ).click();
 				}
@@ -213,14 +214,15 @@ jQuery(
 		);
 
 		// act when pressing enter or esc in configurations
-		$( '.pll-configure' ).keypress(
+		$( '.pll-configure' ).on(
+			'keydown',
 			function( event ){
-				if ( 13 === event.keyCode ) {
+				if ( 'Enter' === event.key ) {
 					event.preventDefault();
 					$( this ).find( '.save' ).click();
 				}
 
-				if ( 27 === event.keyCode ) {
+				if ( 'Escape' === event.key ) {
 					event.preventDefault();
 					$( this ).find( '.cancel' ).click();
 				}

--- a/js/admin.js
+++ b/js/admin.js
@@ -2,7 +2,7 @@
  * @package Polylang
  */
 
-jQuery( document ).ready(
+jQuery(
 	function( $ ) {
 		var transitionTimeout;
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/715 part of jQuery deprecated functions paragraph concerned by Polylang

- Replace `jQuery(document).ready( function($) ... )` long syntax with its short one  `jQuery(  function($) ... ) `
- Remove shorthand `keypress` and replace by `.on()` binding method
- Use `keydown` event instead of `keypress` one to manage correctly the Esc key which doesn't work anymore in URL modifications module of the settings page to simulate de cancel button.
- Use `event.key` to test key instead of `event.keyCode` which is deprecated too
See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
- Replace `change` shorthand with `.on()` binding method 
