### PR TITLE
Fix get_canonical() in PLL_Canonical_UnitTestCase

### DIFF
--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -88,11 +88,11 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 	 */
 	public function get_canonical( $test_url ) {
 		$pll_redirected_url = $this->pll_env->filters_links->check_canonical_url( home_url( $test_url ), false );
-		$wp_redirected_url  = redirect_canonical( $pll_redirected_url, false );
-		if ( ! $wp_redirected_url ) {
+
+		if ( $pll_redirected_url && $pll_redirected_url !== $test_url ) {
 			return $pll_redirected_url;
 		}
 
-		return $wp_redirected_url;
+		return redirect_canonical( $pll_redirected_url, false );
 	}
 }


### PR DESCRIPTION
The method `get_canonical()` in `PLL_Canonical_UnitTestCase` applies successively `PLL_Filters_Links::check_canonical_url()` and `redirect_canonical()`. This however doesn't reproduce the behavior in Polylang. Indeed `redirect_canonical()` is called only if `PLL_Filters_Links::check_canonical_url()` doesn't redirects itself.

This causes [this test](https://github.com/polylang/polylang/pull/645/files#diff-f788d849633ea312a1ed9d404920b14d83617efe27a56217db85c98f7390a713R225-R236) to always pass  even before the bug was fixed.

This PR fixes  `PLL_Canonical_UnitTestCase::get_canonical()` to better reproduce the Polylang behavior.