### PR TITLE
Remove jQuery deprecated functions calls in block-editor.js

### DIFF
--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -39,7 +39,7 @@ function getCurrentLanguage() {
  *
  * @since 2.5
  */
-jQuery( document ).ready(
+jQuery(
 	function( $ ) {
 		// savePost after changing the post's language and reload page for refreshing post translated data
 		$( '.post_lang_choice' ).on(
@@ -118,7 +118,7 @@ jQuery( document ).ready(
  *
  * @since 1.5
  */
-jQuery( document ).ready(
+jQuery(
 	function( $ ) {
 		// Ajax for changing the post's language in the languages metabox
 		$( '.post_lang_choice' ).on(

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -42,7 +42,8 @@ function getCurrentLanguage() {
 jQuery( document ).ready(
 	function( $ ) {
 		// savePost after changing the post's language and reload page for refreshing post translated data
-		$( '.post_lang_choice' ).change(
+		$( '.post_lang_choice' ).on(
+			'change',
 			function() {
 				const select = wp.data.select;
 				const dispatch = wp.data.dispatch;
@@ -120,7 +121,8 @@ jQuery( document ).ready(
 jQuery( document ).ready(
 	function( $ ) {
 		// Ajax for changing the post's language in the languages metabox
-		$( '.post_lang_choice' ).change(
+		$( '.post_lang_choice' ).on(
+			'change',
 			function() {
 				var data = {
 					action:     'post_lang_choice',
@@ -182,7 +184,8 @@ jQuery( document ).ready(
 					);
 
 					// When the input box is emptied
-					$( this ).blur(
+					$( this ).on(
+						'blur',
 						function() {
 							if ( ! $( this ).val() ) {
 								$( '#htr_lang_' + tr_lang ).val( 0 );


### PR DESCRIPTION
## Changes 

- Remove calls to jQuery deprecated functions
- Use recommended jQuery initialization syntax

Fixes https://github.com/polylang/polylang-pro/issues/740

## Known issues

[jQuery UI 1.12.1 Autocomplete Widget](https://jqueryui.com/autocomplete/) still uses functions deprecated in jQuery 3.5