### PR TITLE
Fix the visibility of PLL_Query properties

### DIFF
--- a/include/query.php
+++ b/include/query.php
@@ -12,12 +12,12 @@ class PLL_Query {
 	/**
 	 * @var PLL_Model
 	 */
-	protected $model;
+	public $model;
 
 	/**
 	 * @var WP_Query
 	 */
-	protected $query;
+	public $query;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
In #676, we declared the `PLL_Query` properties which were previously undeclared as protected. This now causes a fatal error in Polylang Pro. So this PR restores the visibility to public. 