### PR TITLE
Require WP 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,9 @@ matrix:
   - name: PHPCS
     php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 PHPCS=1
-  - name: WP 4.9 (oldest)
+  - name: WP 5.1 (oldest)
     php: 7.2
-    env: WP_VERSION=4.9 WP_MULTISITE=0
-  - name: WP 5.0 (oldest with block editor)
-    php: 7.2
-    env: WP_VERSION=5.0 WP_MULTISITE=0
+    env: WP_VERSION=5.1 WP_MULTISITE=0
   - name: PHP 5.6
     php: 5.6
     env: WP_VERSION=latest WP_MULTISITE=0

--- a/include/functions.php
+++ b/include/functions.php
@@ -42,51 +42,6 @@ if ( ! function_exists( 'wpcom_vip_get_page_by_path' ) ) {
 	}
 }
 
-if ( ! function_exists( 'wp_doing_ajax' ) ) {
-	/**
-	 * Determines whether the current request is a WordPress Ajax request.
-	 * Backward compatibility function for WP < 4.7
-	 *
-	 * @since 2.2
-	 *
-	 * @return bool True if it's a WordPress Ajax request, false otherwise.
-	 */
-	function wp_doing_ajax() {
-		/** This filter is documented in wp-includes/load.php */
-		return apply_filters( 'wp_doing_ajax', defined( 'DOING_AJAX' ) && DOING_AJAX );
-	}
-}
-
-if ( ! function_exists( 'wp_doing_cron' ) ) {
-	/**
-	 * Determines whether the current request is a WordPress cron request.
-	 * Backward compatibility function for WP < 4.8
-	 *
-	 * @since 2.6
-	 *
-	 * @return bool True if it's a WordPress cron request, false otherwise.
-	 */
-	function wp_doing_cron() {
-		/** This filter is documented in wp-includes/load.php */
-		return apply_filters( 'wp_doing_cron', defined( 'DOING_CRON' ) && DOING_CRON );
-	}
-}
-
-if ( ! function_exists( 'wp_using_themes' ) ) {
-	/**
-	 * Determines whether the current request should use themes.
-	 * Backward compatibility function for WP < 5.1
-	 *
-	 * @since 2.6
-	 *
-	 * @return bool True if themes should be used, false otherwise.
-	 */
-	function wp_using_themes() {
-		/** This filter is documented in wp-includes/load.php */
-		return apply_filters( 'wp_using_themes', defined( 'WP_USE_THEMES' ) && WP_USE_THEMES );
-	}
-}
-
 /**
  * Determines whether we should load the cache compatibility
  *

--- a/install/install-base.php
+++ b/install/install-base.php
@@ -25,13 +25,8 @@ class PLL_Install_Base {
 		register_activation_hook( $plugin_basename, array( $this, 'activate' ) );
 		register_deactivation_hook( $plugin_basename, array( $this, 'deactivate' ) );
 
-		// Blog creation on multisite.
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '<' ) ) {
-			// FIXME: Backward compatibility with WP < 5.1.
-			add_action( 'wpmu_new_blog', array( $this, 'wpmu_new_blog' ), 5 ); // Before WP attempts to send mails which can break on some PHP versions
-		} else {
-			add_action( 'wp_insert_site', array( $this, 'new_site' ) );
-		}
+		// Site creation on multisite.
+		add_action( 'wp_insert_site', array( $this, 'new_site' ) );
 	}
 
 	/**
@@ -120,20 +115,6 @@ class PLL_Install_Base {
 	 */
 	public function new_site( $new_site ) {
 		switch_to_blog( $new_site->id );
-		$this->_activate();
-		restore_current_blog();
-	}
-
-	/**
-	 * Blog creation on multisite ( to set default options )
-	 * Backward compatibility with WP < 5.1
-	 *
-	 * @since 0.9.4
-	 *
-	 * @param int $blog_id
-	 */
-	public function wpmu_new_blog( $blog_id ) {
-		switch_to_blog( $blog_id );
 		$this->_activate();
 		restore_current_blog();
 	}

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -59,11 +59,7 @@ if ( ! function_exists( 'icl_get_languages' ) ) {
 
 		// NB: When 'skip_missing' is false, WPML returns all languages even if there is no content
 		$languages = PLL()->model->get_languages_list( array( 'hide_empty' => $args['skip_missing'] ) );
-
-		// FIXME: Backward compatibility with WP < 4.7
-		if ( function_exists( 'wp_list_sort' ) ) {
-			$languages = wp_list_sort( $languages, $orderby, $order ); // Since WP 4.7
-		}
+		$languages = wp_list_sort( $languages, $orderby, $order ); // Since WP 4.7
 
 		foreach ( $languages as $lang ) {
 			// We can find a translation only on frontend once the global $wp_query object has been instantiated

--- a/polylang.php
+++ b/polylang.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://polylang.pro
  * Description:       Adds multilingual capability to WordPress
  * Version:           2.9-dev
- * Requires at least: 4.9
+ * Requires at least: 5.1
  * Requires PHP:      5.6
  * Author:            WP SYNTEX
  * Author URI:        https://polylang.pro
@@ -54,7 +54,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 } else {
 	// Go on loading the plugin
 	define( 'POLYLANG_VERSION', '2.9-dev' );
-	define( 'PLL_MIN_WP_VERSION', '4.9' );
+	define( 'PLL_MIN_WP_VERSION', '5.1' );
 	define( 'PLL_MIN_PHP_VERSION', '5.6' );
 
 	define( 'POLYLANG_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Chouby, manooweb, raaaahman, marianne38, sebastienserre
 Donate link: https://polylang.pro
 Tags: multilingual, bilingual, translate, translation, language, multilanguage, international, localization
-Requires at least: 4.9
+Requires at least: 5.1
 Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 2.8.4
@@ -43,7 +43,7 @@ Don't hesitate to [give your feedback](http://wordpress.org/support/view/plugin-
 
 == Installation ==
 
-1. Make sure you are using WordPress 4.9 or later and that your server is running PHP 5.6 or later (same requirement as WordPress itself)
+1. Make sure you are using WordPress 5.1 or later and that your server is running PHP 5.6 or later (same requirement as WordPress itself)
 1. If you tried other multilingual plugins, deactivate them before activating Polylang, otherwise, you may get unexpected results!
 1. Install and activate the plugin as usual from the 'Plugins' menu in WordPress.
 1. Go to the languages settings page and create the languages you need

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -61,7 +61,6 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 	}
 
 	function test_personal_options_update() {
-		$_POST['user_lang'] = 'en_US'; // Backward compatibility with WP < 4.7
 		$_POST['description_de'] = 'Biography in German';
 		remove_action( 'personal_options_update', 'send_confirmation_on_profile_email' );
 		do_action( 'personal_options_update', 1 );


### PR DESCRIPTION
Remove specific code and tests for WP versions older than 5.1.
Update travis tests accordingly.