### PR TITLE
Stop test execution if language is invalid

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -53,6 +53,7 @@ trait PLL_UnitTestCase_Trait {
 	 *
 	 * @param string $locale Language locale.
 	 * @param array  $args   Allows to optionnally override the default values for the language
+	 * @throws InvalidArgumentException If language is not created.
 	 */
 	static function create_language( $locale, $args = array() ) {
 		$languages = include POLYLANG_DIR . '/settings/languages.php';

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -63,7 +63,10 @@ trait PLL_UnitTestCase_Trait {
 		$values['term_group'] = 0; // Default term_group.
 
 		$args = array_merge( $values, $args );
-		self::$polylang->model->add_language( $args );
+		$errors = self::$polylang->model->add_language( $args );
+		if ( is_wp_error( $errors ) ) {
+			throw new InvalidArgumentException( $errors->get_error_message() );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -54,7 +54,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug' ) ) );
 
 		// attempt to create a language with the same slug as an existing one
-		self::create_language( 'en_GB' );
+		self::$polylang->model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
 		$lang = self::$polylang->model->get_language( 'en' );
 		$this->assertEquals( 'en_US', $lang->locale );
 		$this->assertFalse( self::$polylang->model->get_language( 'en_GB' ) );


### PR DESCRIPTION
- test: Do not execute test when incorrect language is set
- test(admin-model): Test the production code instead of the test utilities
