### PR TITLE
Updated wp_nav_menu_args to be in line with wp_nave_menu

### DIFF
--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -263,6 +263,12 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 		// Get the nav menu based on the requested menu
 		$menu = wp_get_nav_menu_object( $args['menu'] );
 
+		// Get the nav menu based on the theme_location.
+		$locations = get_nav_menu_locations();	
+		if ( ! $menu && $args['theme_location'] && $locations && isset( $locations[ $args['theme_location'] ] ) ) {
+			$menu = wp_get_nav_menu_object( $locations[ $args['theme_location'] ] );
+		}
+
 		// Attempt to find a translation of this menu
 		// This obviously does not work if the nav menu has no associated theme location
 		if ( $menu ) {


### PR DESCRIPTION
Not sure if this is on purpose, but I'm proposing this change anyway:

https://developer.wordpress.org/reference/functions/wp_nav_menu/
wp_nav_menu also has a $menu fallback when menu is not found based on $args['menu'], but $args["theme_location"] is set (see line 124-143) of wp_nav_menu.
The polylang wp_nav_menu_args filter does not have this, but seems to loosely follow the wp_nav_menu structure.
By making this change, I have fixed a nav menu not updating to the selected language on page access (not menu click).