### PR TITLE
Use two classes for switcher

### DIFF
--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -115,7 +115,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 				/** This filter is documented in include/switcher.php */
 				$options = apply_filters( 'pll_the_languages_args', $options ); // Honor the filter here for 'show_flags', 'show_names' and 'dropdown'.
 
-				$switcher = PLL_Switcher::create( $this->polylang );
+				$switcher = new PLL_Frontend_Switcher();
 				$args = array_merge( array( 'raw' => 1 ), $options );
 
 				/** @var array */

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -17,6 +17,13 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	public $curlang;
 
 	/**
+	 * Reference to the Polylang object.
+	 *
+	 * @var object
+	 */
+	protected $polylang;
+
+	/**
 	 * Constructor
 	 *
 	 * @since 1.2
@@ -26,6 +33,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	public function __construct( &$polylang ) {
 		parent::__construct( $polylang );
 
+		$this->polylang = &$polylang;
 		$this->curlang = &$polylang->curlang;
 
 		// Split the language switcher menu item in several language menu items
@@ -107,7 +115,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 				/** This filter is documented in include/switcher.php */
 				$options = apply_filters( 'pll_the_languages_args', $options ); // Honor the filter here for 'show_flags', 'show_names' and 'dropdown'.
 
-				$switcher = new PLL_Switcher();
+				$switcher = PLL_Switcher::create( $this->polylang );
 				$args = array_merge( array( 'raw' => 1 ), $options );
 
 				/** @var array */

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -17,13 +17,6 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	public $curlang;
 
 	/**
-	 * Reference to the Polylang object.
-	 *
-	 * @var object
-	 */
-	protected $polylang;
-
-	/**
 	 * Constructor
 	 *
 	 * @since 1.2
@@ -33,7 +26,6 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	public function __construct( &$polylang ) {
 		parent::__construct( $polylang );
 
-		$this->polylang = &$polylang;
 		$this->curlang = &$polylang->curlang;
 
 		// Split the language switcher menu item in several language menu items

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -30,21 +30,7 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
 	public function the_languages( $links, $args = array() ) {
-		$defaults = $this->get_default_the_languages();
-
-		$args = $this->filter_arguments_pll_languages( $args, $defaults );
-
-		$args['hide_if_empty'] = 0;
-		// Force not to hide the language for the block preview even if the option is checked.
-		$args['hide_if_no_translation'] = 0;
-
-		$elements = $this->get_elements( $links, $args );
-
-		if ( $args['raw'] ) {
-			return $elements;
-		}
-
-		list( $out, $args ) = $this->prepare_pll_walker( $this->get_current_language( $links ), $args, $elements );
+		list( $out, $args ) = $this->get_the_languages( $links, $args );
 
 		if ( $args['echo'] ) {
 			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput
@@ -53,32 +39,12 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 		return $out;
 	}
 
-	private function manage_url( $classes, $args, $links, $language, $url ) {
-		if ( null !== $args['post_id'] && ( $tr_id = $links->model->post->get( $args['post_id'], $language ) ) && $links->model->post->current_user_can_read( $tr_id ) ) {
-			$url = get_permalink( $tr_id );
-		}
+	public function manage_url( $classes, $args, $links, $language, $url ) {
+		$no_translation = false;
+		$classes[] = 'no-translation';
 
-		if ( $no_translation = empty( $url ) ) {
-			$classes[] = 'no-translation';
-		}
-
-		/**
-		 * Filter the link in the language switcher
-		 *
-		 * @since 0.7
-		 *
-		 * @param string $url    the link
-		 * @param string $slug   language code
-		 * @param string $locale language locale
-		 */
-		$url = apply_filters( 'pll_the_language_link', $url, $language->slug, $language->locale );
-
-		// Hide if no translation exists
-		if ( empty( $url ) && $args['hide_if_no_translation'] ) {
-			return false;
-		}
-
-		$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
+		// If the page is not translated, link to the home page
+		$url = $links->get_home_url( $language );
 
 		return array( $url, $no_translation, $classes );
 	}
@@ -88,8 +54,17 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	 *
 	 * @return mixed
 	 */
-	protected function get_current_language( $links ) {
+	public function get_current_language( $links ) {
 		return $links->options['default_lang'];
 	}
 
+	/**
+	 * @param $links
+	 * @param $args
+	 *
+	 * @return mixed
+	 */
+	public function get_languages_list( $links, $args ) {
+		return $links->model->get_languages_list();
+	}
 }

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -19,7 +19,7 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
 
-			$curlang = $this->polylang->options['default_lang'];
+			$curlang = $links->options['default_lang'];
 
 			$current_lang = $curlang == $slug;
 
@@ -76,7 +76,7 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 			return $elements;
 		}
 
