### PR TITLE
Raise PHPStan checks at level 3

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -345,7 +345,7 @@ class PLL_Admin_Filters_Columns {
 			wp_die( 0 );
 		}
 
-		global $wp_list_table;
+		/** @var WP_Posts_List_Table $wp_list_table */
 		$wp_list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => sanitize_key( $_POST['screen'] ) ) );
 
 		$x = new WP_Ajax_Response();
@@ -387,7 +387,7 @@ class PLL_Admin_Filters_Columns {
 			wp_die( 0 );
 		}
 
-		global $wp_list_table;
+		/** @var WP_Terms_List_Table $wp_list_table */
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => sanitize_key( $_POST['screen'] ) ) );
 
 		$x = new WP_Ajax_Response();

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -361,20 +361,20 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 * @return string if redirect is not performed
 	 */
 	public function check_canonical_url( $requested_url = '', $do_redirect = true ) {
-		global $wp_query, $post, $is_IIS;
-
-		// Don't redirect in same cases as WP
-		if ( is_trackback() || is_search() || is_admin() || is_preview() || is_robots() || ( $is_IIS && ! iis7_supports_permalinks() ) ) {
+		// Don't redirect in same cases as WP.
+		if ( is_trackback() || is_search() || is_admin() || is_preview() || is_robots() || ( $GLOBALS['is_IIS'] && ! iis7_supports_permalinks() ) ) {
 			return;
 		}
 
-		// Don't redirect mysite.com/?attachment_id= to mysite.com/en/?attachment_id=
+		// Don't redirect mysite.com/?attachment_id= to mysite.com/en/?attachment_id=.
 		if ( 1 == $this->options['force_lang'] && is_attachment() && isset( $_GET['attachment_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
-		// If the default language code is not hidden and the static front page url contains the page name
-		// the customizer lands here and the code below would redirect to the list of posts
+		/*
+		 * If the default language code is not hidden and the static front page url contains the page name,
+		 * the customizer lands here and the code below would redirect to the list of posts.
+		 */
 		if ( is_customize_preview() ) {
 			return;
 		}
@@ -384,15 +384,16 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		if ( is_single() || is_page() ) {
-			if ( isset( $post->ID ) && $this->model->is_translated_post_type( $post->post_type ) ) {
+			$post = get_post();
+			if ( $this->model->is_translated_post_type( $post->post_type ) ) {
 				$language = $this->model->post->get_language( (int) $post->ID );
 			}
 		}
 
-		elseif ( $this->links_model->using_permalinks && is_category() && ! empty( $wp_query->query['cat'] ) ) {
+		elseif ( $this->links_model->using_permalinks && is_category() && ! empty( $this->wp_query()->query['cat'] ) ) {
 			// When we receive a plain permaling with a cat query var, we need to redirect to the pretty permalink.
-			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
-				$term_id = $this->get_queried_term_id( $wp_query->tax_query );
+			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
+				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
 				$language = $this->model->term->get_language( $term_id );
 				$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 			}
@@ -400,27 +401,27 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		elseif ( is_category() || is_tag() || is_tax() ) {
 			// We need to switch the language when there is no language provided in a pretty permalink.
-			$obj = $wp_query->get_queried_object();
+			$obj = get_queried_object();
 			if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
 				$language = $this->model->term->get_language( (int) $obj->term_id );
 			}
 		}
 
-		elseif ( is_404() && ! empty( $wp_query->tax_query ) ) {
+		elseif ( is_404() && ! empty( $this->wp_query()->tax_query ) ) {
 			// When a wrong language is passed through a pretty permalink, we just need to switch the language.
-			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $wp_query->tax_query ) ) ) {
-				$term_id = $this->get_queried_term_id( $wp_query->tax_query );
+			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
+				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
 				$language = $this->model->term->get_language( $term_id );
 			}
 		}
 
-		elseif ( $this->links_model->using_permalinks && $wp_query->is_posts_page && ! empty( $wp_query->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
+		elseif ( $this->links_model->using_permalinks && $this->wp_query()->is_posts_page && ! empty( $this->wp_query()->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
 			$language = $this->model->post->get_language( (int) $id );
 			$redirect_url = $this->maybe_add_page_to_redirect_url( get_permalink( $id ) );
 		}
 
-		elseif ( $wp_query->is_posts_page ) {
-			$obj = $wp_query->get_queried_object();
+		elseif ( $this->wp_query()->is_posts_page ) {
+			$obj = get_queried_object();
 			$language = $this->model->post->get_language( (int) $obj->ID );
 		}
 
@@ -478,9 +479,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 * @return string
 	 */
 	protected function maybe_add_page_to_redirect_url( $redirect_url ) {
-		global $wp_query;
-
-		if ( ! empty( $wp_query->query['paged'] ) && $page = get_query_var( 'paged' ) ) {
+		if ( ! empty( $this->wp_query()->query['paged'] ) && $page = get_query_var( 'paged' ) ) {
 			$redirect_url = $this->links_model->add_paged_to_link( $redirect_url, $page );
 		}
 		return $redirect_url;
@@ -531,5 +530,16 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		unset( $queried_terms['language'] );
 
 		return key( $queried_terms );
+	}
+
+	/**
+	 * Returns the Global WordPress WP_Query object.
+	 *
+	 * @since 3.0
+	 *
+	 * @return WP_Query
+	 */
+	protected function wp_query() {
+		return $GLOBALS['wp_query'];
 	}
 }

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -351,14 +351,14 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	}
 
 	/**
-	 * If the language code is not in agreement with the language of the content
-	 * redirects incoming links to the proper URL to avoid duplicate content
+	 * If the language code is not in agreement with the language of the content,
+	 * redirects incoming links to the proper URL to avoid duplicate content.
 	 *
 	 * @since 0.9.6
 	 *
-	 * @param string $requested_url optional
-	 * @param bool   $do_redirect   optional, whether to perform the redirection or not
-	 * @return string if redirect is not performed
+	 * @param string $requested_url Optional, defaults to requested url.
+	 * @param bool   $do_redirect   Optional, whether to perform the redirect or not.
+	 * @return string|void Returns if redirect is not performed.
 	 */
 	public function check_canonical_url( $requested_url = '', $do_redirect = true ) {
 		// Don't redirect in same cases as WP.

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -163,12 +163,12 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	}
 
 	/**
-	 * Removes current-menu and current-menu-ancestor classes to lang switcher when not on the home page
+	 * Removes current-menu and current-menu-ancestor classes to lang switcher when not on the home page.
 	 *
 	 * @since 1.1.1
 	 *
-	 * @param array $items
-	 * @return array modified menu items
+	 * @param stdClass[] $items An array of menu items.
+	 * @return stdClass[]
 	 */
 	public function wp_nav_menu_objects( $items ) {
 		$r_ids = $k_ids = array();

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -98,9 +98,8 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 * @return bool|string modified url, false if redirection is canceled
 	 */
 	public function redirect_canonical( $redirect_url ) {
-		global $wp_query;
-		if ( is_page() && ! is_feed() && isset( $wp_query->queried_object ) && $wp_query->queried_object->ID == $this->curlang->page_on_front ) {
-			$url = is_paged() ? $this->links_model->add_paged_to_link( $this->links->get_home_url(), $wp_query->query_vars['page'] ) : $this->links->get_home_url();
+		if ( is_page() && ! is_feed() && get_queried_object_id() == $this->curlang->page_on_front ) {
+			$url = is_paged() ? $this->links_model->add_paged_to_link( $this->links->get_home_url(), get_query_var( 'page' ) ) : $this->links->get_home_url();
 
 			// Don't forget additional query vars
 			$query = wp_parse_url( $redirect_url, PHP_URL_QUERY );

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -192,20 +192,22 @@ class PLL_Frontend extends PLL_Base {
 	}
 
 	/**
-	 * Resets some variables when switching blog
-	 * Overrides parent method
+	 * Resets some variables when the blog is switched.
+	 * Overrides the parent method.
 	 *
 	 * @since 1.5.1
 	 *
-	 * @param int $new_blog
-	 * @param int $old_blog
+	 * @param int $new_blog_id  New blog ID.
+	 * @param int $prev_blog_id Previous blog ID.
 	 */
-	public function switch_blog( $new_blog, $old_blog ) {
-		// Need to check that some languages are defined when user is logged in, has several blogs, some without any languages
-		if ( parent::switch_blog( $new_blog, $old_blog ) && did_action( 'pll_language_defined' ) && $this->model->get_languages_list() ) {
+	public function switch_blog( $new_blog_id, $prev_blog_id ) {
+		parent::switch_blog( $new_blog_id, $prev_blog_id );
+
+		// Need to check that some languages are defined when user is logged in, has several blogs, some without any languages.
+		if ( $this->is_active_on_new_blog( $new_blog_id, $prev_blog_id ) && did_action( 'pll_language_defined' ) && $this->model->get_languages_list() ) {
 			static $restore_curlang;
 			if ( empty( $restore_curlang ) ) {
-				$restore_curlang = $this->curlang->slug; // To always remember the current language through blogs
+				$restore_curlang = $this->curlang->slug; // To always remember the current language through blogs.
 			}
 
 			$lang = $this->model->get_language( $restore_curlang );

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -269,7 +269,7 @@ class PLL_CRUD_Posts {
 			return $post_id;
 		}
 
-		$post = get_post( $post_id );
+		$post = get_post( $post_id, ARRAY_A );
 
 		if ( empty( $post ) ) {
 			return $post;
@@ -279,10 +279,10 @@ class PLL_CRUD_Posts {
 
 		// Create a new attachment ( translate attachment parent if exists ).
 		add_filter( 'pll_enable_duplicate_media', '__return_false', 99 ); // Avoid a conflict with automatic duplicate at upload.
-		$post->ID = null; // Will force the creation
-		$post->post_parent = ( $post->post_parent && $tr_parent = $this->model->post->get_translation( $post->post_parent, $lang->slug ) ) ? $tr_parent : 0;
-		$post->tax_input = array( 'language' => array( $lang->slug ) ); // Assigns the language.
-		$tr_id = wp_insert_attachment( wp_slash( (array) $post ) );
+		unset( $post['ID'] ); // Will force the creation.
+		$post['post_parent'] = ( $post['post_parent'] && $tr_parent = $this->model->post->get_translation( $post['post_parent'], $lang->slug ) ) ? $tr_parent : 0;
+		$post['tax_input'] = array( 'language' => array( $lang->slug ) ); // Assigns the language.
+		$tr_id = wp_insert_attachment( wp_slash( $post ) );
 		remove_filter( 'pll_enable_duplicate_media', '__return_false', 99 ); // Restore automatic duplicate at upload.
 
 		// Copy metadata.

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -266,13 +266,13 @@ class PLL_CRUD_Posts {
 	 */
 	public function create_media_translation( $post_id, $lang ) {
 		if ( empty( $post_id ) ) {
-			return $post_id;
+			return 0;
 		}
 
 		$post = get_post( $post_id, ARRAY_A );
 
 		if ( empty( $post ) ) {
-			return $post;
+			return 0;
 		}
 
 		$lang = $this->model->get_language( $lang ); // Make sure we get a valid language slug.

--- a/include/query.php
+++ b/include/query.php
@@ -24,8 +24,8 @@ class PLL_Query {
 	 *
 	 * @since 2.2
 	 *
-	 * @param array  $query Reference to the WP_Query object.
-	 * @param object $model Instance of PLL_Model.
+	 * @param WP_Query  $query Reference to the WP_Query object.
+	 * @param PLL_Model $model Instance of PLL_Model.
 	 */
 	public function __construct( &$query, &$model ) {
 		$this->query = &$query;

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -18,7 +18,7 @@ abstract class PLL_Translated_Object {
 	 * Object type to use when registering the taxonomies.
 	 * Left empty for posts.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $object_type;
 

--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -99,11 +99,12 @@ class PLL_Widget_Languages extends WP_Widget {
 	}
 
 	/**
-	 * Displays the widget form
+	 * Displays the widget form.
 	 *
 	 * @since 0.4
 	 *
-	 * @param array $instance Current settings
+	 * @param array $instance Current settings.
+	 * @return string
 	 */
 	public function form( $instance ) {
 		// Default values
@@ -130,5 +131,7 @@ class PLL_Widget_Languages extends WP_Widget {
 				esc_attr( 'pll-' . $key )
 			);
 		}
+
+		return ''; // Because the parent class returns a string, however not used.
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-	level: 1
+	level: 3
 	paths:
 		- polylang.php
 		- admin/

--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -52,13 +52,13 @@ class PLL_Table_Languages extends WP_List_Table {
 	}
 
 	/**
-	 * Displays the item information in a column ( default case )
+	 * Displays the item information in a column ( default case ).
 	 *
 	 * @since 0.1
 	 *
-	 * @param object $item
-	 * @param string $column_name
-	 * @return string
+	 * @param PLL_Language $item        The current item.
+	 * @param string       $column_name The column name.
+	 * @return string|int
 	 */
 	public function column_default( $item, $column_name ) {
 		switch ( $column_name ) {
@@ -71,7 +71,7 @@ class PLL_Table_Languages extends WP_List_Table {
 				return (int) $item->$column_name;
 
 			default:
-				return $item->$column_name; // flag
+				return $item->$column_name; // Flag.
 		}
 	}
 


### PR DESCRIPTION
This PR refactors `PLL_Frontend::switch_blog()` and its parent method to avoid checking in a hacky way if the parent method has done something. The initial test which was done only once in the parent method has now been moved to a new method `PLL_Base::is_active_on_new_blog()` which is called twice, once in parent method, once in the child method.

This PR also replaces several direct accesses to WordPress global variables by function calls when possible. For the global `$wp_query`, it is accessed through a new method to correctly document the type.

A return value is added to `PLL_Widget_Languages::form()` to match the parent method (even if this return value is not used).

The inline doc was improved in several places to pass the test.

The level is raised to 3 in the PHPStan config file for CI.

See #349  
