### PR TITLE
Fix canonical redirect for paged page for posts

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -391,9 +391,12 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( $wp_query->is_posts_page && ! empty( $wp_query->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
+		elseif ( $this->links_model->using_permalinks && $wp_query->is_posts_page && ! empty( $wp_query->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
 			$language = $this->model->post->get_language( (int) $id );
 			$redirect_url = get_permalink( $id );
+			if ( ! empty( $wp_query->query['paged'] ) && $page = get_query_var( 'paged' ) ) {
+				$redirect_url = $this->links_model->add_paged_to_link( $redirect_url, $page );
+			}
 		}
 
 		elseif ( $wp_query->is_posts_page ) {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -222,6 +222,19 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?page_id=' . self::$page_for_posts_en, '/en/posts/' );
 	}
 
+	public function test_paged_page_for_posts_should_match_page_for_post_option_posts_from_plain_permalink() {
+		update_option( 'posts_per_page', 1 );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', self::$page_for_posts_fr );
+
+		// Create 1 additional English post to have a paged page for posts.
+		$en = $this->factory->post->create();
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		$this->assertCanonical( '?paged=2&page_id=' . self::$page_for_posts_en, '/en/posts/page/2/' );
+	}
+
 	public function test_page_for_post_option_should_be_translated_when_language_is_incorrect() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );


### PR DESCRIPTION
Since #634, we aim to correctly redirect a page for posts requested by its page id in plain permalinks to its correct pretty permalink url. The PR however introduced one bug and missed another one..

In plain permalinks, a paged page for post is not accessible i.e `https://mysite.com?paged=2&page_id=44` is always redirected to  `https://mysite.com?page_id=44`.

In pretty permalinks, `https://mysite.com?paged=2&page_id=44` is redirected to `https://mysite.com/en/posts/` instead of `https://mysite.com/en/posts/page/2/`.

This PR fixes the 2 issues and introduces a test for the second one.