### PR TITLE
Fix wrong action url in search forms

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -49,13 +49,14 @@ class PLL_Frontend_Filters_Search {
 	}
 
 	/**
-	 * Adds the language information in the search form
+	 * Adds the language information in the search form.
+	 *
 	 * Does not work if searchform.php ( prior to WP 3.6 ) is used or if the search form is hardcoded in another template file
 	 *
 	 * @since 0.1
 	 *
-	 * @param string $form Search form
-	 * @return string Modified search form
+	 * @param string $form The search form HTML.
+	 * @return string Modified search form.
 	 */
 	public function get_search_form( $form ) {
 		if ( $form ) {
@@ -63,10 +64,9 @@ class PLL_Frontend_Filters_Search {
 				// Take care to modify only the url in the <form> tag.
 				preg_match( '#<form.+>#', $form, $matches );
 				$old = reset( $matches );
-				$new = preg_replace( '#' . esc_url( $this->links_model->home ) . '\/?#', esc_url( $this->curlang->search_url ), $old );
+				$new = preg_replace( '#action="(.+)"#', 'action="' . esc_url( $this->curlang->search_url ) . '"', $old );
 				$form = str_replace( $old, $new, $form );
-			}
-			else {
+			} else {
 				$form = str_replace( '</form>', '<input type="hidden" name="lang" value="' . esc_attr( $this->curlang->slug ) . '" /></form>', $form );
 			}
 		}

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -60,12 +60,28 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
 		$form = get_search_form( false ); // don't echo
 
-		$this->assertContains( home_url( '/fr/' ), $form );
+		$this->assertContains( 'action="' . home_url( '/fr/' ) . '"', $form );
 
 		$wp_rewrite->set_permalink_structure( '' );
 		self::$polylang->links_model = self::$polylang->model->get_links_model();
 
 		$form = get_search_form( false );
 		$this->assertContains( '<input type="hidden" name="lang" value="fr" />', $form );
+	}
+
+	/**
+	 * Issue #829
+	 */
+	function test_get_search_form_with_wrong_inital_url() {
+		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$form = '<form role="search" method="get" class="search-form" action="http://example.org/fr/accueil/">
+				<label>
+					<span class="screen-reader-text">Search for:</span>
+					<input type="search" class="search-field" placeholder="Search &hellip;" value="test" name="s" />
+				</label>
+				<input type="submit" class="search-submit" value="Search" />
+			</form>';
+		$form = apply_filters( 'get_search_form', $form );
+		$this->assertContains( 'action="' . home_url( '/fr/' ) . '"', $form );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/829

The `PLL_Frontend_Filters_Search::get_search_form()` method used to replace the home url without language code by the search url in the current language, for example  `https://mysite.com`, replaced by  `https://mysite.com/fr/`.

If the filter `get_search_form` is applied directly by a theme, the url is already filtered by `PLL_Frontend_Filters_Links::home_url()`. Thus the search form passed to `PLL_Frontend_Filters_Search::get_search_form()` may contain a url looking like  `https://mysite.com/fr/accueil/` which was transformed to the wrong url  `https://mysite.com/fr/fr/accueil`.

This PR replaces any url in the action attribute instead of looking for the home url.