### PR TITLE
Correct regression introduced by PR #597 and #634

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -383,13 +383,23 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( ( is_category() && empty( $wp_query->query['cat'] ) ) || is_tag() || is_tax() ) {
+		elseif ( $this->links_model->using_permalinks && is_category() && ! empty( $wp_query->query['cat'] ) ) {
+			// When we receive a plain permaling with a cat query var, we need to redirect to the pretty permalink.
+			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
+				$term_id = $this->get_queried_term_id( $wp_query->tax_query );
+				$language = $this->model->term->get_language( $term_id );
+				$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
+			}
+		}
+
+		elseif ( is_category() || is_tag() || is_tax() ) {
 			// We need to switch the language when there is no language provided in a pretty permalink.
 			$obj = $wp_query->get_queried_object();
 			if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
 				$language = $this->model->term->get_language( (int) $obj->term_id );
 			}
 		}
+
 		elseif ( is_404() && ! empty( $wp_query->tax_query ) ) {
 			// When a wrong language is passed through a pretty permalink, we just need to switch the language.
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
@@ -398,21 +408,9 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( is_category() && ! empty( $wp_query->query['cat'] ) ) {
-			// When we recieve a plain permaling with a cat query var we need to redirect to the pretty permalink.
-			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
-				$term_id = $this->get_queried_term_id( $wp_query->tax_query );
-				$language = $this->model->term->get_language( $term_id );
-				$redirect_url = get_term_link( $term_id );
-			}
-		}
-
 		elseif ( $this->links_model->using_permalinks && $wp_query->is_posts_page && ! empty( $wp_query->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
 			$language = $this->model->post->get_language( (int) $id );
-			$redirect_url = get_permalink( $id );
-			if ( ! empty( $wp_query->query['paged'] ) && $page = get_query_var( 'paged' ) ) {
-				$redirect_url = $this->links_model->add_paged_to_link( $redirect_url, $page );
-			}
+			$redirect_url = $this->maybe_add_page_to_redirect_url( get_permalink( $id ) );
 		}
 
 		elseif ( $wp_query->is_posts_page ) {
@@ -462,6 +460,23 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			exit;
 		}
 
+		return $redirect_url;
+	}
+
+	/**
+	 * Returns the link to the paged page if requested.
+	 *
+	 * @since 2.9
+	 *
+	 * @param string $redirect_url The url to redirect to.
+	 * @return string
+	 */
+	protected function maybe_add_page_to_redirect_url( $redirect_url ) {
+		global $wp_query;
+
+		if ( ! empty( $wp_query->query['paged'] ) && $page = get_query_var( 'paged' ) ) {
+			$redirect_url = $this->links_model->add_paged_to_link( $redirect_url, $page );
+		}
 		return $redirect_url;
 	}
 

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -383,7 +383,23 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( is_category() || is_tag() || is_tax() || ( is_404() && ! empty( $wp_query->tax_query ) ) ) {
+		elseif ( ( is_category() && empty( $wp_query->query['cat'] ) ) || is_tag() || is_tax() ) {
+			// We need to switch the language when there is no language provided in a pretty permalink.
+			$obj = $wp_query->get_queried_object();
+			if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
+				$language = $this->model->term->get_language( (int) $obj->term_id );
+			}
+		}
+		elseif ( is_404() && ! empty( $wp_query->tax_query ) ) {
+			// When a wrong language is passed through a pretty permalink, we just need to switch the language.
+			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
+				$term_id = $this->get_queried_term_id( $wp_query->tax_query );
+				$language = $this->model->term->get_language( $term_id );
+			}
+		}
+
+		elseif ( is_category() && ! empty( $wp_query->query['cat'] ) ) {
+			// When we recieve a plain permaling with a cat query var we need to redirect to the pretty permalink.
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
 				$term_id = $this->get_queried_term_id( $wp_query->tax_query );
 				$language = $this->model->term->get_language( $term_id );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -176,6 +176,20 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 	}
 
+	public function test_paged_category_with_name_and_language() {
+		$this->assertCanonical(
+			'/en/category/parent/page/2/',
+			array(
+				'url' => '/en/category/parent/page/2/',
+				'qv'  => array(
+					'lang'          => 'en',
+					'category_name' => 'parent',
+					'paged'         => 2,
+				),
+			)
+		);
+	}
+
 	public function test_category_with_incorrect_language() {
 		$this->assertCanonical( '/fr/category/parent/', '/en/category/parent/' );
 	}
@@ -188,10 +202,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?cat=' . self::$term_en, '/en/category/parent/' );
 	}
 
-	public function test_paged_category() {
+	public function test_paged_category_from_plain_permalink() {
 		update_option( 'posts_per_page', 1 );
 
-		// Create 1 additional English post to have a paged page for posts.
+		// Create 1 additional English post to have a paged category.
 		$en = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $en, 'en' );
 
@@ -199,9 +213,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		wp_set_post_terms( self::$post_en, array( self::$term_en ), 'category' );
 		wp_set_post_terms( $en, array( self::$term_en ), 'category' );
 
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
-		$this->assertCanonical( '/en/category/parent/page/2/', '/en/category/parent/page/2/' );
+		$this->assertCanonical( '?paged=2&cat=' . self::$term_en, '/en/category/parent/page/2/' );
 	}
+
 	public function test_page_for_posts_with_name_and_language() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -188,6 +188,20 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?cat=' . self::$term_en, '/en/category/parent/' );
 	}
 
+	public function test_paged_category(){
+		update_option( 'posts_per_page', 1 );
+
+		// Create 1 additional English post to have a paged page for posts.
+		$en = $this->factory->post->create();
+		self::$polylang->model->post->set_language( $en, 'en' );
+
+		// Set category to the posts.
+		wp_set_post_terms( self::$post_en, array( self::$term_en ), 'category' );
+		wp_set_post_terms( $en, array( self::$term_en ), 'category' );
+
+		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		$this->assertCanonical( '/en/category/parent/page/2/', '/en/category/parent/page/2/' );
+	}
 	public function test_page_for_posts_with_name_and_language() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -188,7 +188,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?cat=' . self::$term_en, '/en/category/parent/' );
 	}
 
-	public function test_paged_category(){
+	public function test_paged_category() {
 		update_option( 'posts_per_page', 1 );
 
 		// Create 1 additional English post to have a paged page for posts.


### PR DESCRIPTION
fix https://github.com/polylang/polylang-pro/issues/762
fix https://github.com/polylang/polylang-pro/issues/765

https://github.com/polylang/polylang/pull/597 and PR https://github.com/polylang/polylang/pull/634 introduced regressions https://github.com/polylang/polylang-pro/issues/762 and https://github.com/polylang/polylang-pro/issues/765 espacially by the modification of this condition https://github.com/polylang/polylang/pull/597/files#r528856855 and adding this redirect result https://github.com/polylang/polylang/pull/634/files#r528862725

This PR propose to fix the two issues by processing the three identified cases separately.

A unit test has been added too to cover the category paginated page ([#765](https://github.com/polylang/polylang-pro/issues/765)). The issue [#762](https://github.com/polylang/polylang-pro/issues/762) concerned shared slugs and then Polylang Pro. So the issue will be covered by unit test proposed by the PR [#767](https://github.com/polylang/polylang-pro/pull/767)