### PR TITLE
Don't filter a WP_Query if it already includes a language tax query

### DIFF
--- a/include/query.php
+++ b/include/query.php
@@ -33,6 +33,30 @@ class PLL_Query {
 	}
 
 	/**
+	 * Checks if the query already includes a language taxonomy.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $qvars WP_Query query vars.
+	 * @return bool
+	 */
+	protected function is_already_filtered( $qvars ) {
+		if ( isset( $qvars['lang'] ) ) {
+			return true;
+		}
+
+		if ( ! empty( $qvars['tax_query'] ) && is_array( $qvars['tax_query'] ) ) {
+			foreach ( $qvars['tax_query'] as $tax_query ) {
+				if ( isset( $tax_query['taxonomy'] ) && 'language' === $tax_query['taxonomy'] ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check if translated taxonomy is queried
 	 * Compatible with nested queries introduced in WP 4.1
 	 *
@@ -119,7 +143,7 @@ class PLL_Query {
 	public function filter_query( $lang ) {
 		$qvars = &$this->query->query_vars;
 
-		if ( ! isset( $qvars['lang'] ) ) {
+		if ( ! $this->is_already_filtered( $qvars ) ) {
 			$taxonomies = array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( array( '_builtin' => false ) ) );
 
 			foreach ( $taxonomies as $tax ) {

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -102,6 +102,20 @@ class Filters_Test extends PLL_UnitTestCase {
 
 		$posts = get_posts( array( 'fields' => 'ids', 'lang' => array( 'fr', 'de' ) ) );
 		$this->assertCount( 4, $posts );
+
+		$args = array(
+			'fields'   => 'ids',
+			'tax_query'   => array(
+				array(
+					'taxonomy' => 'language',
+					'terms'    => self::$polylang->model->get_language( 'en' )->term_id,
+				),
+			),
+		);
+		$posts = get_posts( $args );
+		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $posts ), 'slug' );
+		$this->assertCount( 3, $posts );
+		$this->assertEquals( array( 'en' ), array_values( array_unique( $languages ) ) );
 	}
 
 	function test_sticky_posts() {

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -108,12 +108,12 @@ class Filters_Test extends PLL_UnitTestCase {
 			'tax_query'   => array(
 				array(
 					'taxonomy' => 'language',
-					'terms'    => self::$polylang->model->get_language( 'en' )->term_id,
+					'terms'    => self::$model->get_language( 'en' )->term_id,
 				),
 			),
 		);
 		$posts = get_posts( $args );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $posts ), 'slug' );
+		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $posts ), 'slug' );
 		$this->assertCount( 3, $posts );
 		$this->assertEquals( array( 'en' ), array_values( array_unique( $languages ) ) );
 	}


### PR DESCRIPTION
`PLL_Query` does not filter `WP_Query` if it includes the `lang` query var.
It should also not filter it if includes a `tax_query` with the `language` taxonomy. 

Fix https://github.com/polylang/polylang-pro/issues/842