-		list( $out, $args ) = $this->prepare_pll_walker( $this->polylang->options['default_lang']], $args, $elements );
+		list( $out, $args ) = $this->prepare_pll_walker( $links->options['default_lang'], $args, $elements );
 
 		if ( $args['echo'] ) {
 			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -75,14 +75,4 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	public function get_current_language( $links ) {
 		return $links->options['default_lang'];
 	}
-
-	/**
-	 * @param PLL_Frontend_Links $links
-	 * @param array              $args
-	 *
-	 * @return mixed
-	 */
-	public function get_languages_list( $links, $args ) {
-		return $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) );
-	}
 }

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -16,23 +16,19 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	 *
 	 * @since 0.1
 	 *
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
-	 * @param array              $args {
+	 * @param PLL_Links $links
+	 * @param array     $args {
 	 *   Optional array of arguments.
 	 *
 	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.
 	 *   @type int    $echo                   Echoes the list if set to 1, defaults to 1.
-	 *   @type int    $hide_if_empty          Hides languages with no posts ( or pages ) if set to 1, defaults to 1.
 	 *   @type int    $show_flags             Displays flags if set to 1, defaults to 0.
 	 *   @type int    $show_names             Shows language names if set to 1, defaults to 1.
 	 *   @type string $display_names_as       Whether to display the language name or its slug, valid options are 'slug' and 'name', defaults to name.
-	 *   @type int    $force_home             Will always link to home in translated language if set to 1, defaults to 0.
-	 *   @type int    $hide_if_no_translation Hides the link if there is no translation if set to 1, defaults to 0.
 	 *   @type int    $hide_current           Hides the current language if set to 1, defaults to 0.
 	 *   @type int    $post_id                Returns links to the translations of the post defined by post_id if set, defaults not set.
 	 *   @type int    $raw                    Return a raw array instead of html markup if set to 1, defaults to 0.
 	 *   @type string $item_spacing           Whether to preserve or discard whitespace between list items, valid options are 'preserve' and 'discard', defaults to 'preserve'.
-	 *   @type string $admin_current_lang     The current language code in an admin context. Need to set the admin_render to 1, defaults not set.
 	 * }
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
@@ -49,28 +45,27 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	}
 
 	/**
-	 * @param array              $classes
-	 * @param array              $args
-	 * @param PLL_Frontend_Links $links
-	 * @param PLL_Language       $language
-	 * @param string             $url
+	 * @param string[]     $classes CSS classes, without the leading '.'.
+	 * @param array        $args {@see PLL_Admin_Switcher::the_languages()}.
+	 * @param PLL_Links    $links
+	 * @param PLL_Language $language
+	 * @param string       $url
 	 *
-	 * @return array|mixed
+	 * @return array
 	 */
 	public function manage_url( $classes, $args, $links, $language, $url ) {
 		$no_translation = false;
 		$classes[] = 'no-translation';
 
-		// If the page is not translated, link to the home page
 		$url = $links->get_home_url( $language );
 
 		return array( $url, $no_translation, $classes );
 	}
 
 	/**
-	 * @param PLL_Frontend_Links $links
+	 * @param PLL_Links $links
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function get_current_language( $links ) {
 		return $links->options['default_lang'];

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -19,7 +19,7 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
 
-			$curlang = $args['admin_current_lang'];
+			$curlang = $this->polylang->options['default_lang'];
 
 			$current_lang = $curlang == $slug;
 
@@ -66,13 +66,17 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 
 		$args = $this->filter_arguments_pll_languages( $args, $defaults );
 
+		$args['hide_if_empty'] = 0;
+		// Force not to hide the language for the block preview even if the option is checked.
+		$args['hide_if_no_translation'] = 0;
+
 		$elements = $this->get_elements( $links, $args );
 
 		if ( $args['raw'] ) {
 			return $elements;
 		}
 
-		list( $out, $args ) = $this->prepare_pll_walker( $args['admin_current_lang'], $args, $elements );
+		list( $out, $args ) = $this->prepare_pll_walker( $this->polylang->options['default_lang']], $args, $elements );
 
 		if ( $args['echo'] ) {
 			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -1,0 +1,84 @@
+<?php
+
+
+class PLL_Admin_Switcher extends PLL_Switcher {
+
+	/**
+	 * Get the language elements for use in a walker
+	 *
+	 * @since 1.2
+	 *
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @return array Language switcher elements.
+	 */
+	protected function get_elements( $links, $args ) {
+		$first = true;
+		$out   = array();
+
+		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
+			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
+
+			$curlang = $args['admin_current_lang'];
+
+			$current_lang = $curlang == $slug;
+
+			if ( $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first ) ) {
+				list( $classes, $name, $flag, $first ) = $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first );
+			} else {
+				continue;
+			}
+
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'classes' );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Displays a language switcher
+	 * or returns the raw elements to build a custom language switcher.
+	 *
+	 * @since 0.1
+	 *
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args {
+	 *   Optional array of arguments.
+	 *
+	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.
+	 *   @type int    $echo                   Echoes the list if set to 1, defaults to 1.
+	 *   @type int    $hide_if_empty          Hides languages with no posts ( or pages ) if set to 1, defaults to 1.
+	 *   @type int    $show_flags             Displays flags if set to 1, defaults to 0.
+	 *   @type int    $show_names             Shows language names if set to 1, defaults to 1.
+	 *   @type string $display_names_as       Whether to display the language name or its slug, valid options are 'slug' and 'name', defaults to name.
+	 *   @type int    $force_home             Will always link to home in translated language if set to 1, defaults to 0.
+	 *   @type int    $hide_if_no_translation Hides the link if there is no translation if set to 1, defaults to 0.
+	 *   @type int    $hide_current           Hides the current language if set to 1, defaults to 0.
+	 *   @type int    $post_id                Returns links to the translations of the post defined by post_id if set, defaults not set.
+	 *   @type int    $raw                    Return a raw array instead of html markup if set to 1, defaults to 0.
+	 *   @type string $item_spacing           Whether to preserve or discard whitespace between list items, valid options are 'preserve' and 'discard', defaults to 'preserve'.
+	 *   @type string $admin_current_lang     The current language code in an admin context. Need to set the admin_render to 1, defaults not set.
+	 * }
+	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
+	 */
+	public function the_languages( $links, $args = array() ) {
+		$defaults = $this->get_default_the_languages();
+
+		$args = $this->filter_arguments_pll_languages( $args, $defaults );
+
+		$elements = $this->get_elements( $links, $args );
+
+		if ( $args['raw'] ) {
+			return $elements;
+		}
+
+		list( $out, $args ) = $this->prepare_pll_walker( $args['admin_current_lang'], $args, $elements );
+
+		if ( $args['echo'] ) {
+			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput
+		}
+
+		return $out;
+	}
+
+}

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * @package Polylang
+ */
 
