### PR TITLE
Refresh Media Library frame after switching language

### DIFF
--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -270,8 +270,8 @@ var media = _.extend(
 					 */
 					attachmentsCollection.reset();
 					if (attachmentsCollection.mirroring) {
-						  attachmentsCollection.mirroring._hasMore = true;
-						  attachmentsCollection.mirroring.reset();
+						attachmentsCollection.mirroring._hasMore = true;
+						attachmentsCollection.mirroring.reset();
 					}
 				}
 			);

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -239,7 +239,7 @@ function resetCurrentMediaFrame() {
 	}
 	if (wp.media.editor) {
 		var editorFrame = wp.media.editor.get( wp.media.editor.activeEditor );
-		if (editorFrame) {
+		if (editorFrame && editorFrame !== wp.media.frame) {
 			resetMediaFrame( editorFrame );
 		}
 	}
@@ -257,10 +257,18 @@ function resetMediaFrame(frame) {
 			var attachmentsView = attachmentsBrowser[0].attachments;
 			if (attachmentsView) {
 				var attachmentsCollection = attachmentsView.collection;
+
+				/**
+				 * First reset the { @see wp.media.model.Attachments } collection.
+				 * Then, if it is mirroring a { @see wp.media.model.Query } collection, 
+				 * refresh this one too, so it will fetch new data from the server,
+				 * and then the wp.media.model.Attachments collection will syncrhonize with the new data.
+				 */
+				attachmentsCollection.reset();
 				if (attachmentsCollection.mirroring) {
 					attachmentsCollection.mirroring._hasMore = true;
+					attachmentsCollection.mirroring.reset();
 				}
-				attachmentsCollection.reset();
 			}
 		}
 	}

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -237,6 +237,12 @@ function resetCurrentMediaFrame() {
 	if (wp.media.frame) {
 		resetMediaFrame( wp.media.frame );
 	}
+	if (wp.media.editor) {
+		var editorFrame = wp.media.editor.get( wp.media.editor.activeEditor );
+		if (editorFrame) {
+			resetMediaFrame( editorFrame );
+		}
+	}
 }
 
 /**

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -220,8 +220,11 @@ jQuery(
  * @since 3.0
  */
 function resetFeaturedImage() {
-	if (wp.media.featuredImage._frame) {  // Check the property rather than calling to the function that will instantiate a wp.media.view.MediaFrame.Select object.
-		wp.media.featuredImage.frame()._selection.attachments.reset();
+	if (wp.media.featuredImage && 
+		wp.media.featuredImage._frame && // Check the property rather than calling to the function that will instantiate a wp.media.view.MediaFrame.Select object. 
+		wp.media.featuredImage._frame._selection && 
+		wp.media.featuredImage._frame._selection.attachments instanceof wp.media.model.Attachments) {
+			wp.media.featuredImage._frame._selection.attachments.reset();
 	}
 }
 
@@ -229,9 +232,17 @@ function resetFeaturedImage() {
  * @since 3.0
  */
 function resetCurrentMediaFrame() {
-	if (wp.media.frame) {
-		wp.media.frame.views.get( '.media-frame-content' )[0].attachments.collection.mirroring._hasMore = true;
-		wp.media.frame.views.get( '.media-frame-content' )[0].attachments.collection.reset();
+	if (wp.media.frame && wp.media.frame.views instanceof wp.Backbone.Subviews) {
+		var attachmentsBrowser = wp.media.frame.views.get( '.media-frame-content' );
+		if (attachmentsBrowser) {
+			var attachmentsCollection = attachmentsBrowser[0].attachments.collection;
+			if (attachmentsCollection) {
+				if (attachmentsCollection.mirroring) {
+					attachmentsCollection.mirroring._hasMore = true;
+				}
+				attachmentsBrowser[0].attachments.collection.reset();
+			}
+		}
 	}
 }
 

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -167,6 +167,10 @@ jQuery(
 						$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
 					}
 				);
+
+				resetCurrentMediaFrame();
+
+				resetFeaturedImage();
 			}
 		);
 
@@ -211,3 +215,23 @@ jQuery(
 		init_translations();
 	}
 );
+
+/**
+ * @since 3.0
+ */
+function resetFeaturedImage() {
+	if (wp.media.featuredImage._frame) {  // Check the property rather than calling to the function that will instantiate a wp.media.view.MediaFrame.Select object.
+		wp.media.featuredImage.frame()._selection.attachments.reset();
+	}
+}
+
+/**
+ * @since 3.0
+ */
+function resetCurrentMediaFrame() {
+	if (wp.media.frame) {
+		wp.media.frame.views.get( '.media-frame-content' )[0].attachments.collection.mirroring._hasMore = true;
+		wp.media.frame.views.get( '.media-frame-content' )[0].attachments.collection.reset();
+	}
+}
+

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -165,12 +165,11 @@ jQuery(
 						$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
 						$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
 						$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
+
+						resetCurrentMediaFrame();
+						resetFeaturedImage();
 					}
 				);
-
-				resetCurrentMediaFrame();
-
-				resetFeaturedImage();
 			}
 		);
 
