### PR TITLE
Splits the PLL_Sitemaps class

### DIFF
--- a/modules/sitemaps/abstract-sitemaps.php
+++ b/modules/sitemaps/abstract-sitemaps.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Common class for handling the core sitemaps.
+ *
+ * @since 3.0
+ */
+class PLL_Abstract_Sitemaps {
+	/**
+	 * Setups actions and filters.
+	 *
+	 * @since 2.8
+	 */
+	public function init() {
+		add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
+	}
+
+	/**
+	 * Whitelists the home url filter for the sitemaps.
+	 *
+	 * @since 2.8
+	 *
+	 * @param array $whitelist White list.
+	 * @return array;
+	 */
+	public function home_url_white_list( $whitelist ) {
+		$whitelist[] = array( 'file' => 'class-wp-sitemaps-posts' );
+		return $whitelist;
+	}
+}

--- a/modules/sitemaps/abstract-sitemaps.php
+++ b/modules/sitemaps/abstract-sitemaps.php
@@ -6,9 +6,11 @@
 /**
  * Common class for handling the core sitemaps.
  *
+ * The child classes must called the init() method.
+ *
  * @since 3.0
  */
-class PLL_Abstract_Sitemaps {
+abstract class PLL_Abstract_Sitemaps {
 	/**
 	 * Setups actions and filters.
 	 *

--- a/modules/sitemaps/load.php
+++ b/modules/sitemaps/load.php
@@ -8,6 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 };
 
 if ( $polylang->model->get_languages_list() ) {
-	$polylang->sitemaps = new PLL_Sitemaps( $polylang );
+	if ( $polylang->links_model instanceof PLL_Links_Abstract_Domain ) {
+		$polylang->sitemaps = new PLL_Sitemaps_Domain( $polylang );
+	} else {
+		$polylang->sitemaps = new PLL_Sitemaps( $polylang );
+	}
 	$polylang->sitemaps->init();
 }

--- a/modules/sitemaps/sitemaps-domain.php
+++ b/modules/sitemaps/sitemaps-domain.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Handles the core sitemaps for subdomains and multiple domains.
+ *
+ * @since 3.0
+ */
+class PLL_Sitemaps_Domain extends PLL_Abstract_Sitemaps {
+	/**
+	 * @var PLL_Links_Abstract_Domain
+	 */
+	protected $links_model;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $polylang Main Polylang object.
+	 */
+	public function __construct( &$polylang ) {
+		$this->links_model = &$polylang->links_model;
+	}
+
+	/**
+	 * Setups actions and filters.
+	 *
+	 * @since 3.0
+	 */
+	public function init() {
+		parent::init();
+
+		add_filter( 'wp_sitemaps_index_entry', array( $this, 'index_entry' ) );
+		add_filter( 'wp_sitemaps_stylesheet_url', array( $this->links_model, 'site_url' ) );
+		add_filter( 'wp_sitemaps_stylesheet_index_url', array( $this->links_model, 'site_url' ) );
+		add_filter( 'home_url', array( $this, 'sitemap_url' ) );
+	}
+
+	/**
+	 * Filters the sitemap index entries for subdomains and multiple domains.
+	 *
+	 * @since 2.8
+	 *
+	 * @param array $sitemap_entry Sitemap entry for the post.
+	 * return array
+	 */
+	public function index_entry( $sitemap_entry ) {
+		$sitemap_entry['loc'] = $this->links_model->site_url( $sitemap_entry['loc'] );
+		return $sitemap_entry;
+	}
+
+	/**
+	 * Makes sure that the sitemap urls are always evaluated on the current domain.
+	 *
+	 * @since 2.8.4
+	 *
+	 * @param string $url A sitemap url.
+	 * @return string
+	 */
+	public function sitemap_url( $url ) {
+		if ( false !== strpos( $url, '/wp-sitemap' ) ) {
+			$url = $this->links_model->site_url( $url );
+		}
+		return $url;
+	}
+}

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -4,34 +4,17 @@
  */
 
 /**
- * Handles the core sitemaps.
+ * Handles the core sitemaps for sites using a single domain.
  *
  * @since 2.8
  */
-class PLL_Sitemaps {
+class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	/**
-	 * A reference to the current language.
-	 *
-	 * @since 2.8
-	 *
-	 * @var PLL_Language
-	 */
-	protected $curlang;
-
-	/**
-	 * A reference to the PLL_Links_Model instance.
-	 *
-	 * @since 2.8
-	 *
 	 * @var PLL_Links_Model
 	 */
 	protected $links_model;
 
 	/**
-	 * A reference to the PLL_Model instance.
-	 *
-	 * @since 2.8
-	 *
 	 * @var PLL_Model
 	 */
 	protected $model;
@@ -51,7 +34,6 @@ class PLL_Sitemaps {
 	 * @param object $polylang Main Polylang object.
 	 */
 	public function __construct( &$polylang ) {
-		$this->curlang = &$polylang->curlang;
 		$this->links_model = &$polylang->links_model;
 		$this->model = &$polylang->model;
 		$this->options = &$polylang->options;
@@ -63,18 +45,11 @@ class PLL_Sitemaps {
 	 * @since 2.8
 	 */
 	public function init() {
-		add_filter( 'pll_home_url_white_list', array( $this, 'home_url_white_list' ) );
+		parent::init();
 
-		if ( $this->options['force_lang'] < 2 ) {
-			add_filter( 'pll_set_language_from_query', array( $this, 'set_language_from_query' ), 10, 2 );
-			add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
-			add_filter( 'wp_sitemaps_add_provider', array( $this, 'replace_provider' ) );
-		} elseif ( method_exists( $this->links_model, 'site_url' ) ) {
-			add_filter( 'wp_sitemaps_index_entry', array( $this, 'index_entry' ) );
-			add_filter( 'wp_sitemaps_stylesheet_url', array( $this->links_model, 'site_url' ) );
-			add_filter( 'wp_sitemaps_stylesheet_index_url', array( $this->links_model, 'site_url' ) );
-			add_filter( 'home_url', array( $this, 'sitemap_url' ) );
-		}
+		add_filter( 'pll_set_language_from_query', array( $this, 'set_language_from_query' ), 10, 2 );
+		add_filter( 'rewrite_rules_array', array( $this, 'rewrite_rules' ) );
+		add_filter( 'wp_sitemaps_add_provider', array( $this, 'replace_provider' ) );
 	}
 
 	/**
@@ -159,33 +134,5 @@ class PLL_Sitemaps {
 			$provider = new PLL_Multilingual_Sitemaps_Provider( $provider, $this->links_model );
 		}
 		return $provider;
-	}
-
-	/**
-	 * Filters the sitemap index entries for subdomains and multiple domains.
-	 *
-	 * @since 2.8
-	 *
-	 * @param array $sitemap_entry Sitemap entry for the post.
-	 * return array
-	 */
-	public function index_entry( $sitemap_entry ) {
-		$sitemap_entry['loc'] = $this->links_model->site_url( $sitemap_entry['loc'] );
-		return $sitemap_entry;
-	}
-
-	/**
-	 * Makes sure that the sitemap urls are always evaluated on the current domain.
-	 *
-	 * @since 2.8.4
-	 *
-	 * @param string $url A sitemap url.
-	 * @return string
-	 */
-	public function sitemap_url( $url ) {
-		if ( false !== strpos( $url, '/wp-sitemap' ) ) {
-			$url = $this->links_model->site_url( $url );
-		}
-		return $url;
 	}
 }

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -19,7 +19,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
-	function init() {
+	function init( $sitemap_class = 'PLL_Sitemaps' ) {
 		global $wp_rewrite, $wp_sitemaps;
 
 		// Initialize sitemaps.
@@ -40,7 +40,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 			self::$polylang->links_model->init();
 		}
 
-		self::$polylang->sitemaps = new PLL_Sitemaps( self::$polylang );
+		self::$polylang->sitemaps = new $sitemap_class( self::$polylang );
 		self::$polylang->sitemaps->init();
 
 		wp_sitemaps_get_server(); // Allows to register sitemaps rewrite rules.
@@ -223,7 +223,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 
 	function test_subdomains() {
 		self::$polylang->options['force_lang'] = 2;
-		$this->init();
+		$this->init( 'PLL_Sitemaps_Domain' );
 
 		$_SERVER['HTTP_HOST'] = 'fr.example.org';
 		$_SERVER['REQUEST_URI'] = '/wp-sitemap.xml';
@@ -238,7 +238,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 
 	function test_subdomains_home_url() {
 		self::$polylang->options['force_lang'] = 2;
-		$this->init();
+		$this->init( 'PLL_Sitemaps_Domain' );
 
 		$_SERVER['HTTP_HOST'] = 'fr.example.org';
 		$_SERVER['REQUEST_URI'] = '/wp-sitemap-posts-page-1.xml';
@@ -264,7 +264,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 			'en' => 'http://example.org',
 			'fr' => 'http://example.fr',
 		);
-		$this->init();
+		$this->init( 'PLL_Sitemaps_Domain' );
 
 		$_SERVER['HTTP_HOST'] = 'example.fr';
 		$_SERVER['REQUEST_URI'] = '/wp-sitemap.xml';


### PR DESCRIPTION
The `PLL_Sitemaps` class was used to handle two (almost) completely separate cases (single domains on one side, subdomains and multiple domains on the other side). Only one filter is common to the 2 cases.

This proposal is initially pushed by https://github.com/polylang/polylang-pro/issues/761 and PHPStan which reports that `site_url()` is not a method of `PLL_Links_Model`.

This PR: 
* splits the class and creates a a separate `PLL_Sitemaps_Domain` to handle the second case.
* creates a common parent class `PLL_Abstract_Sitemaps`.
* Specifies the type of links model needed for `PLL_Sitemaps_Domain` in the loader and the doc.  

