### PR TITLE
Parsing HTTP Accept-Language Header

### DIFF
--- a/frontend/accept-language.php
+++ b/frontend/accept-language.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Class Accept_Language
+ *
+ * Represents an Accept-Language HTTP Header, as defined in RFC 2616 Section 14.4 {@see https://tools.ietf.org/html/rfc2616.html#section-14.4}.
+ */
+class PLL_Accept_Language {
+	/**
+	 * Parse Accept-Language HTTP header according to IETF BCP 47.
+	 *
+	 * TODO: Add grand-fathered language codes.
+	 *
+	 * @param string $http_header Value of the Accept-Language HTTP Header. Formatted as stated BCP 47 for language tags {@see https://tools.ietf.org/html/bcp47}.
+	 * @return array {
+	 * @since 3.0
+	 */
+	public static function parse_accept_language_header( $http_header ) {
+		$lang_parse = array();
+		// Break up string into pieces ( languages and q factors )
+		$subtags = array(
+			'language' => '([a-z]{2,3}|[a-z]{4}|[a-z]{5-8})\b',
+			'language-extension' => '(-(?:[a-z]{3}){1,3}\b)?',
+			'script' => '(-[a-z]{4}\b)?',
+			'region' => '(-(?:[a-z]{2}|[0-9]{3})\b)?',
+			'variant' => '(-(?:[0-9][a-z]{1,3}|[a-z][a-z0-9]{4,7})\b)?',
+			'extension' => '(-[a-wy-z]-[a-z0-9]{2,8}\b)?',
+			'private-use' => '(-x-[a-z0-9]{1,8}\b)?',
+		);
+		$language_pattern = "{$subtags['language']}{$subtags['language-extension']}{$subtags['script']}{$subtags['region']}{$subtags['variant']}{$subtags['extension']}{$subtags['private-use']}";
+		$quality_pattern = '\s*;\s*q\s*=\s*((?>1|0)(?>\.[0-9]+)?)';
+		$full_pattern = "/({$language_pattern})({$quality_pattern})?/i";
+		preg_match_all(
+			$full_pattern,
+			sanitize_text_field( wp_unslash( $http_header ) ),
+			$lang_parse
+		);
+		return array('language' => $lang_parse[1], 'quality' => $lang_parse[10]);
+	}
+}

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -11,6 +11,10 @@
 abstract class PLL_Choose_Lang {
 	public $links_model, $model, $options;
 	public $curlang;
+	/**
+	 * @var PLL_Accept_Language
+	 */
+	private $lang_parse;
 
 	/**
 	 * Constructor
@@ -106,7 +110,7 @@ abstract class PLL_Choose_Lang {
 		$accept_langs = array();
 
 		if ( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
-			$lang_parse = $this->parse_accept_language_header( sanitize_text_field( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) );
+			$lang_parse = PLL_Accept_Language::parse_accept_language_header( sanitize_text_field( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) );
 
 			$k = $lang_parse['language'];
 			$v = $lang_parse['quality'];
@@ -156,53 +160,22 @@ abstract class PLL_Choose_Lang {
 		// Looks through sorted list and use first one that matches our language list
 		foreach ( array_keys( $accept_langs ) as $accept_lang ) {
 			// First loop to match the exact locale
-			foreach ( $languages as $language_pattern ) {
-				if ( 0 === strcasecmp( $accept_lang, $language_pattern->get_locale( 'display' ) ) ) {
-					return $language_pattern->slug;
+			foreach ( $languages as $language ) {
+				if ( 0 === strcasecmp( $accept_lang, $language->get_locale( 'display' ) ) ) {
+					return $language->slug;
 				}
 			}
+		}
 
+		foreach ( array_keys( $accept_langs ) as $accept_lang ) {
 			// Second loop to match the language set
-			foreach ( $languages as $language_pattern ) {
-				if ( 0 === stripos( $accept_lang, $language_pattern->slug ) || 0 === stripos( $language_pattern->get_locale( 'display' ), $accept_lang ) ) {
-					return $language_pattern->slug;
+			foreach ( $languages as $language ) {
+				if ( 0 === stripos( $accept_lang, $language->slug ) || 0 === stripos( $language->get_locale( 'display' ), $accept_lang ) ) {
+					return $language->slug;
 				}
 			}
 		}
 		return false;
-	}
-
-	/**
-	 * Parse Accept-Language HTTP header according to IETF BCP 47.
-	 *
-	 * TODO: Add grand-fathered language codes.
-	 *
-	 * @param string $header Value of the Accept-Language HTTP Header.
-	 * @return array {
-	 * @since 3.0
-	 * @type string $language A language code as defined by the IETF BCP 47 @see https://tools.ietf.org/html/bcp47#section-2.1
-	 */
-	protected function parse_accept_language_header( $header ) {
-		$lang_parse = array();
-		// Break up string into pieces ( languages and q factors )
-		$subtags = array(
-			'language' => '([a-z]{2,3}|[a-z]{4}|[a-z]{5-8})\b',
-			'language-extension' => '(-(?:[a-z]{3}){1,3}\b)?',
-			'script' => '(-[a-z]{4}\b)?',
-			'region' => '(-(?:[a-z]{2}|[0-9]{3})\b)?',
-			'variant' => '(-(?:[0-9][a-z]{1,3}|[a-z][a-z0-9]{4,7})\b)?',
-			'extension' => '(-[a-wy-z]-[a-z0-9]{2,8}\b)?',
-			'private-use' => '(-x-[a-z0-9]{1,8}\b)?',
-		);
-		$language_pattern = "{$subtags['language']}{$subtags['language-extension']}{$subtags['script']}{$subtags['region']}{$subtags['variant']}{$subtags['extension']}{$subtags['private-use']}";
-		$quality_pattern = '\s*;\s*q\s*=\s*((?>1|0)(?>\.[0-9]+)?)';
-		$full_pattern = "/({$language_pattern})({$quality_pattern})?/i";
-		preg_match_all(
-			$full_pattern,
-			sanitize_text_field( wp_unslash( $header ) ),
-			$lang_parse
-		);
-		return array( 'language' => $lang_parse[1], 'quality' => $lang_parse[10] );
 	}
 
 	/**

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -110,10 +110,15 @@ abstract class PLL_Choose_Lang {
 		$accept_langs = array();
 
 		if ( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
-			$lang_parse = PLL_Accept_Language::parse_accept_language_header( sanitize_text_field( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) );
+			$accept_langs = PLL_Accept_Language::parse_accept_language_header( sanitize_text_field( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) );
 
-			$k = $lang_parse['language'];
-			$v = $lang_parse['quality'];
+			$k = $accept_langs;
+			$v = array_map(
+				function( $accept_lang ) {
+					return $accept_lang->get_quality();
+				},
+				$accept_langs
+			);
 
 			if ( $n = count( $k ) ) {
 				// Set default to 1 for any without q factor

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -106,15 +106,10 @@ abstract class PLL_Choose_Lang {
 		$accept_langs = array();
 
 		if ( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
-			// Break up string into pieces ( languages and q factors )
-			preg_match_all(
-				'/([a-z]{1,8}(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*((?>1|0)(?>\.[0-9]+)?))?/i',
-				sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ),
-				$lang_parse
-			);
+			$lang_parse = $this->parse_accept_language_header();
 
-			$k = $lang_parse[1];
-			$v = $lang_parse[4];
+			$k = $lang_parse['language'];
+			$v = $lang_parse['quality'];
 
 			if ( $n = count( $k ) ) {
 				// Set default to 1 for any without q factor
@@ -161,16 +156,16 @@ abstract class PLL_Choose_Lang {
 		// Looks through sorted list and use first one that matches our language list
 		foreach ( array_keys( $accept_langs ) as $accept_lang ) {
 			// First loop to match the exact locale
-			foreach ( $languages as $language ) {
-				if ( 0 === strcasecmp( $accept_lang, $language->get_locale( 'display' ) ) ) {
-					return $language->slug;
+			foreach ( $languages as $language_pattern ) {
+				if ( 0 === strcasecmp( $accept_lang, $language_pattern->get_locale( 'display' ) ) ) {
+					return $language_pattern->slug;
 				}
 			}
 
 			// Second loop to match the language set
-			foreach ( $languages as $language ) {
-				if ( 0 === stripos( $accept_lang, $language->slug ) || 0 === stripos( $language->get_locale( 'display' ), $accept_lang ) ) {
-					return $language->slug;
+			foreach ( $languages as $language_pattern ) {
+				if ( 0 === stripos( $accept_lang, $language_pattern->slug ) || 0 === stripos( $language_pattern->get_locale( 'display' ), $accept_lang ) ) {
+					return $language_pattern->slug;
 				}
 			}
 		}
@@ -337,5 +332,39 @@ abstract class PLL_Choose_Lang {
 	protected function set_curlang_in_query( &$query ) {
 		$pll_query = new PLL_Query( $query, $this->model );
 		$pll_query->set_language( $this->curlang );
+	}
+
+	/**
+	 * Parse Accept-Language HTTP header according to IETF BCP 47.
+	 *
+	 * TODO: Add grand-fathered language codes.
+	 *
+	 * @since 3.0
+	 * @return array {
+	 *   @type string $language A language code as defined by the IETF BCP 47 @see https://tools.ietf.org/html/bcp47#section-2.1
+	 *   @type float $quality A quality factor associated with this language.
+	 * }
+	 */
+	protected function parse_accept_language_header() {
+		 $lang_parse = array();
+		// Break up string into pieces ( languages and q factors )
+		$subtags = array(
+			'language' => '([a-z]{2,3}|[a-z]{4}|[a-z]{5-8})\b',
+			'language-extension' => '(-(?:[a-z]{3}){1,3}\b)?',
+			'script' => '(-[a-z]{4}\b)?',
+			'region' => '(-(?:[a-z]{2}|[0-9]{3})\b)?',
+			'variant' => '(-(?:[0-9][a-z]{1,3}|[a-z][a-z0-9]{4,7})\b)?',
+			'extension' => '(-[a-wy-z]-[a-z0-9]{2,8}\b)?',
+			'private-use' => '(-x-[a-z0-9]{1,8}\b)?',
+		);
+		$language_pattern = "{$subtags['language']}{$subtags['language-extension']}{$subtags['script']}{$subtags['region']}{$subtags['variant']}{$subtags['extension']}{$subtags['private-use']}";
+		$quality_pattern = '\s*;\s*q\s*=\s*((?>1|0)(?>\.[0-9]+)?)';
+		$full_pattern = "/({$language_pattern})({$quality_pattern})?/i";
+		preg_match_all(
+			$full_pattern,
+			sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ),
+			$lang_parse
+		);
+		return array( 'language' => $lang_parse[1], 'quality' => $lang_parse[10] );
 	}
 }

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -91,14 +91,15 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 			'Registered script get priority' => array( 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5,en;q=0.1', 'zh-hant-hk' ),
 			'Non registered script fallbacks to base language' => array( 'zh-Hans-HK', 'zh' ),
 			'Quality supersedes closest language when supplied' => array( 'zh-Hans-HK,en;q=0.8,zh-CN;q=0.5,zh-HK;q=0.2', 'en' ),
-			'Non registered script fallback to existing region' => array( 'zh-Hans-HK', 'zh-hk' ),
+			'Unregistered script get skipped for next highest quality' => array( 'zh-hant-cn;q=1.0,zh-hk;q=0.8', 'zh-hk' ), // @see https://github.com/polylang/polylang/issues/591
+			'Non registered script fallback to existing region' => array( 'zh-Hans-HK', 'zh-hk' ), // @see https://github.com/polylang/polylang/issues/591
+			'Non registered script fallback to existing language' => array( 'zh-Hans-TW', 'zh' ),
 			'Quality supersedes closest region when supplied' => array( 'zh-Hans-HK,zh-CN;q=0.5,zh-HK;q=0.2,en;q=0.1', 'zh' ),
 		);
 	}
 
 	/**
 	 * @since 3.0 Bugifx
-	 * @see https://github.com/polylang/polylang/issues/591
 	 *
 	 * @dataProvider accepted_language_with_script_provider
 	 * @param string      $accept_languages_header Accept-Language HTTP header like those issued by web browsers.

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -88,13 +88,8 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 	function accepted_language_with_script_provider() {
 		return array(
 			'Registered script gets picked'  => array( 'zh-Hant-HK,en;q=0.1', 'zh-hant-hk' ),
-			'Registered script get priority' => array( 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5,en;q=0.1', 'zh-hant-hk' ),
-			'Non registered script fallbacks to base language' => array( 'zh-Hans-HK', 'zh' ),
-			'Quality supersedes closest language when supplied' => array( 'zh-Hans-HK,en;q=0.8,zh-CN;q=0.5,zh-HK;q=0.2', 'en' ),
+			'Registered script get priority' => array( 'zh-HK;q=0.8,zh;zh-Hant-HK;q=1.0,q=0.5,en;q=0.1', 'zh-hant-hk' ),
 			'Unregistered script get skipped for next highest quality' => array( 'zh-hant-cn;q=1.0,zh-hk;q=0.8', 'zh-hk' ), // @see https://github.com/polylang/polylang/issues/591
-			'Non registered script fallback to existing region' => array( 'zh-Hans-HK', 'zh-hk' ), // @see https://github.com/polylang/polylang/issues/591
-			'Non registered script fallback to existing language' => array( 'zh-Hans-TW', 'zh' ),
-			'Quality supersedes closest region when supplied' => array( 'zh-Hans-HK,zh-CN;q=0.5,zh-HK;q=0.2,en;q=0.1', 'zh' ),
 		);
 	}
 

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -87,8 +87,12 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 	function accepted_language_with_script_provider() {
 		return array(
-			array( 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5', 'zh-hk' ),
-			array( 'zh-Hant-HK', 'zh-hk' ),
+			'Registered script gets picked'  => array( 'zh-Hant-HK,en;q=0.1', 'zh-hant-hk' ),
+			'Registered script get priority' => array( 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5,en;q=0.1', 'zh-hant-hk' ),
+			'Non registered script fallbacks to base language' => array( 'zh-Hans-HK', 'zh' ),
+			'Quality supersedes closest language when supplied' => array( 'zh-Hans-HK,en;q=0.8,zh-CN;q=0.5,zh-HK;q=0.2', 'en' ),
+			'Non registered script fallback to existing region' => array( 'zh-Hans-HK', 'zh-hk' ),
+			'Quality supersedes closest region when supplied' => array( 'zh-Hans-HK,zh-CN;q=0.5,zh-HK;q=0.2,en;q=0.1', 'zh' ),
 		);
 	}
 
@@ -101,6 +105,7 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
 	 */
 	function test_browser_preferred_language_with_script_tag( $accept_languages_header, $expected_preference ) {
+		self::create_language( 'en_GB', array( 'slug' => 'en' ) );
 		self::create_language( 'zh_CN', array( 'slug' => 'zh' ) );
 		self::create_language( 'zh_HK', array( 'slug' => 'zh-hk' ) );
 		self::create_language( 'zh_HK', array( 'slug' => 'zh-hant-hk' ) );

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -17,7 +17,24 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		parent::tearDown();
 	}
 
