### PR TITLE
Integrate files minification (build process) in the release distribution process

### DIFF
--- a/bin/distribute.sh
+++ b/bin/distribute.sh
@@ -2,7 +2,7 @@
 
 rm -rf vendor/ # Make sure to remove all traces of development dependencies
 
-composer install --no-dev
+composer update --no-dev # composer.lock file is always present because pushed on repository.
 
 npm install && npm run build # minify js and css files
 

--- a/bin/distribute.sh
+++ b/bin/distribute.sh
@@ -2,11 +2,9 @@
 
 rm -rf vendor/ # Make sure to remove all traces of development dependencies
 
-if [[ -e "composer.lock" ]]; then
-	composer update --no-dev
-else
-	composer install --no-dev
-fi
+composer install --no-dev
+
+npm install && npm run build # minify js and css files
 
 rsync -rc --exclude-from=.distignore . polylang/ --delete --delete-excluded
 zip -r polylang.zip polylang/*


### PR DESCRIPTION
This PR propose to integrate the build process (only minification in Polylang) when we want to generate the polylang archive file for a release.
Base on the work done in the PR #593

Notice there is no need to verify if composer.lock file exist because the `composer install` command creates it if it doesn't.
https://getcomposer.org/doc/03-cli.md#install-i