### PR TITLE
Translation's language should match object's language when saving translations group

### DIFF
--- a/admin/admin-filters-post-base.php
+++ b/admin/admin-filters-post-base.php
@@ -52,14 +52,7 @@ abstract class PLL_Admin_Filters_Post_Base {
 		// Security check as 'wp_insert_post' can be called from outside WP admin.
 		check_admin_referer( 'pll_language', '_pll_nonce' );
 
-		$translations = array();
-
-		// Save translations after checking the translated post is in the right language.
-		foreach ( $arr as $lang => $tr_id ) {
-			$translations[ $lang ] = ( $tr_id && $this->model->post->get_language( (int) $tr_id )->slug == $lang ) ? (int) $tr_id : 0;
-		}
-
-		$this->model->post->save_translations( $post_id, $translations );
+		$translations = $this->model->post->save_translations( $post_id, $arr );
 		return $translations;
 	}
 }

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -188,9 +188,9 @@ abstract class PLL_Translated_Object {
 	 * @since 0.5
 	 *
 	 * @param int   $id           Object id ( typically a post_id or term_id ).
-	 * @param array $translations An associative array of translations with language code as key and translation id as value.
+	 * @param int[] $translations An associative array of translations with language code as key and translation id as value.
 	 *
-	 * @return int[] An associative array with locales as key and post ids as values.
+	 * @return int[] An associative array with language codes as key and post ids as values.
 	 */
 	public function save_translations( $id, $translations ) {
 		$translations = $this->validate_translations( $translations );
@@ -248,9 +248,11 @@ abstract class PLL_Translated_Object {
 	/**
 	 * Returns translations after checking the translated post is in the right language
 	 *
-	 * @param array $translations Locales as keys and post ids as values.
+	 * @since 3.1
 	 *
-	 * @return array
+	 * @param int[] $translations An associative array of translations with language code as key and translation id as value.
+	 *
+	 * @return int[]
 	 */
 	public function validate_translations( $translations ) {
 		$valid_translations = array();

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -188,13 +188,21 @@ abstract class PLL_Translated_Object {
 	 * @since 0.5
 	 *
 	 * @param int   $id           Object id ( typically a post_id or term_id ).
+<<<<<<< HEAD
 	 * @param int[] $translations An associative array of translations with language code as key and translation id as value.
 	 * @return void
+=======
+	 * @param array $translations An associative array of translations with language code as key and translation id as value.
+	 *
+	 * @return string[] An associative array containing the processed translations.
+>>>>>>> 34d62ce (fix(include): Move the translations group validation to the model)
 	 */
 	public function save_translations( $id, $translations ) {
+		$translations = $this->validate_translations( $translations );
+
 		$id = (int) $id;
 
-		if ( ( $lang = $this->get_language( $id ) ) && is_array( $translations ) ) {
+		if ( $lang = $this->get_language( $id ) ) {
 			// Sanitize the translations array.
 			$translations = array_map( 'intval', $translations );
 			$translations = array_merge( array( $lang->slug => $id ), $translations ); // Make sure this object is in translations.
@@ -236,7 +244,27 @@ abstract class PLL_Translated_Object {
 					}
 				}
 			}
+			return $translations;
+		} else {
+			return array();
 		}
+	}
+
+	/**
+	 * Returns translations after checking the translated post is in the right language
+	 *
+	 * @param array $translations Locales as keys and post ids as values.
+	 *
+	 * @return array
+	 */
+	public function validate_translations( $translations ) {
+		$valid_translations = array();
+
+		foreach ( $translations as $lang => $tr_id ) {
+			$valid_translations[ $lang ] = ( $tr_id && $this->get_language( (int) $tr_id )->slug == $lang ) ? (int) $tr_id : 0;
+		}
+
+		return $valid_translations;
 	}
 
 	/**

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -188,14 +188,9 @@ abstract class PLL_Translated_Object {
 	 * @since 0.5
 	 *
 	 * @param int   $id           Object id ( typically a post_id or term_id ).
-<<<<<<< HEAD
-	 * @param int[] $translations An associative array of translations with language code as key and translation id as value.
-	 * @return void
-=======
 	 * @param array $translations An associative array of translations with language code as key and translation id as value.
 	 *
-	 * @return string[] An associative array containing the processed translations.
->>>>>>> 34d62ce (fix(include): Move the translations group validation to the model)
+	 * @return int[] An associative array with locales as key and post ids as values.
 	 */
 	public function save_translations( $id, $translations ) {
 		$translations = $this->validate_translations( $translations );

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/testcase.php';
 require_once __DIR__ . '/testcase-ajax.php';
 require_once __DIR__ . '/testcase-canonical.php';
 require_once __DIR__ . '/testcase-domain.php';
+require_once __DIR__ . '/testcase-translated-object.php';
 require_once __DIR__ . '/wp-screen-mock.php';
 require_once __DIR__ . '/check-wp-functions-trait.php';
 

--- a/tests/phpunit/includes/testcase-translated-object.php
+++ b/tests/phpunit/includes/testcase-translated-object.php
@@ -9,7 +9,6 @@
  * Testes PLL_Translated_Object methods tha are common to PLL_Translated_Post and PLL_Translated_Term.
  */
 class PLL_Translated_Object_UnitTestCase extends PLL_UnitTestCase {
-
 	/**
 	 * @covers PLL_Translated_Object::save_translations()
 	 *
@@ -25,6 +24,6 @@ class PLL_Translated_Object_UnitTestCase extends PLL_UnitTestCase {
 
 		$translated_object->save_translations( $id, array( 'fr' => $id ) );
 
-		$this->assertNotEquals( $translated_object->get_translations( $id )['fr'], $id );
+		$this->assertNotContains( 'fr', array_keys( $translated_object->get_translations( $id ) ) );
 	}
 }

--- a/tests/phpunit/includes/testcase-translated-object.php
+++ b/tests/phpunit/includes/testcase-translated-object.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Class PLL_Translated_Object_UnitTestCase
+ *
+ * Testes PLL_Translated_Object methods tha are common to PLL_Translated_Post and PLL_Translated_Term.
+ */
+class PLL_Translated_Object_UnitTestCase extends PLL_UnitTestCase {
+
+	/**
+	 * @covers PLL_Translated_Object::save_translations()
+	 *
+	 * @param PLL_Translated_Object $translated_object An instance of a subclass of PLL_Translated_Object.
+	 */
+	public function dont_save_translations_with_incorrect_language( $translated_object ) {
+		$property = new ReflectionProperty( get_class( $translated_object ), 'type' );
+		$property->setAccessible( true );
+		$object_type = $property->getValue( $translated_object );
+
+		$id = $this->factory()->$object_type->create();
+		$translated_object->set_language( $id, 'en' );
+
+		$translated_object->save_translations( $id, array( 'fr' => $id ) );
+
+		$this->assertNotEquals( $translated_object->get_translations( $id )['fr'], $id );
+	}
+}

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -172,24 +172,23 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		}
 	}
 
-	public function update_language_provider()
-	{
+	public function update_language_provider() {
 		return array(
 			'Update to same language' => array(
-				'original_group' => array('en', 'fr'),
+				'original_group' => array( 'en', 'fr' ),
 				'to' => 'en',
-				'expected_new_group' => array('en', 'fr'),
+				'expected_new_group' => array( 'en', 'fr' ),
 			),
 			'Update to language not in translations group' => array(
-				'original_group' => array('en', 'fr'),
+				'original_group' => array( 'en', 'fr' ),
 				'to' => 'de',
-				'expected_new_group' => array('fr', 'de'),
+				'expected_new_group' => array( 'fr', 'de' ),
 			),
 			'Update to language already in translations group' => array(
-				'original_group' => array('en', 'fr', 'de'),
+				'original_group' => array( 'en', 'fr', 'de' ),
 				'to' => 'fr',
-				'expected_new_group' => array('fr'),
-				'expected_former_group' => array('fr', 'de'),
+				'expected_new_group' => array( 'fr' ),
+				'expected_former_group' => array( 'fr', 'de' ),
 			),
 		);
 	}

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -1,6 +1,6 @@
 <?php
 
-class Translated_Post_Test extends PLL_UnitTestCase {
+class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 
 	/**
 	 * @param WP_UnitTest_Factory $factory
@@ -198,15 +198,10 @@ class Translated_Post_Test extends PLL_UnitTestCase {
 	 * @covers PLL_Translated_Object::save_translations()
 	 */
 	public function test_dont_save_translations_with_incorrect_language() {
-		$post_id = $this->factory()->post->create();
-		self::$model->post->set_language( $post_id, 'en' );
-
 		$options = PLL_Install::get_default_options();
 		$model = new PLL_Model( $options );
 		$model->post = new PLL_Translated_Post( $model );
 
-		$model->post->save_translations( $post_id, array( 'fr' => $post_id ) );
-
-		$this->assertNotEquals( $model->post->get_translations( $post_id )['fr'], $post_id );
+		$this->dont_save_translations_with_incorrect_language( $model->post );
 	}
 }

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -172,24 +172,41 @@ class Translated_Post_Test extends PLL_UnitTestCase {
 		}
 	}
 
-	public function update_language_provider() {
+	public function update_language_provider()
+	{
 		return array(
 			'Update to same language' => array(
-				'original_group' => array( 'en', 'fr' ),
+				'original_group' => array('en', 'fr'),
 				'to' => 'en',
-				'expected_new_group' => array( 'en', 'fr' ),
+				'expected_new_group' => array('en', 'fr'),
 			),
 			'Update to language not in translations group' => array(
-				'original_group' => array( 'en', 'fr' ),
+				'original_group' => array('en', 'fr'),
 				'to' => 'de',
-				'expected_new_group' => array( 'fr', 'de' ),
+				'expected_new_group' => array('fr', 'de'),
 			),
 			'Update to language already in translations group' => array(
-				'original_group' => array( 'en', 'fr', 'de' ),
+				'original_group' => array('en', 'fr', 'de'),
 				'to' => 'fr',
-				'expected_new_group' => array( 'fr' ),
-				'expected_former_group' => array( 'fr', 'de' ),
+				'expected_new_group' => array('fr'),
+				'expected_former_group' => array('fr', 'de'),
 			),
 		);
+	}
+
+	/**
+	 * @covers PLL_Translated_Object::save_translations()
+	 */
+	public function test_dont_save_translations_with_incorrect_language() {
+		$post_id = $this->factory()->post->create();
+		self::$model->post->set_language( $post_id, 'en' );
+
+		$options = PLL_Install::get_default_options();
+		$model = new PLL_Model( $options );
+		$model->post = new PLL_Translated_Post( $model );
+
+		$model->post->save_translations( $post_id, array( 'fr' => $post_id ) );
+
+		$this->assertNotEquals( $model->post->get_translations( $post_id )['fr'], $post_id );
 	}
 }

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -1,6 +1,6 @@
 <?php
 
-class Translated_Term_Test extends PLL_UnitTestCase {
+class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 
 	/**
 	 * @param WP_UnitTest_Factory $factory
@@ -61,5 +61,13 @@ class Translated_Term_Test extends PLL_UnitTestCase {
 		$this->assertFalse( self::$model->term->get_translation( $fr, 'en' ) );
 		$this->assertFalse( self::$model->term->get_translation( $fr, 'de' ) );
 		$this->assertFalse( self::$model->term->get_translation( $de, 'fr' ) );
+	}
+
+	public function test_dont_save_translations_with_incorrect_language() {
+		$options = PLL_Install::get_default_options();
+		$model = new PLL_Model( $options );
+		$model->term = new PLL_Translated_Term( $model );
+
+		$this->dont_save_translations_with_incorrect_language( $model->term );
 	}
 }


### PR DESCRIPTION
## Before

There is no verification of the object language when it is assigned to a translation group. This can lead to translations group having several time the same object with different languages like: 

```php
$polylang->model->post->save_translations( 1, array( 'en' => 1, 'fr' => 1, 'es' => 1 );
```

Although, this was verified when saving a post or media from the classic editor in `PLL_Admin_Filters_Post` and `PLL_Admin_Filters_Media`.

## Changes

Move the protection against incorrectly constituted translations group in the `PLL_Translated_Object::save_translations()` method to improve robustness.

## Related issues 

- https://github.com/polylang/polylang-pro/issues/808
- https://github.com/polylang/polylang-pro/pull/810