-	function test_browser_preferred_language() {
+	function accepted_languages_provider() {
+		return array(
+			array( 'fr,fr-fr;q=0.8,en-us;q=0.5,en;q=0.3', 'en' ),
+			array( 'en-us;q=0.5,de-de', 'de' ),
+			array( 'de-de', 'de' ),
+			array( 'es-es,fr-fr;q=0.8', false ),
+			array( 'de;q=0.3,en;q=1', 'en' ),
+			array( 'de;q=0.3,en;q=1.0', 'en' ),
+			array( 'de;q=0,es-es;', false ),
+		);
+	}
+
+	/**
+	 * @dataProvider accepted_languages_provider
+	 * @param string      $accept_languages_header Accept-Language HTTP header like those issued by web browsers.
+	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
+	 */
+	function test_browser_preferred_language( $accept_languages_header, $expected_preference ) {
 		self::create_language( 'en_US' );
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'fr_FR' );
@@ -30,32 +47,27 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
 
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'fr,fr-fr;q=0.8,en-us;q=0.5,en;q=0.3';
-		$this->assertEquals( 'en', $choose_lang->get_preferred_browser_language() );
-
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-us;q=0.5,de-de'; // just to test sorting
-		$this->assertEquals( 'de', $choose_lang->get_preferred_browser_language() );
-
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de-de';
-		$this->assertEquals( 'de', $choose_lang->get_preferred_browser_language() );
-
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es-es,fr-fr;q=0.8';
-		$this->assertFalse( $choose_lang->get_preferred_browser_language() );
-
-		// Bugs fixed in 2.4 with exotic values of q
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de;q=0.3,en;q=1';
-		$this->assertEquals( 'en', $choose_lang->get_preferred_browser_language() );
-
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de;q=0.3,en;q=1.0';
-		$this->assertEquals( 'en', $choose_lang->get_preferred_browser_language() );
-
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de;q=0,es-es;';
-		$this->assertFalse( $choose_lang->get_preferred_browser_language() );
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept_languages_header;
+		$this->assertEquals( $expected_preference, $choose_lang->get_preferred_browser_language() );
 	}
 
