### PR TITLE
Don't attempt to modify rewrite rules when there is no language

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -118,16 +118,19 @@ class PLL_Sitemaps {
 	public function rewrite_rules( $rules ) {
 		global $wp_rewrite;
 
-		$newrules = array();
-
 		$languages = $this->model->get_languages_list( array( 'fields' => 'slug' ) );
+
+		if ( empty( $languages ) ) {
+			return $rules;
+		}
+
 		if ( $this->options['hide_default'] ) {
 			$languages = array_diff( $languages, array( $this->options['default_lang'] ) );
 		}
 
-		if ( ! empty( $languages ) ) {
-			$slug = $wp_rewrite->root . ( $this->options['rewrite'] ? '^' : '^language/' ) . '(' . implode( '|', $languages ) . ')/';
-		}
+		$slug = $wp_rewrite->root . ( $this->options['rewrite'] ? '^' : '^language/' ) . '(' . implode( '|', $languages ) . ')/';
+
+		$newrules = array();
 
 		foreach ( $rules as $key => $rule ) {
 			if ( isset( $slug ) && false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/744

In this PR, we make sure that the logic to modify the sitemap rewrite rules is not executed when there is no language. 
Indeed although the module is not loaded when there is no languages, this protection is not sufficient when deleting a language and there is none remaining. 