### PR TITLE
Clarify the code of  `PLL_Language::get_flag_informations()`

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -240,7 +240,14 @@ class PLL_Language {
 
 		// Polylang builtin flags.
 		if ( ! empty( $code ) && file_exists( POLYLANG_DIR . ( $file = '/flags/' . $code . '.png' ) ) ) {
-			$flag['url'] = $_url = plugins_url( $file, POLYLANG_FILE );
+			$flag['url'] = plugins_url( $file, POLYLANG_FILE );
+
+			// If base64 encoded flags are preferred.
+			if ( ! defined( 'PLL_ENCODED_FLAGS' ) || PLL_ENCODED_FLAGS ) {
+				list( $flag['width'], $flag['height'] ) = getimagesize( POLYLANG_DIR . $file );
+				$file_contents = file_get_contents( POLYLANG_DIR . $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$flag['src'] = 'data:image/png;base64,' . base64_encode( $file_contents ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			}
 		}
 
 		/**
@@ -257,18 +264,11 @@ class PLL_Language {
 		 */
 		$flag = apply_filters( 'pll_flag', $flag, $code );
 
-		if ( empty( $flag['src'] ) ) {
-			// If using predefined flags and base64 encoded flags are preferred.
-			if ( isset( $_url ) && $flag['url'] === $_url && ( ! defined( 'PLL_ENCODED_FLAGS' ) || PLL_ENCODED_FLAGS ) ) {
-				list( $flag['width'], $flag['height'] ) = getimagesize( POLYLANG_DIR . $file );
-				$file_contents = file_get_contents( POLYLANG_DIR . $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-				$flag['src'] = 'data:image/png;base64,' . base64_encode( $file_contents ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-			} else {
-				$flag['src'] = esc_url( set_url_scheme( $flag['url'], 'relative' ) );
-			}
-		}
-
 		$flag['url'] = esc_url_raw( $flag['url'] );
+
+		if ( empty( $flag['src'] ) ) {
+			$flag['src'] = esc_url( set_url_scheme( $flag['url'], 'relative' ) );
+		}
 
 		return $flag;
 	}


### PR DESCRIPTION
PHPStan returns an error: Variable `$file` might not be defined in `PLL_Language::get_flag_informations()`.

This PR aims to clarify the code of this method in 3 successive steps:
1. Handle the default flag
2. Apply the filter
3. Define the flag src if missing

Whereas previously the first step was handled in 2 parts before and after applying the filter.

This change slightly impacts the function performance as the default flag is always base64 encoded, which wasn't the case previously when not using the default flag. As the function output is finally cached in a transient, I believe that this performance loss is acceptable, compared to the clarity gain.