@@ -220,11 +219,14 @@ jQuery(
  * @since 3.0
  */
 function resetFeaturedImage() {
-	if (wp.media.featuredImage && 
-		wp.media.featuredImage._frame && // Check the property rather than calling to the function that will instantiate a wp.media.view.MediaFrame.Select object. 
-		wp.media.featuredImage._frame._selection && 
-		wp.media.featuredImage._frame._selection.attachments instanceof wp.media.model.Attachments) {
-			wp.media.featuredImage._frame._selection.attachments.reset();
+	if (wp.media.featuredImage && wp.media.featuredImage._frame) { // Check the property rather than calling to the function that will instantiate a wp.media.view.MediaFrame.Select object. 
+		if (wp.media.featuredImage._frame._selection && wp.media.featuredImage._frame._selection.attachments instanceof wp.media.model.Attachments) {
+				wp.media.featuredImage._frame._selection.attachments.reset();
+		}
+
+		if (wp.media.frame !== wp.media.featuredImage._frame) {
+			resetMediaFrame( wp.media.featuredImage._frame );
+		}
 	}
 }
 
@@ -232,15 +234,27 @@ function resetFeaturedImage() {
  * @since 3.0
  */
 function resetCurrentMediaFrame() {
-	if (wp.media.frame && wp.media.frame.views instanceof wp.Backbone.Subviews) {
-		var attachmentsBrowser = wp.media.frame.views.get( '.media-frame-content' );
+	if (wp.media.frame) {
+		resetMediaFrame( wp.media.frame );
+	}
+}
+
+/**
+ * @since 3.0
+ * 
+ * Third party plugins may break the dependency tree, so each subcomponent existence is checked.
+ */
+function resetMediaFrame(frame) {
+	if (frame.views instanceof wp.Backbone.Subviews) {
+		var attachmentsBrowser = frame.views.get( '.media-frame-content' );
 		if (attachmentsBrowser) {
-			var attachmentsCollection = attachmentsBrowser[0].attachments.collection;
-			if (attachmentsCollection) {
+			var attachmentsView = attachmentsBrowser[0].attachments;
+			if (attachmentsView) {
+				var attachmentsCollection = attachmentsView.collection;
 				if (attachmentsCollection.mirroring) {
 					attachmentsCollection.mirroring._hasMore = true;
 				}
-				attachmentsBrowser[0].attachments.collection.reset();
+				attachmentsCollection.reset();
 			}
 		}
 	}


### PR DESCRIPTION
## Goal

Find a way to refresh the attachments in the Media Libraries opened in the Classic Editor, in order to fetch attachments in the new language, after it has been switched from Polylang's metabox.

- Fixes https://github.com/polylang/polylang-pro/issues/756
- Fixes partially (Classic Editor only) https://github.com/polylang/polylang-pro/issues/737
- Fixes https://github.com/polylang/polylang-wc/issues/317

## Use case analysis

Polylang offers users to the possibility to change the language of the currently edited post through its _Language metabox_. However, when doing so, the different WordPress Media Library items are not refreshed to match the new language. This happens in:

- The _Set Featured Image_ action link in the post edition screen
- The  _Add Media_ button in the post edition screen

This Media Library frame is then reused in plugins including:

- WooCommerce
    - The _Set Product Image_ action link and _Add Media_ buttons in the product edition screen work similarly than those in the post edition screen
    - The _Set Category Image_ action link in the product category edition screen work similarly than the _Set Featured Image_ in the post edition screen
- ACF
    - The _Image_, _File_ and _Gallery_ fields extends the behavior of _Add Media_ button in the WordPress' post edition screen

## Code analysis

WordPress Media Library is built upon the Backbone.js framework. The top level view that contains the Media Library is an instance of `wp.media.view.MediaFrame.Select` or `wp.media.view.MediaFrame.Post` component. It is then subdivided into more specific components, down to a `wp.media.view.Attachments` view, displaying the different media attachments.

The `wp.media.view.Attachments` view is linked to a `wp.media.model.Attachments` collection that holds the data to be displayed by the view. When the collection is updated, the associated view updates itself to.

The `wp.media.view.Attachments` is 'mirrored' by a `wp.media.model.Query`, that will decide if it should fetch data from an AJAX request or not.

![Class hierarchy of WordPress' Media Frame components](https://user-images.githubusercontent.com/16425382/100212812-1c8d4500-2f0e-11eb-8a4e-313bdc913944.png)

A `wp.media.frame` global variable will hold the instance of the last opened MediaFrame. **Warning:** this media frame might be a custom subclass of `wp.media.view.MediaFrame` from a plugin like ACF.

A `wp.media.model.Attachments.all` global holds one copy of each unique attachments displayed in any MediaFrame. However, I did not find the usage of these copies.

## Edge cases

- ~~Switching language to a language formerly used language will open an empty list. Example: opening media in English(US), switching to French(FR), opening medias in French, then switching again to English(US) and trying to open the media again.~~
- ~~Opening the Media Library from the _Add Media_ button, then opening it from the _Set Featured Image_ button will open two different MediaFrames. Switching languages will only refresh the last opened frame  (the featured image).~~

## Notes

- Underscore's `_.extend()` might be equivalent to native Javascript's `Object.assign()`.
- FIXME: Because we are now holding a reference to each `wp.media.model.Attachments` collections created, this will prevent the garbage collector to free them from memory when they're not used anywhere else.