### PR TITLE
Stop preventing the usage of an untranslated front page

### DIFF
--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -36,10 +36,6 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		// Refresh language cache when a static front page has been translated
 		add_action( 'pll_save_post', array( $this, 'pll_save_post' ), 10, 3 );
 
-		// Checks if chosen page on front is translated
-		add_filter( 'pre_update_option_page_on_front', array( $this, 'update_page_on_front' ), 10, 2 );
-		add_filter( 'customize_validate_page_on_front', array( $this, 'customize_validate_page_on_front' ), 10, 2 );
-
 		// Prevents WP resetting the option
 		add_filter( 'pre_update_option_show_on_front', array( $this, 'update_show_on_front' ), 10, 2 );
 
@@ -121,63 +117,6 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		if ( in_array( $this->page_on_front, $translations ) ) {
 			$this->model->clean_languages_cache();
 		}
-	}
-
-	/**
-	 * Checks if a page is translated in all languages
-	 *
-	 * @since 2.2
-	 *
-	 * @param int $page_id
-	 * @return bool
-	 */
-	protected function is_page_translated( $page_id ) {
-		if ( $page_id ) {
-			$translations = count( $this->model->post->get_translations( $page_id ) );
-			$languages = count( $this->model->get_languages_list() );
-
-			if ( $languages > 1 && $translations != $languages ) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Prevents choosing an untranslated static front page
-	 * Displays an error message
-	 *
-	 * @since 1.6
-	 *
-	 * @param int $page_id New page on front page id
-	 * @param int $old_id  Old page on front page_id
-	 * @return int
-	 */
-	public function update_page_on_front( $page_id, $old_id ) {
-		if ( ! $this->is_page_translated( $page_id ) ) {
-			$page_id = $old_id;
-			add_settings_error( 'reading', 'pll_page_on_front_error', __( 'The chosen static front page must be translated in all languages.', 'polylang' ) );
-		}
-
-		return $page_id;
-	}
-
-	/**
-	 * Displays an error message in the customizer when choosing an untranslated static front page
-	 *
-	 * @since 2.2
-	 *
-	 * @param object $validity WP_Error object
-	 * @param int    $page_id  New page on front page id
-	 * @return object
-	 */
-	public function customize_validate_page_on_front( $validity, $page_id ) {
-		if ( ! $this->is_page_translated( $page_id ) ) {
-			return new WP_Error( 'pll_page_on_front_error', __( 'The chosen static front page must be translated in all languages.', 'polylang' ) );
-		}
-
-		return $validity;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -435,25 +435,6 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $out, "<span class='post-state'>Posts Page</span>" ) );
 	}
 
-	function test_update_page_on_front() {
-		global $wp_settings_errors;
-		unset( $wp_settings_errors ); // just in case
-
-		// attempt to assign an untranslated message
-		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
-		update_option( 'page_on_front', $en );
-
-		// test option in unchanged
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( self::$home_fr, get_option( 'page_on_front' ) );
-
-		// test error message
-		$this->assertNotEmpty( get_settings_errors() );
-
-		unset( $wp_settings_errors ); // cleanup
-	}
-
 	// Bug fixed in 2.0
 	function test_get_post_type_archive_link_for_posts() {
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );


### PR DESCRIPTION
We use to prevent users to select a page on front if it is not translated in all languages to avoid support requests. This sometimes disturbs users an it is possible to work around this measure by temporarily deactivating Polylang. Since then, we have introduce the wizard which helps the  user to create the translated front pages and an admin notice which informs the user that the front pae is not translated in all languages.

I propose to remove the feature and let users make their choice. 