-	// bug fixed in 1.8
-	// see https://wordpress.org/support/topic/browser-detection
-	function test_browser_preferred_language_with_same_slug() {
+	function accepted_languages_with_same_slug_provider() {
+		return array(
+			array( 'en-gb;q=0.8,en-us;q=0.5,en;q=0.3', 'en' ),
+			array( 'en-us;q=0.8,en-gb;q=0.5,en;q=0.3', 'us' ),
+			array( 'en;q=0.8,fr;q=0.5', 'us' ),
+		);
+	}
+
+	/**
+	 * @since 1.8 Bugfix
+	 * @see https://wordpress.org/support/topic/browser-detection
+	 *
+	 * @dataProvider accepted_languages_with_same_slug_provider
+	 * @param string      $accept_languages_header Accept-Language HTTP header like those issued by web browsers.
+	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
+	 */
+	function test_browser_preferred_language_with_same_slug( $accept_languages_header, $expected_preference ) {
 		self::create_language( 'en_GB', array( 'term_group' => 2 ) );
 		self::create_language( 'en_US', array( 'slug' => 'us', 'term_group' => 1 ) );
 
@@ -69,22 +81,26 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
 
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-gb;q=0.8,en-us;q=0.5,en;q=0.3';
-		$this->assertEquals( 'en', $choose_lang->get_preferred_browser_language() );
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept_languages_header;
+		$this->assertEquals( $expected_preference, $choose_lang->get_preferred_browser_language() );
+	}
 
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-us;q=0.8,en-gb;q=0.5,en;q=0.3';
-		$this->assertEquals( 'us', $choose_lang->get_preferred_browser_language() );
-
-		// when the exact locale is not specified, return the preferred language according to the order
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en;q=0.8,fr;q=0.5';
-		$this->assertEquals( 'us', $choose_lang->get_preferred_browser_language() );
+	function accepted_language_with_script_provider() {
+		return array(
+			array( 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5', 'zh-hk' ),
+			array( 'zh-Hant-HK', 'zh-hk' ),
+		);
 	}
 
 	/**
-	 * @since 3.0
+	 * @since 3.0 Bugifx
 	 * @see https://github.com/polylang/polylang/issues/591
+	 *
+	 * @dataProvider accepted_language_with_script_provider
+	 * @param string      $accept_languages_header Accept-Language HTTP header like those issued by web browsers.
+	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
 	 */
-	function test_browser_preferred_language_with_script_tag() {
+	function test_browser_preferred_language_with_script_tag( $accept_languages_header, $expected_preference ) {
 		self::create_language( 'zh_CN', array( 'slug' => 'zh' ) );
 		self::create_language( 'zh_HK', array( 'slug' => 'zh-hk' ) );
 		self::create_language( 'zh_HK', array( 'slug' => 'zh-hant-hk' ) );
@@ -100,7 +116,7 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
 
-		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5';
-		$this->assertEquals( 'zh-hk', $choose_lang->get_preferred_browser_language() );
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept_languages_header;
+		$this->assertEquals( $expected_preference, $choose_lang->get_preferred_browser_language() );
 	}
 }

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -65,7 +65,7 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_id, 'us' );
 
-		self::$polylang->model->clean_languages_cache(); // FIXME foor some reason the cache is not clean before (resulting in wrong count)
+		self::$polylang->model->clean_languages_cache(); // FIXME for some reason the cache is not clean before (resulting in wrong count)
 
 		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
 
@@ -78,5 +78,29 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		// when the exact locale is not specified, return the preferred language according to the order
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en;q=0.8,fr;q=0.5';
 		$this->assertEquals( 'us', $choose_lang->get_preferred_browser_language() );
+	}
+
+	/**
+	 * @since 3.0
+	 * @see https://github.com/polylang/polylang/issues/591
+	 */
+	function test_browser_preferred_language_with_script_tag() {
+		self::create_language( 'zh_CN', array( 'slug' => 'zh' ) );
+		self::create_language( 'zh_HK', array( 'slug' => 'zh-hk' ) );
+		self::create_language( 'zh_HK', array( 'slug' => 'zh-hant-hk' ) );
+
+		$post_id = $this->factory->post->create();
+		self::$polylang->model->post->set_language( $post_id, 'zh' );
+		$post_id = $this->factory->post->create();
+		self::$polylang->model->post->set_language( $post_id, 'zh-hk' );
+		$post_id = $this->factory->post->create();
+		self::$polylang->model->post->set_language( $post_id, 'zh-hant-hk' );
+
+		self::$polylang->model->clean_languages_cache(); // FIXME for some reason the cache is not clean before (resulting in wrong count)
+
+		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
+
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'zh-Hant-HK,zh-HK;q=0.8,zh;q=0.5';
+		$this->assertEquals( 'zh-hk', $choose_lang->get_preferred_browser_language() );
 	}
 }

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -101,10 +101,10 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
 	 */
 	function test_browser_preferred_language_with_script_tag( $accept_languages_header, $expected_preference ) {
-		self::create_language( 'en_GB', array( 'slug' => 'en' ) );
-		self::create_language( 'zh_CN', array( 'slug' => 'zh' ) );
-		self::create_language( 'zh_HK', array( 'slug' => 'zh-hk' ) );
-		self::create_language( 'zh_HK', array( 'slug' => 'zh-hant-hk' ) );
+		self::create_language( 'en_GB', array( 'slug' => 'en', 'w3c' => 'en' ) );
+		self::create_language( 'zh_CN', array( 'slug' => 'zh', 'w3c' => 'zh' ) );
+		self::create_language( 'zh_HK', array( 'slug' => 'zh-hk', 'w3c' => 'zh-hk' ) );
+		self::create_language( 'zh_HK', array( 'slug' => 'zh-hant-hk', 'w3c' => 'zh-hant-hk' ) );
 
 		$post_id = $this->factory->post->create();
 		self::$polylang->model->post->set_language( $post_id, 'zh' );


### PR DESCRIPTION
## Goal

[IETF BCP 47 Section 2.1](https://tools.ietf.org/html/bcp47#section-2.1) define the different subtags that might exists in a language code.

At the moment, Polylang Browser Preferred Language feature [can only support any language that is composed of a `language` and an optional `region` subtag](https://github.com/polylang/polylang/blob/bd741dc86c23336865fd01dcc247b32e8b65db05/frontend/choose-lang.php#L133-L137). Any other language code composition will cause bugs in the feature, like reported in #591 

## Challenges

### Region inferring

[RFC 723 Section 5.3.5](https://tools.ietf.org/html/rfc7231#section-5.3.5) seems warns that:
  > User agents ought to provide guidance to users when setting
      a preference, since users are rarely familiar with the details of
      language matching as described above.  For example, users might
      assume that on selecting "en-gb", they will be served any kind of
      English document if British English is not available.

But in the actual implementation of the feature, Polylang already provides fallback for the language if the asked region does not exists on the server (e.g.: Polylang will fallback to a base `en` language if the requested `en_GB` is not registered).

What happens if a user then request `zh-hant-hk;q=1,zh-hant-cn;q=0.8;zh-cn;q=0.5` and the website has configured languages `zh-Hant-CN`, `zh-HK`, `zh-CN`? Should Polylang serve the closest script (`zh-Hant-CN`) or the closest region (`zh-HK`) ?

### Scripts in locale

Actually, WordPress do not use any script subtags in its locales. If Polylang was to include script subtags in its locale code, this might cause incompatibilities.

### Confusion with Polylang Pro's Local Fallback feature

If a user defines `zh-Hant-CN` as its locale fallback for `zh-Hant-HK`, but our algorithm decides to match `zh-HK` for the missing `zh-Hant-HK` content (or vice versa), the content and theme / plugins strings translations might not end up in the same language.

## Hints

- The [Negotiation library](https://github.com/willdurand/Negotiation/blob/master/src/Negotiation/AcceptLanguage.php) seems to be a popular and well maintained tool. However, it does not infer closest languages when they are not provided in HTTTP headers (meaning that `Accept-Languages: 'en-CA;q=1.0,en-US;q=0.8'` could not fallback to any `en` default, opposed to the actual Polylang behavior). It also parse script subtags, but does not take it into account when negotiating content.
- [PHP's Locale](https://www.php.net/manual/en/class.locale.php) seems to have useful utilities for the tasks. although it `Locale::acceptFromHttp()` method seems to have bugs with ... chinese scripts...

