### PR TITLE
Fix a fatal error when the translation group is corrupted

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -163,13 +163,14 @@ abstract class PLL_Translated_Object {
 
 		if ( ! empty( $term ) ) {
 			$d = maybe_unserialize( $term->description );
-			$slug = array_search( $id, $this->get_translations( $id ) ); // in case some plugin stores the same value with different key
-			unset( $d[ $slug ] );
+			if ( is_array( $d ) ) {
+				$slug = array_search( $id, $this->get_translations( $id ) ); // In case some plugin stores the same value with different key.
+				unset( $d[ $slug ] );
+			}
 
 			if ( empty( $d ) ) {
 				wp_delete_term( (int) $term->term_id, $this->tax_translations );
-			}
-			else {
+			} else {
 				wp_update_term( (int) $term->term_id, $this->tax_translations, array( 'description' => maybe_serialize( $d ) ) );
 			}
 		}


### PR DESCRIPTION
A fatal error has been reported:
```
PHP Fatal error: Uncaught Error: Cannot unset string offsets in /home/wp/disk/wordpress/wp-content/plugins/polylang-pro/vendor/wpsyntex/polylang/include/translated-object.php:167
```
How to reproduce?
0. Activate Polylang 2.8.4
1. Create 2 posts translations of each other.
2. In the database, empty the description for the corresponding translations group term.
3. Attempt to delete permanently one of the 2 posts.

NB: Unfortunately, we don't know how the description could be removed on the customer's site.