### PR TITLE
Protect against chained redirects.

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -464,9 +464,9 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		$redirect_url = apply_filters( 'pll_check_canonical_url', $redirect_url, $language );
 
 		// The language is not correctly set so let's redirect to the correct url for this object
-		if ( $do_redirect && $redirect_url && $requested_url != $redirect_url ) {
+		if ( $do_redirect ) {
 			// Protect against chained redirects.
-			if ( $redirect_url === $this->check_canonical_url( $redirect_url, false ) ) {
+			if ( $redirect_url && $requested_url != $redirect_url && $redirect_url === $this->check_canonical_url( $redirect_url, false ) ) {
 				wp_safe_redirect( $redirect_url, 301, POLYLANG );
 				exit;
 			} else {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -465,8 +465,13 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		// The language is not correctly set so let's redirect to the correct url for this object
 		if ( $do_redirect && $redirect_url && $requested_url != $redirect_url ) {
-			wp_safe_redirect( $redirect_url, 301, POLYLANG );
-			exit;
+			// Protect against chained redirects.
+			if ( ! redirect_canonical( $redirect_url, false ) ) {
+				wp_safe_redirect( $redirect_url, 301, POLYLANG );
+				exit;
+			} else {
+				return;
+			}
 		}
 
 		return $redirect_url;

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -466,7 +466,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		// The language is not correctly set so let's redirect to the correct url for this object
 		if ( $do_redirect && $redirect_url && $requested_url != $redirect_url ) {
 			// Protect against chained redirects.
-			if ( ! redirect_canonical( $redirect_url, false ) ) {
+			if ( $redirect_url === $this->check_canonical_url( $redirect_url, false ) ) {
 				wp_safe_redirect( $redirect_url, 301, POLYLANG );
 				exit;
 			} else {


### PR DESCRIPTION
After analysis about the issue reported in [#13419](https://secure.helpscout.net/conversation/1391585616/13419?folderId=927655) this PR propose to improve the strenghness of our PLL_Frontend_Filters_Links::check_canonical_url() method to protect against chained redirects as it is done in WordPress.

See https://github.com/WordPress/WordPress/blob/5.6/wp-includes/canonical.php#L761-L769

In fact:

- Polylang is hooked on `template_redirect` with a higher priority https://github.com/polylang/polylang/blob/2.9.1/frontend/frontend-filters-links.php#L73
 than WordPress `redirect_canonical()` function https://github.com/WordPress/WordPress/blob/5.6/wp-includes/default-filters.php#L538 to be able to catch wrong behaviours before WordPress canonical URL calculation and then redirect if necessary
- redirect_canonical() function should always return the same URL
- GN Publisher plugin is a new feed which is unknown from WordPress espacially here https://github.com/WordPress/WordPress/blob/5.6/wp-includes/canonical.php#L422-L432 and the `/feed/gn` is never removed from the URL
-  WordPress redirect_canonical() function then adds `/feed/gn` https://github.com/WordPress/WordPress/blob/5.6/wp-includes/canonical.php#L450 and https://github.com/WordPress/WordPress/blob/5.6/wp-includes/canonical.php#L510-L514 in the URL each time it is called, and then also here https://github.com/WordPress/WordPress/blob/5.6/wp-includes/canonical.php#L762. So WordPress never redirects to the canonical URL even if Polylang is deactivated.
- So Polylang redirects before WordPress which will never redirect because the URL changes everytime.

