### PR TITLE
Deactivate Polylang as soon as possible

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -209,7 +209,7 @@ class Polylang {
 			$class = 'PLL_Admin';
 		} elseif ( self::is_rest_request() ) {
 			$class = 'PLL_REST_Request';
-		} elseif ( $model->get_languages_list() && empty( $_GET['deactivate-polylang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( $model->get_languages_list() ) {
 			$class = 'PLL_Frontend';
 		}
 

--- a/polylang.php
+++ b/polylang.php
@@ -67,6 +67,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 
 	define( 'POLYLANG', ucwords( str_replace( '-', ' ', dirname( POLYLANG_BASENAME ) ) ) );
 
-	require __DIR__ . '/include/class-polylang.php';
-	new Polylang();
+	if ( empty( $_GET['deactivate-polylang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		new Polylang();
+	}
 }


### PR DESCRIPTION
... when the site is queried with deactivate-polylang=1
See https://github.com/polylang/polylang-pro/pull/759

Up to now, integrations are loaded when the querying mysite.com/?deactivate-polylang=1. This can cause issues such as the one reported in https://github.com/polylang/polylang-pro/issues/755. Rather than protecting each integration one by one, I propose to stop loading the plugin very soon.