### PR TITLE
Fix Variable $tr_parent in isset() always exists and is not nullable.

### DIFF
--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -208,7 +208,7 @@ class PLL_Sync {
 					$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
 					$wpdb->update(
 						$wpdb->term_taxonomy,
-						array( 'parent' => isset( $tr_parent ) ? $tr_parent : 0 ),
+						array( 'parent' => $tr_parent ? $tr_parent : 0 ),
 						array( 'term_taxonomy_id' => get_term( (int) $tr_id, $taxonomy )->term_taxonomy_id )
 					);
 


### PR DESCRIPTION
PHPStan reports this error as `PLL_Translated_Term::get_translation()` returns `false` and not `null` when the translation doesn't exist. In consequence, `isset()` is not the right way to test the result.