-
+/**
+ * A class to display a language switcher on Admin
+ *
+ * @since 3.0
+ */
 class PLL_Admin_Switcher extends PLL_Switcher {
 
 	/**
@@ -39,6 +46,15 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 		return $out;
 	}
 
+	/**
+	 * @param array              $classes
+	 * @param array              $args
+	 * @param PLL_Frontend_Links $links
+	 * @param PLL_Language       $language
+	 * @param string             $url
+	 *
+	 * @return array|mixed
+	 */
 	public function manage_url( $classes, $args, $links, $language, $url ) {
 		$no_translation = false;
 		$classes[] = 'no-translation';
@@ -50,7 +66,7 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	}
 
 	/**
-	 * @param $links
+	 * @param PLL_Frontend_Links $links
 	 *
 	 * @return mixed
 	 */
@@ -59,8 +75,8 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	}
 
 	/**
-	 * @param $links
-	 * @param $args
+	 * @param PLL_Frontend_Links $links
+	 * @param array              $args
 	 *
 	 * @return mixed
 	 */

--- a/include/admin-switcher.php
+++ b/include/admin-switcher.php
@@ -37,6 +37,8 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
 	public function the_languages( $links, $args = array() ) {
+		$args['hide_if_empty'] = 0;
+
 		list( $out, $args ) = $this->get_the_languages( $links, $args );
 
 		if ( $args['echo'] ) {
@@ -81,6 +83,6 @@ class PLL_Admin_Switcher extends PLL_Switcher {
 	 * @return mixed
 	 */
 	public function get_languages_list( $links, $args ) {
-		return $links->model->get_languages_list();
+		return $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) );
 	}
 }

--- a/include/api.php
+++ b/include/api.php
@@ -31,7 +31,11 @@
 function pll_the_languages( $args = array() ) {
 	$switcher = PLL_Switcher::create( PLL() );
 
-	return $switcher->the_languages( PLL()->links, $args );
+	if ( $switcher ) {
+		return $switcher->the_languages( PLL()->links, $args );
+	} else {
+		return '';
+	}
 }
 
 /**

--- a/include/api.php
+++ b/include/api.php
@@ -29,11 +29,9 @@
  * @return string|array Either the html markup of the switcher or the raw elements to build a custom language switcher.
  */
 function pll_the_languages( $args = array() ) {
-	if ( PLL() instanceof PLL_Frontend ) {
-		$switcher = new PLL_Switcher();
-		return $switcher->the_languages( PLL()->links, $args );
-	}
-	return '';
+	$switcher = PLL_Switcher::create( PLL() );
+
+	return $switcher->the_languages( PLL()->links, $args );
 }
 
 /**

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * @package Polylang
+ */
 
