### PR TITLE
Fix property access errors reported by PHPStan

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -167,11 +167,16 @@ class PLL_Admin_Classic_Editor {
 		$lang      = $this->model->get_language( sanitize_key( $_POST['lang'] ) );
 		$post_type = sanitize_key( $_POST['post_type'] );
 
-		if ( ! post_type_exists( $post_type ) ) {
+		if ( empty( $lang ) || ! post_type_exists( $post_type ) ) {
 			wp_die( 0 );
 		}
 
 		$post_type_object = get_post_type_object( $post_type );
+
+		if ( empty( $post_type_object ) ) {
+			wp_die( 0 );
+		}
+
 		if ( ! current_user_can( $post_type_object->cap->edit_post, $post_ID ) ) {
 			wp_die( -1 );
 		}
@@ -184,12 +189,10 @@ class PLL_Admin_Classic_Editor {
 		$this->model->post->save_translations( $post_ID, $translations );
 
 		ob_start();
-		if ( $lang ) {
-			if ( 'attachment' === $post_type ) {
-				include __DIR__ . '/view-translations-media.php';
-			} else {
-				include __DIR__ . '/view-translations-post.php';
-			}
+		if ( 'attachment' === $post_type ) {
+			include __DIR__ . '/view-translations-media.php';
+		} else {
+			include __DIR__ . '/view-translations-post.php';
 		}
 		$x = new WP_Ajax_Response( array( 'what' => 'translations', 'data' => ob_get_contents() ) );
 		ob_end_clean();
@@ -201,30 +204,32 @@ class PLL_Admin_Classic_Editor {
 			foreach ( array_map( 'sanitize_key', $_POST['taxonomies'] ) as $taxname ) {
 				$taxonomy = get_taxonomy( $taxname );
 
-				ob_start();
-				$popular_ids = wp_popular_terms_checklist( $taxonomy->name );
-				$supplemental['populars'] = ob_get_contents();
-				ob_end_clean();
+				if ( ! empty( $taxonomy ) ) {
+					ob_start();
+					$popular_ids = wp_popular_terms_checklist( $taxonomy->name );
+					$supplemental['populars'] = ob_get_contents();
+					ob_end_clean();
 
-				ob_start();
-				// Use $post_ID to remember checked terms in case we come back to the original language
-				wp_terms_checklist( $post_ID, array( 'taxonomy' => $taxonomy->name, 'popular_cats' => $popular_ids ) );
-				$supplemental['all'] = ob_get_contents();
-				ob_end_clean();
+					ob_start();
+					// Use $post_ID to remember checked terms in case we come back to the original language
+					wp_terms_checklist( $post_ID, array( 'taxonomy' => $taxonomy->name, 'popular_cats' => $popular_ids ) );
+					$supplemental['all'] = ob_get_contents();
+					ob_end_clean();
 
-				$supplemental['dropdown'] = wp_dropdown_categories(
-					array(
-						'taxonomy'         => $taxonomy->name,
-						'hide_empty'       => 0,
-						'name'             => 'new' . $taxonomy->name . '_parent',
-						'orderby'          => 'name',
-						'hierarchical'     => 1,
-						'show_option_none' => '&mdash; ' . $taxonomy->labels->parent_item . ' &mdash;',
-						'echo'             => 0,
-					)
-				);
+					$supplemental['dropdown'] = wp_dropdown_categories(
+						array(
+							'taxonomy'         => $taxonomy->name,
+							'hide_empty'       => 0,
+							'name'             => 'new' . $taxonomy->name . '_parent',
+							'orderby'          => 'name',
+							'hierarchical'     => 1,
+							'show_option_none' => '&mdash; ' . $taxonomy->labels->parent_item . ' &mdash;',
+							'echo'             => 0,
+						)
+					);
 
-				$x->Add( array( 'what' => 'taxonomy', 'data' => $taxonomy->name, 'supplemental' => $supplemental ) );
+					$x->Add( array( 'what' => 'taxonomy', 'data' => $taxonomy->name, 'supplemental' => $supplemental ) );
+				}
 			}
 		}
 
@@ -232,21 +237,23 @@ class PLL_Admin_Classic_Editor {
 		if ( in_array( $post_type, get_post_types( array( 'hierarchical' => true ) ) ) ) {
 			$post = get_post( $post_ID );
 
-			// Args and filter from 'page_attributes_meta_box' in wp-admin/includes/meta-boxes.php of WP 4.2.1
-			$dropdown_args = array(
-				'post_type'        => $post->post_type,
-				'exclude_tree'     => $post->ID,
-				'selected'         => $post->post_parent,
-				'name'             => 'parent_id',
-				'show_option_none' => __( '(no parent)', 'polylang' ),
-				'sort_column'      => 'menu_order, post_title',
-				'echo'             => 0,
-			);
+			if ( ! empty( $post ) ) {
+				// Args and filter from 'page_attributes_meta_box' in wp-admin/includes/meta-boxes.php of WP 4.2.1
+				$dropdown_args = array(
+					'post_type'        => $post->post_type,
+					'exclude_tree'     => $post->ID,
+					'selected'         => $post->post_parent,
+					'name'             => 'parent_id',
+					'show_option_none' => __( '(no parent)', 'polylang' ),
+					'sort_column'      => 'menu_order, post_title',
+					'echo'             => 0,
+				);
 
-			/** This filter is documented in wp-admin/includes/meta-boxes.php */
-			$dropdown_args = apply_filters( 'page_attributes_dropdown_pages_args', $dropdown_args, $post ); // Since WP 3.3
+				/** This filter is documented in wp-admin/includes/meta-boxes.php */
+				$dropdown_args = apply_filters( 'page_attributes_dropdown_pages_args', $dropdown_args, $post ); // Since WP 3.3
 
-			$x->Add( array( 'what' => 'pages', 'data' => wp_dropdown_pages( $dropdown_args ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput
+				$x->Add( array( 'what' => 'pages', 'data' => wp_dropdown_pages( $dropdown_args ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput
+			}
 		}
 
 		// Flag
@@ -299,14 +306,17 @@ class PLL_Admin_Classic_Editor {
 		// Add current translation in list
 		if ( $post_id = $this->model->post->get_translation( (int) $_GET['pll_post_id'], $translation_language ) ) {
 			$post = get_post( $post_id );
-			array_unshift(
-				$return,
-				array(
-					'id'    => $post_id,
-					'value' => $post->post_title,
-					'link'  => $this->links->edit_post_translation_link( $post_id ),
-				)
-			);
+
+			if ( ! empty( $post ) ) {
+				array_unshift(
+					$return,
+					array(
+						'id'    => $post_id,
+						'value' => $post->post_title,
+						'link'  => $this->links->edit_post_translation_link( $post_id ),
+					)
+				);
+			}
 		}
 
 		wp_die( wp_json_encode( $return ) );

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -151,6 +151,10 @@ class PLL_Admin_Filters_Columns {
 
 		$language = $this->model->get_language( substr( $column, 9 ) );
 
+		if ( empty( $language ) ) {
+			return;
+		}
+
 		// Hidden field containing the post language for quick edit
 		if ( $column == $this->get_first_language_column() ) {
 			printf( '<div class="hidden" id="lang_%d">%s</div>', intval( $post_id ), esc_html( $lang->slug ) );
@@ -172,14 +176,19 @@ class PLL_Admin_Filters_Columns {
 					/* translators: accessibility text, %s is a native language name */
 					$s = sprintf( __( 'Edit the translation in %s', 'polylang' ), $language->name );
 				}
-				printf(
-					'<a class="%1$s" title="%2$s" href="%3$s"><span class="screen-reader-text">%4$s</span>%5$s</a>',
-					esc_attr( $class ),
-					esc_attr( get_post( $id )->post_title ),
-					esc_url( $link ),
-					esc_html( $s ),
-					$flag // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-				);
+
+				$post = get_post( $id );
+
+				if ( ! empty( $post ) ) {
+					printf(
+						'<a class="%1$s" title="%2$s" href="%3$s"><span class="screen-reader-text">%4$s</span>%5$s</a>',
+						esc_attr( $class ),
+						esc_attr( $post->post_title ),
+						esc_url( $link ),
+						esc_html( $s ),
+						$flag // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+					);
+				}
 			} elseif ( $id === $post_id ) {
 				printf(
 					'<span class="pll_column_flag" style=""><span class="screen-reader-text">%1$s</span>%2$s</span>',
@@ -279,6 +288,10 @@ class PLL_Admin_Filters_Columns {
 
 		$term_id = (int) $term_id;
 		$language = $this->model->get_language( substr( $column, 9 ) );
+
+		if ( empty( $language ) ) {
+			return $out;
+		}
 
 		if ( $column == $this->get_first_language_column() ) {
 			$out = sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -54,6 +54,10 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	public function admin_enqueue_scripts() {
 		$screen = get_current_screen();
 
+		if ( empty( $screen ) ) {
+			return;
+		}
+
 		// Hierarchical taxonomies
 		if ( 'edit' == $screen->base && $taxonomies = get_object_taxonomies( $screen->post_type, 'object' ) ) {
 			// Get translated hierarchical taxonomies
@@ -128,7 +132,16 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			check_admin_referer( 'pll_language', '_pll_nonce' );
 
 			$post = get_post( $post_id );
+
+			if ( empty( $post ) ) {
+				return;
+			}
+
 			$post_type_object = get_post_type_object( $post->post_type );
+
+			if ( empty( $post_type_object ) ) {
+				return;
+			}
 
 			if ( current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
 				$this->model->post->set_language( $post_id, $this->model->get_language( sanitize_key( $_POST['post_lang_choice'] ) ) );
@@ -152,7 +165,16 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	 */
 	protected function inline_save_language( $post_id, $lang ) {
 		$post = get_post( $post_id );
+
+		if ( empty( $post ) ) {
+			return;
+		}
+
 		$post_type_object = get_post_type_object( $post->post_type );
+
+		if ( empty( $post_type_object ) ) {
+			return;
+		}
 
 		if ( current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
 			$old_lang = $this->model->post->get_language( $post_id ); // Stores the old  language

--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -69,7 +69,7 @@ class PLL_Admin_Links extends PLL_Links {
 	public function get_new_post_translation_link( $post_id, $language, $context = 'display' ) {
 		$post_type = get_post_type( $post_id );
 		$post_type_object = get_post_type_object( get_post_type( $post_id ) );
-		if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
+		if ( empty( $post_type_object ) || ! current_user_can( $post_type_object->cap->create_posts ) ) {
 			return '';
 		}
 

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -140,7 +140,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Delete the string translations
 		$post = wpcom_vip_get_page_by_title( 'polylang_mo_' . $lang->term_id, OBJECT, 'polylang_mo' );
-		if ( ! empty( $post ) ) {
+		if ( $post instanceof WP_Post ) {
 			wp_delete_post( $post->ID );
 		}
 
@@ -317,10 +317,15 @@ class PLL_Admin_Model extends PLL_Model {
 	public function set_language_in_mass( $type, $ids, $lang ) {
 		global $wpdb;
 
-		$ids    = array_map( 'intval', $ids );
-		$lang   = $this->get_language( $lang );
+		$lang = $this->get_language( $lang );
+
+		if ( empty( $lang ) ) {
+			return;
+		}
+
 		$tt_id  = 'term' === $type ? $lang->tl_term_taxonomy_id : $lang->term_taxonomy_id;
 		$values = array();
+		$ids    = array_map( 'intval', $ids );
 
 		foreach ( $ids as $id ) {
 			$values[] = $wpdb->prepare( '( %d, %d )', $id, $tt_id );

--- a/admin/admin-nav-menu.php
+++ b/admin/admin-nav-menu.php
@@ -96,7 +96,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 	 */
 	public function admin_enqueue_scripts() {
 		$screen = get_current_screen();
-		if ( 'nav-menus' != $screen->base ) {
+		if ( empty( $screen ) || 'nav-menus' !== $screen->base ) {
 			return;
 		}
 

--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -102,6 +102,11 @@ class PLL_Admin_Notices {
 	 */
 	protected function can_display_notice( $notice ) {
 		$screen = get_current_screen();
+
+		if ( empty( $screen ) ) {
+			return false;
+		}
+
 		$screen_id = sanitize_title( __( 'Languages', 'polylang' ) );
 
 		/**

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -149,7 +149,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	public function notice_must_translate() {
 		$screen = get_current_screen();
 
-		if ( 'toplevel_page_mlang' === $screen->id || 'edit-page' === $screen->id ) {
+		if ( ! empty( $screen ) && ( 'toplevel_page_mlang' === $screen->id || 'edit-page' === $screen->id ) ) {
 			$message = $this->get_must_translate_message();
 
 			if ( ! empty( $message ) ) {

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -67,7 +67,8 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 
 		else {
 			foreach ( $this->model->get_translated_taxonomies() as $taxonomy ) {
-				if ( $var = get_query_var( get_taxonomy( $taxonomy )->query_var ) ) {
+				$tax_object = get_taxonomy( $taxonomy );
+				if ( ! empty( $tax_object ) && $var = get_query_var( $tax_object->query_var ) ) {
 					$lang = $this->model->term->get_language( $var, $taxonomy );
 				}
 			}

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -144,7 +144,7 @@ class PLL_Frontend_Auto_Translate {
 		foreach ( array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( array( '_builtin' => false ) ) ) as $taxonomy ) {
 			$tax = get_taxonomy( $taxonomy );
 			$arr = array();
-			if ( ! empty( $qv[ $tax->query_var ] ) ) {
+			if ( ! empty( $tax ) && ! empty( $qv[ $tax->query_var ] ) ) {
 				$sep = strpos( $qv[ $tax->query_var ], ',' ) !== false ? ',' : '+'; // Two possible separators
 				foreach ( explode( $sep, $qv[ $tax->query_var ] ) as $slug ) {
 					$arr[] = $this->get_translated_term_by( 'slug', $slug, $taxonomy );

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -387,7 +387,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		if ( is_single() || is_page() ) {
 			$post = get_post();
-			if ( $this->model->is_translated_post_type( $post->post_type ) ) {
+			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
 				$language = $this->model->post->get_language( (int) $post->ID );
 			}
 		}
@@ -424,7 +424,9 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		elseif ( $this->wp_query()->is_posts_page ) {
 			$obj = get_queried_object();
-			$language = $this->model->post->get_language( (int) $obj->ID );
+			if ( $obj instanceof WP_Post ) {
+				$language = $this->model->post->get_language( (int) $obj->ID );
+			}
 		}
 
 		if ( 3 === $this->options['force_lang'] ) {

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -281,6 +281,10 @@ class PLL_CRUD_Posts {
 
 		$lang = $this->model->get_language( $lang ); // Make sure we get a valid language slug.
 
+		if ( empty( $lang ) ) {
+			return 0;
+		}
+
 		// Create a new attachment ( translate attachment parent if exists ).
 		add_filter( 'pll_enable_duplicate_media', '__return_false', 99 ); // Avoid a conflict with automatic duplicate at upload.
 		unset( $post['ID'] ); // Will force the creation.

--- a/include/filters.php
+++ b/include/filters.php
@@ -245,7 +245,7 @@ class PLL_Filters {
 	 * @param WP_Post $post           WP_Post object.
 	 * @return string Modified JOIN clause.
 	 */
-	public function posts_join( $sql, $in_same_term, $excluded_terms, $taxonomy = '', $post = null ) {
+	public function posts_join( $sql, $in_same_term, $excluded_terms, $taxonomy, $post ) {
 		return $this->model->is_translated_post_type( $post->post_type ) && ! empty( $this->curlang ) ? $sql . $this->model->post->join_clause( 'p' ) : $sql;
 	}
 
@@ -261,7 +261,7 @@ class PLL_Filters {
 	 * @param WP_Post $post           WP_Post object.
 	 * @return string Modified WHERE clause.
 	 */
-	public function posts_where( $sql, $in_same_term, $excluded_terms, $taxonomy = '', $post = null ) {
+	public function posts_where( $sql, $in_same_term, $excluded_terms, $taxonomy, $post ) {
 		return $this->model->is_translated_post_type( $post->post_type ) && ! empty( $this->curlang ) ? $sql . $this->model->post->where_clause( $this->curlang ) : $sql;
 	}
 

--- a/include/language.php
+++ b/include/language.php
@@ -195,7 +195,7 @@ class PLL_Language {
 		}
 
 		// Build the object from taxonomy terms.
-		else {
+		elseif ( ! empty( $term_language ) ) {
 			$this->term_id = (int) $language->term_id;
 			$this->name = $language->name;
 			$this->slug = $language->slug;

--- a/include/model.php
+++ b/include/model.php
@@ -391,7 +391,9 @@ class PLL_Model {
 		$query_vars = array();
 		foreach ( $this->get_filtered_taxonomies() as $filtered_tax ) {
 			$tax = get_taxonomy( $filtered_tax );
-			$query_vars[] = $tax->query_var;
+			if ( ! empty( $tax ) ) {
+				$query_vars[] = $tax->query_var;
+			}
 		}
 		return $query_vars;
 	}

--- a/include/query.php
+++ b/include/query.php
@@ -123,8 +123,8 @@ class PLL_Query {
 			$taxonomies = array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( array( '_builtin' => false ) ) );
 
 			foreach ( $taxonomies as $tax ) {
-				$tax = get_taxonomy( $tax );
-				if ( ! empty( $qvars[ $tax->query_var ] ) ) {
+				$tax_object = get_taxonomy( $tax );
+				if ( ! empty( $tax_object ) && ! empty( $qvars[ $tax_object->query_var ] ) ) {
 					return;
 				}
 			}
@@ -140,7 +140,7 @@ class PLL_Query {
 				if ( $taxonomies && ( empty( $qvars['post_type'] ) || 'any' === $qvars['post_type'] ) ) {
 					foreach ( $taxonomies as $taxonomy ) {
 						$tax_object = get_taxonomy( $taxonomy );
-						if ( $this->model->is_translated_post_type( $tax_object->object_type ) ) {
+						if ( ! empty( $tax_object ) && $this->model->is_translated_post_type( $tax_object->object_type ) ) {
 							$this->set_language( $lang );
 							break;
 						}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -296,12 +296,12 @@ abstract class PLL_Translated_Object {
 	 */
 	public function get( $id, $lang ) {
 		$id = (int) $id;
+		$lang = $this->model->get_language( $lang );
 		$obj_lang = $this->get_language( $id );
-		if ( ! $lang || ! $obj_lang ) {
+		if ( empty( $lang ) || empty( $obj_lang ) ) {
 			return false;
 		}
 
-		$lang = $this->model->get_language( $lang );
 		return $obj_lang->term_id == $lang->term_id ? $id : $this->get_translation( $id, $lang );
 	}
 

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -49,7 +49,9 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	public function set_language( $post_id, $lang ) {
 		$old_lang = $this->get_language( $post_id );
 		$old_lang = $old_lang ? $old_lang->slug : '';
-		$lang = $lang ? $this->model->get_language( $lang )->slug : '';
+
+		$lang = $this->model->get_language( $lang );
+		$lang = $lang ? $lang->slug : '';
 
 		if ( $old_lang !== $lang ) {
 			wp_set_post_terms( (int) $post_id, $lang, 'language' );
@@ -175,6 +177,10 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 
 		if ( 'inherit' === $post->post_status && $post->post_parent ) {
 			$post = get_post( $post->post_parent );
+
+			if ( empty( $post ) ) {
+				return false;
+			}
 		}
 
 		if ( 'inherit' === $post->post_status || in_array( $post->post_status, get_post_stati( array( 'public' => true ) ) ) ) {
@@ -252,7 +258,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 		$posts = get_posts( $args );
 
 		foreach ( $posts as $post ) {
-			if ( ! $this->get_translation( $post->ID, $untranslated_in ) && $this->current_user_can_read( $post->ID, 'edit' ) ) {
+			if ( $post instanceof WP_Post && ! $this->get_translation( $post->ID, $untranslated_in ) && $this->current_user_can_read( $post->ID, 'edit' ) ) {
 				$return[] = $post;
 			}
 		}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -47,7 +47,9 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 
 		$old_lang = $this->get_language( $term_id );
 		$old_lang = $old_lang ? $old_lang->tl_term_id : '';
-		$lang = $lang ? $this->model->get_language( $lang )->tl_term_id : '';
+
+		$lang = $this->model->get_language( $lang );
+		$lang = $lang ? $lang->tl_term_id : '';
 
 		if ( $old_lang !== $lang ) {
 			wp_set_object_terms( $term_id, $lang, 'term_language' );
@@ -90,7 +92,10 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 
 		// get_term_by still not cached in WP 3.5.1 but internally, the function is always called by term_id
 		elseif ( is_string( $value ) && $taxonomy ) {
-			$term_id = get_term_by( 'slug', $value, $taxonomy )->term_id;
+			$term = get_term_by( 'slug', $value, $taxonomy );
+			if ( $term instanceof WP_Term ) {
+				$term_id = $term->term_id;
+			}
 		}
 
 		// Get the language and make sure it is a PLL_Language object

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -187,9 +187,12 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$pattern = '#(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')$#';
 		if ( preg_match( $pattern, $name, $matches ) ) {
 			$lang = $this->model->get_language( $matches[1] );
-			$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
-			$url = $this->provider->get_sitemap_url( $name, $page );
-			return $this->links_model->add_language_to_link( $url, $lang );
+
+			if ( ! empty( $lang ) ) {
+				$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
+				$url = $this->provider->get_sitemap_url( $name, $page );
+				return $this->links_model->add_language_to_link( $url, $lang );
+			}
 		}
 
 		// If no language is present in $name, we may attempt to get the current sitemap url (e.g. in redirect_canonical() ).

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -62,14 +62,16 @@ class PLL_Admin_Sync extends PLL_Sync {
 			$from_post_id = (int) $_GET['from_post'];
 			$from_post    = get_post( $from_post_id );
 
-			foreach ( array( 'menu_order', 'comment_status', 'ping_status' ) as $property ) {
-				$data[ $property ] = $from_post->$property;
-			}
+			if ( $from_post instanceof WP_Post ) {
+				foreach ( array( 'menu_order', 'comment_status', 'ping_status' ) as $property ) {
+					$data[ $property ] = $from_post->$property;
+				}
 
-			// Copy the date only if the synchronization is activated
-			if ( in_array( 'post_date', $this->options['sync'] ) ) {
-				$data['post_date']     = $from_post->post_date;
-				$data['post_date_gmt'] = $from_post->post_date_gmt;
+				// Copy the date only if the synchronization is activated
+				if ( in_array( 'post_date', $this->options['sync'] ) ) {
+					$data['post_date']     = $from_post->post_date;
+					$data['post_date_gmt'] = $from_post->post_date_gmt;
+				}
 			}
 		}
 
@@ -130,14 +132,17 @@ class PLL_Admin_Sync extends PLL_Sync {
 			unset( $postarr['post_date_gmt'] );
 
 			$original = get_post( (int) $_GET['from_post'] );
-			$wpdb->update(
-				$wpdb->posts,
-				array(
-					'post_date'     => $original->post_date,
-					'post_date_gmt' => $original->post_date_gmt,
-				),
-				array( 'ID' => $post->ID )
-			);
+
+			if ( $original instanceof WP_Post ) {
+				$wpdb->update(
+					$wpdb->posts,
+					array(
+						'post_date'     => $original->post_date,
+						'post_date_gmt' => $original->post_date_gmt,
+					),
+					array( 'ID' => $post->ID )
+				);
+			}
 		}
 
 		if ( isset( $GLOBALS['post_type'] ) ) {

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -168,7 +168,7 @@ class PLL_Sync_Tax {
 		$taxonomy_object = get_taxonomy( $taxonomy );
 
 		// Make sure that the taxonomy is registered for a post type
-		if ( ! $avoid_recursion && array_filter( $taxonomy_object->object_type, 'post_type_exists' ) ) {
+		if ( ! $avoid_recursion && ! empty( $taxonomy_object ) && array_filter( $taxonomy_object->object_type, 'post_type_exists' ) ) {
 			$avoid_recursion = true;
 
 			$tr_ids = $this->model->post->get_translations( $object_id );

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -203,18 +203,25 @@ class PLL_Sync {
 
 		if ( is_taxonomy_hierarchical( $taxonomy ) && $this->model->is_translated_taxonomy( $taxonomy ) ) {
 			$term = get_term( $term_id );
-			$translations = $this->model->term->get_translations( $term_id );
 
-			foreach ( $translations as $lang => $tr_id ) {
-				if ( ! empty( $tr_id ) && $tr_id !== $term_id ) {
-					$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
-					$wpdb->update(
-						$wpdb->term_taxonomy,
-						array( 'parent' => $tr_parent ? $tr_parent : 0 ),
-						array( 'term_taxonomy_id' => get_term( (int) $tr_id, $taxonomy )->term_taxonomy_id )
-					);
+			if ( $term instanceof WP_Term ) {
+				$translations = $this->model->term->get_translations( $term_id );
 
-					clean_term_cache( $tr_id, $taxonomy ); // OK since WP 3.9
+				foreach ( $translations as $lang => $tr_id ) {
+					if ( ! empty( $tr_id ) && $tr_id !== $term_id ) {
+						$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
+						$tr_term   = get_term( (int) $tr_id, $taxonomy );
+
+						if ( $tr_term instanceof WP_Term ) {
+							$wpdb->update(
+								$wpdb->term_taxonomy,
+								array( 'parent' => $tr_parent ? $tr_parent : 0 ),
+								array( 'term_taxonomy_id' => $tr_term->term_taxonomy_id )
+							);
+
+							clean_term_cache( $tr_id, $taxonomy ); // OK since WP 3.9.
+						}
+					}
 				}
 			}
 		}

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -238,7 +238,7 @@ class PLL_Wizard {
 	public function can_display_notice( $can_display_notice, $notice ) {
 		if ( ! $can_display_notice && 'wizard' === $notice ) {
 			$screen = get_current_screen();
-			$can_display_notice = in_array(
+			$can_display_notice = ! empty( $screen ) && in_array(
 				$screen->base,
 				array(
 					'edit',

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -226,8 +226,11 @@ class PLL_WPML_API {
 		$type = $args['element_type'];
 		$id = $args['element_id'];
 		$pll_type = ( 'post' == $type || pll_is_translated_post_type( $type ) ) ? 'post' : ( 'term' == $type || pll_is_translated_taxonomy( $type ) ? 'term' : false );
-		if ( 'term' === $pll_type && $term = get_term_by( 'term_taxonomy_id', $id ) ) {
-			$id = $term->term_id;
+		if ( 'term' === $pll_type ) {
+			$term = get_term_by( 'term_taxonomy_id', $id );
+			if ( $term instanceof WP_Term ) {
+				$id = $term->term_id;
+			}
 		}
 		return $pll_type ? call_user_func( "pll_get_{$pll_type}_language", $id ) : $language_code;
 	}

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -128,7 +128,7 @@ if ( ! function_exists( 'icl_link_to_element' ) ) {
 			}
 		} elseif ( taxonomy_exists( $type ) ) {
 			$link = get_term_link( $id, $type );
-			if ( empty( $text ) && ( $term = get_term( $id, $type ) ) && ! empty( $term ) && ! is_wp_error( $term ) ) {
+			if ( empty( $text ) && ( $term = get_term( $id, $type ) ) && $term instanceof WP_Term ) {
 				$text = $term->name;
 			}
 		}


### PR DESCRIPTION
Often our code doesn't check for errors. For example, when we can write:
```php
$term = get_term( $term_id );
$slug = $term->slug
```
So we suppose that we got a term, which is true in most cases, but may be wrong.

This PR adds several tests to protect our code from fatals when something went wrong.
Errors reported by PHPStan at level 7.
