### PR TITLE
Remove deprecated function in classic-editor.js

### DIFF
--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -6,7 +6,8 @@
 (function( $ ){
 	$.ajaxPrefilter(
 		function( options, originalOptions, jqXHR ) {
-			if ( 'string' === typeof options.data && -1 !== options.url.indexOf( 'action=ajax-tag-search' ) && ( lang = $( '.post_lang_choice' ).val() ) ) {
+			var lang = $( '.post_lang_choice' ).val();
+			if ( 'string' === typeof options.data && -1 !== options.url.indexOf( 'action=ajax-tag-search' ) && lang ) {
 				options.data = 'lang=' + lang + '&' + options.data;
 			}
 		}
@@ -44,8 +45,10 @@
 					}
 				);
 
+				var tagCloud = $('#tagcloud-' + tax);
 				// add an if else condition to allow modifying the tags outputed when switching the language
-				if ( v = $( '#tagcloud-' + tax ).css( 'display' ) ) {
+				var v = tagCloud.css( 'display' );
+				if ( v ) {
 					// See the comment above when r variable is created.
 					$( '#tagcloud-' + tax ).replaceWith( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
 					$( '#tagcloud-' + tax ).css( 'display', v );

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -187,7 +187,8 @@ jQuery( document ).ready(
 					);
 
 					// when the input box is emptied
-					$( this ).blur(
+					$( this ).on(
+						'blur',
 						function() {
 							if ( ! $( this ).val() ) {
 								$( '#htr_lang_' + tr_lang ).val( 0 );

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -3,7 +3,7 @@
  */
 
 // tag suggest in metabox
-(function( $ ){
+jQuery( function( $ ) {
 	$.ajaxPrefilter(
 		function( options, originalOptions, jqXHR ) {
 			var lang = $( '.post_lang_choice' ).val();
@@ -12,10 +12,10 @@
 			}
 		}
 	);
-})( jQuery );
+});
 
 // overrides tagBox.get
-(function( $ ){
+jQuery( function( $ ) {
 	// overrides function to add the language
 	tagBox.get = function( id ) {
 		var tax = id.substr( id.indexOf( '-' ) + 1 );
@@ -60,10 +60,9 @@
 			}
 		);
 	}
-})( jQuery );
+});
 
-jQuery( document ).ready(
-	function( $ ) {
+jQuery( function ( $ ) {
 		// collect taxonomies - code partly copied from WordPress
 		var taxonomies = new Array();
 		$( '.categorydiv' ).each(

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -3,66 +3,71 @@
  */
 
 // tag suggest in metabox
-jQuery( function( $ ) {
-	$.ajaxPrefilter(
-		function( options, originalOptions, jqXHR ) {
-			var lang = $( '.post_lang_choice' ).val();
-			if ( 'string' === typeof options.data && -1 !== options.url.indexOf( 'action=ajax-tag-search' ) && lang ) {
-				options.data = 'lang=' + lang + '&' + options.data;
-			}
-		}
-	);
-});
-
-// overrides tagBox.get
-jQuery( function( $ ) {
-	// overrides function to add the language
-	tagBox.get = function( id ) {
-		var tax = id.substr( id.indexOf( '-' ) + 1 );
-
-		// add the language in the $_POST variable
-		var data = {
-			action: 'get-tagcloud',
-			lang:   $( '.post_lang_choice' ).val(),
-			tax:    tax
-		}
-
-		$.post(
-			ajaxurl,
-			data,
-			function( r, stat ) {
-				if ( 0 == r || 'success' != stat ) {
-					r = wpAjax.broken;
-				}
-
-				// @see code from WordPress core https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/js/tags-box.js#L291
-				// @see wp_generate_tag_cloud function which generate the escaped HTML https://github.com/WordPress/WordPress/blob/a02b5cc2a8eecb8e076fbb7cf4de7bd2ec8a8eb1/wp-includes/category-template.php#L966-L975
-				r = $( '<div />' ).addClass( 'the-tagcloud' ).attr( 'id', 'tagcloud-' + tax ).html( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-				$( 'a', r ).click(
-					function(){
-						tagBox.flushTags( $( this ).closest( '.inside' ).children( '.tagsdiv' ), this );
-						return false;
-					}
-				);
-
-				var tagCloud = $('#tagcloud-' + tax);
-				// add an if else condition to allow modifying the tags outputed when switching the language
-				var v = tagCloud.css( 'display' );
-				if ( v ) {
-					// See the comment above when r variable is created.
-					$( '#tagcloud-' + tax ).replaceWith( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
-					$( '#tagcloud-' + tax ).css( 'display', v );
-				}
-				else {
-					// See the comment above when r variable is created.
-					$( '#' + id ).after( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
+jQuery(
+	function( $ ) {
+		$.ajaxPrefilter(
+			function( options, originalOptions, jqXHR ) {
+				var lang = $( '.post_lang_choice' ).val();
+				if ( 'string' === typeof options.data && -1 !== options.url.indexOf( 'action=ajax-tag-search' ) && lang ) {
+					options.data = 'lang=' + lang + '&' + options.data;
 				}
 			}
 		);
 	}
-});
+);
 
-jQuery( function ( $ ) {
+// overrides tagBox.get
+jQuery(
+	function( $ ) {
+		// overrides function to add the language
+		tagBox.get = function( id ) {
+			var tax = id.substr( id.indexOf( '-' ) + 1 );
+
+			// add the language in the $_POST variable
+			var data = {
+				action: 'get-tagcloud',
+				lang:   $( '.post_lang_choice' ).val(),
+				tax:    tax
+			}
+
+			$.post(
+				ajaxurl,
+				data,
+				function( r, stat ) {
+					if ( 0 == r || 'success' != stat ) {
+						r = wpAjax.broken;
+					}
+
+					// @see code from WordPress core https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/js/tags-box.js#L291
+					// @see wp_generate_tag_cloud function which generate the escaped HTML https://github.com/WordPress/WordPress/blob/a02b5cc2a8eecb8e076fbb7cf4de7bd2ec8a8eb1/wp-includes/category-template.php#L966-L975
+					r = $( '<div />' ).addClass( 'the-tagcloud' ).attr( 'id', 'tagcloud-' + tax ).html( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+					$( 'a', r ).click(
+						function(){
+							tagBox.flushTags( $( this ).closest( '.inside' ).children( '.tagsdiv' ), this );
+							return false;
+						}
+					);
+
+					var tagCloud = $( '#tagcloud-' + tax );
+					// add an if else condition to allow modifying the tags outputed when switching the language
+					var v = tagCloud.css( 'display' );
+					if ( v ) {
+						// See the comment above when r variable is created.
+						$( '#tagcloud-' + tax ).replaceWith( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+						$( '#tagcloud-' + tax ).css( 'display', v );
+					}
+					else {
+						// See the comment above when r variable is created.
+						$( '#' + id ).after( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
+					}
+				}
+			);
+		}
+	}
+);
+
+jQuery(
+	function ( $ ) {
 		// collect taxonomies - code partly copied from WordPress
 		var taxonomies = new Array();
 		$( '.categorydiv' ).each(


### PR DESCRIPTION
## Changes

- Remove the use of jQuery deprecated functions
- Explicitly declare variables in the local context
- Use recommended `jQuery( function( $ ) { /* ... */ ]);` syntax

Fixes https://github.com/polylang/polylang-pro/issues/732