### PR TITLE
Define abstract methods in PLL_Links_Model

### DIFF
--- a/include/links-model.php
+++ b/include/links-model.php
@@ -4,43 +4,130 @@
  */
 
 /**
- * Links model abstract class
+ * Links model abstract class.
  *
  * @since 1.5
  */
 abstract class PLL_Links_Model {
-	public $model, $options;
-	public $home; // used to store the home url before it is filtered
+	/**
+	 * True if the child class uses pretty permalinks, false otherwise.
+	 *
+	 * @var bool
+	 */
 	public $using_permalinks;
 
 	/**
-	 * Constructor
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Stores the home url before it is filtered.
+	 *
+	 * @var string
+	 */
+	public $home;
+
+	/**
+	 * Constructor.
 	 *
 	 * @since 1.5
 	 *
-	 * @param object $model PLL_Model instance
+	 * @param object $model PLL_Model instance.
 	 */
 	public function __construct( &$model ) {
-		$this->model = &$model;
+		$this->model   = &$model;
 		$this->options = &$model->options;
 
 		$this->home = home_url();
 
-		add_filter( 'pll_languages_list', array( $this, 'pll_languages_list' ), 4 ); // after PLL_Static_Pages
+		add_filter( 'pll_languages_list', array( $this, 'pll_languages_list' ), 4 ); // After PLL_Static_Pages.
 		add_filter( 'pll_after_languages_cache', array( $this, 'pll_after_languages_cache' ) );
 
-		// adds our domains or subdomains to allowed hosts for safe redirection
+		// Adds our domains or subdomains to allowed hosts for safe redirection.
 		add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 	}
 
 	/**
-	 * Changes the language code in url
+	 * Adds the language code in url.
+	 *
+	 * @since 1.2
+	 *
+	 * @param string $url  The url to modify.
+	 * @param object $lang Language.
+	 * @return string Modified url.
+	 */
+	abstract public function add_language_to_link( $url, $lang );
+
+	/**
+	 * Returns the url without language code.
+	 *
+	 * @since 1.2
+	 *
+	 * @param string $url The url to modify.
+	 * @return string Modified url.
+	 */
+	abstract public function remove_language_from_link( $url );
+
+	/**
+	 * Returns the link to the first page.
+	 *
+	 * @since 1.2
+	 *
+	 * @param string $url The url to modify.
+	 * @return string Modified url.
+	 */
+	abstract public function remove_paged_from_link( $url );
+
+	/**
+	 * Returns the link to a paged page.
 	 *
 	 * @since 1.5
 	 *
-	 * @param string $url  url to modify
-	 * @param object $lang language
-	 * @return string modified url
+	 * @param string $url  The url to modify.
+	 * @param int    $page The page number.
+	 * @return string Modified url.
+	 */
+	abstract public function add_paged_to_link( $url, $page );
+
+	/**
+	 * Returns the language based on language code in url.
+	 *
+	 * @since 1.2
+	 * @since 2.0 add $url argument.
+	 *
+	 * @param string $url Optional, defaults to thej current url.
+	 * @return string Language slug.
+	 */
+	abstract public function get_language_from_url( $url = '' );
+
+	/**
+	 * Returns the static front page url.
+	 *
+	 * @since 1.8
+	 *
+	 * @param object $lang Language.
+	 * @return string The front page url.
+	 */
+	abstract public function front_page_url( $lang );
+
+	/**
+	 * Changes the language code in url.
+	 *
+	 * @since 1.5
+	 *
+	 * @param string $url  The url to modify.
+	 * @param object $lang Language.
+	 * @return string Modified url.
 	 */
 	public function switch_language_in_link( $url, $lang ) {
 		$url = $this->remove_language_from_link( $url );
@@ -48,22 +135,22 @@ abstract class PLL_Links_Model {
 	}
 
 	/**
-	 * Get hosts managed on the website
+	 * Get hosts managed on the website.
 	 *
 	 * @since 1.5
 	 *
-	 * @return array list of hosts
+	 * @return array The list of hosts.
 	 */
 	public function get_hosts() {
 		return array( wp_parse_url( $this->home, PHP_URL_HOST ) );
 	}
 
 	/**
-	 * Returns the home url
+	 * Returns the home url in a given language.
 	 *
 	 * @since 1.3.1
 	 *
-	 * @param object $lang PLL_Language object
+	 * @param object $lang PLL_Language object.
 	 * @return string
 	 */
 	public function home_url( $lang ) {
@@ -72,11 +159,11 @@ abstract class PLL_Links_Model {
 	}
 
 	/**
-	 * Sets the home urls
+	 * Sets the home urls in PLL_Language.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $language
+	 * @param object $language PLL_Language object.
 	 */
 	protected function set_home_url( $language ) {
 		// We should always have a default language here, except, temporarily, in PHPUnit tests. The test here protects against PHP notices.
@@ -88,11 +175,11 @@ abstract class PLL_Links_Model {
 	}
 
 	/**
-	 * Sets the home urls and flags before the languages are persistently cached
+	 * Sets the home urls and flags before the languages are persistently cached.
 	 *
 	 * @since 1.8
 	 *
-	 * @param array $languages array of PLL_Language objects
+	 * @param array $languages Array of PLL_Language objects.
 	 * @return array
 	 */
 	public function pll_languages_list( $languages ) {
@@ -104,17 +191,17 @@ abstract class PLL_Links_Model {
 	}
 
 	/**
-	 * Sets the home urls when not cached
-	 * Sets the home urls scheme
+	 * Sets the home urls when not cached.
+	 * Sets the home urls scheme.
 	 *
 	 * @since 1.8
 	 *
-	 * @param array $languages array of PLL_Language objects
+	 * @param array $languages Array of PLL_Language objects.
 	 * @return array
 	 */
 	public function pll_after_languages_cache( $languages ) {
 		foreach ( $languages as $language ) {
-			// Get the home urls when not cached
+			// Get the home urls when not cached.
 			if ( ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) || ( defined( 'PLL_CACHE_HOME_URL' ) && ! PLL_CACHE_HOME_URL ) ) {
 				$this->set_home_url( $language );
 			}
@@ -130,7 +217,7 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.4.3
 	 *
-	 * @param array $hosts allowed hosts
+	 * @param array $hosts Allowed hosts.
 	 * @return array
 	 */
 	public function allowed_redirect_hosts( $hosts ) {


### PR DESCRIPTION
We already propose 4 links models, but our users may need to implement a different one. This requires to extend `PLL_Links_Model`. However it's currently not clear enough which methods need to be implemented, as our parent class "transparently" uses methods defined only in our child classes.

This PR adds abstract methods to `PLL_Links_Model` to clarify which methods child classes are required to implement. 