### PR TITLE
Set language by GET parameter

### DIFF
--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -73,6 +73,10 @@ class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
 			$curlang = $this->model->get_language( $slug );
 		}
 
+		elseif ( $_GET['lng'] && $this->model->get_language( $_GET['lng'] ) ) {
+      			$curlang = $this->model->get_language( $_GET['lng'] );
+		}
+		
 		elseif ( $this->options['hide_default'] ) {
 			$curlang = $this->model->get_language( $this->options['default_lang'] );
 		}


### PR DESCRIPTION
Added ability to define the language based on the GET parameter `lng`.

In some circumstances for a given page there might be the need to show the UI in a specific language, even though the content should remain in the original language at the original URL.

This is the case, for example, for online scientific journals. For citation purposes the link to an article should preferably be unique, so it should not change based on the language of the UI. Morover, the text of the article should remain the same in all languages, as there can only be one version of a paper. In the scientific community each translation is considered a different article.

In these cisrmustances it is preferrable not to create a new version of the article for each language supported by the website. Rather, it is advisable to modify the language of the UI, so the article is unique, as well as the URL.

IMO the cleanest way to achieve this goal is to add the ability to set the language with a GET parameter. In this way by simply adding the GET parameter to any link we can serve the page in any given language.