### PR TITLE
Add missing documentation for class properties

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -9,7 +9,33 @@
  * @since 2.4
  */
 class PLL_Admin_Classic_Editor {
-	public $model, $links, $curlang, $pref_lang;
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of PLL_Admin_Links.
+	 *
+	 * @var PLL_Admin_Links
+	 */
+	public $links;
+
+	/**
+	 * Current language (used to filter the content).
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
+
+	/**
+	 * Preferred language to assign to new contents.
+	 *
+	 * @var PLL_Language
+	 */
+	public $pref_lang;
 
 	/**
 	 * Constructor: setups filters and actions

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -10,7 +10,26 @@
  * @since 1.2
  */
 class PLL_Admin_Filters_Columns {
-	public $links, $model, $filter_lang;
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of PLL_Links.
+	 *
+	 * @var PLL_Links
+	 */
+	public $links;
+
+	/**
+	 * Language selected in the admin language filter.
+	 *
+	 * @var PLL_Language
+	 */
+	public $filter_lang;
 
 	/**
 	 * Constructor: setups filters and actions

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -10,6 +10,11 @@
  * @since 1.2
  */
 class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
+	/**
+	 * Instance of PLL_CRUD_Posts.
+	 *
+	 * @var string PLL_CRUD_Posts
+	 */
 	public $posts;
 
 	/**

--- a/admin/admin-filters-post-base.php
+++ b/admin/admin-filters-post-base.php
@@ -9,7 +9,26 @@
  * @since 1.5
  */
 abstract class PLL_Admin_Filters_Post_Base {
-	public $links, $model, $pref_lang;
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of PLL_Links
+	 *
+	 * @var PLL_Links
+	 */
+	public $links;
+
+	/**
+	 * Language selected in the admin language filter.
+	 *
+	 * @var PLL_Language
+	 */
+	public $filter_lang;
 
 	/**
 	 * Constructor: setups filters and actions

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -9,6 +9,11 @@
  * @since 1.2
  */
 class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
+	/**
+	 * Current language (used to filter the content).
+	 *
+	 * @var PLL_Language
+	 */
 	public $curlang;
 
 	/**

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -9,9 +9,47 @@
  * @since 1.2
  */
 class PLL_Admin_Filters_Term {
-	public $links, $model, $options, $pref_lang;
-	protected $pre_term_name; // Used to store the term name before creating a slug if needed
-	protected $post_id; // Used to store the current post_id when bulk editing posts
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of PLL_Links.
+	 *
+	 * @var PLL_Links
+	 */
+	public $links;
+
+	/**
+	 * Language selected in the admin language filter.
+	 *
+	 * @var PLL_Language
+	 */
+	public $filter_lang;
+
+	/**
+	 * Stores the term name before creating a slug if needed.
+	 *
+	 * @var string
+	 */
+	protected $pre_term_name;
+
+	/**
+	 * Stores the current post_id when bulk editing posts.
+	 *
+	 * @var int
+	 */
+	protected $post_id;
 
 	/**
 	 * Constructor: setups filters and actions

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -9,6 +9,11 @@
  * @since 1.8
  */
 class PLL_Admin_Static_Pages extends PLL_Static_Pages {
+	/**
+	 * Instance of PLL_Admin_Links.
+	 *
+	 * @var PLL_Admin_Links
+	 */
 	protected $links;
 
 	/**

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -9,8 +9,19 @@
  * @since 1.6
  */
 class PLL_Admin_Strings {
-	protected static $strings = array(); // strings to translate
-	protected static $default_strings; // default strings to register
+	/**
+	 * Stores the strings to translate.
+	 *
+	 * @var array
+	 */
+	protected static $strings = array();
+
+	/**
+	 * The strings to register by default
+	 *
+	 * @var string[]
+	 */
+	protected static $default_strings;
 
 	/**
 	 * Add filters

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -12,12 +12,17 @@ class PLL_Admin_Strings {
 	/**
 	 * Stores the strings to translate.
 	 *
-	 * @var array
+	 * @var array {
+	 *   @type string $name      A unique name for the string.
+	 *   @type string $string    The actual string to translate.
+	 *   @type string $context   The group in which the string is registered.
+	 *   @type bool   $multiline Whether the string table should display a multiline textarea or a single line input.
+	 * }
 	 */
 	protected static $strings = array();
 
 	/**
-	 * The strings to register by default
+	 * The strings to register by default.
 	 *
 	 * @var string[]
 	 */

--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -11,7 +11,14 @@
  * @since 1.2
  */
 class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
-	protected $index = 'index.php'; // Need this before $wp_rewrite is created, also hardcoded in wp-includes/rewrite.php
+	/**
+	 * The name of the index file which is the entry point to all requests.
+	 * We need this before the global $wp_rewrite is created.
+	 * Also hardcoded in WP_Rewrite.
+	 *
+	 * @var string
+	 */
+	protected $index = 'index.php';
 
 	/**
 	 * Sets the language

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -9,7 +9,32 @@
  * @since 1.2
  */
 abstract class PLL_Choose_Lang {
-	public $links_model, $model, $options;
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of a child class of PLL_Links_Model.
+	 *
+	 * @var PLL_Links_Model
+	 */
+	public $links_model;
+
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
 	public $curlang;
 
 	/**

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -10,7 +10,19 @@
  * @since 1.1
  */
 class PLL_Frontend_Auto_Translate {
-	public $model, $curlang;
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
 
 	/**
 	 * Constructor

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -9,7 +9,19 @@
  * @since 1.2
  */
 class PLL_Frontend_Filters_Search {
-	public $links_model, $curlang;
+	/**
+	 * Instance of a child class of PLL_Links_Model.
+	 *
+	 * @var PLL_Links_Model
+	 */
+	public $links_model;
+
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
 
 	/**
 	 * Constructor

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -9,6 +9,11 @@
  * @since 1.2
  */
 class PLL_Frontend_Filters extends PLL_Filters {
+	/**
+	 * Internal non persistent cache object.
+	 *
+	 * @var PLL_Cache
+	 */
 	public $cache;
 
 	/**

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -9,8 +9,19 @@
  * @since 1.2
  */
 class PLL_Frontend_Links extends PLL_Links {
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
 	public $curlang;
-	public $cache; // Our internal non persistent cache object
+
+	/**
+	 * Internal non persistent cache object.
+	 *
+	 * @var PLL_Cache
+	 */
+	public $cache;
 
 	/**
 	 * Constructor

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -9,6 +9,11 @@
  * @since 1.2
  */
 class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
 	public $curlang;
 
 	/**

--- a/include/cache.php
+++ b/include/cache.php
@@ -10,7 +10,19 @@
  * @since 1.7
  */
 class PLL_Cache {
-	protected $blog_id, $cache;
+	/**
+	 * Current site id.
+	 *
+	 * @var int
+	 */
+	protected $blog_id;
+
+	/**
+	 * The cache container.
+	 *
+	 * @var array
+	 */
+	protected $cache;
 
 	/**
 	 * Constructor

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -10,7 +10,39 @@
  * @since 2.4
  */
 class PLL_CRUD_Terms {
-	public $model, $curlang, $filter_lang, $pref_lang;
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Current language (used to filter the content).
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
+
+	/**
+	 * Language selected in the admin language filter.
+	 *
+	 * @var PLL_Language
+	 */
+	public $filter_lang;
+
+	/**
+	 * Preferred language to assign to new contents.
+	 *
+	 * @var PLL_Language
+	 */
+	public $pref_lang;
+
+	/**
+	 * Stores the 'lang' query var from WP_Query.
+	 *
+	 * @var string
+	 */
 	private $tax_query_lang;
 
 	/**

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -9,7 +9,40 @@
  * @since 1.8
  */
 class PLL_Filters_Links {
-	public $links, $links_model, $model, $options, $curlang;
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of a child class of PLL_Links_Model.
+	 *
+	 * @var PLL_Links_Model
+	 */
+	public $links_model;
+
+	/**
+	 * Instance of PLL_Links
+	 *
+	 * @var PLL_Links
+	 */
+	public $links;
+
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
 
 	/**
 	 * Constructor

--- a/include/filters.php
+++ b/include/filters.php
@@ -9,7 +9,33 @@
  * @since 1.4
  */
 class PLL_Filters {
-	public $links_model, $model, $options, $curlang;
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of a child class of PLL_Links_Model.
+	 *
+	 * @var PLL_Links_Model
+	 */
+	public $links_model;
+
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
 
 	/**
 	 * Constructor: setups filters

--- a/include/license.php
+++ b/include/license.php
@@ -9,8 +9,60 @@
  * @since 1.9
  */
 class PLL_License {
-	public $id, $name, $license_key, $license_data;
-	private $file, $version, $author;
+	/**
+	 * Sanitized plugin name.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Plugin name.
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * License key.
+	 *
+	 * @var string
+	 */
+	public $license_key;
+
+	/**
+	 * License data, obtained from the API request.
+	 *
+	 * @var array
+	 */
+	public $license_data;
+
+	/**
+	 * Main plugin file.
+	 *
+	 * @var string
+	 */
+	private $file;
+
+	/**
+	 * Current plugin version.
+	 *
+	 * @var string
+	 */
+	private $version;
+
+	/**
+	 * Plugin author.
+	 *
+	 * @var string
+	 */
+	private $author;
+
+	/**
+	 * API url.
+	 *
+	 * @var string.
+	 */
 	private $api_url = 'https://polylang.pro';
 
 	/**

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -11,6 +11,11 @@
  * @since 1.2
  */
 class PLL_Links_Default extends PLL_Links_Model {
+	/**
+	 * Tells this child class of PLL_Links_Model does not use pretty permalinks.
+	 *
+	 * @var bool
+	 */
 	public $using_permalinks = false;
 
 	/**

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -11,6 +11,11 @@
  * @since 1.2
  */
 class PLL_Links_Directory extends PLL_Links_Permalinks {
+	/**
+	 * Relative path to the home url.
+	 *
+	 * @var string
+	 */
 	protected $home_relative;
 
 	/**

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -40,7 +40,7 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	protected $use_trailing_slashes;
 
 	/**
-	 * Rewrite rules to always filter
+	 * The name of the rewrite rules to always modify.
 	 *
 	 * @var string[]
 	 */

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -9,9 +9,41 @@
  * @since 1.6
  */
 abstract class PLL_Links_Permalinks extends PLL_Links_Model {
+	/**
+	 * Tells this child class of PLL_Links_Model is for pretty permalinks.
+	 *
+	 * @var bool
+	 */
 	public $using_permalinks = true;
-	protected $index = 'index.php'; // Need this before $wp_rewrite is created, also hardcoded in wp-includes/rewrite.php
-	protected $root, $use_trailing_slashes;
+
+	/**
+	 * The name of the index file which is the entry point to all requests.
+	 * We need this before the global $wp_rewrite is created.
+	 * Also hardcoded in WP_Rewrite.
+	 *
+	 * @var string
+	 */
+	protected $index = 'index.php';
+
+	/**
+	 * The prefix for all permalink structures.
+	 *
+	 * @var string
+	 */
+	protected $root;
+
+	/**
+	 * Whether to add trailing slashes.
+	 *
+	 * @var bool
+	 */
+	protected $use_trailing_slashes;
+
+	/**
+	 * Rewrite rules to always filter
+	 *
+	 * @var string[]
+	 */
 	protected $always_rewrite = array( 'date', 'root', 'comments', 'search', 'author' );
 
 	/**

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -11,6 +11,12 @@
  * @since 1.2
  */
 class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
+	/**
+	 * Stores whether the home url includes www. or not.
+	 * Either '://' or '://www.'.
+	 *
+	 * @var string
+	 */
 	protected $www;
 
 	/**

--- a/include/links.php
+++ b/include/links.php
@@ -9,7 +9,26 @@
  * @since 1.2
  */
 class PLL_Links {
-	public $links_model, $model, $options;
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * Instance of a child class of PLL_Links_Model.
+	 *
+	 * @var PLL_Links_Model
+	 */
+	public $links_model;
 
 	/**
 	 * Constructor

--- a/include/model.php
+++ b/include/model.php
@@ -9,9 +9,33 @@
  * @since 1.2
  */
 class PLL_Model {
-	public $cache; // Our internal non persistent cache object
+	/**
+	 * Internal non persistent cache object.
+	 *
+	 * @var PLL_Cache
+	 */
+	public $cache;
+
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
 	public $options;
-	public $post, $term; // Translated objects models
+
+	/**
+	 * Translated post model.
+	 *
+	 * @var PLL_Translated_Post
+	 */
+	public $post;
+
+	/**
+	 * Translated term model.
+	 *
+	 * @var PLL_Translated_Term
+	 */
+	public $term;
 
 	/**
 	 * Constructor

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -13,10 +13,33 @@
  * @since 1.2
  */
 class PLL_OLT_Manager {
-	protected static $instance; // For singleton
+	/**
+	 * Singleton instance
+	 *
+	 * @var PLL_OLT_Manager
+	 */
+	protected static $instance;
+
+	/**
+	 * Stores the default site locale before it is modified.
+	 *
+	 * @var string
+	 */
 	protected $default_locale;
-	protected $list_textdomains = array(); // All text domains
-	public $labels = array(); // Post types and taxonomies labels to translate
+
+	/**
+	 * Stores all loded text domains and mo files.
+	 *
+	 * @var array
+	 */
+	protected $list_textdomains = array();
+
+	/**
+	 * Stores post types an taxonomies labels to translate.
+	 *
+	 * @var array
+	 */
+	public $labels = array();
 
 	/**
 	 * Constructor: setups relevant filters

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -11,6 +11,7 @@
 class PLL_Walker_Dropdown extends Walker {
 	/**
 	 * Database fields to use.
+	 *
 	 * @see https://developer.wordpress.org/reference/classes/walker/#properties Walker::$db_fields.
 	 *
 	 * @var array

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -11,7 +11,7 @@
 class PLL_Walker_Dropdown extends Walker {
 	/**
 	 * Database fields to use.
-	 * See Walker::$db_fields
+	 * @see https://developer.wordpress.org/reference/classes/walker/#properties Walker::$db_fields.
 	 *
 	 * @var array
 	 */

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -9,6 +9,12 @@
  * @since 1.2
  */
 class PLL_Walker_Dropdown extends Walker {
+	/**
+	 * Database fields to use.
+	 * See Walker::$db_fields
+	 *
+	 * @var array
+	 */
 	public $db_fields = array( 'parent' => 'parent', 'id' => 'id' );
 
 	/**

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -9,6 +9,12 @@
  * @since 1.2
  */
 class PLL_Walker_List extends Walker {
+	/**
+	 * Database fields to use.
+	 * See Walker::$db_fields
+	 *
+	 * @var array
+	 */
 	public $db_fields = array( 'parent' => 'parent', 'id' => 'id' );
 
 	/**

--- a/install/install-base.php
+++ b/install/install-base.php
@@ -9,6 +9,11 @@
  * @since 1.7
  */
 class PLL_Install_Base {
+	/**
+	 * The plugin basename.
+	 *
+	 * @var string
+	 */
 	protected $plugin_basename;
 
 	/**

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -9,6 +9,11 @@
  * @since 1.2
  */
 class PLL_Upgrade {
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
 	public $options;
 
 	/**

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -9,6 +9,11 @@
  * @since 1.2
  */
 class PLL_WP_Import extends WP_Import {
+	/**
+	 * Stores post_translations terms.
+	 *
+	 * @var array
+	 */
 	public $post_translations = array();
 
 	/**

--- a/integrations/wp-offload-media/as3cf.php
+++ b/integrations/wp-offload-media/as3cf.php
@@ -10,6 +10,11 @@
  * @since 2.6
  */
 class PLL_AS3CF {
+	/**
+	 * Stores if a media is translated when it is deleted.
+	 *
+	 * @var bool[]
+	 */
 	private $is_media_translated;
 
 	/**

--- a/modules/sync/sync-metas.php
+++ b/modules/sync/sync-metas.php
@@ -9,8 +9,33 @@
  * @since 2.3
  */
 abstract class PLL_Sync_Metas {
+	/**
+	 * Instance of PLL_Model.
+	 *
+	 * @var PLL_Model
+	 */
 	public $model;
-	protected $meta_type, $prev_value, $to_copy;
+
+	/**
+	 * Meta type. Typically 'post' or 'term'.
+	 *
+	 * @var string
+	 */
+	protected $meta_type;
+
+	/**
+	 * Stores the previous values when updating a meta.
+	 *
+	 * @var array
+	 */
+	protected $prev_value;
+
+	/**
+	 * Stores the metas to synchronize before deleting them.
+	 *
+	 * @var array
+	 */
+	protected $to_copy;
 
 	/**
 	 * Constructor

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -9,6 +9,11 @@
  * @since 2.3
  */
 class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
+	/**
+	 * Stores the plugin options.
+	 *
+	 * @var array
+	 */
 	public $options;
 
 	/**

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -12,6 +12,11 @@
  * @since 2.0
  */
 class PLL_WPML_API {
+	/**
+	 * Stores the original language when the language is switched.
+	 *
+	 * @var PLL_Language
+	 */
 	private static $original_language = null;
 
 	/**

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -11,8 +11,25 @@
  * @since 1.0.2
  */
 class PLL_WPML_Compat {
-	protected static $instance; // For singleton
-	protected static $strings; // Used for cache
+	/**
+	 * Singleton instance
+	 *
+	 * @var PLL_OLT_Manager
+	 */
+	protected static $instance;
+
+	/**
+	 * Stores the strings registered with the WPML API.
+	 *
+	 * @var array
+	 */
+	protected static $strings;
+
+	/**
+	 * Instance of PLL_WPML_API.
+	 *
+	 * @var PLL_WPML_API
+	 */
 	public $api;
 
 	/**

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -11,8 +11,19 @@
  * @since 1.0
  */
 class PLL_WPML_Config {
-	protected static $instance; // For singleton
-	protected $xmls, $options;
+	/**
+	 * Singleton instance
+	 *
+	 * @var PLL_OLT_Manager
+	 */
+	protected static $instance;
+
+	/**
+	 * The content of all read xml files.
+	 *
+	 * @var SimpleXMLElement[]
+	 */
+	protected $xmls;
 
 	/**
 	 * Constructor

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,8 +45,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="Squiz.Commenting.InlineComment.SpacingAfter"/>
-		<exclude name="Squiz.Commenting.VariableComment.Missing"/>
-		<exclude name="Squiz.Commenting.VariableComment.WrongStyle"/>
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
@@ -118,6 +116,14 @@
 	</rule>
 
 	<rule ref="Squiz.Commenting.FunctionComment.WrongStyle" >
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Squiz.Commenting.VariableComment.Missing" >
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Squiz.Commenting.VariableComment.WrongStyle" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -14,7 +14,33 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
  * @since 0.6
  */
 class PLL_Table_String extends WP_List_Table {
-	protected $languages, $strings, $groups, $selected_group;
+	/**
+	 * The list of languages.
+	 *
+	 * @var PLL_Language[]
+	 */
+	protected $languages;
+
+	/**
+	 * Registered strings.
+	 *
+	 * @var array
+	 */
+	protected $strings;
+
+	/**
+	 * The string groups.
+	 *
+	 * @var string[]
+	 */
+	protected $groups;
+
+	/**
+	 * The selected string group or -1 if none is selected.
+	 *
+	 * @var string|int
+	 */
+	protected $selected_group;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
This adds all missing PHPDoc comments to all class properties and enables the sniff Squiz.Commenting.VariableComment in PHPCS config, except for tests.