### PR TITLE
Use PHPDoc to document the main Polylang object properties

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -4,12 +4,59 @@
  */
 
 /**
- * Base class for both admin
+ * Base class for both PLL_Admin and PLL_Settings.
  *
  * @since 1.8
  */
-class PLL_Admin_Base extends PLL_Base {
-	public $filter_lang, $curlang, $pref_lang;
+abstract class PLL_Admin_Base extends PLL_Base {
+	/**
+	 * Current language (used to filter the content).
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
+
+	/**
+	 * Language selected in the admin language filter.
+	 *
+	 * @var PLL_Language
+	 */
+	public $filter_lang;
+
+	/**
+	 * Preferred language to assign to new contents.
+	 *
+	 * @var PLL_Language
+	 */
+	public $pref_lang;
+
+	/**
+	 * Instance of PLL_Filters_Links.
+	 *
+	 * @var PLL_Filters_Links
+	 */
+	public $filters_links;
+
+	/**
+	 * Instance of PLL_Admin_Links.
+	 *
+	 * @var PLL_Admin_Links
+	 */
+	public $links;
+
+	/**
+	 * Instance of PLL_Admin_Notices.
+	 *
+	 * @var PLL_Admin_Notices
+	 */
+	public $notices;
+
+	/**
+	 * Instance of PLL_Admin_Static_Pages.
+	 *
+	 * @var PLL_Admin_Static_Pages
+	 */
+	public $static_pages;
 
 	/**
 	 * Loads the polylang text domain

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Base class for both PLL_Admin and PLL_Settings.
+ * Setup features available on all admin pages.
  *
  * @since 1.8
  */

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -4,84 +4,75 @@
  */
 
 /**
- * Admin side controller
- * accessible in $polylang global object
- *
- * Properties:
- * options              => inherited, reference to Polylang options array
- * model                => inherited, reference to PLL_Model object
- * links_model          => inherited, reference to PLL_Links_Model object
- * links                => inherited, reference to PLL_Admin_Links object
- * static_pages         => inherited, reference to PLL_Admin_Static_Pages object
- * filters_links        => inherited, reference to PLL_Filters_Links object
- * curlang              => inherited, optional, current language used to filter the content (language of the post or term being edited, equal to filter_lang otherwise)
- * filter_lang          => inherited, optional, current status of the admin languages filter (in the admin bar)
- * pref_lang            => inherited, preferred language used as default when saving posts or terms
- * posts                => reference to PLL_CRUD_Posts object
- * terms                => reference to PLL_CRUD_Terms object
- * filters              => reference to PLL_Admin_Filters object
- * filters_sanitization => reference to PLL_Filters_Sanitization object
- * filters_columns      => reference to PLL_Admin_Filters_Columns object
- * filters_post         => reference to PLL_Admin_Filters_Post object
- * filters_term         => reference to PLL_Admin_filters_Term object
- * nav_menu             => reference to PLL_Admin_Nav_Menu object
- * block_editor         => reference to PLL_Admin_Block_Editor object
- * classic_editor       => reference to PLL_Admin_Classic_Editor object
- * filters_media        => optional, reference to PLL_Admin_Filters_Media object
+ * Admin side controller, accessible from PLL().
  *
  * @since 1.2
  */
 class PLL_Admin extends PLL_Admin_Base {
 	/**
-	 * Instance of PLL_Admin_Filters
+	 * Instance of PLL_Admin_Filters.
 	 *
 	 * @var PLL_Admin_Filters
 	 */
 	public $filters;
 
 	/**
-	 * Instance of PLL_Admin_Filters_Columns
+	 * Instance of PLL_Admin_Filters_Columns.
 	 *
 	 * @var PLL_Admin_Filters_Columns
 	 */
 	public $filters_columns;
 
 	/**
-	 * Instance of PLL_Admin_Filters_Post
+	 * Instance of PLL_Admin_Filters_Post.
 	 *
 	 * @var PLL_Admin_Filters_Post
 	 */
 	public $filters_post;
 
 	/**
-	 * Instance of PLL_Admin_filters_Term
+	 * Instance of PLL_Admin_filters_Term.
 	 *
 	 * @var PLL_Admin_filters_Term
 	 */
 	public $filters_term;
 
 	/**
-	 * Instance of PLL_Admin_Nav_Menu
-	 *
-	 * @var PLL_Admin_Nav_Menu
-	 */
-	public $nav_menu;
-
-	/**
-	 * Instance of PLL_Admin_Filters_Media
+	 * Instance of PLL_Admin_Filters_Media.
 	 *
 	 * @var PLL_Admin_Filters_Media
 	 */
 	public $filters_media;
 
 	/**
-	 * Instance of PLL_Filters_Sanitization
+	 * Instance of PLL_Filters_Sanitization.
 	 *
 	 * @since 2.9
 	 *
 	 * @var PLL_Filters_Sanitization
 	 */
 	public $filters_sanitization;
+
+	/**
+	 * Instance of PLL_Admin_Block_Editor.
+	 *
+	 * @var PLL_Admin_Block_Editor
+	 */
+	public $block_editor;
+
+	/**
+	 * Instance of PLL_Admin_Classic_Editor.
+	 *
+	 * @var PLL_Admin_Classic_Editor
+	 */
+	public $classic_editor;
+
+	/**
+	 * Instance of PLL_Admin_Nav_Menu.
+	 *
+	 * @var PLL_Admin_Nav_Menu
+	 */
+	public $nav_menu;
 
 	/**
 	 * Loads the polylang text domain
@@ -172,6 +163,7 @@ class PLL_Admin extends PLL_Admin_Base {
 			$this->$obj = new $class( $this );
 		}
 	}
+
 	/**
 	 * Retrieve the locale according to the current language instead of the language
 	 * of the admin interface.

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Admin side controller, accessible from PLL().
+ * Main Polylang class for admin (except Polylang pages), accessible from @see PLL().
  *
  * @since 1.2
  */

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Frontend controller, accessible from PLL().
+ * Main Polylang class when on frontend, accessible from @see PLL().
  *
  * @since 1.2
  */
@@ -24,7 +24,7 @@ class PLL_Frontend extends PLL_Base {
 	public $auto_translate;
 
 	/**
-	 * Instance of the class selecting the current language.
+	 * The class selecting the current language.
 	 *
 	 * @var PLL_Choose_Lang
 	 */

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -4,30 +4,73 @@
  */
 
 /**
- * Frontend controller
- * accessible as $polylang global object
- *
- * Properties:
- * options        => inherited, reference to Polylang options array
- * model          => inherited, reference to PLL_Model object
- * links_model    => inherited, reference to PLL_Links_Model object
- * links          => reference to PLL_Links object
- * static_pages   => reference to PLL_Frontend_Static_Pages object
- * choose_lang    => reference to PLL_Choose_Lang object
- * curlang        => current language
- * filters        => reference to PLL_Frontend_Filters object
- * filters_links  => reference to PLL_Frontend_Filters_Links object
- * filters_search => reference to PLL_Frontend_Filters_Search object
- * posts          => reference to PLL_CRUD_Posts object
- * terms          => reference to PLL_CRUD_Terms object
- * nav_menu       => reference to PLL_Frontend_Nav_Menu object
- * auto_translate => optional, reference to PLL_Auto_Translate object
+ * Frontend controller, accessible from PLL().
  *
  * @since 1.2
  */
 class PLL_Frontend extends PLL_Base {
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
 	public $curlang;
-	public $links, $choose_lang, $filters, $filters_search, $nav_menu, $auto_translate;
+
+	/**
+	 * Instance of PLL_Auto_Translate.
+	 *
+	 * @var PLL_Auto_Translate
+	 */
+	public $auto_translate;
+
+	/**
+	 * Instance of the class selecting the current language.
+	 *
+	 * @var PLL_Choose_Lang
+	 */
+	public $choose_lang;
+
+	/**
+	 * Instance of PLL_Frontend_Filters.
+	 *
+	 * @var PLL_Frontend_Filters
+	 */
+	public $filters;
+
+	/**
+	 * Instance of PLL_Frontend_Filters_Links.
+	 *
+	 * @var PLL_Frontend_Filters_Links
+	 */
+	public $filters_links;
+
+	/**
+	 * Instance of PLL_Frontend_Filters_Search.
+	 *
+	 * @var PLL_Frontend_Filters_Search
+	 */
+	public $filters_search;
+
+	/**
+	 * Instance of PLL_Frontend_Links.
+	 *
+	 * @var PLL_Frontend_Links
+	 */
+	public $links;
+
+	/**
+	 * Instance of PLL_Frontend_Nav_Menu.
+	 *
+	 * @var PLL_Frontend_Nav_Menu
+	 */
+	public $nav_menu;
+
+	/**
+	 * Instance of PLL_Frontend_Static_Pages.
+	 *
+	 * @var PLL_Frontend_Static_Pages
+	 */
+	public $static_pages;
 
 	/**
 	 * Constructor

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * REST API controller, accessible from PLL().
+ * Main Polylang class for REST API requrests, accessible from @see PLL().
  *
  * @since 2.6
  */
@@ -61,7 +61,7 @@ class PLL_REST_Request extends PLL_Base {
 			$this->filters_links = new PLL_Filters_Links( $this );
 			$this->filters = new PLL_Filters( $this );
 
-			// Static front page and page for posts?
+			// Static front page and page for posts.
 			if ( 'page' === get_option( 'show_on_front' ) ) {
 				$this->static_pages = new PLL_Static_Pages( $this );
 			}

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -4,27 +4,49 @@
  */
 
 /**
- * REST API controller
- * accessible as $polylang global object
- *
- * Properties:
- * options        => inherited, reference to Polylang options array
- * model          => inherited, reference to PLL_Model object
- * links_model    => inherited, reference to PLL_Links_Model object
- * links          => reference to PLL_Admin_Links object
- * static_pages   => reference to PLL_Static_Pages object
- * filters        => reference to PLL_Frontend_Filters object
- * filters_links  => reference to PLL_Filters_Links object
- * posts          => reference to PLL_CRUD_Posts object
- * terms          => reference to PLL_CRUD_Terms object
+ * REST API controller, accessible from PLL().
  *
  * @since 2.6
  */
 class PLL_REST_Request extends PLL_Base {
-	public $links, $static_pages, $posts, $terms, $filters, $filters_links;
 
 	/**
-	 * Setup filters
+	 * Instance of PLL_Filters.
+	 *
+	 * @var PLL_Filters
+	 */
+	public $filters;
+
+	/**
+	 * Instance of PLL_Filters_Links.
+	 *
+	 * @var PLL_Filters_Links
+	 */
+	public $filters_links;
+
+	/**
+	 * Instance of PLL_Admin_Links.
+	 *
+	 * @var PLL_Admin_Links
+	 */
+	public $links;
+
+	/**
+	 * Instance of PLL_Nav_Menu.
+	 *
+	 * @var PLL_Nav_Menu
+	 */
+	public $nav_menu;
+
+	/**
+	 * Instance of PLL_Static_Pages.
+	 *
+	 * @var PLL_Static_Pages
+	 */
+	public $static_pages;
+
+	/**
+	 * Setup filters.
 	 *
 	 * @since 2.6
 	 */
@@ -39,14 +61,14 @@ class PLL_REST_Request extends PLL_Base {
 			$this->filters_links = new PLL_Filters_Links( $this );
 			$this->filters = new PLL_Filters( $this );
 
-			// Static front page and page for posts
+			// Static front page and page for posts?
 			if ( 'page' === get_option( 'show_on_front' ) ) {
 				$this->static_pages = new PLL_Static_Pages( $this );
 			}
 
 			$this->links = new PLL_Admin_Links( $this );
 
-			$this->nav_menu = new PLL_Nav_Menu( $this ); // For auto added pages to menu
+			$this->nav_menu = new PLL_Nav_Menu( $this ); // For auto added pages to menu.
 		}
 	}
 }

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -4,32 +4,21 @@
  */
 
 /**
- * A class for the Polylang settings pages
- * accessible in $polylang global object
- *
- * Properties:
- * options          => inherited, reference to Polylang options array
- * model            => inherited, reference to PLL_Model object
- * links_model      => inherited, reference to PLL_Links_Model object
- * links            => inherited, reference to PLL_Admin_Links object
- * static_pages     => inherited, reference to PLL_Admin_Static_Pages object
- * filters_links    => inherited, reference to PLL_Filters_Links object
- * curlang          => inherited, optional, current language used to filter admin content
- * pref_lang        => inherited, preferred language used as default when saving posts or terms
+ * A class for the Polylang settings pages, accessible from PLL().
  *
  * @since 1.2
  */
 class PLL_Settings extends PLL_Admin_Base {
 
 	/**
-	 * Name of the active module
+	 * Name of the active module.
 	 *
 	 * @var string $active_tab
 	 */
 	protected $active_tab;
 
 	/**
-	 * Array of modules classes
+	 * Array of modules classes.
 	 *
 	 * @var array $modules
 	 */

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * A class for the Polylang settings pages, accessible from PLL().
+ * A class for the Polylang settings pages, accessible from @see PLL().
  *
  * @since 1.2
  */
@@ -13,14 +13,14 @@ class PLL_Settings extends PLL_Admin_Base {
 	/**
 	 * Name of the active module.
 	 *
-	 * @var string $active_tab
+	 * @var string
 	 */
 	protected $active_tab;
 
 	/**
 	 * Array of modules classes.
 	 *
-	 * @var array $modules
+	 * @var PLL_Settings_Module[]
 	 */
 	protected $modules;
 


### PR DESCRIPTION
This PR replaces the old documentation of the child classes of `PLL_Base` - main Polylang object accessible with `PLL()` - by PHPDoc.