### PR TITLE
Fix PHP notice undefined index wp_the_query

### DIFF
--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -89,7 +89,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	 * @param object $query instance of WP_Query
 	 */
 	public function parse_main_query( $query ) {
-		if ( $query !== $GLOBALS['wp_the_query'] ) {
+		if ( empty( $GLOBALS['wp_the_query'] ) || $query !== $GLOBALS['wp_the_query'] ) {
 			return;
 		}
 


### PR DESCRIPTION
Fix `PHP Notice:  Undefined index: wp_the_query in /polylang/frontend/choose-lang-content.php on line 92`
It may happen if a 3rd party plugin makes a WP_Query very soon in a function hooked to `plugins_loaded` and Polylang is set to get the language from the content. 

To test, add this in a plugin:
```php
add_action(
	'plugins_loaded',
	function() {
		get_posts();
	}
);
```