### PR TITLE
Compute the path to scripts with static function

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -146,7 +146,7 @@ class PLL_Admin_Base extends PLL_Base {
 
 		foreach ( $scripts as $script => $v ) {
 			if ( in_array( $screen->base, $v[0] ) && ( $v[2] || $this->model->get_languages_list() ) ) {
-				wp_enqueue_script( 'pll_' . $script, plugins_url( '/js/build/' . $script . $suffix . '.js', POLYLANG_FILE ), $v[1], POLYLANG_VERSION, $v[3] );
+				wp_enqueue_script( 'pll_' . $script, self::get_script_path( $script, $suffix ), $v[1], POLYLANG_VERSION, $v[3] );
 			}
 		}
 
@@ -163,7 +163,7 @@ class PLL_Admin_Base extends PLL_Base {
 	public function customize_controls_enqueue_scripts() {
 		if ( $this->model->get_languages_list() ) {
 			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-			wp_enqueue_script( 'pll_widgets', plugins_url( '/js/build/widgets' . $suffix . '.js', POLYLANG_FILE ), array( 'jquery' ), POLYLANG_VERSION, true );
+			wp_enqueue_script( 'pll_widgets', self::get_script_path( 'widgets', $suffix ), array( 'jquery' ), POLYLANG_VERSION, true );
 			$this->localize_scripts();
 		}
 	}
@@ -247,6 +247,15 @@ class PLL_Admin_Base extends PLL_Base {
 			}
 		</script>
 		<?php
+	}
+
+	/**
+	 * @param string $script Script name, without path nor extension.
+	 * @param string $suffix Suffix to add before extension, typically '.min'.
+	 * @return string
+	 */
+	public static function get_script_path( $script, $suffix ) {
+		return plugins_url( '/js/dist/' . $script . $suffix . '.js', POLYLANG_FILE );
 	}
 
 	/**

--- a/admin/admin-nav-menu.php
+++ b/admin/admin-nav-menu.php
@@ -95,7 +95,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		}
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'pll_nav_menu', plugins_url( '/js/build/nav-menu' . $suffix . '.js', POLYLANG_FILE ), array( 'jquery' ), POLYLANG_VERSION );
+		wp_enqueue_script( 'pll_nav_menu', PLL_Admin_Base::get_script_path( 'nav-menu', $suffix ), array( 'jquery' ), POLYLANG_VERSION );
 
 		$data = array(
 			'strings' => PLL_Switcher::get_switcher_options( 'menu', 'string' ), // The strings for the options

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -338,7 +338,7 @@ class PLL_Wizard {
 		// Add ajax action on deactivate button in licenses step.
 		add_action( 'wp_ajax_pll_deactivate_license', array( $this, 'deactivate_license' ) );
 
-		wp_enqueue_script( 'pll_admin', plugins_url( '/js/build/admin' . $this->get_suffix() . '.js', POLYLANG_FILE ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
+		wp_enqueue_script( 'pll_admin', PLL_Admin_Base::get_script_path( 'admin', $this->get_suffix() ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
 		wp_localize_script( 'pll_admin', 'pll_dismiss_notice', esc_html__( 'Dismiss this notice.', 'polylang' ) );
 		if ( $this->is_licenses_step_displayable() ) {
 			$steps['licenses'] = array(
@@ -428,9 +428,9 @@ class PLL_Wizard {
 	 * @since 2.7
 	 */
 	public function add_step_languages( $steps ) {
-		wp_enqueue_script( 'pll-wizard-language-choice', plugins_url( '/js/build/admin' . $this->get_suffix() . '.js', POLYLANG_FILE ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
+		wp_enqueue_script( 'pll-wizard-language-choice', PLL_Admin_Base::get_script_path( 'admin', $this->get_suffix() ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
 		wp_localize_script( 'pll-wizard-language-choice', 'pll_dismiss_notice', esc_html__( 'Dismiss this notice.', 'polylang' ) );
-		wp_register_script( 'pll-wizard-languages', plugins_url( '/js/build/languages-step' . $this->get_suffix() . '.js', POLYLANG_FILE ), array( 'jquery', 'jquery-ui-dialog' ), POLYLANG_VERSION, true );
+		wp_register_script( 'pll-wizard-languages', PLL_Admin_Base::get_script_path( 'languages-step', $this->get_suffix() ), array( 'jquery', 'jquery-ui-dialog' ), POLYLANG_VERSION, true );
 		wp_localize_script(
 			'pll-wizard-languages',
 			'pll_wizard_params',
@@ -608,7 +608,7 @@ class PLL_Wizard {
 	 */
 	public function add_step_untranslated_contents( $steps ) {
 		if ( ! $this->model->get_languages_list() || $this->model->get_objects_with_no_lang( 1 ) ) {
-			wp_enqueue_script( 'pll-wizard-language-choice', plugins_url( '/js/build/admin' . $this->get_suffix() . '.js', POLYLANG_FILE ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
+			wp_enqueue_script( 'pll-wizard-language-choice', PLL_Admin_Base::get_script_path( 'admin', $this->get_suffix() ), array( 'jquery', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
 			wp_localize_script( 'pll-wizard-language-choice', 'pll_dismiss_notice', esc_html__( 'Dismiss this notice.', 'polylang' ) );
 			wp_enqueue_style( 'pll-wizard-selectmenu', plugins_url( '/css/selectmenu' . $this->get_suffix() . '.css', POLYLANG_FILE ), array( 'dashicons', 'install', 'common' ), POLYLANG_VERSION );
 			$steps['untranslated-contents'] = array(

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -323,7 +323,7 @@ class PLL_Settings extends PLL_Admin_Base {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		wp_enqueue_script( 'pll_admin', plugins_url( '/js/build/admin' . $suffix . '.js', POLYLANG_FILE ), array( 'jquery', 'wp-ajax-response', 'postbox', 'jquery-ui-selectmenu' ), POLYLANG_VERSION );
+		wp_enqueue_script( 'pll_admin', PLL_Admin_Base::get_script_path( 'admin', $suffix ), array( 'jquery', 'wp-ajax-response', 'postbox', 'jquery-ui-selectmenu' ), POLYLANG_VERSION );
 		wp_localize_script( 'pll_admin', 'pll_flag_base_url', plugins_url( '/flags/', POLYLANG_FILE ) );
 		wp_localize_script( 'pll_admin', 'pll_dismiss_notice', esc_html__( 'Dismiss this notice.', 'polylang' ) );
 

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -58,11 +58,11 @@ class Admin_Test extends PLL_UnitTestCase {
 		in_array( 'pll_ajax_backend', $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 
 		foreach ( array( 'post', 'term' ) as $key ) {
-			$test = strpos( $footer, plugins_url( "/js/build/$key.min.js", POLYLANG_FILE ) );
+			$test = strpos( $footer, PLL_Admin_Base::get_script_path( $key, '.min' ) );
 			in_array( $key, $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 		}
 
-		$test = strpos( $head, plugins_url( '/js/build/user.min.js', POLYLANG_FILE ) );
+		$test = strpos( $head, PLL_Admin_Base::get_script_path( 'user', '.min' ) );
 		in_array( 'user', $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 
 		$test = strpos( $footer, 'polylang_admin-css' );

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -409,6 +409,6 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$head = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $head, 'pll_data' ) );
-		$this->assertNotFalse( strpos( $head, plugins_url( '/js/build/nav-menu.min.js', POLYLANG_FILE ) ) );
+		$this->assertNotFalse( strpos( $head, PLL_Admin_Base::get_script_path( 'nav-menu', '.min' ) ) );
 	}
 }


### PR DESCRIPTION
## Before

Script paths where all hardcoded inside our plugin. These paths where also tested with a hardcoded value inside the test. Changing the folder from where to enqueue scripts in our production code would make test fails, whether the new path is actually valid or not.

## Changes 

Compute the paths from a static function, to have only one place where to change the path folder.

## Going further

The folder in the `PLL_Admin_Script` could be different from the one used in our build scripts, resulting in scripts not being loaded. The tests won't catch that.

What value does these tests add?