-
+/**
+ * A class to display a language switcher on Frontend
+ *
+ * @since 3.0
+ */
 class PLL_Frontend_Switcher extends PLL_Switcher {
 
 	/**
@@ -62,11 +69,11 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	}
 
 	/**
-	 * @param $classes
-	 * @param $args
-	 * @param $links
-	 * @param $language
-	 * @param $slug
+	 * @param array              $classes
+	 * @param array              $args
+	 * @param PLL_Frontend_Links $links
+	 * @param PLL_Language       $language
+	 * @param string             $url
 	 *
 	 * @return false|array
 	 */
@@ -104,17 +111,17 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	}
 
 	/**
-	 * @param $links
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function get_current_language( $links ) {
 		return $links->curlang->slug;
 	}
 
 	/**
-	 * @param $links
-	 * @param $args
+	 * @param PLL_Frontend_Links $links
+	 * @param array              $args
 	 *
 	 * @return mixed
 	 */

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -4,44 +4,6 @@
 class PLL_Frontend_Switcher extends PLL_Switcher {
 
 	/**
-	 * Get the language elements for use in a walker
-	 *
-	 * @since 1.2
-	 *
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
-	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
-	 * @return array Language switcher elements.
-	 */
-	protected function get_elements( $links, $args ) {
-		$first = true;
-		$out   = array();
-
-		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
-			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
-
-			$curlang = $links->curlang->slug;
-
-			$current_lang = $curlang == $slug;
-
-			if ( $this->manage_url( $classes, $args, $links, $language, $url ) ) {
-				list( $url, $no_translation, $classes ) = $this->manage_url( $classes, $args, $links, $language, $url );
-			} else {
-				continue;
-			}
-
-			if ( $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first ) ) {
-				list( $classes, $name, $flag, $first ) = $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first );
-			} else {
-				continue;
-			}
-
-			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
-		}
-
-		return $out;
-	}
-
-	/**
 	 * Displays a language switcher
 	 * or returns the raw elements to build a custom language switcher.
 	 *
@@ -77,7 +39,7 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 			return $elements;
 		}
 
-		list( $out, $args ) = $this->prepare_pll_walker( $links->curlang->slug, $args, $elements );
+		list( $out, $args ) = $this->prepare_pll_walker( $this->get_current_language( $links ), $args, $elements );
 
 		// Javascript to switch the language when using a dropdown list
 		if ( $args['dropdown'] ) {
@@ -142,5 +104,14 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 		$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
 
 		return array( $url, $no_translation, $classes );
+	}
+
+	/**
+	 * @param $links
+	 *
+	 * @return mixed
+	 */
+	protected function get_current_language( $links ) {
+		return $links->curlang->slug;
 	}
 }

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -29,17 +29,7 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
 	public function the_languages( $links, $args = array() ) {
-		$defaults = $this->get_default_the_languages();
-
-		$args = $this->filter_arguments_pll_languages( $args, $defaults );
-
-		$elements = $this->get_elements( $links, $args );
-
-		if ( $args['raw'] ) {
-			return $elements;
-		}
-
-		list( $out, $args ) = $this->prepare_pll_walker( $this->get_current_language( $links ), $args, $elements );
+		list( $out, $args ) = $this->get_the_languages( $links, $args );
 
 		// Javascript to switch the language when using a dropdown list
 		if ( $args['dropdown'] ) {
@@ -74,7 +64,7 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	 *
 	 * @return false|array
 	 */
-	private function manage_url( $classes, $args, $links, $language, $url ) {
+	public function manage_url( $classes, $args, $links, $language, $url ) {
 		if ( null !== $args['post_id'] && ( $tr_id = $links->model->post->get( $args['post_id'], $language ) ) && $links->model->post->current_user_can_read( $tr_id ) ) {
 			$url = get_permalink( $tr_id );
 		} elseif ( null === $args['post_id'] ) {
@@ -101,7 +91,8 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 			return false;
 		}
 
-		$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
+		// If the page is not translated, link to the home page
+		$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url;
 
 		return array( $url, $no_translation, $classes );
 	}
@@ -111,7 +102,17 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	 *
 	 * @return mixed
 	 */
-	protected function get_current_language( $links ) {
+	public function get_current_language( $links ) {
 		return $links->curlang->slug;
+	}
+
+	/**
+	 * @param $links
+	 * @param $args
+	 *
+	 * @return mixed
+	 */
+	public function get_languages_list( $links, $args ) {
+		return $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) );
 	}
 }

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -1,0 +1,146 @@
+<?php
+
+
+class PLL_Frontend_Switcher extends PLL_Switcher {
+
+	/**
+	 * Get the language elements for use in a walker
+	 *
+	 * @since 1.2
+	 *
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @return array Language switcher elements.
+	 */
+	protected function get_elements( $links, $args ) {
+		$first = true;
+		$out   = array();
+
+		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
+			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
+
+			$curlang = $links->curlang->slug;
+
+			$current_lang = $curlang == $slug;
+
+			if ( $this->manage_url( $classes, $args, $links, $language, $url ) ) {
+				list( $url, $no_translation, $classes ) = $this->manage_url( $classes, $args, $links, $language, $url );
+			} else {
+				continue;
+			}
+
+			if ( $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first ) ) {
+				list( $classes, $name, $flag, $first ) = $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first );
+			} else {
+				continue;
+			}
+
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Displays a language switcher
+	 * or returns the raw elements to build a custom language switcher.
+	 *
+	 * @since 0.1
+	 *
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args {
+	 *   Optional array of arguments.
+	 *
+	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.
+	 *   @type int    $echo                   Echoes the list if set to 1, defaults to 1.
+	 *   @type int    $hide_if_empty          Hides languages with no posts ( or pages ) if set to 1, defaults to 1.
+	 *   @type int    $show_flags             Displays flags if set to 1, defaults to 0.
+	 *   @type int    $show_names             Shows language names if set to 1, defaults to 1.
+	 *   @type string $display_names_as       Whether to display the language name or its slug, valid options are 'slug' and 'name', defaults to name.
+	 *   @type int    $force_home             Will always link to home in translated language if set to 1, defaults to 0.
+	 *   @type int    $hide_if_no_translation Hides the link if there is no translation if set to 1, defaults to 0.
+	 *   @type int    $hide_current           Hides the current language if set to 1, defaults to 0.
+	 *   @type int    $post_id                Returns links to the translations of the post defined by post_id if set, defaults not set.
+	 *   @type int    $raw                    Return a raw array instead of html markup if set to 1, defaults to 0.
+	 *   @type string $item_spacing           Whether to preserve or discard whitespace between list items, valid options are 'preserve' and 'discard', defaults to 'preserve'.
+	 * }
+	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
+	 */
+	public function the_languages( $links, $args = array() ) {
+		$defaults = $this->get_default_the_languages();
+
+		$args = $this->filter_arguments_pll_languages( $args, $defaults );
+
+		$elements = $this->get_elements( $links, $args );
+
+		if ( $args['raw'] ) {
+			return $elements;
+		}
+
+		list( $out, $args ) = $this->prepare_pll_walker( $links->curlang->slug, $args, $elements );
+
+		// Javascript to switch the language when using a dropdown list
+		if ( $args['dropdown'] ) {
+			// Accept only few valid characters for the urls_x variable name ( as the widget id includes '-' which is invalid )
+			$out .= sprintf(
+				'<script type="text/javascript">
+					//<![CDATA[
+					var %1$s = %2$s;
+					document.getElementById( "%3$s" ).onchange = function() {
+						location.href = %1$s[this.value];
+					}
+					//]]>
+				</script>',
+				'urls_' . preg_replace( '#[^a-zA-Z0-9]#', '', $args['dropdown'] ),
+				wp_json_encode( wp_list_pluck( $elements, 'url' ) ),
+				esc_js( $args['name'] )
+			);
+		}
+
+		if ( $args['echo'] ) {
+			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput
+		}
+		return $out;
+	}
+
+	/**
+	 * @param $classes
+	 * @param $args
+	 * @param $links
+	 * @param $language
+	 * @param $slug
+	 *
+	 * @return false|array
+	 */
+	private function manage_url( $classes, $args, $links, $language, $url ) {
+		if ( null !== $args['post_id'] && ( $tr_id = $links->model->post->get( $args['post_id'], $language ) ) && $links->model->post->current_user_can_read( $tr_id ) ) {
+			$url = get_permalink( $tr_id );
+		} elseif ( null === $args['post_id'] ) {
+			$url = $links->get_translation_url( $language );
+		}
+
+		if ( $no_translation = empty( $url ) ) {
+			$classes[] = 'no-translation';
+		}
+
+		/**
+		 * Filter the link in the language switcher
+		 *
+		 * @since 0.7
+		 *
+		 * @param string $url    the link
+		 * @param string $slug   language code
+		 * @param string $locale language locale
+		 */
+		$url = apply_filters( 'pll_the_language_link', $url, $language->slug, $language->locale );
+
+		// Hide if no translation exists
+		if ( empty( $url ) && $args['hide_if_no_translation'] ) {
+			return false;
+		}
+
+		$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
+
+		return array( $url, $no_translation, $classes );
+	}
+}

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -29,7 +29,13 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
 	public function the_languages( $links, $args = array() ) {
-		list( $out, $args ) = $this->get_the_languages( $links, $args );
+		$get_the_languages = $this->get_the_languages( $links, $args );
+
+		if ( array_key_exists( 'elements', $get_the_languages ) ) {
+			return $get_the_languages['elements'];
+		} else {
+			list( $out, $args, $elements ) = $get_the_languages;
+		}
 
 		// Javascript to switch the language when using a dropdown list
 		if ( $args['dropdown'] ) {

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -118,14 +118,4 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	public function get_current_language( $links ) {
 		return $links->curlang->slug;
 	}
-
-	/**
-	 * @param PLL_Frontend_Links $links
-	 * @param array              $args
-	 *
-	 * @return mixed
-	 */
-	public function get_languages_list( $links, $args ) {
-		return $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) );
-	}
 }

