### PR TITLE
Handle SameSite parameter for language cookie

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -84,29 +84,13 @@ abstract class PLL_Choose_Lang {
 	 * @since 1.5
 	 */
 	public function maybe_setcookie() {
-		// Don't set cookie in javascript when a cache plugin is active
-		// Check headers have not been sent to avoid ugly error
-		// Cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
-		if ( ! pll_is_cache_active() && ! headers_sent() && PLL_COOKIE !== false && ! empty( $this->curlang ) && ( ! isset( $_COOKIE[ PLL_COOKIE ] ) || $_COOKIE[ PLL_COOKIE ] != $this->curlang->slug ) && ! is_404() ) {
-
-			/**
-			 * Filter the Polylang cookie duration
-			 * /!\ this filter may be fired *before* the theme is loaded
-			 *
-			 * @since 1.8
-			 *
-			 * @param int $duration cookie duration in seconds
-			 */
-			$expiration = apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS );
-
-			setcookie(
-				PLL_COOKIE,
-				$this->curlang->slug,
-				time() + $expiration,
-				COOKIEPATH,
-				2 == $this->options['force_lang'] ? wp_parse_url( $this->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN,
-				is_ssl()
+		// Don't set cookie in javascript when a cache plugin is active.
+		if ( ! pll_is_cache_active() && ! empty( $this->curlang ) && ! is_404() ) {
+			$args = array(
+				'domain'   => 2 === $this->options['force_lang'] ? wp_parse_url( $this->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN,
+				'samesite' => 3 === $this->options['force_lang'] ? 'None' : 'Lax',
 			);
+			PLL_Cookie::set( $this->curlang->slug, $args );
 		}
 	}
 

--- a/include/cookie.php
+++ b/include/cookie.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * A class to manage manage the language cookie
+ *
+ * @since 2.9
+ */
+class PLL_Cookie {
+	/**
+	 * Parses the cookie parameters
+	 *
+	 * @since 2.9
+	 *
+	 * @param array $args {@see PLL_Cookie::set()}
+	 * @return array
+	 */
+	protected static function parse_args( $args ) {
+		/**
+		 * Filter the Polylang cookie duration
+		 * /!\ this filter may be fired *before* the theme is loaded
+		 *
+		 * @since 1.8
+		 *
+		 * @param int $duration cookie duration in seconds
+		 */
+		$expiration = apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS );
+
+		$defaults = array(
+			'expires'  => time() + $expiration,
+			'path'     => COOKIEPATH,
+			'domain'   => COOKIE_DOMAIN, // Cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
+			'secure'   => is_ssl(),
+			'httponly' => false,
+			'samesite' => 'Lax',
+		);
+
+		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
+	 * Sets the cookie.
+	 *
+	 * @since 2.9
+	 *
+	 * @param string $lang Language cookie value.
+	 * @param array  $args {
+	 *   Optional. Array of arguments for setting the cookie.
+	 *
+	 *   @type string $path     Cookie path, defaults to COOKIEPATH.
+	 *   @type string $domain   Cookie domain, defaults to COOKIE_DOMAIN
+	 *   @type bool   $secure   Should the cookie be sent only over https?
+	 *   @type bool   $httponly Should the cookie accessed only over http protocol? Defaults to false.
+	 *   @type string $samesite Either 'Strict', 'Lax' or 'None', defaults to 'Lax'.
+	 * }
+	 */
+	public static function set( $lang, $args = array() ) {
+		$args = self::parse_args( $args );
+
+		if ( ! headers_sent() && PLL_COOKIE !== false && self::get() !== $lang ) {
+			if ( version_compare( PHP_VERSION, '7.3', '<' ) ) {
+				$args['path'] .= '; SameSite=' . $args['samesite']; // Hack to set SameSite value in PHP < 7.3. Doesn't work with newer versions.
+				setcookie( PLL_COOKIE, $lang, $args['expires'], $args['path'], $args['domain'], $args['secure'], $args['httponly'] );
+			} else {
+				setcookie( PLL_COOKIE, $lang, $args );
+			}
+		}
+	}
+
+	/**
+	 * Returns the language cookie value.
+	 *
+	 * @since 2.9
+	 *
+	 * @return string
+	 */
+	public static function get() {
+		return isset( $_COOKIE[ PLL_COOKIE ] ) ? sanitize_key( $_COOKIE[ PLL_COOKIE ] ) : '';
+	}
+}

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -34,19 +34,22 @@ class PLL_Cache_Compat {
 	 * @since 2.3
 	 */
 	public function add_cookie_script() {
-		$domain = ( 2 == PLL()->options['force_lang'] ) ? wp_parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
+		$domain   = ( 2 === PLL()->options['force_lang'] ) ? wp_parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
+		$samesite = ( 3 === $this->options['force_lang'] ) ? 'None' : 'Lax';
+
 		$js = sprintf(
 			'(function() {
 				var expirationDate = new Date();
 				expirationDate.setTime( expirationDate.getTime() + %d * 1000 );
-				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s%s";
+				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s%s%s";
 			}());',
 			esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) ),
 			esc_js( PLL_COOKIE ),
 			esc_js( pll_current_language() ),
 			esc_js( COOKIEPATH ),
 			$domain ? '; domain=' . esc_js( $domain ) : '',
-			is_ssl() ? '; secure' : ''
+			is_ssl() ? '; secure' : '',
+			'; SameSite=' . $samesite
 		);
 		echo '<script type="text/javascript">' . $js . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput
 	}


### PR DESCRIPTION
Since Chrome 80, we need to handle the SameSite parameter when setting the language cookie.

This parameter is available in PHP only since the version 7.3. We need to support previous versions which still concern 55% of WordPress installs at the time of writing this. A hack was possible in these previous versions to add the SameSite parameter, however it looks like this hack doesn't work anymore in PHP 7.3.

This PR adds a `PLL_Cookie` static class to wrap the `setcookie` function. The method `set()` uses one or the other method depending on the PHP version.