### PR TITLE
Fix missing or useless isset

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -256,7 +256,7 @@ class PLL_Admin_Filters_Columns {
 			$taxonomy = $GLOBALS['taxonomy'];
 		}
 
-		if (  ! isset( $taxonomy, $post_type ) || ! post_type_exists( $post_type ) || ! taxonomy_exists( $taxonomy ) ) {
+		if ( ! isset( $taxonomy, $post_type ) || ! post_type_exists( $post_type ) || ! taxonomy_exists( $taxonomy ) ) {
 			return $out;
 		}
 

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -256,7 +256,7 @@ class PLL_Admin_Filters_Columns {
 			$taxonomy = $GLOBALS['taxonomy'];
 		}
 
-		if ( ! post_type_exists( $post_type ) || ! taxonomy_exists( $taxonomy ) ) {
+		if (  ! isset( $taxonomy, $post_type ) || ! post_type_exists( $post_type ) || ! taxonomy_exists( $taxonomy ) ) {
 			return $out;
 		}
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -70,7 +70,7 @@ class PLL_Admin_Filters_Term {
 			$post_type = $GLOBALS['post_type'];
 		}
 
-		if ( empty( $taxonomy ) || ! taxonomy_exists( $taxonomy ) || ! post_type_exists( $post_type ) ) {
+		if ( ! isset( $taxonomy, $post_type ) || ! taxonomy_exists( $taxonomy ) || ! post_type_exists( $post_type ) ) {
 			return;
 		}
 
@@ -132,7 +132,7 @@ class PLL_Admin_Filters_Term {
 			$post_type = $GLOBALS['post_type'];
 		}
 
-		if ( ! post_type_exists( $post_type ) ) {
+		if ( ! isset( $post_type ) || ! post_type_exists( $post_type ) ) {
 			return;
 		}
 

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -282,7 +282,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Validate slug is unique
 		foreach ( $this->get_languages_list() as $language ) {
-			if ( $language->slug === $args['slug'] && ( null === $lang || ( isset( $lang ) && $lang->term_id != $language->term_id ) ) ) {
+			if ( $language->slug === $args['slug'] && ( null === $lang || $lang->term_id !== $language->term_id ) ) {
 				$errors->add( 'pll_non_unique_slug', __( 'The language code must be unique', 'polylang' ) );
 			}
 		}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -165,7 +165,7 @@ abstract class PLL_Translated_Object {
 	public function save_translations( $id, $translations ) {
 		$id = (int) $id;
 
-		if ( ( $lang = $this->get_language( $id ) ) && isset( $translations ) && is_array( $translations ) ) {
+		if ( ( $lang = $this->get_language( $id ) ) && is_array( $translations ) ) {
 			// Sanitize the translations array.
 			$translations = array_map( 'intval', $translations );
 			$translations = array_merge( array( $lang->slug => $id ), $translations ); // Make sure this object is in translations.

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -133,7 +133,7 @@ class PLL_Sitemaps {
 		$newrules = array();
 
 		foreach ( $rules as $key => $rule ) {
-			if ( isset( $slug ) && false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
+			if ( false !== strpos( $rule, 'sitemap=$matches[1]' ) ) {
 				$newrules[ str_replace( '^wp-sitemap', $slug . 'wp-sitemap', $key ) ] = str_replace(
 					array( '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '[1]', '?' ),
 					array( '[9]', '[8]', '[7]', '[6]', '[5]', '[4]', '[3]', '[2]', '?lang=$matches[1]&' ),


### PR DESCRIPTION
This PR fixes errors reported by PHPStan (level 1)
- Useless `isset()`.
- Variables which might not be defined due to missing `isset()`.