--- a/include/frontend-switcher.php
+++ b/include/frontend-switcher.php
@@ -69,8 +69,8 @@ class PLL_Frontend_Switcher extends PLL_Switcher {
 	}
 
 	/**
-	 * @param array              $classes
-	 * @param array              $args
+	 * @param string[]           $classes CSS classes, without the leading '.'.
+	 * @param array              $args {@see PLL_Frontend_Switcher::the_languages()}
 	 * @param PLL_Frontend_Links $links
 	 * @param PLL_Language       $language
 	 * @param string             $url

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -16,7 +16,7 @@ class PLL_Switcher {
 		} else if ( $polylang instanceof  PLL_Admin ) {
 			return new PLL_Admin_Switcher();
 		} else {
-			return '';
+			return null;
 		}
 	}
 
@@ -40,6 +40,45 @@ class PLL_Switcher {
 			'hide_if_no_translation' => array( 'string' => __( 'Hides languages with no translation', 'polylang' ), 'default' => 0 ),
 		);
 		return wp_list_pluck( $options, $key );
+	}
+
+	/**
+	 * Get the language elements for use in a walker
+	 *
+	 * @since 1.2
+	 *
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @return array Language switcher elements.
+	 */
+	protected function get_elements( $links, $args ) {
+		$first = true;
+		$out   = array();
+
+		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
+			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
+
+			$curlang = $this->get_current_language( $links );
+
+			$current_lang = $curlang == $slug;
+
+			$manage_url = $this->manage_url( $classes, $args, $links, $language, $url );
+			if ( $manage_url ) {
+				list( $url, $no_translation, $classes ) = $manage_url;
+			} else {
+				continue;
+			}
+
+			if ( $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first ) ) {
+				list( $classes, $name, $flag, $first ) = $this->manage_current_lang_display( $classes, $current_lang, $args, $language, $first );
+			} else {
+				continue;
+			}
+
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes' );
+		}
+
+		return $out;
 	}
 
 	protected function init_foreach_language( $language ) {

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -10,10 +10,17 @@
  */
 abstract class PLL_Switcher {
 
+	/**
+	 * Define which class of the switcher to return.
+	 *
+	 * @param object $polylang Polylang Object.
+	 *
+	 * @return PLL_Admin_Switcher|PLL_Frontend_Switcher|null
+	 */
 	public static function create( $polylang ) {
 		if ( $polylang instanceof PLL_Frontend ) {
 			return new PLL_Frontend_Switcher();
-		} else if ( $polylang instanceof  PLL_Admin ) {
+		} elseif ( $polylang instanceof PLL_Admin ) {
 			return new PLL_Admin_Switcher();
 		} else {
 			return null;
@@ -82,6 +89,13 @@ abstract class PLL_Switcher {
 		return $out;
 	}
 
+	/**
+	 * Inits all the variables used in the loop.
+	 *
+	 * @param PLL_Language $language
+	 *
+	 * @return array
+	 */
 	protected function init_foreach_language( $language ) {
 		$id = (int) $language->term_id;
 		$order = (int) $language->term_group;
@@ -93,6 +107,15 @@ abstract class PLL_Switcher {
 		return array( $id, $order, $slug, $locale, $classes, $url );
 	}
 
+	/**
+	 * @param array        $classes
+	 * @param string       $current_lang
+	 * @param array        $args
+	 * @param PLL_Language $language
+	 * @param bool         $first
+	 *
+	 * @return array|bool
+	 */
 	protected function manage_current_lang_display( $classes, $current_lang, $args, $language, $first ) {
 		if ( $current_lang ) {
 			if ( $args['hide_current'] && ! ( $args['dropdown'] && ! $args['raw'] ) ) {
@@ -113,6 +136,11 @@ abstract class PLL_Switcher {
 		return array( $classes, $name, $flag, $first );
 	}
 
+	/**
+	 * Get the default languages switcher options array.
+	 *
+	 * @return array
+	 */
 	private function get_default_the_languages() {
 		return array(
 			'dropdown'               => 0, // display as list and not as dropdown
@@ -132,7 +160,15 @@ abstract class PLL_Switcher {
 		);
 	}
 
-	private function filter_arguments_pll_languages( $args, $defaults) {
+	/**
+	 * Filters the args.
+	 *
+	 * @param array $args
+	 * @param array $defaults
+	 *
+	 * @return array|mixed|void
+	 */
+	private function filter_arguments_pll_languages( $args, $defaults ) {
 		$args = wp_parse_args( $args, $defaults );
 
 		/**
@@ -152,6 +188,15 @@ abstract class PLL_Switcher {
 		return $args;
 	}
 
+	/**
+	 * Define PLL walker to use and filter the HTML.
+	 *
+	 * @param string $curlang
+	 * @param array  $args
+	 * @param array  $elements
+	 *
+	 * @return array
+	 */
 	private function prepare_pll_walker( $curlang, $args, $elements ) {
 		if ( $args['dropdown'] ) {
 			$args['name'] = 'lang_choice_' . $args['dropdown'];
@@ -175,6 +220,12 @@ abstract class PLL_Switcher {
 		return array( $out, $args, $elements );
 	}
 
+	/**
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param array              $args
+	 *
+	 * @return array
+	 */
 	protected function get_the_languages( $links, $args ) {
 		$defaults = $this->get_default_the_languages();
 
@@ -183,15 +234,35 @@ abstract class PLL_Switcher {
 		$elements = $this->get_elements( $links, $args );
 
 		if ( $args['raw'] ) {
-			return array ('elements' =>  $elements );
+			return array( 'elements' => $elements );
 		}
 
 		return $this->prepare_pll_walker( $this->get_current_language( $links ), $args, $elements );
 	}
 
-	abstract function get_current_language( $links );
+	/**
+	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 *
+	 * @return string
+	 */
+	abstract public function get_current_language( $links );
 
-	abstract function get_languages_list( $links, $args );
+	/**
+	 * @param PLL_Frontend_Links $links
+	 * @param array              $args
+	 *
+	 * @return mixed
+	 */
+	abstract public function get_languages_list( $links, $args );
 
-	abstract function manage_url( $classes, $args, $links, $language, $url );
+	/**
+	 * @param array              $classes
+	 * @param array              $args
+	 * @param PLL_Frontend_Links $links
+	 * @param PLL_Language       $language
+	 * @param string             $url
+	 *
+	 * @return mixed
+	 */
+	abstract public function manage_url( $classes, $args, $links, $language, $url );
 }

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * A class to display a language switcher on frontend
+ * A class to display a language switcher
  *
  * @since 1.2
  */

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -172,7 +172,7 @@ abstract class PLL_Switcher {
 		 */
 		$out = apply_filters( 'pll_the_languages', $walker->walk( $elements, -1, $args ), $args );
 
-		return array( $out, $args );
+		return array( $out, $args, $elements );
 	}
 
 	protected function get_the_languages( $links, $args ) {
@@ -183,11 +183,12 @@ abstract class PLL_Switcher {
 		$elements = $this->get_elements( $links, $args );
 
 		if ( $args['raw'] ) {
-			return $elements;
+			return array ('elements' =>  $elements );
 		}
 
 		return $this->prepare_pll_walker( $this->get_current_language( $links ), $args, $elements );
 	}
+
 	abstract function get_current_language( $links );
 
 	abstract function get_languages_list( $links, $args );

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -109,7 +109,7 @@ abstract class PLL_Switcher {
 
 	/**
 	 * @param array        $classes
-	 * @param bool       $current_lang
+	 * @param bool         $current_lang
 	 * @param array        $args
 	 * @param PLL_Language $language
 	 * @param bool         $first

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -62,7 +62,7 @@ abstract class PLL_Switcher {
 		$first = true;
 		$out   = array();
 
-		foreach ( $this->get_languages_list( $links, $args ) as $language ) {
+		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			list( $id, $order, $slug, $locale, $classes, $url ) = $this->init_foreach_language( $language );
 
 			$curlang = $this->get_current_language( $links );
@@ -246,14 +246,6 @@ abstract class PLL_Switcher {
 	 * @return string
 	 */
 	abstract public function get_current_language( $links );
-
-	/**
-	 * @param PLL_Frontend_Links $links
-	 * @param array              $args
-	 *
-	 * @return mixed
-	 */
-	abstract public function get_languages_list( $links, $args );
 
 	/**
 	 * @param array              $classes

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -109,7 +109,7 @@ abstract class PLL_Switcher {
 
 	/**
 	 * @param array        $classes
-	 * @param string       $current_lang
+	 * @param bool       $current_lang
 	 * @param array        $args
 	 * @param PLL_Language $language
 	 * @param bool         $first

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -13,7 +13,7 @@ abstract class PLL_Switcher {
 	/**
 	 * Define which class of the switcher to return.
 	 *
-	 * @param object $polylang Polylang Object.
+	 * @param PLL_Base $polylang Polylang Object.
 	 *
 	 * @return PLL_Admin_Switcher|PLL_Frontend_Switcher|null
 	 */
@@ -54,8 +54,8 @@ abstract class PLL_Switcher {
 	 *
 	 * @since 1.2
 	 *
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
-	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @param PLL_Links $links
+	 * @param array     $args  Arguments passed to {@see PLL_Switcher::get_the_languages()}.
 	 * @return array Language switcher elements.
 	 */
 	protected function get_elements( $links, $args ) {
@@ -108,9 +108,9 @@ abstract class PLL_Switcher {
 	}
 
 	/**
-	 * @param array        $classes
+	 * @param string[]     $classes CSS classes, without the leading '.'.
 	 * @param bool         $current_lang
-	 * @param array        $args
+	 * @param array        $args {@see PLL_Switcher::get_the_languages()}.
 	 * @param PLL_Language $language
 	 * @param bool         $first
 	 *
@@ -163,10 +163,10 @@ abstract class PLL_Switcher {
 	/**
 	 * Filters the args.
 	 *
-	 * @param array $args
-	 * @param array $defaults
+	 * @param array $args {@see PLL_Switcher::get_the_languages()}.
+	 * @param array $defaults {@see PLL_Switcher::get_default_the_languages()}.
 	 *
-	 * @return array|mixed|void
+	 * @return mixed
 	 */
 	private function filter_arguments_pll_languages( $args, $defaults ) {
 		$args = wp_parse_args( $args, $defaults );
@@ -192,10 +192,10 @@ abstract class PLL_Switcher {
 	 * Define PLL walker to use and filter the HTML.
 	 *
 	 * @param string $curlang
-	 * @param array  $args
-	 * @param array  $elements
+	 * @param array  $args {@see PLL_Switcher::get_the_languages()}.
+	 * @param array  $elements {@see PLL_Switcher::get_elements()}.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
 	private function prepare_pll_walker( $curlang, $args, $elements ) {
 		if ( $args['dropdown'] ) {
@@ -221,10 +221,25 @@ abstract class PLL_Switcher {
 	}
 
 	/**
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
-	 * @param array              $args
+	 * @param PLL_Links $links
+	 * @param array     $args {
+	 *   Optional array of arguments.
 	 *
-	 * @return array
+	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.
+	 *   @type int    $echo                   Echoes the list if set to 1, defaults to 1.
+	 *   @type int    $hide_if_empty          Hides languages with no posts ( or pages ) if set to 1, defaults to 1.
+	 *   @type int    $show_flags             Displays flags if set to 1, defaults to 0.
+	 *   @type int    $show_names             Shows language names if set to 1, defaults to 1.
+	 *   @type string $display_names_as       Whether to display the language name or its slug, valid options are 'slug' and 'name', defaults to name.
+	 *   @type int    $force_home             Will always link to home in translated language if set to 1, defaults to 0.
+	 *   @type int    $hide_if_no_translation Hides the link if there is no translation if set to 1, defaults to 0.
+	 *   @type int    $hide_current           Hides the current language if set to 1, defaults to 0.
+	 *   @type int    $post_id                Returns links to the translations of the post defined by post_id if set, defaults not set.
+	 *   @type int    $raw                    Return a raw array instead of html markup if set to 1, defaults to 0.
+	 *   @type string $item_spacing           Whether to preserve or discard whitespace between list items, valid options are 'preserve' and 'discard', defaults to 'preserve'.
+	 * }
+	 *
+	 * @return mixed
 	 */
 	protected function get_the_languages( $links, $args ) {
 		$defaults = $this->get_default_the_languages();
@@ -241,18 +256,18 @@ abstract class PLL_Switcher {
 	}
 
 	/**
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
+	 * @param PLL_Links $links
 	 *
 	 * @return string
 	 */
 	abstract public function get_current_language( $links );
 
 	/**
-	 * @param array              $classes
-	 * @param array              $args
-	 * @param PLL_Frontend_Links $links
-	 * @param PLL_Language       $language
-	 * @param string             $url
+	 * @param string[]     $classes CSS classes, without the leading '.'.
+	 * @param array        $args {@see PLL_Admin_Switcher::the_languages()}.
+	 * @param PLL_Links    $links
+	 * @param PLL_Language $language
+	 * @param string       $url
 	 *
 	 * @return mixed
 	 */

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -29,8 +29,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->frontend->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		$this->frontend->links->cache->method( 'get' )->willReturn( false );
 
-		$polylang = new PLL_Frontend( $links_model );
-		$this->switcher = PLL_Switcher::create( $polylang );
+		$this->switcher = new PLL_Frontend_Switcher();
 	}
 
 	function test_the_languages_raw() {

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -29,7 +29,8 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->frontend->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		$this->frontend->links->cache->method( 'get' )->willReturn( false );
 
-		$this->switcher = PLL_Switcher::create( self::$polylang );
+		$polylang = new PLL_Frontend( $links_model );
+		$this->switcher = PLL_Switcher::create( $polylang );
 	}
 
 	function test_the_languages_raw() {

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -29,7 +29,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->frontend->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		$this->frontend->links->cache->method( 'get' )->willReturn( false );
 
-		$this->switcher = new PLL_Switcher();
+		$this->switcher = PLL_Switcher::create( self::$polylang );
 	}
 
 	function test_the_languages_raw() {


### PR DESCRIPTION
Use of two classes to manage the Switcher, one in Frontend and the other in Admin.

See : https://github.com/polylang/polylang-pro/pull/851

Fix https://github.com/polylang/polylang-pro/issues/835