### PR TITLE
Increase PHPStan checks to level 6

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -134,7 +134,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			$page = 'lang' === $tab ? 'mlang' : "mlang_$tab";
 			if ( empty( $parent ) ) {
 				$parent = $page;
-				add_menu_page( $title, __( 'Languages', 'polylang' ), 'manage_options', $page, null, 'dashicons-translation' );
+				add_menu_page( $title, __( 'Languages', 'polylang' ), 'manage_options', $page, '__return_null', 'dashicons-translation' );
 				$admin_page_hooks[ $page ] = 'languages'; // Hack to avoid the localization of the hook name. See: https://core.trac.wordpress.org/ticket/18857
 			}
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -197,7 +197,7 @@ class PLL_Admin_Filters_Term {
 			array(
 				'name'     => 'term_lang_choice',
 				'value'    => 'term_id',
-				'selected' => $lang ? $lang->term_id : '',
+				'selected' => $lang->term_id,
 				'disabled' => $disabled,
 				'flag'     => true,
 			)
@@ -221,9 +221,7 @@ class PLL_Admin_Filters_Term {
 		);
 
 		echo '<tr id="term-translations" class="form-field">';
-		if ( $lang ) {
-			include __DIR__ . '/view-translations-term.php';
-		}
+		include __DIR__ . '/view-translations-term.php';
 		echo '</tr>' . "\n";
 	}
 

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -131,7 +131,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	 */
 	public function wp() {
 		// Nothing to do if the language has already been set ( although normally the filter has been removed )
-		if ( ! $this->curlang && $curlang = $this->get_language_from_content() ) {
+		if ( empty( $this->curlang ) && $curlang = $this->get_language_from_content() ) {
 			parent::set_language( $curlang );
 		}
 	}

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -82,7 +82,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		global $wpdb;
 
 		// Do not filter sticky posts on REST requests as $this->curlang is *not* the 'lang' parameter set in the request
-		if ( ! defined( 'REST_REQUEST' ) && $this->curlang && ! empty( $posts ) ) {
+		if ( ! defined( 'REST_REQUEST' ) && ! empty( $this->curlang ) && ! empty( $posts ) ) {
 			$_posts = wp_cache_get( 'sticky_posts', 'options' ); // This option is usually cached in 'all_options' by WP
 
 			if ( empty( $_posts ) || ! is_array( $_posts[ $this->curlang->term_taxonomy_id ] ) ) {

--- a/include/filters.php
+++ b/include/filters.php
@@ -96,22 +96,22 @@ class PLL_Filters {
 	}
 
 	/**
-	 * Get the language to filter a comments query
+	 * Get the language to filter a comments query.
 	 *
 	 * @since 2.0
 	 *
-	 * @param object $query
-	 * @return object|bool the language(s) to use in the filter, false otherwise
+	 * @param WP_Comment_Query $query  WP_Comment_Query object.
+	 * @return PLL_Language|false The language to use in the filter, false otherwise.
 	 */
 	protected function get_comments_queried_language( $query ) {
-		// Don't filter comments if comment ids or post ids are specified
+		// Don't filter comments if comment ids or post ids are specified.
 		$plucked = wp_array_slice_assoc( $query->query_vars, array( 'comment__in', 'parent', 'post_id', 'post__in', 'post_parent' ) );
 		$fields = array_filter( $plucked );
 		if ( ! empty( $fields ) ) {
 			return false;
 		}
 
-		// Don't filter comments if a non translated post type is specified
+		// Don't filter comments if a non translated post type is specified.
 		if ( ! empty( $query->query_vars['post_type'] ) && ! $this->model->is_translated_post_type( $query->query_vars['post_type'] ) ) {
 			return false;
 		}
@@ -120,31 +120,32 @@ class PLL_Filters {
 	}
 
 	/**
-	 * Adds language dependent cache domain when querying comments
-	 * Useful as the 'lang' parameter is not included in cache key by WordPress
-	 * Needed since WP 4.6 as comments have been added to persistent cache. See #36906, #37419
+	 * Adds a language dependent cache domain when querying comments.
+	 * Useful as the 'lang' parameter is not included in cache key by WordPress.
+	 * Needed since WP 4.6 as comments have been added to persistent cache. See #36906, #37419.
 	 *
 	 * @since 2.0
 	 *
-	 * @param object $query
+	 * @param WP_Comment_Query $query WP_Comment_Query object.
 	 * @return void
 	 */
 	public function parse_comment_query( $query ) {
-		if ( $lang = $this->get_comments_queried_language( $query ) ) {
-			$key = '_' . ( is_array( $lang ) ? implode( ',', $lang ) : $this->model->get_language( $lang )->slug );
+		$lang = $this->get_comments_queried_language( $query );
+		if ( $lang ) {
+			$key = '_' . $lang->slug;
 			$query->query_vars['cache_domain'] = empty( $query->query_vars['cache_domain'] ) ? 'pll' . $key : $query->query_vars['cache_domain'] . $key;
 		}
 	}
 
 	/**
-	 * Filters the comments according to the current language
-	 * Used by the recent comments widget and admin language filter
+	 * Filters the comments according to the current language.
+	 * Used by the recent comments widget and admin language filter.
 	 *
 	 * @since 0.2
 	 *
-	 * @param array  $clauses sql clauses
-	 * @param object $query   WP_Comment_Query object
-	 * @return array modified $clauses
+	 * @param string[]         $clauses SQL clauses.
+	 * @param WP_Comment_Query $query   WP_Comment_Query object.
+	 * @return string[] Modified $clauses.
 	 */
 	public function comments_clauses( $clauses, $query ) {
 		global $wpdb;
@@ -152,7 +153,7 @@ class PLL_Filters {
 		$lang = $this->get_comments_queried_language( $query );
 
 		if ( ! empty( $lang ) ) {
-			// If this clause is not already added by WP
+			// If this clause is not already added by WP.
 			if ( ! strpos( $clauses['join'], '.ID' ) ) {
 				$clauses['join'] .= " JOIN $wpdb->posts ON $wpdb->posts.ID = $wpdb->comments.comment_post_ID";
 			}

--- a/include/mo.php
+++ b/include/mo.php
@@ -36,14 +36,16 @@ class PLL_MO extends MO {
 	public function export_to_db( $lang ) {
 		$this->add_entry( $this->make_entry( '', '' ) ); // Empty string translation, just in case
 
-		// Would be convenient to store the whole object but it would take a huge space in DB
-		// So let's keep only the strings in an array
+		/*
+		 * It would be convenient to store the whole object but it would take a huge space in DB.
+		 * So let's keep only the strings in an array.
+		 * The strings are slashed to avoid breaking slashed strings in update_post_meta.
+		 * @see https://codex.wordpress.org/Function_Reference/update_post_meta#Character_Escaping.
+		 */
 		$strings = array();
 		foreach ( $this->entries as $entry ) {
-			$strings[] = array( $entry->singular, $this->translate( $entry->singular ) );
+			$strings[] = wp_slash( array( $entry->singular, $this->translate( $entry->singular ) ) );
 		}
-
-		$strings = wp_slash( $strings ); // Avoid breaking slashed strings in update_post_meta. See https://codex.wordpress.org/Function_Reference/update_post_meta#Character_Escaping
 
 		if ( empty( $lang->mo_id ) ) {
 			$post = array(

--- a/include/model.php
+++ b/include/model.php
@@ -189,7 +189,7 @@ class PLL_Model {
 	 *
 	 * @since 0.1
 	 *
-	 * @param int|string $value term_id, tl_term_id, slug or locale of the queried language.
+	 * @param mixed $value term_id, tl_term_id, slug or locale of the queried language.
 	 * @return PLL_Language|false Language object, false if no language found.
 	 */
 	public function get_language( $value ) {

--- a/include/model.php
+++ b/include/model.php
@@ -548,7 +548,7 @@ class PLL_Model {
 			$select = "SELECT pll_tr.term_taxonomy_id, COUNT( * ) AS num_posts FROM {$wpdb->posts}";
 			$join = $this->post->join_clause();
 			$where = sprintf( " WHERE post_status = '%s'", esc_sql( $q['post_status'] ) );
-			$where .= sprintf( " AND {$wpdb->posts}.post_type IN ( '%s' )", join( "', '", esc_sql( $q['post_type'] ) ) );
+			$where .= sprintf( " AND {$wpdb->posts}.post_type IN ( '%s' )", implode( "', '", esc_sql( $q['post_type'] ) ) );
 			$where .= $this->post->where_clause( $this->get_languages_list() );
 			$groupby = ' GROUP BY pll_tr.term_taxonomy_id';
 

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -107,7 +107,7 @@ class PLL_OLT_Manager {
 			 * See WP_Locale_Switcher::change_locale()
 			 */
 			if ( ! class_exists( 'WP_Textdomain_Registry' ) && function_exists( '_get_path_to_translation' ) ) {
-				_get_path_to_translation( null, true );
+				_get_path_to_translation( '', true );
 			}
 
 			foreach ( $this->list_textdomains as $textdomain ) {

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -70,16 +70,16 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	}
 
 	/**
-	 * Deletes a translation
+	 * Deletes a translation.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int $id post id
+	 * @param int $id Post id.
 	 * @return void
 	 */
 	public function delete_translation( $id ) {
 		parent::delete_translation( $id );
-		wp_set_object_terms( $id, null, $this->tax_translations );
+		wp_set_object_terms( $id, array(), $this->tax_translations );
 	}
 
 	/**

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -84,7 +84,7 @@ class PLL_Walker_Dropdown extends Walker {
 	public function walk( $elements, $max_depth, ...$args ) { // // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
 		$output = '';
 
-		if ( is_array( $max_depth ) ) {
+		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
 			// Backward compatibility with Polylang < 2.6.7
 			if ( WP_DEBUG ) {
 				trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -74,7 +74,7 @@ class PLL_Walker_List extends Walker {
 	 * @return string The hierarchical item output.
 	 */
 	public function walk( $elements, $max_depth, ...$args ) { // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
-		if ( is_array( $max_depth ) ) {
+		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
 			// Backward compatibility with Polylang < 2.6.7
 			if ( WP_DEBUG ) {
 				trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -216,7 +216,7 @@ class PLL_Sync_Tax {
 		$taxonomies = array_intersect( get_post_taxonomies( $from ), $this->get_taxonomies_to_copy( false, $from, $to, $lang ) );
 
 		// Update the term cache to reduce the number of queries in the loop
-		update_object_term_cache( $from, get_post_type( $from ) );
+		update_object_term_cache( array( $from ), get_post_type( $from ) );
 
 		// Copy
 		foreach ( $taxonomies as $tax ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-	level: 3
+	level: 6
 	paths:
 		- polylang.php
 		- admin/
@@ -17,8 +17,37 @@ parameters:
 		- install/plugin-updater.php
 	bootstrapFiles:
 		- tests/phpstan/constants.php
+	dynamicConstantNames:
+		- PLL_ADMIN
+		- PLL_SETTINGS
+	checkMissingIterableValueType: false
 	ignoreErrors:
 		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
 		- '#^Function remove_filter invoked with [4567] parameters, 2-3 required\.$#'
 		- '#^Function remove_action invoked with [4567] parameters, 2-3 required\.$#'
 		- '#^Function vip_safe_wp_remote_get not found\.$#'
+		- '#^Parameter \#1 \$message of function wp_die expects string|WP_Error, int given\.$#'
+		-
+			message: "#^Left side of \\|\\| is always false\\.$#"
+			count: 1
+			path: admin/admin-base.php
+
+		-
+			message: "#^Parameter \\#5 \\$in_footer of function wp_enqueue_script expects bool, int given\\.$#"
+			count: 1
+			path: admin/admin-base.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: include/api.php
+
+		-
+			message: "#^Function wpcom_vip_get_page_by_path\\(\\) never returns array so it can be removed from the return typehint\\.$#"
+			count: 1
+			path: include/functions.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with int will always evaluate to false\\.$#"
+			count: 1
+			path: include/translated-object.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,26 +27,32 @@ parameters:
 		- '#^Function remove_action invoked with [4567] parameters, 2-3 required\.$#'
 		- '#^Function vip_safe_wp_remote_get not found\.$#'
 		- '#^Parameter \#1 \$message of function wp_die expects string|WP_Error, int given\.$#'
+
+		# Temporarily ignored
 		-
 			message: "#^Left side of \\|\\| is always false\\.$#"
 			count: 1
 			path: admin/admin-base.php
 
+		# Temporarily ignored
 		-
 			message: "#^Parameter \\#5 \\$in_footer of function wp_enqueue_script expects bool, int given\\.$#"
 			count: 1
 			path: admin/admin-base.php
 
+		# Ignored because of https://github.com/polylang/polylang/commit/fedd9b62354ae4179e39e1fd822cfee1a12643d5
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: include/api.php
 
+		# False positive?
 		-
 			message: "#^Function wpcom_vip_get_page_by_path\\(\\) never returns array so it can be removed from the return typehint\\.$#"
 			count: 1
 			path: include/functions.php
 
+		# Ignored because of https://github.com/polylang/polylang/pull/166
 		-
 			message: "#^Call to function is_wp_error\\(\\) with int will always evaluate to false\\.$#"
 			count: 1


### PR DESCRIPTION
This PR fixes errors reported by PHPStan at level 6 and includes checks at this level in CI.

A few errors are ignored for now:

- Usage of `wp_die()` which doesn't officially accept `int` although WordPress itself often pass `0` or `-1` to this function as we do.
- The 2 errors in `admin/admin-base.php` should be removed once we will refactor script enqueueing as already planned (not fixed here to avoid conflicts with the ongoing work).
- Errors reported in `include/api.php` and `include/translated-object.php` are about checks that should be useless but which are protecting us from 3rd party code doing things wrong. I prefer to keep the situation as is for now.
- The error reported in `include/functions.php` about `wpcom_vip_get_page_by_path()` seems to be a false positive.