### PR TITLE
Replace shorthands which trigger events

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -237,7 +237,7 @@ jQuery(
 			function( event ){
 				if ( 'Enter' === event.key ) {
 					event.preventDefault();
-					$( '#submit' ).click();
+					$( '#submit' ).trigger( 'click' );
 				}
 			}
 		);
@@ -347,12 +347,12 @@ jQuery(
 			function( event ){
 				if ( 'Enter' === event.key ) {
 					event.preventDefault();
-					$( this ).find( '.save' ).click();
+					$( this ).find( '.save' ).trigger( 'click' );
 				}
 
 				if ( 'Escape' === event.key ) {
 					event.preventDefault();
-					$( this ).find( '.cancel' ).click();
+					$( this ).find( '.cancel' ).trigger( 'click' );
 				}
 			}
 		);


### PR DESCRIPTION
By watching the issue [#743](https://github.com/polylang/polylang-pro/issues/743) I saw that Jquery migrate warns about the shorthand to trigger `focus` event.
However jQuery migrate didn't warn about the shorthand to trigger `click` event in admin.js script.

So this PR complete the [previous one](https://github.com/polylang/polylang/pull/624) by replacing `.click()` shorthand with the use of `.trigger()` method.

Notice that [these lines](https://github.com/polylang/polylang/blob/2.8.4/js/admin.js#L102-L110) will become useless when all the input fields in the strings translations will be multiline fields by merging this [PR](https://github.com/polylang/polylang/pull/613)