### PR TITLE
Improve inline doc

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -401,11 +401,11 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	}
 
 	/**
-	 * Adds the languages list in admin bar for the admin languages filter
+	 * Adds the languages list in admin bar for the admin languages filter.
 	 *
 	 * @since 0.9
 	 *
-	 * @param object $wp_admin_bar
+	 * @param WP_Admin_Bar $wp_admin_bar WP_Admin_Bar global object.
 	 * @return void
 	 */
 	public function admin_bar_menu( $wp_admin_bar ) {

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -313,13 +313,13 @@ class PLL_Admin_Classic_Editor {
 	}
 
 	/**
-	 * Filters the pages by language in the parent dropdown list in the page attributes metabox
+	 * Filters the pages by language in the parent dropdown list in the page attributes metabox.
 	 *
 	 * @since 0.6
 	 *
-	 * @param array  $dropdown_args Arguments passed to wp_dropdown_pages
-	 * @param object $post
-	 * @return array Modified arguments
+	 * @param array   $dropdown_args Arguments passed to wp_dropdown_pages().
+	 * @param WP_Post $post          The page being edited.
+	 * @return array Modified arguments.
 	 */
 	public function page_attributes_dropdown_pages_args( $dropdown_args, $post ) {
 		$dropdown_args['lang'] = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
@@ -331,11 +331,11 @@ class PLL_Admin_Classic_Editor {
 	}
 
 	/**
-	 * Displays a notice if the user has not sufficient rights to overwrite synchronized taxonomies and metas
+	 * Displays a notice if the user has not sufficient rights to overwrite synchronized taxonomies and metas.
 	 *
 	 * @since 2.6
 	 *
-	 * @param object $post Post currently being edited
+	 * @param WP_Post $post the post currently being edited.
 	 * @return void
 	 */
 	public function edit_form_top( $post ) {

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -423,7 +423,7 @@ class PLL_Admin_Filters_Columns {
 	 *
 	 * @since 2.8
 	 *
-	 * @param object $language PLL_Language object.
+	 * @param PLL_Language $language PLL_Language object.
 	 * @return string
 	 */
 	protected function get_flag_html( $language ) {

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -40,14 +40,14 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 	}
 
 	/**
-	 * Adds the language field and translations tables in the 'Edit Media' panel
+	 * Adds the language field and translations tables in the 'Edit Media' panel.
 	 * Needs WP 3.5+
 	 *
 	 * @since 0.9
 	 *
-	 * @param array  $fields list of form fields
-	 * @param object $post
-	 * @return array modified list of form fields
+	 * @param array   $fields List of form fields.
+	 * @param WP_Post $post   The attachment being edited.
+	 * @return array Modified list of form fields.
 	 */
 	public function attachment_fields_to_edit( $fields, $post ) {
 		if ( 'post.php' == $GLOBALS['pagenow'] ) {

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -104,11 +104,11 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	}
 
 	/**
-	 * Filters posts, pages and media by language
+	 * Filters posts, pages and media by language.
 	 *
 	 * @since 0.1
 	 *
-	 * @param object $query a WP_Query object
+	 * @param WP_Query $query WP_Query object.
 	 * @return void
 	 */
 	public function parse_query( $query ) {
@@ -141,13 +141,13 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	}
 
 	/**
-	 * Save language when inline editing or bulk editing a post
-	 * Fix translations if necessary
+	 * Saves a post language when inline editing or bulk editing.
+	 * Fixes the translations if necessary.
 	 *
 	 * @since 2.3
 	 *
-	 * @param int    $post_id Post ID
-	 * @param object $lang    Language
+	 * @param int          $post_id Post ID.
+	 * @param PLL_Language $lang    Language.
 	 * @return void
 	 */
 	protected function inline_save_language( $post_id, $lang ) {

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -160,11 +160,11 @@ class PLL_Admin_Filters_Term {
 	}
 
 	/**
-	 * Adds the language field and translations tables in the 'Edit Category' and 'Edit Tag' panels
+	 * Adds the language field and translations tables in the 'Edit Category' and 'Edit Tag' panels.
 	 *
 	 * @since 0.1
 	 *
-	 * @param object $tag
+	 * @param WP_Term $tag The term being edited.
 	 * @return void
 	 */
 	public function edit_term_form( $tag ) {

--- a/admin/admin-filters.php
+++ b/admin/admin-filters.php
@@ -40,13 +40,13 @@ class PLL_Admin_Filters extends PLL_Filters {
 	}
 
 	/**
-	 * Modifies the widgets forms to add our language dropdown list
+	 * Modifies the widgets forms to add our language dropdown list.
 	 *
 	 * @since 0.3
 	 *
-	 * @param object $widget   Widget instance
-	 * @param null   $return   Not used
-	 * @param array  $instance Widget settings
+	 * @param WP_Widget $widget   Widget instance.
+	 * @param null      $return   Not used.
+	 * @param array     $instance Widget settings.
 	 * @return void
 	 */
 	public function in_widget_form( $widget, $return, $instance ) {
@@ -80,16 +80,16 @@ class PLL_Admin_Filters extends PLL_Filters {
 	}
 
 	/**
-	 * Called when widget options are saved
-	 * saves the language associated to the widget
+	 * Called when widget options are saved.
+	 * Saves the language associated to the widget.
 	 *
 	 * @since 0.3
 	 *
-	 * @param array  $instance     Widget options
-	 * @param array  $new_instance Not used
-	 * @param array  $old_instance Not used
-	 * @param object $widget       WP_Widget object
-	 * @return array Widget options
+	 * @param array     $instance     Widget options.
+	 * @param array     $new_instance Not used.
+	 * @param array     $old_instance Not used.
+	 * @param WP_Widget $widget       WP_Widget object.
+	 * @return array Widget options.
 	 */
 	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
 		$key = $widget->id . '_lang_choice';
@@ -124,11 +124,11 @@ class PLL_Admin_Filters extends PLL_Filters {
 	}
 
 	/**
-	 * Outputs hidden information to modify the biography form with js
+	 * Outputs hidden information to modify the biography form with js.
 	 *
 	 * @since 0.4
 	 *
-	 * @param object $profileuser
+	 * @param WP_User $profileuser The current WP_User object.
 	 * @return void
 	 */
 	public function personal_options( $profileuser ) {

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -258,8 +258,8 @@ class PLL_Admin_Model extends PLL_Model {
 	 *
 	 * @since 0.4
 	 *
-	 * @param array  $args Parameters of {@see PLL_Admin_Model::add_language() or @see PLL_Admin_Model::update_language()}.
-	 * @param object $lang Optional the language currently updated, the language is created if not set.
+	 * @param array        $args Parameters of {@see PLL_Admin_Model::add_language() or @see PLL_Admin_Model::update_language()}.
+	 * @param PLL_Language $lang Optional the language currently updated, the language is created if not set.
 	 * @return WP_Error
 	 */
 	protected function validate_lang( $args, $lang = null ) {

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -64,13 +64,13 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Removes the editor for translations of the pages for posts
-	 * Removes the page template select dropdown in page attributes metabox too
+	 * Removes the editor for the translations of the pages for posts.
+	 * Removes the page template select dropdown in page attributes metabox too.
 	 *
 	 * @since 2.2.2
 	 *
-	 * @param string $post_type Current post type
-	 * @param object $post      Current post
+	 * @param string  $post_type Current post type.
+	 * @param WP_Post $post      Current post.
 	 * @return void
 	 */
 	public function add_meta_boxes( $post_type, $post ) {

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -84,12 +84,12 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	}
 
 	/**
-	 * Sets the language for home page
-	 * Add the lang query var when querying archives with no language code
+	 * Sets the language for the home page.
+	 * Adds the lang query var when querying archives with no language code.
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $query instance of WP_Query
+	 * @param WP_Query $query Instance of WP_Query.
 	 * @return void
 	 */
 	public function parse_main_query( $query ) {

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -324,12 +324,12 @@ abstract class PLL_Choose_Lang {
 	}
 
 	/**
-	 * Modifies some main query vars for home page and page for posts
-	 * to enable one home page ( and one page for posts ) per language
+	 * Modifies some main query vars for the home page and the page for posts
+	 * to enable one home page (and one page for posts) per language.
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $query instance of WP_Query
+	 * @param WP_Query $query Instance of WP_Query.
 	 * @return void
 	 */
 	public function parse_main_query( $query ) {
@@ -342,8 +342,8 @@ abstract class PLL_Choose_Lang {
 		 *
 		 * @since 1.8
 		 *
-		 * @param bool|object $lang  false or language object
-		 * @param object      $query WP_Query object
+		 * @param PLL_Language|false $lang  Language object or false.
+		 * @param WP_Query           $query WP_Query object.
 		 */
 		if ( $lang = apply_filters( 'pll_set_language_from_query', false, $query ) ) {
 			$this->set_language( $lang );

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -66,7 +66,7 @@ class PLL_Frontend_Auto_Translate {
 	 *
 	 * @since 1.1
 	 *
-	 * @param object $query WP_Query object
+	 * @param WP_Query $query WP_Query object
 	 * @return void
 	 */
 	public function pre_get_posts( $query ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -492,7 +492,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 *
 	 * @since 2.9
 	 *
-	 * @param object $tax_query An instance of WP_Tax_Query.
+	 * @param WP_Tax_Query $tax_query An instance of WP_Tax_Query.
 	 * @return int
 	 */
 	protected function get_queried_term_id( $tax_query ) {
@@ -524,7 +524,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 *
 	 * @since 2.9
 	 *
-	 * @param object $tax_query An instance of WP_Tax_Query.
+	 * @param WP_Tax_Query $tax_query An instance of WP_Tax_Query.
 	 * @return string A taxonomy slug
 	 */
 	protected function get_queried_taxonomy( $tax_query ) {

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -39,11 +39,11 @@ class PLL_Frontend_Links extends PLL_Links {
 	}
 
 	/**
-	 * Returns the url of the translation ( if exists ) of the current page
+	 * Returns the url of the translation (if it exists) of the current page.
 	 *
 	 * @since 0.1
 	 *
-	 * @param object $language
+	 * @param PLL_Language $language Language object.
 	 * @return string
 	 */
 	public function get_translation_url( $language ) {
@@ -58,14 +58,14 @@ class PLL_Frontend_Links extends PLL_Links {
 		$queried_object_id = $wp_query->get_queried_object_id();
 
 		/**
-		 * Filter the translation url before Polylang attempts to find one
-		 * Internally used by Polylang for the static front page and posts page
+		 * Filters the translation url before Polylang attempts to find one.
+		 * Internally used by Polylang for the static front page and posts page.
 		 *
 		 * @since 1.8
 		 *
-		 * @param string $url               Empty or the url of the translation of teh current page
-		 * @param object $language          Language of the translation
-		 * @param int    $queried_object_id Queried object id
+		 * @param string       $url               Empty or the url of the translation of teh current page.
+		 * @param PLL_Language $language          Language of the translation.
+		 * @param int          $queried_object_id Queried object id.
 		 */
 		if ( ! $url = apply_filters( 'pll_pre_translation_url', '', $language, $queried_object_id ) ) {
 			$qv = $wp_query->query_vars;

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -45,12 +45,12 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	}
 
 	/**
-	 * Sort menu items by menu order
+	 * Sorts menu items by menu order.
 	 *
 	 * @since 1.7.9
 	 *
-	 * @param object $a The first object to compare
-	 * @param object $b The second object to compare
+	 * @param stdClass $a The first object to compare.
+	 * @param stdClass $b The second object to compare.
 	 * @return int -1 or 1 if $a is considered to be respectively less than or greater than $b.
 	 */
 	protected function usort_menu_items( $a, $b ) {

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -120,14 +120,14 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Translates the url of the page on front and page for posts
+	 * Translates the url of the page on front and page for posts.
 	 *
 	 * @since 1.8
 	 *
-	 * @param string $url               not used
-	 * @param object $language          language in which we want the translation
-	 * @param int    $queried_object_id id of the queried object
-	 * @return string
+	 * @param string       $url               Not used.
+	 * @param PLL_Language $language          Language in which we want the translation.
+	 * @param int          $queried_object_id Id of the queried object.
+	 * @return string The translation url.
 	 */
 	public function pll_pre_translation_url( $url, $language, $queried_object_id ) {
 		if ( ! empty( $queried_object_id ) ) {
@@ -162,7 +162,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 *
 	 * @since 2.3
 	 *
-	 * @param object $query
+	 * @param WP_Query $query The WP_Query object.
 	 * @return bool
 	 */
 	protected function is_front_page( $query ) {
@@ -238,9 +238,9 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 *
 	 * @since 1.8
 	 *
-	 * @param bool|object $lang
-	 * @param object      $query
-	 * @return bool|object
+	 * @param PLL_Language|false $lang  The current language, false if it is not set yet.
+	 * @param WP_Query           $query The main WP query.
+	 * @return PLL_Language|false
 	 */
 	public function page_for_posts_query( $lang, $query ) {
 		if ( empty( $lang ) && $this->page_for_posts ) {
@@ -260,14 +260,15 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Get queried page_id ( if exists )
-	 * If permalinks are used, WordPress does set and use $query->queried_object_id and sets $query->query_vars['page_id'] to 0
-	 * and does set and use $query->query_vars['page_id'] if permalinks are not used :(
+	 * Get the queried page_id (if it exists ).
+	 *
+	 * If permalinks are used, WordPress does set and use `$query->queried_object_id` and sets `$query->query_vars['page_id']` to 0,
+	 * and does set and use `$query->query_vars['page_id']` if permalinks are not used :(.
 	 *
 	 * @since 1.5
 	 *
-	 * @param object $query instance of WP_Query
-	 * @return int page_id
+	 * @param WP_Query $query Instance of WP_Query.
+	 * @return int The page_id.
 	 */
 	protected function get_page_id( $query ) {
 		if ( ! empty( $query->query_vars['pagename'] ) && isset( $query->queried_object_id ) ) {
@@ -278,6 +279,6 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 			return $query->query_vars['page_id'];
 		}
 
-		return 0; // No page queried
+		return 0; // No page queried.
 	}
 }

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -127,11 +127,11 @@ class PLL_Frontend extends PLL_Base {
 	}
 
 	/**
-	 * When querying multiple taxonomies, makes sure that the language is not the queried object
+	 * When querying multiple taxonomies, makes sure that the language is not the queried object.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $query WP_Query object
+	 * @param WP_Query $query WP_Query object.
 	 * @return void
 	 */
 	public function parse_tax_query( $query ) {
@@ -144,11 +144,11 @@ class PLL_Frontend extends PLL_Base {
 	}
 
 	/**
-	 * Modifies some query vars to "hide" that the language is a taxonomy and avoid conflicts
+	 * Modifies some query vars to "hide" that the language is a taxonomy and avoid conflicts.
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $query WP_Query object
+	 * @param WP_Query $query WP_Query object.
 	 * @return void
 	 */
 	public function parse_query( $query ) {

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -162,7 +162,8 @@ class PLL_Filters_Links {
 
 		// In case someone calls get_term_link for the 'language' taxonomy.
 		if ( 'language' === $tax ) {
-			return $this->links_model->home_url( $term );
+			$lang = $this->model->get_language( $term->term_id );
+			return $this->links_model->home_url( $lang );
 		}
 
 		return $link;

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -104,13 +104,13 @@ class PLL_Filters_Links {
 	}
 
 	/**
-	 * Modifies custom posts links
+	 * Modifies custom posts links.
 	 *
 	 * @since 1.6
 	 *
-	 * @param string $link post link
-	 * @param object $post post object
-	 * @return string modified post link
+	 * @param string  $link Post link.
+	 * @param WP_Post $post Post object.
+	 * @return string Modified post link.
 	 */
 	public function post_type_link( $link, $post ) {
 		// /!\ WP does not use pretty permalinks for preview
@@ -119,13 +119,13 @@ class PLL_Filters_Links {
 			$link = $this->options['force_lang'] ? $this->links_model->switch_language_in_link( $link, $lang ) : $link;
 
 			/**
-			 * Filter a post or custom post type link
+			 * Filters a post or custom post type link.
 			 *
 			 * @since 1.6
 			 *
-			 * @param string $link the post link
-			 * @param object $lang the current language
-			 * @param object $post the post object
+			 * @param string       $link The post link.
+			 * @param PLL_Language $lang The current language.
+			 * @param WP_Post      $post The post object.
 			 */
 			$link = apply_filters( 'pll_post_type_link', $link, $lang, $post );
 		}
@@ -134,14 +134,14 @@ class PLL_Filters_Links {
 	}
 
 	/**
-	 * Modifies term link
+	 * Modifies term links.
 	 *
 	 * @since 0.7
 	 *
-	 * @param string $link term link
-	 * @param object $term term object
-	 * @param string $tax  taxonomy name
-	 * @return string modified term link
+	 * @param string  $link Term link.
+	 * @param WP_Term $term Term object.
+	 * @param string  $tax  Taxonomy name;
+	 * @return string Modified term link.
 	 */
 	public function term_link( $link, $term, $tax ) {
 		if ( $this->model->is_translated_taxonomy( $tax ) ) {
@@ -153,14 +153,14 @@ class PLL_Filters_Links {
 			 *
 			 * @since 1.6
 			 *
-			 * @param string $link the term link
-			 * @param object $lang the current language
-			 * @param object $term the term object
+			 * @param string       $link The term link.
+			 * @param PLL_Language $lang The current language.
+			 * @param WP_Term      $term The term object.
 			 */
 			return apply_filters( 'pll_term_link', $link, $lang, $term );
 		}
 
-		// in case someone calls get_term_link for the 'language' taxonomy
+		// In case someone calls get_term_link for the 'language' taxonomy.
 		if ( 'language' === $tax ) {
 			return $this->links_model->home_url( $term );
 		}

--- a/include/links-abstract-domain.php
+++ b/include/links-abstract-domain.php
@@ -48,15 +48,15 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 	}
 
 	/**
-	 * Sets the home urls
+	 * Sets the home urls.
 	 *
 	 * @since 2.2
 	 *
-	 * @param object $language
+	 * @param PLL_Language $language Language object.
 	 */
 	protected function set_home_url( $language ) {
 		$home_url = $this->home_url( $language );
-		$language->set_home_url( $home_url, $home_url ); // Search url and home url are the same
+		$language->set_home_url( $home_url, $home_url ); // Search url and home url are the same.
 	}
 
 	/**

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -19,14 +19,14 @@ class PLL_Links_Default extends PLL_Links_Model {
 	public $using_permalinks = false;
 
 	/**
-	 * Adds language information to an url
-	 * links_model interface
+	 * Adds the language code in a url.
+	 * links_model interface.
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $url  url to modify
-	 * @param object $lang language
-	 * @return string modified url
+	 * @param string       $url  The url to modify.
+	 * @param PLL_Language $lang The language object.
+	 * @return string Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		return empty( $lang ) || ( $this->options['hide_default'] && $this->options['default_lang'] == $lang->slug ) ? $url : add_query_arg( 'lang', $lang->slug, $url );
@@ -91,12 +91,12 @@ class PLL_Links_Default extends PLL_Links_Model {
 	}
 
 	/**
-	 * Returns the static front page url
+	 * Returns the static front page url.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $lang
-	 * @return string
+	 * @param PLL_Language $lang The language object.
+	 * @return string The static front page url.
 	 */
 	public function front_page_url( $lang ) {
 		if ( $this->options['hide_default'] && $lang->slug == $this->options['default_lang'] ) {

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -56,14 +56,14 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	}
 
 	/**
-	 * Adds the language code in url
-	 * links_model interface
+	 * Adds the language code in a url.
+	 * links_model interface.
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $url  url to modify
-	 * @param object $lang language
-	 * @return string modified url
+	 * @param string       $url  The url to modify.
+	 * @param PLL_Language $lang The language object.
+	 * @return string Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
@@ -133,12 +133,12 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	}
 
 	/**
-	 * Returns the home url
-	 * links_model interface
+	 * Returns the home url in a given language.
+	 * links_model interface.
 	 *
 	 * @since 1.3.1
 	 *
-	 * @param object $lang PLL_Language object
+	 * @param PLL_Language $lang PLL_Language object.
 	 * @return string
 	 */
 	public function home_url( $lang ) {

--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -42,9 +42,9 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $url  url to modify
-	 * @param object $lang language
-	 * @return string modified url
+	 * @param string       $url  The url to modify.
+	 * @param PLL_Language $lang The language object.
+	 * @return string Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) && ! empty( $this->hosts[ $lang->slug ] ) ) {
@@ -70,12 +70,12 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 	}
 
 	/**
-	 * Returns the home url
-	 * links_model interface
+	 * Returns the home url in a given language.
+	 * links_model interface.
 	 *
 	 * @since 1.3.1
 	 *
-	 * @param object $lang PLL_Language object
+	 * @param PLL_Language $lang PLL_Language object.
 	 * @return string
 	 */
 	public function home_url( $lang ) {

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -161,7 +161,7 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $language PLL_Language object.
+	 * @param PLL_Language $language PLL_Language object.
 	 * @return void
 	 */
 	protected function set_home_url( $language ) {

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -60,8 +60,8 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $url  The url to modify.
-	 * @param object $lang Language.
+	 * @param string       $url  The url to modify.
+	 * @param PLL_Language $lang The language object.
 	 * @return string Modified url.
 	 */
 	abstract public function add_language_to_link( $url, $lang );
@@ -113,8 +113,8 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $lang Language.
-	 * @return string The front page url.
+	 * @param PLL_Language $lang The language object.
+	 * @return string The static front page url.
 	 */
 	abstract public function front_page_url( $lang );
 
@@ -123,8 +123,8 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.5
 	 *
-	 * @param string $url  The url to modify.
-	 * @param object $lang Language.
+	 * @param string       $url  The url to modify.
+	 * @param PLL_Language $lang The language object.
 	 * @return string Modified url.
 	 */
 	public function switch_language_in_link( $url, $lang ) {
@@ -148,7 +148,7 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.3.1
 	 *
-	 * @param object $lang PLL_Language object.
+	 * @param PLL_Language $lang PLL_Language object.
 	 * @return string
 	 */
 	public function home_url( $lang ) {

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -117,12 +117,12 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	}
 
 	/**
-	 * Returns the static front page url
+	 * Returns the static front page url.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $lang
-	 * @return string
+	 * @param PLL_Language $lang The language object.
+	 * @return string The static front page url.
 	 */
 	public function front_page_url( $lang ) {
 		if ( $this->options['hide_default'] && $lang->slug == $this->options['default_lang'] ) {

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -32,14 +32,14 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	}
 
 	/**
-	 * Adds the language code in url
-	 * links_model interface
+	 * Adds the language code in a url.
+	 * links_model interface.
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $url  url to modify
-	 * @param object $lang language
-	 * @return string modified url
+	 * @param string       $url  The url to modify.
+	 * @param PLL_Language $lang The language object.
+	 * @return string Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) && false === strpos( $url, '://' . $lang->slug . '.' ) ) {

--- a/include/mo.php
+++ b/include/mo.php
@@ -26,11 +26,11 @@ class PLL_MO extends MO {
 	}
 
 	/**
-	 * Writes a PLL_MO object into a custom post meta
+	 * Writes a PLL_MO object into a custom post meta.
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $lang The language in which we want to export strings
+	 * @param PLL_Language $lang The language in which we want to export strings.
 	 * @return void
 	 */
 	public function export_to_db( $lang ) {
@@ -61,11 +61,11 @@ class PLL_MO extends MO {
 	}
 
 	/**
-	 * Reads a PLL_MO object from a custom post meta
+	 * Reads a PLL_MO object from a custom post meta.
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $lang The language in which we want to get strings
+	 * @param PLL_Language $lang The language in which we want to get strings.
 	 * @return void
 	 */
 	public function import_from_db( $lang ) {
@@ -80,11 +80,11 @@ class PLL_MO extends MO {
 	}
 
 	/**
-	 * Returns the post id of the post storing the strings translations
+	 * Returns the post id of the post storing the strings translations.
 	 *
 	 * @since 1.4
 	 *
-	 * @param object $lang
+	 * @param PLL_Language $lang The language object.
 	 * @return int
 	 */
 	public static function get_id( $lang ) {

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -63,8 +63,8 @@ class PLL_Nav_Menu {
 	 *
 	 * @since 2.6
 	 *
-	 * @param object $item Menu item.
-	 * @return object
+	 * @param stdClass $item Menu item.
+	 * @return stdClass
 	 */
 	public function wp_setup_nav_menu_item( $item ) {
 		if ( '#pll_switcher' === $item->url ) {
@@ -105,8 +105,8 @@ class PLL_Nav_Menu {
 	 *
 	 * @since 1.8
 	 *
-	 * @param string $loc nav menu location
-	 * @param object $lang
+	 * @param string       $loc  Nav menu location.
+	 * @param PLL_Language $lang Language object.
 	 * @return string
 	 */
 	public function combine_location( $loc, $lang ) {
@@ -118,7 +118,7 @@ class PLL_Nav_Menu {
 	 *
 	 * @since 1.8
 	 *
-	 * @param string $loc Temporary location
+	 * @param string $loc Temporary location.
 	 * @return string[] {
 	 *   @type string $location Nav menu location.
 	 *   @type string $lang     Language code.
@@ -146,13 +146,13 @@ class PLL_Nav_Menu {
 	}
 
 	/**
-	 * Filters _wp_auto_add_pages_to_menu by language
+	 * Filters _wp_auto_add_pages_to_menu by language.
 	 *
 	 * @since 0.9.4
 	 *
-	 * @param string $new_status Transition to this post status.
-	 * @param string $old_status Previous post status.
-	 * @param object $post Post data.
+	 * @param string  $new_status Transition to this post status.
+	 * @param string  $old_status Previous post status.
+	 * @param WP_Post $post       Post object.
 	 * @return void
 	 */
 	public function auto_add_pages_to_menu( $new_status, $old_status, $post ) {

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -216,11 +216,11 @@ class PLL_OLT_Manager {
 	}
 
 	/**
-	 * Translates post types and taxonomies labels once the language is known
+	 * Translates post types and taxonomies labels once the language is known.
 	 *
 	 * @since 0.9
 	 *
-	 * @param object $type either a post type or a taxonomy
+	 * @param WP_Post_Type|WP_Taxonomy $type Either a post type or a taxonomy.
 	 * @return void
 	 */
 	public function translate_labels( $type ) {

--- a/include/query.php
+++ b/include/query.php
@@ -72,12 +72,12 @@ class PLL_Query {
 	}
 
 	/**
-	 * Sets the language in query
-	 * Optimized for ( needs ) WP 3.5+
+	 * Sets the language in query.
+	 * Optimized for (and requires) WP 3.5+.
 	 *
 	 * @since 2.2
 	 *
-	 * @param object $lang
+	 * @param PLL_Language $lang Language object.
 	 * @return void
 	 */
 	public function set_language( $lang ) {

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -35,13 +35,11 @@ class PLL_Switcher {
 	/**
 	 * Get the language elements for use in a walker
 	 *
-	 * @see PLL_Switcher::the_languages() for the list of parameters accepted in $args
-	 *
 	 * @since 1.2
 	 *
-	 * @param object $links instance of PLL_Frontend_Links
-	 * @param array  $args
-	 * @return array
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @return array Language switcher elements.
 	 */
 	protected function get_elements( $links, $args ) {
 		$first = true;
@@ -113,8 +111,8 @@ class PLL_Switcher {
 	 *
 	 * @since 0.1
 	 *
-	 * @param object $links Instance of PLL_Frontend_Links.
-	 * @param array  $args {
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args {
 	 *   Optional array of arguments.
 	 *
 	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -23,11 +23,11 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $output            Passed by reference. Used to append additional content.
-	 * @param object $element           The data object.
-	 * @param int    $depth             Depth of the item.
-	 * @param array  $args              An array of additional arguments.
-	 * @param int    $current_object_id ID of the current item.
+	 * @param string   $output            Passed by reference. Used to append additional content.
+	 * @param stdClass $element           The data object.
+	 * @param int      $depth             Depth of the item.
+	 * @param array    $args              An array of additional arguments.
+	 * @param int      $current_object_id ID of the current item.
 	 * @return void
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
@@ -46,12 +46,12 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $element           Data object.
-	 * @param array  $children_elements List of elements to continue traversing.
-	 * @param int    $max_depth         Max depth to traverse.
-	 * @param int    $depth             Depth of current element.
-	 * @param array  $args              An array of arguments.
-	 * @param string $output            Passed by reference. Used to append additional content.
+	 * @param stdClass $element           Data object.
+	 * @param array    $children_elements List of elements to continue traversing.
+	 * @param int      $max_depth         Max depth to traverse.
+	 * @param int      $depth             Depth of current element.
+	 * @param array    $args              An array of arguments.
+	 * @param string   $output            Passed by reference. Used to append additional content.
 	 * @return void
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -23,11 +23,11 @@ class PLL_Walker_List extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $output            Passed by reference. Used to append additional content.
-	 * @param object $element           The data object.
-	 * @param int    $depth             Depth of the item.
-	 * @param array  $args              An array of additional arguments.
-	 * @param int    $current_object_id ID of the current item.
+	 * @param string   $output            Passed by reference. Used to append additional content.
+	 * @param stdClass $element           The data object.
+	 * @param int      $depth             Depth of the item.
+	 * @param array    $args              An array of additional arguments.
+	 * @param int      $current_object_id ID of the current item.
 	 * @return void
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
@@ -48,12 +48,12 @@ class PLL_Walker_List extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $element           Data object.
-	 * @param array  $children_elements List of elements to continue traversing.
-	 * @param int    $max_depth         Max depth to traverse.
-	 * @param int    $depth             Depth of current element.
-	 * @param array  $args              An array of arguments.
-	 * @param string $output            Passed by reference. Used to append additional content.
+	 * @param stdClass $element           Data object.
+	 * @param array    $children_elements List of elements to continue traversing.
+	 * @param int      $max_depth         Max depth to traverse.
+	 * @param int      $depth             Depth of current element.
+	 * @param array    $args              An array of arguments.
+	 * @param string   $output            Passed by reference. Used to append additional content.
 	 * @return void
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -128,25 +128,31 @@ class PLL_Upgrade {
 	}
 
 	/**
-	 * Upgrades if the previous version is < 2.1
-	 * Moves strings translations from polylang_mo post_content to post meta _pll_strings_translations
+	 * Upgrades if the previous version is < 2.1.
+	 * Moves strings translations from polylang_mo post_content to post meta _pll_strings_translations.
 	 *
 	 * @since 2.1
 	 *
 	 * @return void
 	 */
 	protected function upgrade_2_1() {
-		$languages = get_terms( 'language', array( 'hide_empty' => 0 ) );
-		if ( is_array( $languages ) ) {
-			foreach ( $languages as $lang ) {
-				$mo_id = PLL_MO::get_id( $lang );
-				$meta = get_post_meta( $mo_id, '_pll_strings_translations', true );
+		$posts = get_posts(
+			array(
+				'post_type'   => 'polylang_mo',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'nopaging'    => true,
+			)
+		);
+
+		if ( is_array( $posts ) ) {
+			foreach ( $posts as $post ) {
+				$meta = get_post_meta( $post->ID, '_pll_strings_translations', true );
 
 				if ( empty( $meta ) ) {
-					$post = get_post( $mo_id, OBJECT );
 					$strings = maybe_unserialize( $post->post_content );
 					if ( is_array( $strings ) ) {
-						update_post_meta( $mo_id, '_pll_strings_translations', $strings );
+						update_post_meta( $post->ID, '_pll_strings_translations', $strings );
 					}
 				}
 			}

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -218,7 +218,7 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @since 2.8
 	 *
-	 * @param object $language Language object.
+	 * @param PLL_Language $language Language object.
 	 * @return string
 	 */
 	protected function get_flag( $language ) {

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -61,7 +61,7 @@ class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	 * @since 2.8
 	 *
 	 * @param string|bool $lang  Current language code, false if not set yet.
-	 * @param object      $query Main WP query object.
+	 * @param WP_Query    $query Main WP query object.
 	 * @return string|bool
 	 */
 	public function set_language_from_query( $lang, $query ) {

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -10,28 +10,28 @@
  */
 class PLL_Wizard {
 	/**
-	 * Reference to PLL_Model object
+	 * Reference to the model object
 	 *
-	 * @var object $model
+	 * @var PLL_Admin_Model
 	 */
 	protected $model;
 
 	/**
-	 * Reference to Polylang options array
+	 * Reference to the Polylang options array.
 	 *
-	 * @var array $options
+	 * @var array
 	 */
 	protected $options;
 
 	/**
-	 * List of steps
+	 * List of steps.
 	 *
 	 * @var array $steps {
-	 *     @type string $name      i18n string which names the step.
+	 *     @type string   $name    I18n string which names the step.
 	 *     @type callable $view    The callback function use to display the step content.
 	 *     @type callable $handler The callback function use to process the step after it is submitted.
-	 *     @type array $scripts    List of scripts handle needed by the step.
-	 *     @type array $styles     The list of styles handle needed by the step.
+	 *     @type array    $scripts List of scripts handle needed by the step.
+	 *     @type array    $styles  The list of styles handle needed by the step.
 	 * }
 	 */
 	protected $steps = array();

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -52,7 +52,7 @@ class PLL_WPML_Compat {
 	 *
 	 * @since 1.7
 	 *
-	 * @return object
+	 * @return PLL_WPML_Compat
 	 */
 	public static function instance() {
 		if ( empty( self::$instance ) ) {

--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -30,11 +30,11 @@ class PLL_Table_Languages extends WP_List_Table {
 	}
 
 	/**
-	 * Generates content for a single row of the table
+	 * Generates content for a single row of the table.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $item The current item
+	 * @param PLL_Language $item The language item.
 	 * @return void
 	 */
 	public function single_row( $item ) {
@@ -43,8 +43,8 @@ class PLL_Table_Languages extends WP_List_Table {
 		 *
 		 * @since 1.8
 		 *
-		 * @param array  $classes list of class names
-		 * @param object $item    the current item
+		 * @param array        $classes The list of class names.
+		 * @param PLL_Language $item    The language item.
 		 */
 		$classes = apply_filters( 'pll_languages_row_classes', array(), $item );
 		echo '<tr' . ( empty( $classes ) ? '>' : ' class="' . esc_attr( implode( ' ', $classes ) ) . '">' );
@@ -57,7 +57,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	 *
 	 * @since 0.1
 	 *
-	 * @param PLL_Language $item        The current item.
+	 * @param PLL_Language $item        The language item.
 	 * @param string       $column_name The column name.
 	 * @return string|int
 	 */
@@ -82,7 +82,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	 *
 	 * @since 0.1
 	 *
-	 * @param object $item
+	 * @param PLL_Language $item The language item.
 	 * @return string
 	 */
 	public function column_name( $item ) {
@@ -100,7 +100,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $item
+	 * @param PLL_Language $item The language item.
 	 * @return string
 	 */
 	public function column_default_lang( $item ) {
@@ -118,12 +118,12 @@ class PLL_Table_Languages extends WP_List_Table {
 			);
 
 			/**
-			 * Filter the default language row action in the languages list table
+			 * Filters the default language row action in the languages list table.
 			 *
 			 * @since 1.8
 			 *
-			 * @param string $s    html markup of the action
-			 * @param object $item
+			 * @param string       $s    The html markup of the action.
+			 * @param PLL_Language $item The language item.
 			 */
 			$s = apply_filters( 'pll_default_lang_row_action', $s, $item );
 		} else {
@@ -189,9 +189,9 @@ class PLL_Table_Languages extends WP_List_Table {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $item        The item being acted upon.
-	 * @param string $column_name Current column name.
-	 * @param string $primary     Primary column name.
+	 * @param PLL_Language $item        The language item being acted upon.
+	 * @param string       $column_name Current column name.
+	 * @param string       $primary     Primary column name.
 	 * @return string The row actions output.
 	 */
 	protected function handle_row_actions( $item, $column_name, $primary ) {
@@ -216,12 +216,12 @@ class PLL_Table_Languages extends WP_List_Table {
 		);
 
 		/**
-		 * Filter the list of row actions in the languages list table
+		 * Filters the list of row actions in the languages list table.
 		 *
 		 * @since 1.8
 		 *
-		 * @param array  $actions list of html markup actions
-		 * @param object $item
+		 * @param array        $actions A list of html markup actions.
+		 * @param PLL_Language $item    The language item.
 		 */
 		$actions = apply_filters( 'pll_languages_row_actions', $actions, $item );
 

--- a/settings/table-settings.php
+++ b/settings/table-settings.php
@@ -38,11 +38,11 @@ class PLL_Table_Settings extends WP_List_Table {
 	}
 
 	/**
-	 * Displays a single row
+	 * Displays a single row.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $item PLL_Settings_Module object
+	 * @param PLL_Settings_Module $item Settings module item.
 	 * @return void
 	 */
 	public function single_row( $item ) {
@@ -89,11 +89,11 @@ class PLL_Table_Settings extends WP_List_Table {
 	}
 
 	/**
-	 * Generates the columns for a single row of the table
+	 * Generates the columns for a single row of the table.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $item The current item
+	 * @param PLL_Settings_Module $item Settings module item.
 	 * @return void
 	 */
 	protected function single_row_columns( $item ) {
@@ -120,13 +120,13 @@ class PLL_Table_Settings extends WP_List_Table {
 	}
 
 	/**
-	 * Displays the item information in a column ( default case )
+	 * Displays the item information in a column (default case).
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $item
-	 * @param string $column_name
-	 * @return string
+	 * @param PLL_Settings_Module $item        Settings module item.
+	 * @param string              $column_name Column name.
+	 * @return string The column name.
 	 */
 	protected function column_default( $item, $column_name ) {
 		if ( 'plugin-title' == $column_name ) {
@@ -166,7 +166,7 @@ class PLL_Table_Settings extends WP_List_Table {
 	 *
 	 * @since 1.8
 	 *
-	 * @param array $items
+	 * @param PLL_Settings_Module[] $items Array of settings module items.
 	 * @return void
 	 */
 	public function prepare_items( $items = array() ) {


### PR DESCRIPTION
This PR improves the precision of the inline doc for objects. This fixes errors reported by PHPStan at level 7 (call to undefined methods and access to undefiend properties).

After this doc change I had to modify one line of code to convert a `WP_Term` to a `PLL_Language` to pass the current level of PHPStan tests. This is also included in this PR. See:  https://github.com/polylang/polylang/pull/727/files#diff-273f6e535c932726956ef771d69f9e76fdf21035b75a9f2b7b510aa055cce60fR165-R166. Everything else is only doc.