### PR TITLE
Translate title-search-wpseo option

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -385,8 +385,13 @@ class PLL_WPSEO {
 				break;
 
 			case 'system-page':
-				if ( '404' === $presentation->model->object_sub_type ) {
-					$presentation->model->title = WPSEO_Options::get( 'title-404-wpseo' );
+				switch ( $presentation->model->object_sub_type ) {
+					case '404':
+						$presentation->model->title = WPSEO_Options::get( 'title-404-wpseo' );
+						break;
+					case 'search-result':
+						$presentation->model->title = WPSEO_Options::get( 'title-search-wpseo' );
+						break;
 				}
 				break;
 		}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/780

Since this PR #583  which rewrote a part of the WordPress SEO compatibility, we missed one of the indexable option: title-search-wpseo which isn't translated as it's reported in the issue.
