### PR TITLE
Use the filter get_object_terms instead of wp_get_object_terms

### DIFF
--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -28,7 +28,7 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 
 		// Filters to prime terms cache
 		add_filter( 'get_terms', array( $this, '_prime_terms_cache' ), 10, 2 );
-		add_filter( 'wp_get_object_terms', array( $this, 'wp_get_object_terms' ), 10, 3 );
+		add_filter( 'get_object_terms', array( $this, 'wp_get_object_terms' ), 10, 3 );
 
 		add_action( 'clean_term_cache', array( $this, 'clean_term_cache' ) );
 	}
@@ -180,17 +180,16 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	}
 
 	/**
-	 * When terms are found for posts, add their language and translations to cache
+	 * When terms are found for posts, add their language and translations to cache.
 	 *
 	 * @since 1.2
 	 *
-	 * @param array $terms      terms found
-	 * @param array $object_ids not used
-	 * @param array $taxonomies terms taxonomies
-	 * @return array unmodified $terms
+	 * @param WP_Term[] $terms      Array of terms for the given object or objects.
+	 * @param int[]     $object_ids Array of object IDs for which terms were retrieved.
+	 * @param string[]  $taxonomies Array of taxonomy names from which terms were retrieved.
+	 * @return WP_Term[] Unmodified $terms.
 	 */
 	public function wp_get_object_terms( $terms, $object_ids, $taxonomies ) {
-		$taxonomies = explode( "', '", trim( $taxonomies, "'" ) );
 		if ( ! in_array( 'term_translations', $taxonomies ) ) {
 			$this->_prime_terms_cache( $terms, $taxonomies );
 		}


### PR DESCRIPTION
Since WP 4.2, the filter `get_object_terms` is available as an alternative to `wp_get_object_terms` and is more convenient to use for us as it provides directly the array of taxonomies as 3rd parameter instead of a comma separated list of taxnomies that we need to explode.

I propose to take profit of this "new" filter and slighly simplify the code. The inline doc is updated accordingly. 