### PR TITLE
Fix broken coverage for page for posts

### DIFF
--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -66,14 +66,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		self::$polylang->model->post->save_translations( self::$page_for_posts_en, compact( 'en', 'fr' ) );
 
-		update_option( 'page_for_posts', self::$page_for_posts_fr );
-
 		self::$page_on_front_en = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'home' ) );
 
 		self::$polylang->model->post->set_language( self::$page_on_front_en, 'en' );
-
-		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
-		update_option( 'show_on_front', 'posts' );
 
 		// Translated cpt and tax
 		register_post_type( 'trcpt', array( 'public' => true ) );
@@ -118,6 +113,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		_unregister_post_type( 'pllcanonical' );
+		_unregister_post_type( 'trcpt' );
 
 		parent::wpTearDownAfterClass();
 	}
@@ -236,10 +232,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public function test_page_for_posts_should_match_page_for_post_option_when_language_is_incorrect() {
+		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		$this->assertCanonical( '/fr/posts/', '/en/posts/' );
 	}
 
 	public function test_page_for_posts_should_match_page_for_post_option_posts_without_language() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		$this->assertCanonical( '/posts/', '/en/posts/' );
 	}
 
@@ -248,10 +248,16 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public function test_page_for_post_option_should_be_translated_when_language_is_incorrect() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		$this->assertCanonical( '/en/articles/', '/fr/articles/' );
 	}
 
 	public function test_page_for_post_option_should_be_translated_when_no_language_is_set() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		$this->assertCanonical( '/articles/', '/fr/articles/' );
 	}
 
@@ -259,7 +265,13 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?page_id=' . self::$page_for_posts_fr, '/fr/articles/' );
 	}
 
+	/**
+	 *  Bug introduced in 1.8.2 and fixed in 1.8.3.
+	 */
 	public function test_static_front_page_with_name_and_language() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'posts' );
+
 		$this->assertCanonical(
 			'/en/home/',
 			array(
@@ -269,15 +281,28 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 	}
 
+	/**
+	 *  Bug introduced in 1.8.2 and fixed in 1.8.3.
+	 */
 	public function test_static_front_page_with_incorrect_language() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'posts' );
+
 		$this->assertCanonical( '/fr/home/', '/en/home/' );
 	}
 
+	/**
+	 *  Bug introduced in 1.8.2 and fixed in 1.8.3.
+	 */
 	public function test_static_front_page_without_language() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'posts' );
 		$this->assertCanonical( '/home/', '/en/home/' );
 	}
 
 	public function test_static_front_page_from_plain_permalink() {
+		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		update_option( 'show_on_front', 'posts' );
 		$this->assertCanonical( '?page_id=' . self::$page_on_front_en, '/en/home/' );
 	}
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -55,9 +55,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$polylang->model->term->set_language( self::$term_en, 'en' );
 
-		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
-		update_option( 'show_on_front', 'page' );
-
 		$en = self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$polylang->model->post->set_language( self::$page_for_posts_en, 'en' );
 
@@ -83,7 +80,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$polylang->model->term->set_language( $trtax_en, 'en' );
 
 		wp_set_post_terms( $trcpt_en, 'test', 'trtax' );
-
 
 		// Untranslated cpt and tax
 		register_post_type( 'cpt', array( 'public' => true ) );
@@ -114,6 +110,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public static function wpTearDownAfterClass() {
 		_unregister_post_type( 'pllcanonical' );
 		_unregister_post_type( 'trcpt' );
+		_unregister_post_type( 'cpt' );
 
 		parent::wpTearDownAfterClass();
 	}
@@ -134,6 +131,12 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				),
 			)
 		);
+	}
+
+	public function tearDown() {
+		unset( self::$polylang->static_pages );
+
+		parent::tearDown();
 	}
 
 	public function test_post_with_name_and_language() {


### PR DESCRIPTION
## Before

#592 introduced an error in tests which made this condition not tested anymore:

https://github.com/polylang/polylang/blob/c12f911078a5dc6b006e9f685b8aa64e3f4afeee/frontend/frontend-filters-links.php#L393-L396

## Changes

- Modifies some tests to correctly cover this conditional branch
- Instantiates the `PLL_Admin_Pages` module only in the tests that need it.

Partially fixes https://github.com/polylang/polylang-pro/issues/701 Although some conditional branches have never been covered. 

Replaces #604 (rebase)