### PR TITLE
Refactor tests to stop using a static $polylang object

### DIFF
--- a/tests/bin/install-plugins.sh
+++ b/tests/bin/install-plugins.sh
@@ -22,6 +22,12 @@ if [[ ! -f "$WP_CORE_DIR/wp-content/themes/twentyfourteen/style.css" ]]; then
 	unzip -q $TMPDIR/downloads/twentyfourteen.zip -d $WP_CORE_DIR/wp-content/themes
 fi
 
+# Install Twenty Seventeen
+if [[ ! -f "$WP_CORE_DIR/wp-content/themes/twentyseventeen/style.css" ]]; then
+	download https://downloads.wordpress.org/theme/twentyseventeen.zip $TMPDIR/downloads/twentyseventeen.zip
+	unzip -q $TMPDIR/downloads/twentyseventeen.zip -d $WP_CORE_DIR/wp-content/themes
+fi
+
 # Install WordPress Importer
 download https://downloads.wordpress.org/plugin/wordpress-importer.zip $TMPDIR/downloads/wordpress-importer.zip
 unzip -q $TMPDIR/downloads/wordpress-importer.zip -d  $TMPDIR/downloads/

--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -27,33 +27,33 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 	function test_add_language_to_link() {
 		$url = $this->hosts['en'] . '/test/';
 
-		$this->assertEquals( $this->hosts['en'] . '/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->hosts['fr'] . '/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_double_add_language_to_link() {
-		$this->assertEquals( $this->hosts['fr'] . '/test/', self::$polylang->links_model->add_language_to_link( $this->hosts['fr'] . '/test/', self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->add_language_to_link( $this->hosts['fr'] . '/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_remove_language_from_link() {
-		$this->assertEquals( $this->hosts['en'] . '/test/', self::$polylang->links_model->remove_language_from_link( $this->hosts['en'] . '/test/' ) );
-		$this->assertEquals( $this->hosts['en'] . '/test/', self::$polylang->links_model->remove_language_from_link( $this->hosts['fr'] . '/test/' ) );
+		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->remove_language_from_link( $this->hosts['en'] . '/test/' ) );
+		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->remove_language_from_link( $this->hosts['fr'] . '/test/' ) );
 	}
 
 	function test_switch_language_in_link() {
-		$this->assertEquals( $this->hosts['en'] . '/test/', self::$polylang->links_model->switch_language_in_link( $this->hosts['fr'] . '/test/', self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->hosts['de'] . '/test/', self::$polylang->links_model->switch_language_in_link( $this->hosts['fr'] . '/test/', self::$polylang->model->get_language( 'de' ) ) );
-		$this->assertEquals( $this->hosts['fr'] . '/test/', self::$polylang->links_model->switch_language_in_link( $this->hosts['en'] . '/test/', self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->switch_language_in_link( $this->hosts['fr'] . '/test/', self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->hosts['de'] . '/test/', $this->links_model->switch_language_in_link( $this->hosts['fr'] . '/test/', self::$model->get_language( 'de' ) ) );
+		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->switch_language_in_link( $this->hosts['en'] . '/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_add_paged_to_link() {
-		$this->assertEquals( $this->hosts['en'] . '/test/page/2/', self::$polylang->links_model->add_paged_to_link( $this->hosts['en'] . '/test/', 2 ) );
-		$this->assertEquals( $this->hosts['fr'] . '/test/page/2/', self::$polylang->links_model->add_paged_to_link( $this->hosts['fr'] . '/test/', 2 ) );
+		$this->assertEquals( $this->hosts['en'] . '/test/page/2/', $this->links_model->add_paged_to_link( $this->hosts['en'] . '/test/', 2 ) );
+		$this->assertEquals( $this->hosts['fr'] . '/test/page/2/', $this->links_model->add_paged_to_link( $this->hosts['fr'] . '/test/', 2 ) );
 	}
 
 	function test_remove_paged_from_link() {
-		$this->assertEquals( $this->hosts['en'] . '/test/', self::$polylang->links_model->remove_paged_from_link( $this->hosts['en'] . '/test/page/2/' ) );
-		$this->assertEquals( $this->hosts['fr'] . '/test/', self::$polylang->links_model->remove_paged_from_link( $this->hosts['fr'] . '/test/page/2/' ) );
+		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->remove_paged_from_link( $this->hosts['en'] . '/test/page/2/' ) );
+		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->remove_paged_from_link( $this->hosts['fr'] . '/test/page/2/' ) );
 	}
 
 	function test_get_language_from_url() {
@@ -61,20 +61,20 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 		$server = $_SERVER;
 		$_SERVER['REQUEST_URI'] = '/test/';
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->hosts['fr'], PHP_URL_HOST );
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		// clean up
 		$_SERVER = $server;
 	}
 
 	function test_home_url() {
-		$this->assertEquals( $this->hosts['en'] . '/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->hosts['fr'] . '/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->hosts['en'] . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->hosts['fr'] . '/', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_allowed_redirect_hosts() {
 		$hosts = str_replace( 'http://', '', array_values( $this->hosts ) );
-		$this->assertEquals( $hosts, self::$polylang->links_model->allowed_redirect_hosts( array() ) );
+		$this->assertEquals( $hosts, $this->links_model->allowed_redirect_hosts( array() ) );
 		$this->assertEquals( $this->hosts['fr'], wp_validate_redirect( $this->hosts['fr'] ) );
 	}
 

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -9,7 +9,7 @@ trait PLL_UnitTestCase_Trait {
 	 *
 	 * @var object
 	 */
-	static $polylang;
+	static $model;
 
 	/**
 	 * Initialization before all tests run.
@@ -17,12 +17,9 @@ trait PLL_UnitTestCase_Trait {
 	 * @param WP_UnitTest_Factory $factory
 	 */
 	static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-		self::$polylang = new StdClass();
-
-		self::$polylang->options = PLL_Install::get_default_options();
-		self::$polylang->options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
-		self::$polylang->model = new PLL_Admin_Model( self::$polylang->options );
-		self::$polylang->links_model = self::$polylang->model->get_links_model(); // We always need a links model due to PLL_Language::set_home_url().
+		$options = PLL_Install::get_default_options();
+		$options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
+		self::$model = new PLL_Admin_Model( $options );
 	}
 
 	/**
@@ -36,7 +33,7 @@ trait PLL_UnitTestCase_Trait {
 	 * Empties the languages cache after all tests
 	 */
 	function tearDown() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-		self::$polylang->model->clean_languages_cache(); // We must do it before database ROLLBACK otherwhise it is impossible to delete the transient
+		self::$model->clean_languages_cache(); // We must do it before database ROLLBACK otherwhise it is impossible to delete the transient
 
 		$globals = array( 'current_screen', 'hook_suffix', 'wp_settings_errors', 'post_type', 'wp_scripts', 'wp_styles' );
 		foreach ( $globals as $global ) {
@@ -64,7 +61,7 @@ trait PLL_UnitTestCase_Trait {
 		$values['term_group'] = 0; // Default term_group.
 
 		$args = array_merge( $values, $args );
-		$errors = self::$polylang->model->add_language( $args );
+		$errors = self::$model->add_language( $args );
 		if ( is_wp_error( $errors ) ) {
 			throw new InvalidArgumentException( $errors->get_error_message() );
 		}
@@ -74,11 +71,11 @@ trait PLL_UnitTestCase_Trait {
 	 * Deletes all languages
 	 */
 	static function delete_all_languages() {
-		$languages = self::$polylang->model->get_languages_list();
+		$languages = self::$model->get_languages_list();
 		if ( is_array( $languages ) ) {
 			// Delete the default categories first.
 			$tt = wp_get_object_terms( get_option( 'default_category' ), 'term_translations' );
-			$terms = self::$polylang->model->term->get_translations( get_option( 'default_category' ) );
+			$terms = self::$model->term->get_translations( get_option( 'default_category' ) );
 
 			wp_delete_term( $tt, 'term_translations' );
 
@@ -87,7 +84,7 @@ trait PLL_UnitTestCase_Trait {
 			}
 
 			foreach ( $languages as $lang ) {
-				self::$polylang->model->delete_language( $lang->term_id );
+				self::$model->delete_language( $lang->term_id );
 			}
 		}
 	}

--- a/tests/phpunit/tests/plugins/test-duplicate-post.php
+++ b/tests/phpunit/tests/plugins/test-duplicate-post.php
@@ -12,7 +12,7 @@ if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 		public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 			parent::wpSetUpBeforeClass( $factory );
 
-			self::$polylang->model->post->registered_post_type( 'post' ); // Important.
+			self::$model->post->registered_post_type( 'post' ); // Important.
 
 			self::create_language( 'en_US' );
 			self::create_language( 'fr_FR' );
@@ -23,12 +23,12 @@ if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 
 		function test_exclude_post_translations() {
 			$en = $this->factory->post->create();
-			self::$polylang->model->post->set_language( $en, 'en' );
+			self::$model->post->set_language( $en, 'en' );
 
 			$fr = $this->factory->post->create();
-			self::$polylang->model->post->set_language( $fr, 'fr' );
+			self::$model->post->set_language( $fr, 'fr' );
 
-			self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
+			self::$model->post->save_translations( $en, compact( 'fr' ) );
 
 			$post = get_post( $en );
 			duplicate_post_admin_init();
@@ -39,8 +39,8 @@ if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 			$this->assertContains( 'post_translations', get_option( 'duplicate_post_taxonomies_blacklist' ) );
 
 			// Check the integration.
-			$this->assertEquals( $fr, self::$polylang->model->post->get( $en, 'fr' ) );
-			$this->assertFalse( self::$polylang->model->post->get( $new_id, 'fr' ) );
+			$this->assertEquals( $fr, self::$model->post->get( $en, 'fr' ) );
+			$this->assertFalse( self::$model->post->get( $new_id, 'fr' ) );
 		}
 	}
 }

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -5,7 +5,6 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '>=' ) && file_exists( DIR_
 	require_once DIR_TESTROOT . '/../jetpack/functions.opengraph.php';
 
 	class Jetpack_Test extends PLL_UnitTestCase {
-
 		/**
 		 * @param WP_UnitTest_Factory $factory
 		 */
@@ -22,23 +21,24 @@ if ( version_compare( $GLOBALS['wp_version'], '5.2', '>=' ) && file_exists( DIR_
 			require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
 			require_once DIR_TESTROOT . '/../jetpack/jetpack.php';
 
-			$GLOBALS['polylang'] = &self::$polylang; // we still use the global $polylang
-			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-			self::$polylang->init();
+			$links_model = self::$model->get_links_model();
+			$this->frontend = new PLL_Frontend( $links_model );
+			$this->frontend->init();
+			$GLOBALS['polylang'] = &$this->frontend; // we still use the global $polylang
 		}
 
 		function test_opengraph() {
 			// create posts to get something  on home page
 			$en = $this->factory->post->create();
-			self::$polylang->model->post->set_language( $en, 'en' );
+			self::$model->post->set_language( $en, 'en' );
 
 			$fr = $this->factory->post->create();
-			self::$polylang->model->post->set_language( $fr, 'fr' );
+			self::$model->post->set_language( $fr, 'fr' );
 
 			$this->go_to( home_url( '/?lang=fr' ) );
-			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-			do_action_ref_array( 'pll_init', array( &self::$polylang ) );
+			do_action_ref_array( 'pll_init', array( &$this->frontend ) );
 
 			ob_start();
 			jetpack_og_tags();

--- a/tests/phpunit/tests/plugins/test-yarpp.php
+++ b/tests/phpunit/tests/plugins/test-yarpp.php
@@ -1,12 +1,6 @@
 <?php
 
 class YARPP_Test extends PLL_UnitTestCase {
-	function setUp() {
-		parent::setUp();
-
-		$GLOBALS['polylang'] = &self::$polylang; // Avoid conflicts when other tests are executed before.
-	}
-
 	// bug introduced in 1.8 and fixed in 1.8.2
 	function test_yarpp_support() {
 		define( 'YARPP_VERSION', '1.0' ); // Fake.

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -21,23 +21,26 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang ); // To activate the fix_delete_default_category() filter
-		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+
+		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // To activate the fix_delete_default_category() filter
+		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
 	}
 
 	function test_default_language() {
 		// User preferred language
-		self::$polylang->pref_lang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->pref_lang = self::$model->get_language( 'fr' );
 		$term_id = $this->factory->category->create();
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
 
 		// Language set from parent
 		$parent = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $parent, 'de' );
+		self::$model->term->set_language( $parent, 'de' );
 		$term_id = $this->factory->category->create( array( 'parent' => $parent ) );
-		$this->assertEquals( 'de', self::$polylang->model->term->get_language( $term_id )->slug );
+		$this->assertEquals( 'de', self::$model->term->get_language( $term_id )->slug );
 	}
 
 	function test_save_term_from_edit_tags() {
@@ -47,7 +50,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
 		$en = $this->factory->category->create();
-		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en )->slug );
+		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
 
 		// Set the language and translations
 		$_REQUEST = $_POST = array(
@@ -58,8 +61,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 
 		$fr = $this->factory->category->create();
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr )->slug );
-		$this->assertEqualSets( compact( 'en', 'fr' ), self::$polylang->model->term->get_translations( $en ) );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
+		$this->assertEqualSets( compact( 'en', 'fr' ), self::$model->term->get_translations( $en ) );
 	}
 
 	function test_create_term_from_categories_metabox() {
@@ -70,20 +73,20 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 
 		$fr = $this->factory->category->create();
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr )->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
 	}
 
 	function test_save_term_from_quick_edit() {
 		$term_id = $en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$de = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $de, 'de' );
+		self::$model->term->set_language( $de, 'de' );
 
 		$es = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $es, 'es' );
+		self::$model->term->set_language( $es, 'es' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'de', 'es' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'de', 'es' ) );
 
 		// Post quick edit
 		// + the language is free in the translation group
@@ -94,8 +97,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 
 		wp_update_term( $fr = $term_id, 'category' );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
-		$this->assertEqualSetsWithIndex( compact( 'fr', 'de', 'es' ), self::$polylang->model->term->get_translations( $es ) );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
+		$this->assertEqualSetsWithIndex( compact( 'fr', 'de', 'es' ), self::$model->term->get_translations( $es ) );
 
 		// edit-tags quick edit
 		// + the language is *not* free in the translation group
@@ -106,21 +109,21 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 
 		wp_update_term( $term_id, 'category' );
-		$this->assertEquals( 'de', self::$polylang->model->term->get_language( $term_id )->slug );
-		$this->assertEqualSetsWithIndex( compact( 'de', 'es' ), self::$polylang->model->term->get_translations( $es ) );
-		$this->assertEquals( array( 'de' => $term_id ), self::$polylang->model->term->get_translations( $term_id ) );
+		$this->assertEquals( 'de', self::$model->term->get_language( $term_id )->slug );
+		$this->assertEqualSetsWithIndex( compact( 'de', 'es' ), self::$model->term->get_translations( $es ) );
+		$this->assertEquals( array( 'de' => $term_id ), self::$model->term->get_translations( $term_id ) );
 	}
 
 	function test_create_term_from_post_bulk_edit() {
-		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang ); // We need this too
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
+		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin ); // We need this too
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
 
 		$posts = $this->factory->post->create_many( 2 );
-		self::$polylang->model->post->set_language( $posts[0], 'en' );
-		self::$polylang->model->post->set_language( $posts[1], 'fr' );
+		self::$model->post->set_language( $posts[0], 'en' );
+		self::$model->post->set_language( $posts[1], 'fr' );
 
 		$test_tag = $this->factory->tag->create( array( 'name' => 'test_tag' ) );
-		self::$polylang->model->term->set_language( $test_tag, 'fr' );
+		self::$model->term->set_language( $test_tag, 'fr' );
 
 		// First do not modify any language
 		$_REQUEST = $_GET = array(
@@ -147,12 +150,12 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$test_fr = reset( $test_fr );
 
 		$this->assertEquals( $test_tag, $test_fr );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $new_fr )->slug );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $test_fr )->slug );
-		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $new_en )->slug );
-		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $test_en )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $new_en, 'fr' => $new_fr ), self::$polylang->model->term->get_translations( $new_en ) );
-		$this->assertEqualSetsWithIndex( array( 'en' => $test_en, 'fr' => $test_fr ), self::$polylang->model->term->get_translations( $test_en ) );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $new_fr )->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $test_fr )->slug );
+		$this->assertEquals( 'en', self::$model->term->get_language( $new_en )->slug );
+		$this->assertEquals( 'en', self::$model->term->get_language( $test_en )->slug );
+		$this->assertEqualSetsWithIndex( array( 'en' => $new_en, 'fr' => $new_fr ), self::$model->term->get_translations( $new_en ) );
+		$this->assertEqualSetsWithIndex( array( 'en' => $test_en, 'fr' => $test_fr ), self::$model->term->get_translations( $test_en ) );
 
 		// Second modify all languages
 		$_GET['inline_lang_choice'] = $_REQUEST['inline_lang_choice'] = 'fr';
@@ -163,7 +166,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$tags = wp_get_post_tags( $posts[0] );
 		$third = wp_filter_object_list( $tags, array( 'name' => 'third_tag' ), 'AND', 'term_id' );
 		$third = reset( $third );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $third )->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $third )->slug );
 
 		$tags = wp_list_pluck( $tags, 'term_id' );
 		$this->assertEqualSets( array( $new_fr, $test_fr, $third ), $tags );
@@ -175,22 +178,22 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_delete_term() {
 		$en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$de = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $de, 'de' );
+		self::$model->term->set_language( $de, 'de' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr', 'de' ) );
 
 		wp_delete_term( $en, 'category' ); // Forces delete
-		$this->assertEqualSetsWithIndex( compact( 'fr', 'de' ), self::$polylang->model->term->get_translations( $fr ) );
+		$this->assertEqualSetsWithIndex( compact( 'fr', 'de' ), self::$model->term->get_translations( $fr ) );
 
 		// Bug fixed in 2.2
-		$this->assertEmpty( self::$polylang->model->term->get_object_term( $en, 'term_translations' ) ); // Relationship deleted
-		$group = self::$polylang->model->term->get_object_term( $fr, 'term_translations' );
+		$this->assertEmpty( self::$model->term->get_object_term( $en, 'term_translations' ) ); // Relationship deleted
+		$group = self::$model->term->get_object_term( $fr, 'term_translations' );
 		$this->assertEquals( 2, $group->count ); // Count updated
 	}
 
@@ -205,7 +208,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$message = '';
 		set_current_screen( 'edit-tags' );
 		$GLOBALS['pagenow'] = 'term.php'; // WP 4.5+
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		ob_start();
 		include ABSPATH . 'wp-admin/edit-tag-form.php';
@@ -214,26 +217,26 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_parent_dropdown_in_edit_tags() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$tag_ID = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $tag_ID, 'fr' );
+		self::$model->term->set_language( $tag_ID, 'fr' );
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
 		$form = $this->get_edit_term_form( $tag_ID, 'category' );
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
 
 		// The admin language filter must have no impact
-		self::$polylang->pref_lang = self::$polylang->filter_lang = self::$polylang->model->get_language( 'en' );
+		$this->pll_admin->pref_lang = $this->pll_admin->filter_lang = self::$model->get_language( 'en' );
 		$form = $this->get_edit_term_form( $tag_ID, 'category' );
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
-		self::$polylang->filter_lang = false;
+		$this->pll_admin->filter_lang = false;
 
 		// Even when we just activated the admin language filter
 		$_REQUEST['lang'] = $_GET['lang'] = 'en';
@@ -244,16 +247,16 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_language_dropdown_and_translations_in_edit_tags() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
-		$lang = self::$polylang->model->get_language( 'fr' );
+		$lang = self::$model->get_language( 'fr' );
 		$form = $this->get_edit_term_form( $fr, 'category' );
 		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
 		$doc = new DomDocument();
@@ -271,10 +274,10 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_default_category_in_edit_tags() {
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
-		$default = self::$polylang->model->term->get( get_option( 'default_category' ), 'de' );
-		$de = self::$polylang->model->get_language( 'de' );
+		$default = self::$model->term->get( get_option( 'default_category' ), 'de' );
+		$de = self::$model->get_language( 'de' );
 		$form = $this->get_edit_term_form( $default, 'category' );
 		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
 		$doc = new DomDocument();
@@ -316,19 +319,19 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_parent_dropdown_in_new_tag() {
-		self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
+		$this->pll_admin->pref_lang = self::$model->get_language( 'en' );
 		$_GET['taxonomy'] = 'category';
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'parent' => $en ) );
 
 		$GLOBALS['pagenow'] = 'edit-tags.php';
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 		$dropdown = $this->get_parent_dropdown_in_new_term_form( 'category' );
 
 		$this->assertNotFalse( strpos( $dropdown, '<option class="level-0" value="' . $en . '">test</option>' ) );
@@ -340,14 +343,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'new_lang' => 'fr',
 			'from_tag' => $child,
 		);
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 		$dropdown = $this->get_parent_dropdown_in_new_term_form( 'category' );
 
 		$this->assertFalse( strpos( $dropdown, '<option class="level-0" value="' . $en . '">test</option>' ) );
 		$this->assertNotFalse( strpos( $dropdown, '<option class="level-0" value="' . $fr . '">essai</option>' ) );
 		$this->assertFalse( strpos( $dropdown, 'selected' ) );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 		$dropdown = $this->get_parent_dropdown_in_new_term_form( 'category' );
 
 		$this->assertNotFalse( strpos( $dropdown, '<option class="level-0" value="' . $fr . '" selected="selected">essai</option>' ) );
@@ -355,14 +358,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_language_dropdown_and_translations_in_new_tags() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
 		$_GET['taxonomy'] = 'category';
 		$GLOBALS['post_type'] = 'post';
-		$lang = self::$polylang->pref_lang = self::$polylang->model->get_language( 'en' );
-		self::$polylang->set_current_language();
+		$lang = $this->pll_admin->pref_lang = self::$model->get_language( 'en' );
+		$this->pll_admin->set_current_language();
 
 		ob_start();
 		do_action( 'category_add_form_fields' );
@@ -382,8 +385,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$_GET['from_tag'] = $en;
 		$_GET['new_lang'] = 'fr';
-		self::$polylang->set_current_language();
-		$lang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->set_current_language();
+		$lang = self::$model->get_language( 'fr' );
 
 		ob_start();
 		do_action( 'category_add_form_fields' );
@@ -410,23 +413,23 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		update_option( 'default_category', $term_id );
 
 		$this->assertEquals( $term_id, get_option( 'default_category' ) );
-		$translations = self::$polylang->model->term->get_translations( $term_id );
+		$translations = self::$model->term->get_translations( $term_id );
 		$this->assertEqualSets( array( 'en', 'fr', 'de', 'es' ), array_keys( $translations ) );
 	}
 
 	function test_post_categories_meta_box() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$post = $this->factory->post->create_and_get();
-		self::$polylang->model->post->set_language( $post->ID, 'fr' );
+		self::$model->post->set_language( $post->ID, 'fr' );
 
 		$_GET['post'] = $post->ID;
 		$GLOBALS['pagenow'] = 'post.php';
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 		require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
 
 		ob_start();
@@ -439,14 +442,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_nav_menu_item_taxonomy_meta_box() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		require_once ABSPATH . 'wp-admin/includes/nav-menu.php';
 		$taxonomy['args'] = get_taxonomy( 'category' );
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		ob_start();
 		wp_nav_menu_item_taxonomy_meta_box( null, $taxonomy );
@@ -456,8 +459,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $out, 'essai' ) );
 
 		// The admin language filter is active
-		self::$polylang->pref_lang = self::$polylang->filter_lang = self::$polylang->model->get_language( 'en' );
-		self::$polylang->set_current_language();
+		$this->pll_admin->pref_lang = $this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		$this->pll_admin->set_current_language();
 
 		ob_start();
 		wp_nav_menu_item_taxonomy_meta_box( null, $taxonomy );
@@ -469,13 +472,13 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	function test_get_terms_language_filter() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$es = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
-		self::$polylang->model->term->set_language( $es, 'es' );
+		self::$model->term->set_language( $es, 'es' );
 
 		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
 		$this->assertEqualSets( array( $en ), $terms );
@@ -498,7 +501,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->assertEquals( 'en', self::$polylang->model->term->get_language( $en )->slug );
+		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
 
 		// Second category in English with the same name.
 		$error = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
@@ -510,7 +513,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$term = get_term( $fr, 'category' );
 		$this->assertEquals( 'test-fr', $term->slug );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $fr )->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
 
 		// Second category in French with the same name.
 		$error = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -16,82 +16,91 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
 	}
+
 	function test_sanitize_title_for_current_language_without_character_conversion() {
-		$pll_admin = new PLL_Admin( self::$polylang->links_model );
-		$pll_admin->curlang = self::$polylang->model->get_language( 'en' );
-		$pll_admin->add_filters();
+		$this->pll_admin->curlang = self::$model->get_language( 'en' );
+		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fullmenge', sanitize_title( 'Füllmenge' ) );
 	}
+
 	function test_sanitize_title_for_language_from_form_without_character_conversion() {
 			// Bug fixed in 2.4.1
 		$_POST['post_lang_choice'] = 'en';
-		$pll_admin = new PLL_Admin( self::$polylang->links_model );
-		$pll_admin->add_filters();
+		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fullmenge', sanitize_title( 'Füllmenge' ) );
 	}
+
 	function test_sanitize_title_for_current_language_with_character_conversion() {
-		$pll_admin = new PLL_Admin( self::$polylang->links_model );
-		$pll_admin->curlang = self::$polylang->model->get_language( 'de' );
-		$pll_admin->add_filters();
+		$this->pll_admin->curlang = self::$model->get_language( 'de' );
+		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fuellmenge', sanitize_title( 'Füllmenge' ) );
 	}
 
 	function test_sanitize_title_for_language_from_form_with_character_conversion() {
 		// Bug fixed in 2.4.1
 		$_POST['post_lang_choice'] = 'de';
-		$pll_admin = new PLL_Admin( self::$polylang->links_model );
-		$pll_admin->add_filters();
+		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fuellmenge', sanitize_title( 'Füllmenge' ) );
 	}
 
 	function test_sanitize_user_without_character_conversion() {
-		$pll_admin = new PLL_Admin( self::$polylang->links_model );
-		$pll_admin->curlang = self::$polylang->model->get_language( 'en' );
-		$pll_admin->add_filters();
+		$this->pll_admin->curlang = self::$model->get_language( 'en' );
+		$this->pll_admin->add_filters();
 		$this->assertEquals( 'angstrom', sanitize_user( 'ångström' ) );
 	}
 
 	function test_sanitize_user_with_character_conversion() {
-		$pll_admin = new PLL_Admin( self::$polylang->links_model );
-		$pll_admin->curlang = self::$polylang->model->get_language( 'de' );
-		$pll_admin->add_filters();
+		$this->pll_admin->curlang = self::$model->get_language( 'de' );
+		$this->pll_admin->add_filters();
 		$this->assertEquals( 'angstroem', sanitize_user( 'ångström' ) );
 	}
 
 	function test_personal_options_update() {
+		$this->pll_admin->add_filters();
 		$_POST['description_de'] = 'Biography in German';
 		remove_action( 'personal_options_update', 'send_confirmation_on_profile_email' );
 		do_action( 'personal_options_update', 1 );
 		$this->assertEquals( $_POST['description_de'], get_user_meta( 1, 'description_de', true ) );
 	}
 
-	function test_admin_body_class() {
+	function test_admin_body_class_ltr() {
 		// Since WP 5.4, remove this filter which requires a WP_Screen that we don't provide and is not relevant for our test.
 		if ( class_exists( 'WP_Site_Health' ) ) {
 			remove_filter( 'admin_body_class', array( WP_Site_Health::get_instance(), 'admin_body_class' ) );
 		}
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$this->pll_admin->curlang = self::$model->get_language( 'en' );
+		$this->pll_admin->add_filters();
 		$this->assertEquals( ' pll-dir-ltr', apply_filters( 'admin_body_class', '' ) );
-
-		self::$polylang->curlang = self::$polylang->model->get_language( 'ar' );
-		$this->assertEquals( ' pll-dir-rtl', apply_filters( 'admin_body_class', '' ) );
-
-		unset( self::$polylang->curlang );
 	}
+
+	function test_admin_body_class_rtl() {
+		// Since WP 5.4, remove this filter which requires a WP_Screen that we don't provide and is not relevant for our test.
+		if ( class_exists( 'WP_Site_Health' ) ) {
+			remove_filter( 'admin_body_class', array( WP_Site_Health::get_instance(), 'admin_body_class' ) );
+		}
+
+		$this->pll_admin->curlang = self::$model->get_language( 'ar' );
+		$this->pll_admin->add_filters();
+		$this->assertEquals( ' pll-dir-rtl', apply_filters( 'admin_body_class', '' ) );
+	}
+
 
 	function test_privacy_page_post_states() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		update_option( 'wp_page_for_privacy_policy', $en );
 
 		$de = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $de, 'de' );
+		self::$model->post->set_language( $de, 'de' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'de' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'de' ) );
+
+		$this->pll_admin->add_filters();
 
 		ob_start();
 		_post_states( get_post( $en ) );

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -20,26 +20,26 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$args['flag'] = $lang->flag_code;
 		$args['lang_id'] = $lang->term_id;
 		$args = wp_parse_args( $args, $defaults );
-		self::$polylang->model->update_language( $args );
+		self::$model->update_language( $args );
 	}
 
 	function test_change_language_slug() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$this->update_language( self::$polylang->model->get_language( 'en' ), array( 'slug' => 'eng' ) );
-		$this->assertFalse( self::$polylang->model->get_language( 'en' ) );
-		$this->assertEquals( 'eng', self::$polylang->options['default_lang'] );
-		$this->assertEquals( 'eng', self::$polylang->model->post->get_language( $en )->slug );
+		$this->update_language( self::$model->get_language( 'en' ), array( 'slug' => 'eng' ) );
+		$this->assertFalse( self::$model->get_language( 'en' ) );
+		$this->assertEquals( 'eng', self::$model->options['default_lang'] );
+		$this->assertEquals( 'eng', self::$model->post->get_language( $en )->slug );
 
-		$this->update_language( self::$polylang->model->get_language( 'fr' ), array( 'slug' => 'fra' ) );
-		$this->assertEquals( $fr, self::$polylang->model->post->get( $en, 'fra' ) );
-		$this->assertEquals( $en, self::$polylang->model->post->get( $fr, 'eng' ) );
+		$this->update_language( self::$model->get_language( 'fr' ), array( 'slug' => 'fra' ) );
+		$this->assertEquals( $fr, self::$model->post->get( $en, 'fra' ) );
+		$this->assertEquals( $en, self::$model->post->get( $fr, 'eng' ) );
 
 		// FIXME test widgets, menu locations and domains
 	}
@@ -50,10 +50,10 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 
 		// 2 posts with language
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 
 		// 2 posts in non translated post types
 		$this->factory->post->create( array( 'post_type' => 'nav_menu_item' ) );
@@ -65,10 +65,10 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 
 		// 2 terms with language
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $term_id, 'en' );
+		self::$model->term->set_language( $term_id, 'en' );
 
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
-		self::$polylang->model->term->set_language( $term_id, 'fr' );
+		self::$model->term->set_language( $term_id, 'fr' );
 
 		// 2 terms in non translated taxonomies
 		$this->factory->term->create( array( 'taxonomy' => 'nav_menu' ) );
@@ -78,7 +78,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$expected['terms'][] = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		$expected['terms'][] = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
 
-		$nolang = self::$polylang->model->get_objects_with_no_lang();
+		$nolang = self::$model->get_objects_with_no_lang();
 
 		// sort arrays as values don't have necessarily the same keys and order
 		$this->assertTrue( sort( $expected['posts'] ), sort( $nolang['posts'] ) );
@@ -90,36 +90,36 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 
 	function test_set_language_in_mass_for_posts() {
 		foreach ( $this->factory->post->create_many( 2, array() ) as $p ) {
-			self::$polylang->model->post->set_language( $p, 'en' );
+			self::$model->post->set_language( $p, 'en' );
 		}
 
 		foreach ( $this->factory->post->create_many( 2, array() ) as $p ) {
-			self::$polylang->model->post->set_language( $p, 'fr' );
+			self::$model->post->set_language( $p, 'fr' );
 		}
 
 		$posts = $this->factory->post->create_many( 2 );
-		self::$polylang->model->set_language_in_mass( 'post', $posts, 'fr' );
+		self::$model->set_language_in_mass( 'post', $posts, 'fr' );
 
 		$posts = get_posts( array( 'fields' => 'ids', 'posts_per_page' => -1 ) );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->post, 'get_language' ), $posts ), 'slug' );
+		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $posts ), 'slug' );
 		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
 		$this->assertEmpty( get_terms( 'post_translations' ) ); // no translation group for posts
 	}
 
 	function test_set_language_in_mass_for_terms() {
 		foreach ( $this->factory->tag->create_many( 2 ) as $t ) {
-			self::$polylang->model->term->set_language( $t, 'en' );
+			self::$model->term->set_language( $t, 'en' );
 		}
 
 		foreach ( $this->factory->tag->create_many( 2 ) as $t ) {
-			self::$polylang->model->term->set_language( $t, 'fr' );
+			self::$model->term->set_language( $t, 'fr' );
 		}
 
 		$tags = $this->factory->tag->create_many( 2 );
-		self::$polylang->model->set_language_in_mass( 'term', $tags, 'fr' );
+		self::$model->set_language_in_mass( 'term', $tags, 'fr' );
 
 		$terms = get_terms( 'post_tag', array( 'hide_empty' => false, 'fields' => 'ids' ) );
-		$languages = wp_list_pluck( array_map( array( self::$polylang->model->term, 'get_language' ), $terms ), 'slug' );
+		$languages = wp_list_pluck( array_map( array( self::$model->term, 'get_language' ), $terms ), 'slug' );
 		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
 		$this->assertCount( 7, get_terms( 'term_translations' ) ); // one translation group per tag + 1 for default categories
 	}

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -1,9 +1,16 @@
 <?php
 
-class Admin_Notice_Test extends PLL_UnitTestCase {
+class Admin_Notices_Test extends PLL_UnitTestCase {
 
 	static function wp_redirect() {
 		throw new Exception( 'Call to wp_redirect' );
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
 	function test_hide_notice() {
@@ -24,8 +31,8 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 			'_pll_notice_nonce' => wp_create_nonce( 'review' ),
 		);
 
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
-		self::$polylang->admin_notices->hide_notice();
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
+		$this->pll_admin->admin_notices->hide_notice();
 
 		$this->assertEquals( array( 'review' ), get_user_meta( 1, 'pll_dismissed_notices', true ) );
 	}
@@ -37,7 +44,7 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'plugins.php';
 		set_current_screen();
 
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		ob_start();
 		do_action( 'admin_notices' );
@@ -53,8 +60,8 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'plugins.php';
 		set_current_screen();
 
-		self::$polylang->options['first_activation'] = 1; // Some very old timestanp
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->pll_admin->options['first_activation'] = 1; // Some very old timestanp
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		ob_start();
 		do_action( 'admin_notices' );
@@ -75,8 +82,8 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'plugins.php';
 		set_current_screen();
 
-		self::$polylang->options['first_activation'] = 1; // Some very old timestanp
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->pll_admin->options['first_activation'] = 1; // Some very old timestanp
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		ob_start();
 		do_action( 'admin_notices' );
@@ -93,8 +100,8 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'plugins.php';
 		set_current_screen();
 
-		self::$polylang->options['first_activation'] = 1; // Some very old timestanp
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->pll_admin->options['first_activation'] = 1; // Some very old timestanp
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		ob_start();
 		do_action( 'admin_notices' );
@@ -113,7 +120,7 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		if ( ! defined( 'WOOCOMMERCE_VERSION' ) ) {
 			define( 'WOOCOMMERCE_VERSION', '3.4.0' );
 		}
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		ob_start();
 		do_action( 'admin_notices' );
@@ -129,14 +136,12 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'plugins.php';
 		set_current_screen();
 
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-
 		if ( class_exists( 'PLL_Lingotek' ) ) {
 			$l = new PLL_Lingotek();
 			$l->init();
 		}
 
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		ob_start();
 		do_action( 'admin_notices' );
@@ -153,8 +158,8 @@ class Admin_Notice_Test extends PLL_UnitTestCase {
 		wp_set_current_user( 1 );
 		update_user_meta( 1, 'pll_dismissed_notices', array( 'test_notice' ) );
 
-		self::$polylang->admin_notices = new PLL_Admin_Notices( self::$polylang );
-		$this->assertTrue( self::$polylang->admin_notices->is_dismissed( 'test_notice' ) );
+		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
+		$this->assertTrue( $this->pll_admin->admin_notices->is_dismissed( 'test_notice' ) );
 		$this->assertEquals( array( 'test_notice' ), get_option( 'pll_dismissed_notices' ) );
 		if ( is_multisite() ) {
 			$this->assertEquals( array( 'test_notice' ), get_user_meta( 1, 'pll_dismissed_notices', true ) );

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -10,17 +10,16 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
-
-		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
-
 	}
 
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
-		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
+		$this->pll_admin->static_pages = new PLL_Admin_Static_Pages( $this->pll_admin );
 	}
 
 	function tearDown() {
@@ -31,18 +30,18 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 
 	function test_deactivate_editor_for_page_for_posts() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $en );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->set_language( $fr, 'fr' );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		self::$polylang->model->clean_languages_cache();
+		self::$model->clean_languages_cache();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		do_action( 'add_meta_boxes', 'page', get_post( $fr ) );
 		$this->assertFalse( post_type_supports( 'page', 'editor' ) );
 
@@ -54,21 +53,21 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 	// Bug introduced in 2.2.2 and fixed in 2.2.3
 	function test_editor_on_page() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $en );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->set_language( $fr, 'fr' );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		self::$polylang->model->clean_languages_cache();
+		self::$model->clean_languages_cache();
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		do_action( 'add_meta_boxes', 'page', get_post( $fr ) );
 		$this->assertTrue( post_type_supports( 'page', 'editor' ) );
 
@@ -83,29 +82,29 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		}
 
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $en );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) ); // Content must be empty to deactivate editor.
-		self::$polylang->model->post->set_language( $fr, 'fr' );
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->set_language( $fr, 'fr' );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		self::$polylang->model->clean_languages_cache();
+		self::$model->clean_languages_cache();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$this->pll_admin->curlang = self::$model->get_language( 'en' );
 		$this->assertFalse( use_block_editor_for_post( $en ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		$this->assertFalse( use_block_editor_for_post( $fr ) );
 
 		$page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
-		self::$polylang->model->post->set_language( $page_id, 'fr' );
+		self::$model->post->set_language( $page_id, 'fr' );
 		$this->assertTrue( use_block_editor_for_post( $page_id ) );
 
 		$post_id = $this->factory->post->create( array( 'post_content' => '' ) );
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 		$this->assertTrue( use_block_editor_for_post( $post_id ) );
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -17,8 +17,9 @@ class Admin_Test extends PLL_UnitTestCase {
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
 
 		$this->go_to( home_url( '/wp-admin/edit.php' ) );
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->init();
+		$links_model = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$pll_admin->init();
 
 		_wp_admin_bar_init();
 		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
@@ -37,8 +38,9 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 	function _test_scripts( $scripts ) {
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
 
 		$GLOBALS['wp_styles'] = new WP_Styles();
 		$GLOBALS['wp_scripts'] = new WP_Scripts();

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -20,18 +20,21 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
-		self::$polylang->filters_columns = new PLL_Admin_Filters_Columns( self::$polylang );
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
+		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
 	}
 
 	function test_post_translations() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$_POST = array(
 			'action'       => 'pll_update_post_rows',
@@ -86,12 +89,12 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 
 	function test_term_translations() {
 		$en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$_POST = array(
 			'action'       => 'pll_update_term_rows',

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -21,25 +21,28 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->classic_editor = new PLL_Admin_Classic_Editor( self::$polylang );
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+
+		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin );
+		$this->pll_admin->classic_editor = new PLL_Admin_Classic_Editor( $this->pll_admin );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 	}
 
 	function test_post_lang_choice() {
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang ); // We need this for categories and tags
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin ); // We need this for categories and tags
 
 		// categories
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		// the post
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 
 		$_POST = array(
 			'action'      => 'post_lang_choice',
@@ -52,7 +55,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		);
 
 		$_REQUEST['lang'] = $_POST['lang'];
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		try {
 			$this->_handleAjax( 'post_lang_choice' );
@@ -82,18 +85,18 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	}
 
 	function test_page_lang_choice() {
-		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang ); // we need this for the pages dropdown
+		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // we need this for the pages dropdown
 
 		// possible parents
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		// the post
 		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 
 		$_POST = array(
 			'action'      => 'post_lang_choice',
@@ -105,7 +108,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		);
 
 		$_REQUEST['lang'] = $_POST['lang'];
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		try {
 			$this->_handleAjax( 'post_lang_choice' );
@@ -136,18 +139,18 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 	function test_posts_not_translated() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test english' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'test français' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$searched = $this->factory->post->create( array( 'post_title' => 'test searched' ) );
-		self::$polylang->model->post->set_language( $searched, 'en' );
+		self::$model->post->set_language( $searched, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$_GET = array(
 			'action'               => 'pll_posts_not_translated',
@@ -159,7 +162,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 			'pll_post_id'          => $fr,
 		);
 
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
@@ -173,9 +176,9 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		// translate the current post
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		// the search must contain the current translation
 		try {
@@ -191,12 +194,12 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 	function test_save_post_from_quick_edit() {
 		$post_id = $en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 
 		$es = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $es, 'es' );
+		self::$model->post->set_language( $es, 'es' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'es' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'es' ) );
 
 		// Switch to a free language in the translation group
 		$_REQUEST = $_POST = array(
@@ -212,10 +215,10 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 			unset( $e );
 		}
 
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $post_id )->slug );
-		$this->assertEquals( 'es', self::$polylang->model->post->get_language( $es )->slug );
-		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$polylang->model->post->get_translations( $post_id ) );
-		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$polylang->model->post->get_translations( $es ) );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $post_id )->slug );
+		$this->assertEquals( 'es', self::$model->post->get_language( $es )->slug );
+		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$model->post->get_translations( $post_id ) );
+		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$model->post->get_translations( $es ) );
 
 		// Switch to a *non* free language in the translation group
 		$_REQUEST['inline_lang_choice'] = $_POST['inline_lang_choice'] = 'es';
@@ -226,9 +229,9 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 			unset( $e );
 		}
 
-		$this->assertEquals( 'es', self::$polylang->model->post->get_language( $post_id )->slug );
-		$this->assertEquals( 'es', self::$polylang->model->post->get_language( $es )->slug );
-		$this->assertEquals( array( 'es' => $post_id ), self::$polylang->model->post->get_translations( $post_id ) );
-		$this->assertEquals( array( 'es' => $es ), self::$polylang->model->post->get_translations( $es ) );
+		$this->assertEquals( 'es', self::$model->post->get_language( $post_id )->slug );
+		$this->assertEquals( 'es', self::$model->post->get_language( $es )->slug );
+		$this->assertEquals( array( 'es' => $post_id ), self::$model->post->get_translations( $post_id ) );
+		$this->assertEquals( array( 'es' => $es ), self::$model->post->get_translations( $es ) );
 	}
 }

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -20,19 +20,22 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		remove_all_actions( 'admin_init' ); // To save (a lot of) time as WP will attempt to update core and plugins.
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests.
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+
+		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 	}
 
 	public function test_term_lang_choice_in_edit_category() {
 		// Possible parents.
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		// The category.
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
@@ -47,7 +50,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		);
 
 		$_REQUEST['lang'] = $_POST['lang'];
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		try {
 			$this->_handleAjax( 'term_lang_choice' );
@@ -77,10 +80,10 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 	public function test_term_lang_choice_in_new_tag() {
 		// Possible parents.
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		// We need posts for the tag cloud.
 		$this->factory->post->create( array( 'tags_input' => 'test' ) );
@@ -98,7 +101,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		);
 
 		$_REQUEST['lang'] = $_POST['lang'];
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		try {
 			$this->_handleAjax( 'term_lang_choice' );
@@ -128,18 +131,18 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 	public function test_terms_not_translated() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$searched = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test searched' ) );
-		self::$polylang->model->term->set_language( $searched, 'en' );
+		self::$model->term->set_language( $searched, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$_GET = array(
 			'action'               => 'pll_terms_not_translated',
@@ -152,7 +155,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 			'term_id'              => $fr,
 		);
 
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		try {
 			$this->_handleAjax( 'pll_terms_not_translated' );
@@ -166,9 +169,9 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 		// Translate the current term.
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		// The search must contain the current translation.
 		try {
@@ -184,12 +187,12 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 	public function test_format_not_translated_term() {
 		$parent = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'Parent' ) );
-		self::$polylang->model->term->set_language( $parent, 'en' );
+		self::$model->term->set_language( $parent, 'en' );
 
 		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'Child', 'parent' => $parent ) );
-		self::$polylang->model->term->set_language( $child, 'en' );
+		self::$model->term->set_language( $child, 'en' );
 
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		// A term with a parent.
 		$_GET = array(

--- a/tests/phpunit/tests/test-ajax-on-front.php
+++ b/tests/phpunit/tests/test-ajax-on-front.php
@@ -37,8 +37,10 @@ class Ajax_On_Front_Test extends PLL_Ajax_UnitTestCase {
 		wp_set_current_user( 1 );
 		update_user_meta( 1, 'locale', 'en_US' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		new PLL_Frontend_Filters( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$frontend = new PLL_Frontend( $links_model );
+		$frontend->curlang = self::$model->get_language( 'fr' );
+		new PLL_Frontend_Filters( $frontend );
 
 		add_action( 'wp_ajax_test_locale', array( $this, '_ajax_test_locale' ) );
 

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -15,20 +15,22 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->options['post_types'] = array(
+		self::$model->options['post_types'] = array(
 			'trcpt' => 'trcpt',
 		);
-		self::$polylang->options['taxonomies'] = array(
+		self::$model->options['taxonomies'] = array(
 			'trtax' => 'trtax',
 		);
 
 		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax
 
-		self::$polylang->auto_translate = new PLL_Frontend_Auto_Translate( self::$polylang );
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
-		self::$polylang->filters = new PLL_Frontend_Filters( self::$polylang );
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$frontend = new PLL_Frontend( $links_model );
+		new PLL_Frontend_Auto_Translate( $frontend );
+		$frontend->curlang = self::$model->get_language( 'fr' );
+		new PLL_Frontend_Filters( $frontend );
+		new PLL_CRUD_Terms( $frontend );
 	}
 
 	function tearDown() {
@@ -40,18 +42,18 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	function test_category() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_fr, 'fr' );
+		self::$model->post->set_language( $post_fr, 'fr' );
 		wp_set_post_terms( $post_fr, array( $fr ), 'category' );
 
 		$post_en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_en, 'en' );
+		self::$model->post->set_language( $post_en, 'en' );
 		wp_set_post_terms( $post_en, array( $en ), 'category' );
 
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'cat' => $en ) ) );
@@ -61,24 +63,24 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	function test_tag() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai2' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test2' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_fr = $this->factory->post->create( array( 'tags_input' => array( 'essai', 'essai2' ) ) );
-		self::$polylang->model->post->set_language( $post_fr, 'fr' );
+		self::$model->post->set_language( $post_fr, 'fr' );
 
 		$post_en = $this->factory->post->create( array( 'tags_input' => array( 'test', 'test2' ) ) );
-		self::$polylang->model->post->set_language( $post_en, 'en' );
+		self::$model->post->set_language( $post_en, 'en' );
 
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag_id' => $en ) ) );
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test' ) ) );
@@ -89,33 +91,33 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	function test_custom_tax() {
 		$term_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$term_en = $en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai2' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test2' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai3' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test3' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
 		wp_set_post_terms( $post_fr, array( 'essai', 'essai2' ), 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
-		self::$polylang->model->post->set_language( $post_fr, 'fr' );
+		self::$model->post->set_language( $post_fr, 'fr' );
 
 		$post_en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
 		wp_set_post_terms( $post_en, array( 'test', 'test2' ), 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
-		self::$polylang->model->post->set_language( $post_en, 'en' );
+		self::$model->post->set_language( $post_en, 'en' );
 
 		// old way
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test' ) ) );
@@ -187,12 +189,12 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	function test_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'p' => $en ) ) );
 		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'name' => 'test' ) ) );
@@ -204,20 +206,20 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	function test_page() {
 		$parent_en = $en = $this->factory->post->create( array( 'post_title' => 'test_parent', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$parent_fr = $fr = $this->factory->post->create( array( 'post_title' => 'essai_parent', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page', 'post_parent' => $parent_en ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page', 'post_parent' => $parent_fr ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$query = new WP_Query( array( 'page_id' => $en ) );
 		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
@@ -233,11 +235,11 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	function test_get_terms() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$expected = get_term( $fr, 'category' );
 		$terms = get_terms( 'category', array( 'hide_empty' => 0, 'include' => array( $en ) ) );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -29,10 +29,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	 */
 	public static function generate_shared_fixtures( WP_UnitTest_Factory $factory ) {
 		self::$post_en = $factory->post->create( array( 'post_title' => 'post-format-test-audio' ) );
-		self::$polylang->model->post->set_language( self::$post_en, 'en' );
+		self::$model->post->set_language( self::$post_en, 'en' );
 
 		self::$page_id = $factory->post->create( array( 'post_type' => 'page', 'post_title' => 'parent-page' ) );
-		self::$polylang->model->post->set_language( self::$page_id, 'en' );
+		self::$model->post->set_language( self::$page_id, 'en' );
 
 		add_action(
 			'registered_taxonomy',
@@ -49,18 +49,18 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				'post_title' => 'custom-post',
 			)
 		);
-		self::$polylang->model->post->set_language( self::$custom_post_id, 'en' );
+		self::$model->post->set_language( self::$custom_post_id, 'en' );
 
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
-		self::$polylang->model->term->set_language( self::$term_en, 'en' );
+		self::$model->term->set_language( self::$term_en, 'en' );
 
 		$en = self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( self::$page_for_posts_en, 'en' );
+		self::$model->post->set_language( self::$page_for_posts_en, 'en' );
 
 		$fr = self::$page_for_posts_fr = $factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( self::$page_for_posts_fr, 'fr' );
+		self::$model->post->set_language( self::$page_for_posts_fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( self::$page_for_posts_en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( self::$page_for_posts_en, compact( 'en', 'fr' ) );
 	}
 
 	public function init_for_sitemaps() {
@@ -230,7 +230,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		// Create 1 additional English post to have a paged category.
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		// Set category to the posts.
 		wp_set_post_terms( self::$post_en, array( self::$term_en ), 'category' );
@@ -242,7 +242,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public function test_page_for_posts_with_name_and_language() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical(
 			'/en/posts/',
 			array(
@@ -255,21 +255,21 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public function test_page_for_posts_should_match_page_for_post_option_when_language_is_incorrect() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/fr/posts/', '/en/posts/' );
 	}
 
 	public function test_page_for_posts_should_match_page_for_post_option_posts_without_language() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/posts/', '/en/posts/' );
 	}
 
 	public function test_page_for_posts_should_match_page_for_post_option_posts_from_plain_permalink() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '?page_id=' . self::$page_for_posts_en, '/en/posts/' );
 	}
 
@@ -280,30 +280,30 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		// Create 1 additional English post to have a paged page for posts.
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '?paged=2&page_id=' . self::$page_for_posts_en, '/en/posts/page/2/' );
 	}
 
 	public function test_page_for_post_option_should_be_translated_when_language_is_incorrect() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/en/articles/', '/fr/articles/' );
 	}
 
 	public function test_page_for_post_option_should_be_translated_when_no_language_is_set() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/articles/', '/fr/articles/' );
 	}
 
 	public function test_page_for_post_option_should_be_translated_from_plain_permalink() {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '?page_id=' . self::$page_for_posts_fr, '/fr/articles/' );
 	}
 
@@ -340,7 +340,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_from_plain_permalink_when_front_page_displays_posts() {
 		update_option( 'show_on_front', 'posts' );
-		self::$polylang->model->clean_languages_cache(); // Clean the languages transient.
+		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '?page_id=' . self::$page_id, '/en/parent-page/' );
 	}
 

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -13,7 +13,6 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
 	function setUp() {
@@ -21,25 +20,25 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		global $wp_rewrite;
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 0;
-		self::$polylang->options['browser'] = 0;
+		self::$model->options['hide_default'] = 1;
+		self::$model->options['force_lang'] = 0;
+		self::$model->options['browser'] = 0;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->links_model->init();
+		$links_model = self::$model->get_links_model();
+		$links_model->init();
 
 		// flush rules
 		$wp_rewrite->flush_rules();
 
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
+		$this->frontend = new PLL_Frontend( $links_model );
 	}
 
 	// overrides WP_UnitTestCase::go_to
@@ -74,8 +73,8 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		// insert Polylang specificity
 		unset( $GLOBALS['wp_actions']['pll_language_defined'] );
-		unset( self::$polylang->curlang );
-		self::$polylang->init();
+		unset( $this->frontend->curlang );
+		$this->frontend->init();
 
 		// restart copy paste of WP_UnitTestCase::go_to
 		$GLOBALS['wp_the_query'] = new WP_Query();
@@ -88,107 +87,107 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 	function test_home_latest_posts() {
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 	}
 
 	function test_home_latest_posts_with_hide_default() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
 	function test_single_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/essai/' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 
 		$this->go_to( home_url( '/test/' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
 	function test_page() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/essai/' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 
 		$this->go_to( home_url( '/test/' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
 	function test_category_default_lang() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/category/test/' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
 	function test_category_non_default_lang() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/category/essai/' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 	}
 
 	function test_post_tag_default_lang() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/tag/test/' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
 	function test_post_tag_non_default_lang() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/tag/essai/' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 	}
 
 	function test_archive() {
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/2007/' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 
 		$this->go_to( home_url( '/2007/' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
 	function test_archive_with_default_permalinks() {
 		$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '?year=2007&lang=fr' ) );
-		$this->assertEquals( 'fr', self::$polylang->curlang->slug );
+		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 
 		$this->go_to( home_url( '?year=2007' ) );
-		$this->assertEquals( 'en', self::$polylang->curlang->slug );
+		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 }

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -8,13 +8,20 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
-		self::$polylang->model->post->register_taxonomy();
+		self::$model->post->register_taxonomy();
 	}
 
 	function tearDown() {
 		self::delete_all_languages();
 
 		parent::tearDown();
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		$links_model = self::$model->get_links_model();
+		$this->frontend = new PLL_Frontend( $links_model );
 	}
 
 	function test_browser_preferred_language() {
@@ -24,11 +31,11 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 		// Only languages with posts will be accepted
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'de' );
+		self::$model->post->set_language( $post_id, 'de' );
 
-		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
+		$choose_lang = new PLL_Choose_Lang_Url( $this->frontend );
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'fr,fr-fr;q=0.8,en-us;q=0.5,en;q=0.3';
 		$this->assertEquals( 'en', $choose_lang->get_preferred_browser_language() );
@@ -61,13 +68,13 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 		// only languages with posts will be accepted
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'us' );
+		self::$model->post->set_language( $post_id, 'us' );
 
-		self::$polylang->model->clean_languages_cache(); // FIXME foor some reason the cache is not clean before (resulting in wrong count)
+		self::$model->clean_languages_cache(); // FIXME foor some reason the cache is not clean before (resulting in wrong count)
 
-		$choose_lang = new PLL_Choose_Lang_Url( self::$polylang );
+		$choose_lang = new PLL_Choose_Lang_Url( $this->frontend );
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-gb;q=0.8,en-us;q=0.5,en;q=0.3';
 		$this->assertEquals( 'en', $choose_lang->get_preferred_browser_language() );

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -21,12 +21,15 @@ class Columns_Test extends PLL_UnitTestCase {
 		// set a user to pass current_user_can tests
 		wp_set_current_user( self::$editor );
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
-		self::$polylang->filters_columns = new PLL_Admin_Filters_Columns( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
+		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
 	}
 
 	function tearDown() {
-		unset( self::$polylang->filter_lang );
+		unset( $this->pll_admin->filter_lang );
 
 		parent::tearDown();
 	}
@@ -35,25 +38,25 @@ class Columns_Test extends PLL_UnitTestCase {
 		$post_id = $this->factory->post->create();
 
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_en', $post_id );
-		self::$polylang->filters_columns->post_column( 'language_fr', $post_id );
+		$this->pll_admin->filters_columns->post_column( 'language_en', $post_id );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $post_id );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
 	function test_post_language() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		// with capability
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_en', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_en', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) && strpos( $column, 'href' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_en', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_en', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) );
 		$this->assertFalse( strpos( $column, 'href' ) );
@@ -61,57 +64,57 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_untranslated_post() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		// with capability
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_fr', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_icon_add' ) && strpos( $column, 'from_post' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_fr', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
 	// special case for media
 	function test_untranslated_media() {
 		$en = $this->factory->attachment->create_object( 'image.jpg' );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		// with capability
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_fr', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_icon_add' ) && strpos( $column, 'from_media' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_fr', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
 	function test_translated_post() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		// with capability
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_fr', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$this->assertNotFalse( strpos( ob_get_clean(), 'pll_icon_edit' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		self::$polylang->filters_columns->post_column( 'language_fr', $en );
+		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
@@ -121,8 +124,8 @@ class Columns_Test extends PLL_UnitTestCase {
 
 		$term_id = $this->factory->category->create();
 
-		$column_en = self::$polylang->filters_columns->term_column( '', 'language_en', $term_id );
-		$column_fr = self::$polylang->filters_columns->term_column( '', 'language_fr', $term_id );
+		$column_en = $this->pll_admin->filters_columns->term_column( '', 'language_en', $term_id );
+		$column_fr = $this->pll_admin->filters_columns->term_column( '', 'language_fr', $term_id );
 		$this->assertEmpty( $column_en );
 		$this->assertEmpty( $column_fr );
 	}
@@ -132,15 +135,15 @@ class Columns_Test extends PLL_UnitTestCase {
 		$GLOBALS['taxonomy'] = 'category';
 
 		$en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		// with capability
-		$column = self::$polylang->filters_columns->term_column( '', 'language_en', $en );
+		$column = $this->pll_admin->filters_columns->term_column( '', 'language_en', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) && strpos( $column, 'href' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
-		$column = self::$polylang->filters_columns->term_column( '', 'language_en', $en );
+		$column = $this->pll_admin->filters_columns->term_column( '', 'language_en', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) );
 		$this->assertFalse( strpos( $column, 'href' ) );
 	}
@@ -152,7 +155,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$default = (int) get_option( 'default_category' );
 
 		// with capability
-		$column = self::$polylang->filters_columns->term_column( '', 'language_en', $default );
+		$column = $this->pll_admin->filters_columns->term_column( '', 'language_en', $default );
 		$this->assertNotFalse( strpos( $column, 'default_cat' ) );
 	}
 
@@ -161,16 +164,16 @@ class Columns_Test extends PLL_UnitTestCase {
 		$GLOBALS['taxonomy'] = 'category';
 
 		$en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		// with capability
-		$column = self::$polylang->filters_columns->term_column( '', 'language_fr', $en );
+		$column = $this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_icon_add' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		self::$polylang->filters_columns->term_column( '', 'language_fr', $en );
+		$this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
@@ -179,21 +182,21 @@ class Columns_Test extends PLL_UnitTestCase {
 		$GLOBALS['taxonomy'] = 'category';
 
 		$en = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		// with capability
-		$column = self::$polylang->filters_columns->term_column( '', 'language_fr', $en );
+		$column = $this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_icon_edit' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		self::$polylang->filters_columns->term_column( '', 'language_fr', $en );
+		$this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
@@ -212,7 +215,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	function test_add_post_column_with_filter() {
-		self::$polylang->filter_lang = self::$polylang->model->get_language( 'en' );
+		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
 		$this->assertNotFalse( array_search( 'language_en', $hidden ) );
@@ -234,7 +237,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	function test_add_term_column_with_filter() {
-		self::$polylang->filter_lang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->filter_lang = self::$model->get_language( 'fr' );
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
 		$this->assertNotFalse( array_search( 'language_fr', $hidden ) );
@@ -243,7 +246,7 @@ class Columns_Test extends PLL_UnitTestCase {
 
 	function test_post_inline_edit() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		$list_table->prepare_items();

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -13,9 +13,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 2,
 		);
 
-		$this->assertTrue( self::$polylang->model->add_language( $args ) );
+		$this->assertTrue( self::$model->add_language( $args ) );
 
-		$lang = self::$polylang->model->get_language( 'en' );
+		$lang = self::$model->get_language( 'en' );
 
 		$this->assertEquals( 'English', $lang->name );
 		$this->assertEquals( 'en', $lang->slug );
@@ -33,9 +33,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertTrue( self::$polylang->model->add_language( $args ) );
+		$this->assertTrue( self::$model->add_language( $args ) );
 
-		$lang = self::$polylang->model->get_language( 'ar' );
+		$lang = self::$model->get_language( 'ar' );
 
 		$this->assertEquals( 'العربية', $lang->name );
 		$this->assertEquals( 'ar', $lang->slug );
@@ -44,31 +44,31 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 1, $lang->term_group );
 
 		// check default language
-		$this->assertEquals( 'en', self::$polylang->options['default_lang'] );
+		$this->assertEquals( 'en', self::$model->options['default_lang'] );
 
 		// check default category
-		$default_cat_lang = self::$polylang->model->term->get_language( get_option( 'default_category' ) );
+		$default_cat_lang = self::$model->term->get_language( get_option( 'default_category' ) );
 		$this->assertEquals( 'en', $default_cat_lang->slug );
 
 		// check language order
-		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
 
 		// attempt to create a language with the same slug as an existing one
-		self::$polylang->model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
-		$lang = self::$polylang->model->get_language( 'en' );
+		self::$model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
+		$lang = self::$model->get_language( 'en' );
 		$this->assertEquals( 'en_US', $lang->locale );
-		$this->assertFalse( self::$polylang->model->get_language( 'en_GB' ) );
-		$this->assertEquals( 2, count( self::$polylang->model->get_languages_list() ) );
+		$this->assertFalse( self::$model->get_language( 'en_GB' ) );
+		$this->assertEquals( 2, count( self::$model->get_languages_list() ) );
 
 		// delete 1 language
-		$lang = self::$polylang->model->get_language( 'en_US' );
-		self::$polylang->model->delete_language( $lang->term_id );
-		$this->assertEquals( 'ar', self::$polylang->options['default_lang'] );
+		$lang = self::$model->get_language( 'en_US' );
+		self::$model->delete_language( $lang->term_id );
+		$this->assertEquals( 'ar', self::$model->options['default_lang'] );
 
 		// delete the last language
-		$lang = self::$polylang->model->get_language( 'ar' );
-		self::$polylang->model->delete_language( $lang->term_id );
-		$this->assertEquals( array(), self::$polylang->model->get_languages_list() );
+		$lang = self::$model->get_language( 'ar' );
+		self::$model->delete_language( $lang->term_id );
+		$this->assertEquals( array(), self::$model->get_languages_list() );
 	}
 
 	// Bug fixed in 2.3
@@ -83,14 +83,14 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertTrue( self::$polylang->model->add_language( $args ) );
+		$this->assertTrue( self::$model->add_language( $args ) );
 
-		$lang = self::$polylang->model->get_language( 'ar' );
+		$lang = self::$model->get_language( 'ar' );
 		$args['lang_id'] = $lang->term_id;
 		$args['slug'] = 'ar';
-		$this->assertTrue( self::$polylang->model->update_language( $args ) );
+		$this->assertTrue( self::$model->update_language( $args ) );
 
-		self::$polylang->model->delete_language( $lang->term_id );
+		self::$model->delete_language( $lang->term_id );
 	}
 
 	function test_invalid_languages() {
@@ -105,25 +105,25 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertWPError( self::$polylang->model->add_language( $args ), 'The language must have a name' );
+		$this->assertWPError( self::$model->add_language( $args ), 'The language must have a name' );
 
 		$args['name'] = 'English';
 		$args['locale'] = 'EN';
 
-		$this->assertWPError( self::$polylang->model->add_language( $args ), 'Enter a valid WordPress locale' );
+		$this->assertWPError( self::$model->add_language( $args ), 'Enter a valid WordPress locale' );
 
 		$args['locale'] = 'en-US';
 
-		$this->assertWPError( self::$polylang->model->add_language( $args ), 'Enter a valid WordPress locale' );
+		$this->assertWPError( self::$model->add_language( $args ), 'Enter a valid WordPress locale' );
 
 		$args['locale'] = 'en_US';
 		$args['slug'] = 'EN';
 
-		$this->assertWPError( self::$polylang->model->add_language( $args ), 'The language code contains invalid characters' );
+		$this->assertWPError( self::$model->add_language( $args ), 'The language code contains invalid characters' );
 
 		$args['slug'] = 'en';
 		$args['flag'] = 'en';
 
-		$this->assertWPError( self::$polylang->model->add_language( $args ), 'The flag does not exist' );
+		$this->assertWPError( self::$model->add_language( $args ), 'The flag does not exist' );
 	}
 }

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -22,18 +22,14 @@ class Flags_Test extends PLL_UnitTestCase {
 		rmdir( WP_CONTENT_DIR . '/polylang' );
 	}
 
-	function setUp() {
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-	}
-
 	function test_default_flag() {
-		$lang = self::$polylang->model->get_language( 'en' );
+		$lang = self::$model->get_language( 'en' );
 		$this->assertEquals( plugins_url( '/flags/us.png', POLYLANG_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.
 		$this->assertEquals( 1, preg_match( '#<img src="data:image\/png;base64,(.+)" alt="English" width="16" height="11" style="(.+)" \/>#', $lang->get_display_flag() ) );
 	}
 
 	function test_custom_flag() {
-		$lang = self::$polylang->model->get_language( 'fr' );
+		$lang = self::$model->get_language( 'fr' );
 		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->get_display_flag_url() );
 		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" alt="Français" />', $lang->get_display_flag() );
 	}
@@ -44,7 +40,7 @@ class Flags_Test extends PLL_UnitTestCase {
 	function test_default_flag_ssl() {
 		$_SERVER['HTTPS'] = 'on';
 
-		$lang = self::$polylang->model->get_language( 'en' );
+		$lang = self::$model->get_language( 'en' );
 		$this->assertContains( 'https', $lang->get_display_flag_url() );
 
 		unset( $_SERVER['HTTPS'] );
@@ -53,7 +49,7 @@ class Flags_Test extends PLL_UnitTestCase {
 	function test_custom_flag_ssl() {
 		$_SERVER['HTTPS'] = 'on';
 
-		$lang = self::$polylang->model->get_language( 'fr' );
+		$lang = self::$model->get_language( 'fr' );
 		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->get_display_flag_url() );
 		$this->assertContains( 'https', $lang->get_display_flag_url() );
 

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -44,21 +44,21 @@ class Install_Test extends PLL_UnitTestCase {
 		do_action( 'activate_' . POLYLANG_BASENAME );
 
 		self::create_language( 'en_US' );
-		$english = self::$polylang->model->get_language( 'en' );
+		$english = self::$model->get_language( 'en' );
 
 		self::create_language( 'fr_FR' );
 
 		// Posts and terms
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$post_translations_groups = get_terms( 'post_translations' );
 		$post_group = reset( $post_translations_groups );

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -17,106 +17,110 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->options['post_types'] = array(
+		self::$model->options['post_types'] = array(
 			'cpt' => 'cpt',
 		);
 		register_post_type( 'cpt', array( 'public' => true ) ); // translated custom post type
 
-		self::$polylang->options['hide_default'] = 1;
+		self::$model->options['hide_default'] = 1;
+
+		$this->links_model = self::$model->get_links_model();
 	}
 
 	function test_add_language_to_link() {
 		$url = $this->host . '/?p=test';
 
-		$this->assertEquals( $this->host . '/?p=test', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->host . '/?p=test&lang=fr', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->host . '/?p=test', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_double_add_language_to_link() {
-		$this->assertEquals( $this->host . '/?p=test&lang=fr', self::$polylang->links_model->add_language_to_link( $this->host . '/?p=test&lang=fr', self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->add_language_to_link( $this->host . '/?p=test&lang=fr', self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_remove_language_from_link() {
-		$this->assertEquals( $this->host . '/?p=test', self::$polylang->links_model->remove_language_from_link( $this->host . '/?p=test&lang=fr' ) );
+		$this->assertEquals( $this->host . '/?p=test', $this->links_model->remove_language_from_link( $this->host . '/?p=test&lang=fr' ) );
 	}
 
 	function test_switch_language_in_link() {
-		$this->assertEquals( $this->host . '/?p=test', self::$polylang->links_model->switch_language_in_link( $this->host . '/?p=test&lang=fr', self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->host . '/?p=test&lang=de', self::$polylang->links_model->switch_language_in_link( $this->host . '/?p=test&lang=fr', self::$polylang->model->get_language( 'de' ) ) );
-		$this->assertEquals( $this->host . '/?p=test&lang=fr', self::$polylang->links_model->switch_language_in_link( $this->host . '/?p=test', self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->host . '/?p=test', $this->links_model->switch_language_in_link( $this->host . '/?p=test&lang=fr', self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->host . '/?p=test&lang=de', $this->links_model->switch_language_in_link( $this->host . '/?p=test&lang=fr', self::$model->get_language( 'de' ) ) );
+		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->switch_language_in_link( $this->host . '/?p=test', self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_add_paged_to_link() {
-		$this->assertEquals( $this->host . '/?p=test&paged=2', self::$polylang->links_model->add_paged_to_link( $this->host . '/?p=test', 2 ) );
-		$this->assertEquals( $this->host . '/?p=test&lang=fr&paged=2', self::$polylang->links_model->add_paged_to_link( $this->host . '/?p=test&lang=fr', 2 ) );
+		$this->assertEquals( $this->host . '/?p=test&paged=2', $this->links_model->add_paged_to_link( $this->host . '/?p=test', 2 ) );
+		$this->assertEquals( $this->host . '/?p=test&lang=fr&paged=2', $this->links_model->add_paged_to_link( $this->host . '/?p=test&lang=fr', 2 ) );
 	}
 
 	function test_remove_paged_from_link() {
-		$this->assertEquals( $this->host . '/?p=test', self::$polylang->links_model->remove_paged_from_link( $this->host . '/?p=test&paged=2' ) );
-		$this->assertEquals( $this->host . '/?p=test&lang=fr', self::$polylang->links_model->remove_paged_from_link( $this->host . '/?p=test&lang=fr&paged=2' ) );
+		$this->assertEquals( $this->host . '/?p=test', $this->links_model->remove_paged_from_link( $this->host . '/?p=test&paged=2' ) );
+		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->remove_paged_from_link( $this->host . '/?p=test&lang=fr&paged=2' ) );
 	}
 
 	function test_get_language_from_url() {
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->host, PHP_URL_HOST );
 		$_SERVER['REQUEST_URI'] = '/?p=test&lang=fr';
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 	}
 
 	// bug fixed in 1.8
 	function test_home_url() {
-		$this->assertEquals( $this->host . '/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->host . '/?lang=fr', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->host . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->host . '/?lang=fr', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
 	// bug fixed in v1.8
 	function test_language_code_in_post_url() {
-		self::$polylang->options['force_lang'] = 1;
-		self::$polylang->filter_links = new PLL_Filters_Links( self::$polylang );
+		self::$model->options['force_lang'] = 1;
+		$frontend = new PLL_Frontend( $this->links_model );
+		new PLL_Filters_Links( $frontend );
 
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=en', get_permalink( $en ) );
 		$this->assertContains( 'lang=fr', get_permalink( $fr ) );
 
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=en', get_permalink( $en ) );
 		$this->assertContains( 'lang=fr', get_permalink( $fr ) );
 
 		$en = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=en', get_permalink( $en ) );
 		$this->assertContains( 'lang=fr', get_permalink( $fr ) );
 	}
 
 	function test_language_from_post_content() {
-		self::$polylang->options['force_lang'] = 0;
-		self::$polylang->filter_links = new PLL_Filters_Links( self::$polylang );
+		self::$model->options['force_lang'] = 0;
+		$frontend = new PLL_Frontend( $this->links_model );
+		new PLL_Filters_Links( $frontend );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=fr', get_permalink( $fr ) );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=fr', get_permalink( $fr ) );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->assertNotContains( 'lang=fr', get_permalink( $fr ) );
 	}

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -20,63 +20,63 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 
 		global $wp_rewrite;
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['rewrite'] = 1;
+		self::$model->options['hide_default'] = 1;
+		self::$model->options['rewrite'] = 1;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( $this->structure );
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->links_model->init();
+		$this->links_model = self::$model->get_links_model();
+		$this->links_model->init();
 	}
 
 	function _test_add_language_to_link() {
 		$url = $this->root . '/test/';
 
-		self::$polylang->options['rewrite'] = 1;
-		$this->assertEquals( $this->root . '/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->root . '/fr/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
+		self::$model->options['rewrite'] = 1;
+		$this->assertEquals( $this->root . '/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 
-		self::$polylang->options['rewrite'] = 0;
-		$this->assertEquals( $this->root . '/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->root . '/language/fr/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
+		self::$model->options['rewrite'] = 0;
+		$this->assertEquals( $this->root . '/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->root . '/language/fr/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
 	function _test_double_add_language_to_link() {
-		self::$polylang->options['rewrite'] = 1;
-		$this->assertEquals( $this->root . '/fr/test/', self::$polylang->links_model->add_language_to_link( $this->root . '/fr/test/', self::$polylang->model->get_language( 'fr' ) ) );
+		self::$model->options['rewrite'] = 1;
+		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->add_language_to_link( $this->root . '/fr/test/', self::$model->get_language( 'fr' ) ) );
 
-		self::$polylang->options['rewrite'] = 0;
-		$this->assertEquals( $this->root . '/language/fr/test/', self::$polylang->links_model->add_language_to_link( $this->root . '/language/fr/test/', self::$polylang->model->get_language( 'fr' ) ) );
+		self::$model->options['rewrite'] = 0;
+		$this->assertEquals( $this->root . '/language/fr/test/', $this->links_model->add_language_to_link( $this->root . '/language/fr/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
 	function _test_remove_language_from_link() {
-		self::$polylang->options['rewrite'] = 1;
-		$this->assertEquals( $this->root . '/en/test/', self::$polylang->links_model->remove_language_from_link( $this->root . '/en/test/' ) );
-		$this->assertEquals( $this->root . '/test/', self::$polylang->links_model->remove_language_from_link( $this->root . '/fr/test/' ) );
+		self::$model->options['rewrite'] = 1;
+		$this->assertEquals( $this->root . '/en/test/', $this->links_model->remove_language_from_link( $this->root . '/en/test/' ) );
+		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_language_from_link( $this->root . '/fr/test/' ) );
 
-		self::$polylang->options['rewrite'] = 0;
-		$this->assertEquals( $this->root . '/language/en/test/', self::$polylang->links_model->remove_language_from_link( $this->root . '/language/en/test/' ) );
-		$this->assertEquals( $this->root . '/test/', self::$polylang->links_model->remove_language_from_link( $this->root . '/language/fr/test/' ) );
+		self::$model->options['rewrite'] = 0;
+		$this->assertEquals( $this->root . '/language/en/test/', $this->links_model->remove_language_from_link( $this->root . '/language/en/test/' ) );
+		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_language_from_link( $this->root . '/language/fr/test/' ) );
 	}
 
 	function _test_switch_language_in_link() {
-		self::$polylang->options['rewrite'] = 1;
-		$this->assertEquals( $this->root . '/test/', self::$polylang->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->root . '/de/test/', self::$polylang->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$polylang->model->get_language( 'de' ) ) );
-		$this->assertEquals( $this->root . '/fr/test/', self::$polylang->links_model->switch_language_in_link( $this->root . '/test/', self::$polylang->model->get_language( 'fr' ) ) );
+		self::$model->options['rewrite'] = 1;
+		$this->assertEquals( $this->root . '/test/', $this->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->root . '/de/test/', $this->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$model->get_language( 'de' ) ) );
+		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->switch_language_in_link( $this->root . '/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
 	function _test_add_paged_to_link() {
-		self::$polylang->options['rewrite'] = 1;
-		$this->assertEquals( $this->root . '/test/page/2/', self::$polylang->links_model->add_paged_to_link( $this->root . '/test/', 2 ) );
-		$this->assertEquals( $this->root . '/fr/test/page/2/', self::$polylang->links_model->add_paged_to_link( $this->root . '/fr/test/', 2 ) );
+		self::$model->options['rewrite'] = 1;
+		$this->assertEquals( $this->root . '/test/page/2/', $this->links_model->add_paged_to_link( $this->root . '/test/', 2 ) );
+		$this->assertEquals( $this->root . '/fr/test/page/2/', $this->links_model->add_paged_to_link( $this->root . '/fr/test/', 2 ) );
 	}
 
 	function _test_remove_paged_from_link() {
-		self::$polylang->options['rewrite'] = 1;
-		$this->assertEquals( $this->root . '/test/', self::$polylang->links_model->remove_paged_from_link( $this->root . '/test/page/2/' ) );
-		$this->assertEquals( $this->root . '/fr/test/', self::$polylang->links_model->remove_paged_from_link( $this->root . '/fr/test/page/2/' ) );
+		self::$model->options['rewrite'] = 1;
+		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_paged_from_link( $this->root . '/test/page/2/' ) );
+		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->remove_paged_from_link( $this->root . '/fr/test/page/2/' ) );
 	}
 
 	function test_link_filters_with_absolute_links() {
@@ -103,7 +103,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 
 	// Bug fixed in 2.6
 	function test_link_filters_mixing_ssl() {
-		$this->root = 'https://example.org'; // self::$polylang->links_model->home uses http
+		$this->root = 'https://example.org'; // $this->links_model->home uses http
 		$this->_test_add_language_to_link();
 		$this->_test_double_add_language_to_link();
 		$this->_test_remove_language_from_link();
@@ -115,7 +115,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 
 	function test_link_filters_with_home_in_subdirectory() {
 		$this->root = 'http://example.org/polylang-pro';
-		self::$polylang->links_model->home = $this->root;
+		$this->links_model->home = $this->root;
 		$this->_test_add_language_to_link();
 		$this->_test_double_add_language_to_link();
 		$this->_test_remove_language_from_link();
@@ -127,32 +127,32 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 	function test_get_language_from_url() {
 		$server = $_SERVER;
 
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url( home_url( '/fr' ) ) );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url( home_url( '/fr' ) ) );
 
 		$_SERVER['REQUEST_URI'] = '/test/';
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() );
+		$this->assertEmpty( $this->links_model->get_language_from_url() );
 
 		$_SERVER['REQUEST_URI'] = '/fr/test/';
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		// Bug fixed in 2.6.10.
 		$_SERVER['REQUEST_URI'] = '/test/fr/';
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() );
+		$this->assertEmpty( $this->links_model->get_language_from_url() );
 
-		self::$polylang->options['rewrite'] = 0;
+		self::$model->options['rewrite'] = 0;
 		$_SERVER['REQUEST_URI'] = '/language/fr/test/';
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		$_SERVER = $server;
 	}
 
 	function test_home_url() {
-		$this->assertEquals( $this->host . '/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->host . '/fr/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->host . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->host . '/fr/', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 
-		self::$polylang->options['rewrite'] = 0;
-		$this->assertEquals( $this->host . '/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'en' ) ) );
-		$this->assertEquals( $this->host . '/language/fr/', self::$polylang->links_model->home_url( self::$polylang->model->get_language( 'fr' ) ) );
+		self::$model->options['rewrite'] = 0;
+		$this->assertEquals( $this->host . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
+		$this->assertEquals( $this->host . '/language/fr/', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
 	// Issue fixed in version 2.1.2
@@ -161,10 +161,10 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 
 		$_SERVER['REQUEST_URI'] = '/fr/test/';
 		$_SERVER['SERVER_PORT'] = 80;
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		$_SERVER['SERVER_PORT'] = 443;
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		$_SERVER = $server;
 	}

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -13,22 +13,22 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 			'de' => 'http://example.de',
 		);
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 3;
-		self::$polylang->options['domains'] = $this->hosts;
+		self::$model->options['hide_default'] = 1;
+		self::$model->options['force_lang'] = 3;
+		self::$model->options['domains'] = $this->hosts;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( $this->structure );
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		$this->links_model = self::$model->get_links_model();
 	}
 
 	function test_wrong_get_language_from_url() {
 		$_SERVER['HTTP_HOST'] = 'de.example.fr';
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() );
+		$this->assertEmpty( $this->links_model->get_language_from_url() );
 
 		$_SERVER['HTTP_HOST'] = 'example.com';
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() );
+		$this->assertEmpty( $this->links_model->get_language_from_url() );
 	}
 
 	function test_login_url() {
@@ -41,23 +41,24 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 
 	// Bug fixed in version 2.1.2
 	function test_second_level_domain() {
-		self::$polylang->options['domains']['fr'] = 'http://example.org.fr';
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		self::$model->options['domains']['fr'] = 'http://example.org.fr';
+		$this->links_model = self::$model->get_links_model();
 
 		$url = 'http://example.org.fr';
 
-		$this->assertEquals( 'http://example.org.fr', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( 'http://example.org', self::$polylang->links_model->remove_language_from_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( 'http://example.org.fr', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( 'http://example.org', $this->links_model->remove_language_from_link( $url, self::$model->get_language( 'fr' ) ) );
 
 		$url = 'http://example.org.fr/test/';
 
-		$this->assertEquals( 'http://example.org.fr/test/', self::$polylang->links_model->add_language_to_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( 'http://example.org/test/', self::$polylang->links_model->remove_language_from_link( $url, self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( 'http://example.org.fr/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( 'http://example.org/test/', $this->links_model->remove_language_from_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
 	// Bug fixed in 2.3.5
 	function test_redirect_www() {
-		$filters_links = new PLL_Frontend_Filters_Links( self::$polylang );
+		$frontend = new PLL_Frontend( $this->links_model );
+		$filters_links = new PLL_Frontend_Filters_Links( $frontend );
 
 		// www. to non www.
 		$_SERVER['HTTP_HOST'] = 'www.example.fr';
@@ -65,24 +66,26 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEquals( 'http://example.fr/test/', $filters_links->check_canonical_url( 'http://' . $_SERVER['HTTP_HOST'] . '/test/', false ) );
 
 		// non www. to www.
-		self::$polylang->options['domains']['fr'] = 'http://www.example.fr';
+		self::$model->options['domains']['fr'] = 'http://www.example.fr';
 		$_SERVER['HTTP_HOST'] = 'example.fr';
 		$this->assertEquals( 'http://www.example.fr', $filters_links->check_canonical_url( 'http://' . $_SERVER['HTTP_HOST'], false ) );
 		$this->assertEquals( 'http://www.example.fr/test/', $filters_links->check_canonical_url( 'http://' . $_SERVER['HTTP_HOST'] . '/test/', false ) );
 	}
 
 	function test_permalink_and_shortlink() {
-		self::$polylang->filters_links = new PLL_Frontend_Filters_Links( self::$polylang );
-		self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
+		$frontend = new PLL_Frontend( $this->links_model );
+		$filters_links = new PLL_Frontend_Filters_Links( $frontend );
+
+		$filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		$filters_links->cache->method( 'get' )->willReturn( false );
 
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( 'http://example.org/test/', get_permalink( $post_id ) );
 		$this->assertEquals( 'http://example.org/?p=' . $post_id, wp_get_shortlink( $post_id ) );
 
 		$post_id = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 		$this->assertEquals( 'http://example.fr/essai/', get_permalink( $post_id ) );
 		$this->assertEquals( 'http://example.fr/?p=' . $post_id, wp_get_shortlink( $post_id ) );
 	}

--- a/tests/phpunit/tests/test-links-subdomain.php
+++ b/tests/phpunit/tests/test-links-subdomain.php
@@ -13,41 +13,41 @@ class Links_Subdomain_Test extends PLL_Domain_UnitTestCase {
 			'de' => 'http://de.example.org',
 		);
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['force_lang'] = 2;
+		self::$model->options['hide_default'] = 1;
+		self::$model->options['force_lang'] = 2;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( $this->structure );
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		$this->links_model = self::$model->get_links_model();
 	}
 
 	function test_get_language_from_url() {
-		$this->assertEquals( 'en', self::$polylang->links_model->get_language_from_url( 'http://example.org' ) );
-		$this->assertEquals( 'en', self::$polylang->links_model->get_language_from_url( 'http://example.org/test/' ) );
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url( 'http://fr.example.org/test/' ) );
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url( 'http://fr.example.org' ) );
+		$this->assertEquals( 'en', $this->links_model->get_language_from_url( 'http://example.org' ) );
+		$this->assertEquals( 'en', $this->links_model->get_language_from_url( 'http://example.org/test/' ) );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url( 'http://fr.example.org/test/' ) );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url( 'http://fr.example.org' ) );
 	}
 
 	function test_get_language_from_url_with_empty_param() {
 		$_SERVER['HTTP_HOST'] = 'fr.example.org';
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		$_SERVER['REQUEST_URI'] = '/test/';
-		$this->assertEquals( 'fr', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
 		$_SERVER['HTTP_HOST'] = 'example.org';
-		$this->assertEquals( 'en', self::$polylang->links_model->get_language_from_url() );
+		$this->assertEquals( 'en', $this->links_model->get_language_from_url() );
 	}
 
 	function test_wrong_get_language_from_url() {
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url( 'http://es.example.org' ) );
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url( 'http://fr.org' ) );
+		$this->assertEmpty( $this->links_model->get_language_from_url( 'http://es.example.org' ) );
+		$this->assertEmpty( $this->links_model->get_language_from_url( 'http://fr.org' ) );
 
 		$_SERVER['HTTP_HOST'] = 'es.example.org';
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() ); // ok
+		$this->assertEmpty( $this->links_model->get_language_from_url() ); // ok
 
 		$_SERVER['HTTP_HOST'] = 'fr.org';
-		$this->assertEmpty( self::$polylang->links_model->get_language_from_url() ); // fails ( returns 'fr' )
+		$this->assertEmpty( $this->links_model->get_language_from_url() ); // fails ( returns 'fr' )
 	}
 }

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -12,34 +12,33 @@ class Model_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
 	function test_languages_list() {
-		self::$polylang->model->post->register_taxonomy(); // needed otherwise posts are not counted
+		self::$model->post->register_taxonomy(); // needed otherwise posts are not counted
 
-		$this->assertEquals( array( 'en', 'fr' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug' ) ) );
-		$this->assertEquals( array( 'English', 'Français' ), self::$polylang->model->get_languages_list( array( 'fields' => 'name' ) ) );
-		$this->assertEquals( array(), self::$polylang->model->get_languages_list( array( 'hide_empty' => true ) ) );
+		$this->assertEquals( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertEquals( array( 'English', 'Français' ), self::$model->get_languages_list( array( 'fields' => 'name' ) ) );
+		$this->assertEquals( array(), self::$model->get_languages_list( array( 'hide_empty' => true ) ) );
 
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 
-		$this->assertEquals( array( 'en' ), self::$polylang->model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
+		$this->assertEquals( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
 	}
 
 	function test_term_exists() {
 		$parent = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
-		self::$polylang->model->term->set_language( $parent, 'en' );
+		self::$model->term->set_language( $parent, 'en' );
 		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $parent ) );
-		self::$polylang->model->term->set_language( $child, 'en' );
+		self::$model->term->set_language( $child, 'en' );
 
-		$this->assertEquals( $parent, self::$polylang->model->term_exists( 'parent', 'category', 0, 'en' ) );
-		$this->assertEquals( $child, self::$polylang->model->term_exists( 'child', 'category', 0, 'en' ) );
-		$this->assertEquals( $child, self::$polylang->model->term_exists( 'child', 'category', $parent, 'en' ) );
-		$this->assertEmpty( self::$polylang->model->term_exists( 'parent', 'category', 0, 'fr' ) );
-		$this->assertEmpty( self::$polylang->model->term_exists( 'child', 'category', 0, 'fr' ) );
-		$this->assertEmpty( self::$polylang->model->term_exists( 'child', 'category', $parent, 'fr' ) );
+		$this->assertEquals( $parent, self::$model->term_exists( 'parent', 'category', 0, 'en' ) );
+		$this->assertEquals( $child, self::$model->term_exists( 'child', 'category', 0, 'en' ) );
+		$this->assertEquals( $child, self::$model->term_exists( 'child', 'category', $parent, 'en' ) );
+		$this->assertEmpty( self::$model->term_exists( 'parent', 'category', 0, 'fr' ) );
+		$this->assertEmpty( self::$model->term_exists( 'child', 'category', 0, 'fr' ) );
+		$this->assertEmpty( self::$model->term_exists( 'child', 'category', $parent, 'fr' ) );
 	}
 
 	/**
@@ -47,85 +46,89 @@ class Model_Test extends PLL_UnitTestCase {
 	 */
 	function test_term_exists_with_special_character() {
 		$term = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'Cook & eat' ) );
-		self::$polylang->model->term->set_language( $term, 'en' );
-		$this->assertEquals( $term, self::$polylang->model->term_exists( 'Cook & eat', 'category', 0, 'en' ) );
+		self::$model->term->set_language( $term, 'en' );
+		$this->assertEquals( $term, self::$model->term_exists( 'Cook & eat', 'category', 0, 'en' ) );
 	}
 
 	function test_count_posts() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
 		set_post_format( $en, 'aside' );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1, 'post_status' => 'draft' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
 		set_post_format( $fr, 'aside' );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		$language = self::$polylang->model->get_language( 'fr' );
-		$this->assertEquals( 2, self::$polylang->model->count_posts( $language ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'post_format' => 'post-format-aside' ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'year' => 2007 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9, 'day' => 4 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'm' => 2007 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'm' => 200709 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'm' => 20070904 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'author' => 1 ) ) );
-		$this->assertEquals( 1, self::$polylang->model->count_posts( $language, array( 'author_name' => 'admin' ) ) );
+		$language = self::$model->get_language( 'fr' );
+		$this->assertEquals( 2, self::$model->count_posts( $language ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'post_format' => 'post-format-aside' ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'year' => 2007 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9, 'day' => 4 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'm' => 2007 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'm' => 200709 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'm' => 20070904 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'author' => 1 ) ) );
+		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'author_name' => 'admin' ) ) );
 
 		// Bug fixed in version 2.2.6
-		$this->assertEquals( 2, self::$polylang->model->count_posts( $language, array( 'post_type' => array( 'post', 'page' ) ) ) );
+		$this->assertEquals( 2, self::$model->count_posts( $language, array( 'post_type' => array( 'post', 'page' ) ) ) );
 	}
 
 	function test_translated_post_types() {
 		// deactivate the cache
-		self::$polylang->model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->model->cache->method( 'get' )->willReturn( false );
+		self::$model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		self::$model->cache->method( 'get' )->willReturn( false );
 
-		self::$polylang->options['media_support'] = 0;
+		self::$model->options['media_support'] = 0;
 
-		$this->assertTrue( self::$polylang->model->is_translated_post_type( 'post' ) );
-		$this->assertTrue( self::$polylang->model->is_translated_post_type( 'page' ) );
-		$this->assertFalse( self::$polylang->model->is_translated_post_type( 'nav_menu_item' ) );
-		$this->assertFalse( self::$polylang->model->is_translated_post_type( 'attachment' ) );
+		$this->assertTrue( self::$model->is_translated_post_type( 'post' ) );
+		$this->assertTrue( self::$model->is_translated_post_type( 'page' ) );
+		$this->assertFalse( self::$model->is_translated_post_type( 'nav_menu_item' ) );
+		$this->assertFalse( self::$model->is_translated_post_type( 'attachment' ) );
 
-		self::$polylang->options['media_support'] = 1;
-		$this->assertTrue( self::$polylang->model->is_translated_post_type( 'attachment' ) );
+		self::$model->options['media_support'] = 1;
+		$this->assertTrue( self::$model->is_translated_post_type( 'attachment' ) );
 
-		self::$polylang->model->cache = new PLL_Cache();
+		self::$model->cache = new PLL_Cache();
 	}
 
 	function test_translated_taxonomies() {
-		$this->assertTrue( self::$polylang->model->is_translated_taxonomy( 'category' ) );
-		$this->assertTrue( self::$polylang->model->is_translated_taxonomy( 'post_tag' ) );
-		$this->assertFalse( self::$polylang->model->is_translated_taxonomy( 'post_format' ) );
-		$this->assertFalse( self::$polylang->model->is_translated_taxonomy( 'nav_menu' ) );
-		$this->assertFalse( self::$polylang->model->is_translated_taxonomy( 'language' ) );
+		$this->assertTrue( self::$model->is_translated_taxonomy( 'category' ) );
+		$this->assertTrue( self::$model->is_translated_taxonomy( 'post_tag' ) );
+		$this->assertFalse( self::$model->is_translated_taxonomy( 'post_format' ) );
+		$this->assertFalse( self::$model->is_translated_taxonomy( 'nav_menu' ) );
+		$this->assertFalse( self::$model->is_translated_taxonomy( 'language' ) );
 	}
 
 	function test_filtered_taxonomies() {
-		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( 'post_format' ) );
-		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( 'category' ) );
-		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( 'post_tag' ) );
-		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( 'nav_menu' ) );
-		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( 'language' ) );
+		$this->assertTrue( self::$model->is_filtered_taxonomy( 'post_format' ) );
+		$this->assertFalse( self::$model->is_filtered_taxonomy( 'category' ) );
+		$this->assertFalse( self::$model->is_filtered_taxonomy( 'post_tag' ) );
+		$this->assertFalse( self::$model->is_filtered_taxonomy( 'nav_menu' ) );
+		$this->assertFalse( self::$model->is_filtered_taxonomy( 'language' ) );
 	}
 
 	function test_is_translated_post_type() {
-		self::$polylang->options['post_types'] = array(
+		self::$model->options['post_types'] = array(
 			'trcpt' => 'trcpt',
 		);
 
+
 		register_post_type( 'trcpt' ); // translated custom post type
 		register_post_type( 'cpt' ); // *untranslated* custom post type
+
+		$links_model = self::$model->get_links_model();
+		$GLOBALS['polylang'] = new PLL_Admin( $links_model );
 
 		$this->assertTrue( pll_is_translated_post_type( 'trcpt' ) );
 		$this->assertFalse( pll_is_translated_post_type( 'cpt' ) );
@@ -137,15 +140,19 @@ class Model_Test extends PLL_UnitTestCase {
 
 		_unregister_post_type( 'cpt' );
 		_unregister_post_type( 'trcpt' );
+		unset( $GLOBALS['polylang'] );
 	}
 
 	function test_is_translated_taxonomy() {
-		self::$polylang->options['taxonomies'] = array(
+		self::$model->options['taxonomies'] = array(
 			'trtax' => 'trtax',
 		);
 
 		register_taxonomy( 'trtax', 'post' ); // translated custom tax
 		register_taxonomy( 'tax', 'post' ); // *untranslated* custom tax
+
+		$links_model = self::$model->get_links_model();
+		$GLOBALS['polylang'] = new PLL_Admin( $links_model );
 
 		$this->assertTrue( pll_is_translated_taxonomy( 'trtax' ) );
 		$this->assertFalse( pll_is_translated_taxonomy( 'tax' ) );
@@ -157,13 +164,13 @@ class Model_Test extends PLL_UnitTestCase {
 
 		_unregister_taxonomy( 'tax' );
 		_unregister_taxonomy( 'trtax' );
+		unset( $GLOBALS['polylang'] );
 	}
 
 	function test_is_filtered_taxonomy() {
-		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( array( 'post_format' ) ) );
-		$this->assertFalse( self::$polylang->model->is_filtered_taxonomy( array( 'category' ) ) );
-
-		$this->assertTrue( self::$polylang->model->is_filtered_taxonomy( array( 'post_format', 'category' ) ) );
+		$this->assertTrue( self::$model->is_filtered_taxonomy( array( 'post_format' ) ) );
+		$this->assertFalse( self::$model->is_filtered_taxonomy( array( 'category' ) ) );
+		$this->assertTrue( self::$model->is_filtered_taxonomy( array( 'post_format', 'category' ) ) );
 	}
 }
 

--- a/tests/phpunit/tests/test-no-languages.php
+++ b/tests/phpunit/tests/test-no-languages.php
@@ -5,7 +5,9 @@ class No_Languages_Test extends PLL_UnitTestCase {
 	// bug fixed in 1.8.2
 	function test_api_on_admin() {
 		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
-		$GLOBALS['polylang'] = self::$polylang;
+
+		$links_model = self::$model->get_links_model();
+		$GLOBALS['polylang'] = new PLL_Admin( $links_model );
 
 		// FIXME can't test pll_the_languages due to the constant PLL_ADMIN
 		$this->assertFalse( pll_current_language() );

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -11,9 +11,6 @@ class Query_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
-
-		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
 	function setUp() {
@@ -21,11 +18,11 @@ class Query_Test extends PLL_UnitTestCase {
 
 		global $wp_rewrite;
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['post_types'] = array(
+		self::$model->options['hide_default'] = 1;
+		self::$model->options['post_types'] = array(
 			'trcpt' => 'trcpt',
 		);
-		self::$polylang->options['taxonomies'] = array(
+		self::$model->options['taxonomies'] = array(
 			'trtax' => 'trtax',
 		);
 
@@ -34,28 +31,28 @@ class Query_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax
 		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
 		register_taxonomy( 'tax', 'cpt' ); // *untranslated* custom tax
 
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->links_model->init();
+		$links_model = self::$model->get_links_model();
+		$links_model->init();
 
 		// flush rules
 		$wp_rewrite->flush_rules();
 
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
+		$this->frontend = new PLL_Frontend( $links_model );
+		$this->frontend->init();
 
 		// de-activate cache for links
-		self::$polylang->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->links->cache->method( 'get' )->willReturn( false );
+		$this->frontend->links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		$this->frontend->links->cache->method( 'get' )->willReturn( false );
 
-		self::$polylang->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->filters_links->cache->method( 'get' )->willReturn( false );
+		$this->frontend->filters_links->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		$this->frontend->filters_links->cache->method( 'get' )->willReturn( false );
 	}
 
 	function tearDown() {
@@ -69,10 +66,10 @@ class Query_Test extends PLL_UnitTestCase {
 
 	function test_home_latest_posts() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/' ) );
 
@@ -83,23 +80,23 @@ class Query_Test extends PLL_UnitTestCase {
 
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_single_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->go_to( home_url( '/fr/essai/' ) );
 
 		$this->assertQueryTrue( 'is_single', 'is_singular' );
-		$this->assertEquals( home_url( '/fr/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( home_url( '/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/fr/essai/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_single_post_private_translation() {
@@ -107,128 +104,128 @@ class Query_Test extends PLL_UnitTestCase {
 		$author_en = $this->factory->user->create( array( 'role' => 'author' ) );
 
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_author' => $author_en, 'post_status' => 'private' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->go_to( home_url( '/fr/essai/' ) );
 
 		// administator can read everything
 		wp_set_current_user( 1 );
-		$this->assertEquals( home_url( '/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 
 		// author can read his own post
 		wp_set_current_user( $author_en );
-		$this->assertEquals( home_url( '/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 
 		wp_set_current_user( 0 );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 
 		$this->delete_user( $author_en );
 	}
 
 	function test_page() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->go_to( home_url( '/fr/essai/' ) );
 
 		$this->assertQueryTrue( 'is_page', 'is_singular' );
-		$this->assertEquals( home_url( '/fr/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( home_url( '/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/fr/essai/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_category() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $en, 'en' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 		wp_set_post_terms( $post_id, array( $fr ), 'category' );
 
 		$this->go_to( home_url( '/fr/category/essai/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_category' );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEquals( home_url( '/fr/category/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) ); // Link to self
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/category/essai/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) ); // Link to self
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		wp_set_post_terms( $post_id, array( $en ), 'category' );
 
-		$this->assertEquals( home_url( '/category/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/category/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_post_tag() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $fr, 'fr' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_id = $this->factory->post->create( array( 'tags_input' => array( 'essai' ) ) );
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 
 		$this->go_to( home_url( '/fr/tag/essai/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_tag' );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEquals( home_url( '/fr/tag/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/tag/essai/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		$post_id = $this->factory->post->create( array( 'tags_input' => array( 'test' ) ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 
-		$this->assertEquals( home_url( '/tag/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/tag/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_post_format() {
 		$post_id = $this->factory->post->create();
 		set_post_format( $post_id, 'aside' );
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 
 		$this->go_to( home_url( '/fr/type/aside/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_tax' );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEquals( home_url( '/fr/type/aside/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/type/aside/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		$post_id = $this->factory->post->create();
 		set_post_format( $post_id, 'aside' );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		wp_cache_flush(); // otherwise count_posts has only posts in fr
 
-		$this->assertEquals( home_url( '/type/aside/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/type/aside/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_translated_custom_tax() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $fr, 'fr' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_id = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 		wp_set_post_terms( $post_id, 'essai', 'trtax' ); // don't use 'tax_input' above as we don't pass current_user_can test in wp_insert_post
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // Otherwise the test fails for WP 4.8+ due to the changes in get_term_by()
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // Otherwise the test fails for WP 4.8+ due to the changes in get_term_by()
 
 		$this->go_to( home_url( '/fr/trtax/essai/' ) );
 
@@ -236,14 +233,14 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_tax( 'trtax' ) );
 		$this->assertFalse( is_tax( 'language' ) );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEquals( home_url( '/fr/trtax/essai/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/trtax/essai/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		$post_id = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		wp_set_post_terms( $post_id, 'test', 'trtax' );
 
-		$this->assertEquals( home_url( '/trtax/test/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/trtax/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_untranslated_custom_tax() {
@@ -256,26 +253,26 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertQueryTrue( 'is_archive', 'is_tax' );
 		$this->assertTrue( is_tax( 'tax' ) );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 	}
 
 	function test_translated_post_type_archive() {
 		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/trcpt/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_post_type_archive' ); // we don't want is_tax
-		$this->assertEquals( home_url( '/fr/trcpt/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/trcpt/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$this->go_to( home_url( '/fr/trcpt/' ) );
 
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/trcpt/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/trcpt/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_untranslated_post_type_archive() {
@@ -285,7 +282,7 @@ class Query_Test extends PLL_UnitTestCase {
 
 		$this->assertQueryTrue( 'is_archive', 'is_post_type_archive' );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 
 		// Secondary query which would erroneously forces the language
 		$query = new WP_Query( array( 'post_type' => 'cpt', 'lang' => 'fr' ) );
@@ -294,151 +291,151 @@ class Query_Test extends PLL_UnitTestCase {
 
 	function test_archives() {
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		// author
 		$this->go_to( home_url( '/fr/author/admin/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_author' ); // we don't want is_tax
-		$this->assertEquals( home_url( '/fr/author/admin/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/author/admin/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		// year
 		$this->go_to( home_url( '/fr/2007/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_date', 'is_year' ); // we don't want is_tax
-		$this->assertEquals( home_url( '/fr/2007/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/2007/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		// month
 		$this->go_to( home_url( '/fr/2007/09/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_date', 'is_month' ); // we don't want is_tax
-		$this->assertEquals( home_url( '/fr/2007/09/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/2007/09/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		// day
 		$this->go_to( home_url( '/fr/2007/09/04/' ) );
 
 		$this->assertQueryTrue( 'is_archive', 'is_date', 'is_day' ); // we don't want is_tax
-		$this->assertEquals( home_url( '/fr/2007/09/04/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // no content in translation
+		$this->assertEquals( home_url( '/fr/2007/09/04/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // no content in translation
 
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		// author
 		$this->go_to( home_url( '/fr/author/admin/' ) );
 
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/author/admin/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/author/admin/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 
 		// year
 		$this->go_to( home_url( '/fr/2007/' ) );
 
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/2007/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/2007/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 
 		// month
 		$this->go_to( home_url( '/fr/2007/09/' ) );
 
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/2007/09/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/2007/09/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 
 		// day
 		$this->go_to( home_url( '/fr/2007/09/04/' ) );
 
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/2007/09/04/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/2007/09/04/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_search() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'test fr' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/?s=test' ) );
 
 		$this->assertQueryTrue( 'is_search' ); // we don't want is_tax
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/fr/?s=test' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
-		$this->assertEquals( home_url( '/?s=test' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/fr/?s=test' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/?s=test' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_search_in_category() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->set_language( $fr, 'fr' );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $post_id, 'en' );
+		self::$model->post->set_language( $post_id, 'en' );
 		wp_set_post_terms( $post_id, array( $en ), 'category' );
 
 		$searched = $this->factory->post->create( array( 'post_title' => 'test fr' ) );
-		self::$polylang->model->post->set_language( $searched, 'fr' );
+		self::$model->post->set_language( $searched, 'fr' );
 		wp_set_post_terms( $searched, array( $fr ), 'category' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force otherwise get_translation_url fails to translate the category slug
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force otherwise get_translation_url fails to translate the category slug
 		$this->go_to( home_url( '/fr/category/essai/?s=test' ) );
 
 		$this->assertQueryTrue( 'is_search', 'is_category', 'is_archive' ); // we don't want is_tax
 		$this->assertEquals( array( get_post( $searched ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/category/test/?s=test' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/category/test/?s=test' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	// bug fixed in v1.7.11: error 404 for attachments
 	// bug fixed in v1.9.1: language switcher does not link to media translation for anonymous user
 	function test_attachment() {
 		$post_en = $this->factory->post->create( array( 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $post_en, 'en' );
+		self::$model->post->set_language( $post_en, 'en' );
 
 		$post_fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $post_fr, 'fr' );
+		self::$model->post->set_language( $post_fr, 'fr' );
 
 		$en = $this->factory->post->create( array( 'post_title' => 'img_en', 'post_type' => 'attachment', 'post_parent' => $post_en ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'img_fr', 'post_type' => 'attachment', 'post_parent' => $post_fr ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->go_to( home_url( '/fr/essai/img_fr/' ) );
 
 		$this->assertQueryTrue( 'is_attachment', 'is_singular', 'is_single' ); // bug fixed in v1.7.11
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/test/img_en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
+		$this->assertEquals( home_url( '/test/img_en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
 	}
 
 	// Bug fixed in 2.1: language switcher does not link to media translation for unattached media
 	function test_unattached_attachment() {
 		$en = $this->factory->post->create( array( 'post_title' => 'img_en', 'post_type' => 'attachment' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'img_fr', 'post_type' => 'attachment' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->go_to( home_url( '/fr/img_fr/' ) );
 
 		$this->assertQueryTrue( 'is_attachment', 'is_singular', 'is_single' );
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts ); // only posts in fr
-		$this->assertEquals( home_url( '/img_en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
+		$this->assertEquals( home_url( '/img_en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
 	}
 
 	// bug fixed in v1.8: is_tax set on main feeds
 	function test_main_feed() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->go_to( home_url( '/fr/feed/' ) );
 		$this->assertQueryTrue( 'is_feed' ); // we don't want is_tax
@@ -455,14 +452,14 @@ class Query_Test extends PLL_UnitTestCase {
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
 
 		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 		wp_set_post_terms( $en, 'test', 'tax' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 		wp_set_post_terms( $fr, 'test', 'tax' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'post_type' => 'trcpt', 'tax' => 'test' ) ) ); // initial bug
 
 		// additional test for post_type = any
@@ -476,36 +473,36 @@ class Query_Test extends PLL_UnitTestCase {
 	// "Issue" fixed in 2.0.10: Drafts should not appear in language switcher
 	function test_draft() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_status' => 'draft' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_title' => 'essai' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$this->go_to( home_url( '/fr/essai/' ) );
 
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
 	function test_cat() {
 		// Categories
 		$cat_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $cat_en, 'en' );
+		self::$model->term->set_language( $cat_en, 'en' );
 
 		$cat_fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $cat_fr, 'fr' );
+		self::$model->term->set_language( $cat_fr, 'fr' );
 
 		// Posts
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 		wp_set_post_terms( $en, array( $cat_en ), 'category' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 		wp_set_post_terms( $fr, array( $cat_fr ), 'category' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$this->frontend->curlang = self::$model->get_language( 'en' );
 
 		$query = new WP_Query( array( 'cat' => $cat_en ) );
 		$this->assertEquals( array( get_post( $en ) ), $query->posts );
@@ -528,15 +525,15 @@ class Query_Test extends PLL_UnitTestCase {
 	function test_any() {
 		// Posts
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$query = new WP_Query( array( 'post_type' => 'any', 'lang' => 'en' ) );
 		$this->assertEquals( array( get_post( $en ) ), $query->posts );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$this->frontend->curlang = self::$model->get_language( 'en' );
 
 		$query = new WP_Query( array( 'post_type' => 'any' ) );
 		$this->assertEquals( array( get_post( $en ) ), $query->posts );
@@ -554,14 +551,14 @@ class Query_Test extends PLL_UnitTestCase {
 
 		// Posts
 		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 		wp_set_post_terms( $en, array( $tag ), 'tax' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 		wp_set_post_terms( $fr, array( $tag ), 'tax' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$this->frontend->curlang = self::$model->get_language( 'en' );
 
 		$args = array(
 			'post_type' => 'trcpt',
@@ -582,10 +579,10 @@ class Query_Test extends PLL_UnitTestCase {
 	// Tests cases with 'lang' and no post type in query.
 	function test_language_and_no_post_type_in_query() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 
 		$page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'test' ) );
-		self::$polylang->model->post->set_language( $page_id, 'fr' );
+		self::$model->post->set_language( $page_id, 'fr' );
 
 		$query = new WP_Query( array( 'lang' => 'fr' ) );
 		$this->assertEquals( array( get_post( $post_id ) ), $query->posts );
@@ -600,16 +597,16 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $page_id ) ), $query->posts );
 
 		$media_id = $this->factory->post->create( array( 'post_type' => 'attachment', 'post_title' => 'attached' ) );
-		self::$polylang->model->post->set_language( $media_id, 'fr' );
+		self::$model->post->set_language( $media_id, 'fr' );
 
 		$query = new WP_Query( array( 'lang' => 'fr', 'attachment' => 'attached' ) );
 		$this->assertEquals( array( get_post( $media_id ) ), $query->posts );
 
 		$cpt_id = $this->factory->post->create( array( 'post_type' => 'trcpt', 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
-		self::$polylang->model->post->set_language( $cpt_id, 'fr' );
+		self::$model->post->set_language( $cpt_id, 'fr' );
 
 		$tax_id = $this->factory->term->create( array( 'taxonomy' => 'trtax' ) );
-		self::$polylang->model->term->set_language( $tax_id, 'fr' );
+		self::$model->term->set_language( $tax_id, 'fr' );
 		wp_set_post_terms( $cpt_id, array( $tax_id ), 'trtax' );
 
 		$args = array(
@@ -638,10 +635,10 @@ class Query_Test extends PLL_UnitTestCase {
 		register_taxonomy_for_object_type( 'category', array( 'post', 'trcpt' ) );
 
 		$cpt_id = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $cpt_id, 'fr' );
+		self::$model->post->set_language( $cpt_id, 'fr' );
 
 		$cat_id = $this->factory->category->create();
-		self::$polylang->model->term->set_language( $cat_id, 'fr' );
+		self::$model->term->set_language( $cat_id, 'fr' );
 		wp_set_post_terms( $cpt_id, array( $cat_id ), 'category' );
 
 		// Assign the post type in a hook after our pare_query action
@@ -664,10 +661,10 @@ class Query_Test extends PLL_UnitTestCase {
 	 */
 	function test_sticky_posts() {
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 		stick_post( $fr );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
 		$this->go_to( home_url( '/fr/' ) );
 		$this->assertEquals( 1, $GLOBALS['wp_query']->post_count );

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -11,9 +11,6 @@ class Search_Form_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
-
-		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
 	}
 
 	function setUp() {
@@ -21,30 +18,30 @@ class Search_Form_Test extends PLL_UnitTestCase {
 
 		global $wp_rewrite;
 
-		self::$polylang->options['hide_default'] = 1;
+		self::$model->options['hide_default'] = 1;
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->links_model->init();
+		$this->links_model = self::$model->get_links_model();
+		$this->links_model->init();
 
 		// flush rules
 		$wp_rewrite->flush_rules();
 
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
+		$this->frontend = new PLL_Frontend( $this->links_model );
+		$this->frontend->init();
 	}
 
 	function test_admin_bar_search_form() {
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
 		$admin_bar = new WP_Admin_Bar();
 		$admin_bar->add_menus();
@@ -57,13 +54,13 @@ class Search_Form_Test extends PLL_UnitTestCase {
 	function test_get_search_form() {
 		global $wp_rewrite;
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$form = get_search_form( false ); // don't echo
 
 		$this->assertContains( 'action="' . home_url( '/fr/' ) . '"', $form );
 
 		$wp_rewrite->set_permalink_structure( '' );
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		$this->frontend->links_model = self::$model->get_links_model();
 
 		$form = get_search_form( false );
 		$this->assertContains( '<input type="hidden" name="lang" value="fr" />', $form );
@@ -73,7 +70,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 	 * Issue #829
 	 */
 	function test_get_search_form_with_wrong_inital_url() {
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$form = '<form role="search" method="get" class="search-form" action="http://example.org/fr/accueil/">
 				<label>
 					<span class="screen-reader-text">Search for:</span>

--- a/tests/phpunit/tests/test-settings-browser.php
+++ b/tests/phpunit/tests/test-settings-browser.php
@@ -2,15 +2,22 @@
 
 class Settings_Browser_Test extends PLL_UnitTestCase {
 
+	function setUp() {
+		parent::setUp();
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_env = new PLL_Settings( $links_model );
+	}
+
 	function test_active_true() {
-		self::$polylang->options['browser'] = 1;
-		$module = new PLL_Settings_Browser( self::$polylang );
+		self::$model->options['browser'] = 1;
+		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertTrue( $module->is_active() );
 	}
 
 	function test_active_false() {
-		self::$polylang->options['browser'] = 0;
-		$module = new PLL_Settings_Browser( self::$polylang );
+		self::$model->options['browser'] = 0;
+		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertFalse( $module->is_active() );
 	}
 }

--- a/tests/phpunit/tests/test-settings-cpt.php
+++ b/tests/phpunit/tests/test-settings-cpt.php
@@ -6,11 +6,14 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		// De-activate cache for translated post types and taxonomies
-		self::$polylang->model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$polylang->model->cache->method( 'get' )->willReturn( false );
+		self::$model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		self::$model->cache->method( 'get' )->willReturn( false );
 
-		self::$polylang->options['post_types'] = array();
-		self::$polylang->options['taxonomies'] = array();
+		self::$model->options['post_types'] = array();
+		self::$model->options['taxonomies'] = array();
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_env = new PLL_Settings( $links_model );
 	}
 
 	function tearDown() {
@@ -65,13 +68,13 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_no_cpt_no_tax() {
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_untranslated_public_post_type() {
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -83,9 +86,9 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_public_post_type() {
-		self::$polylang->options['post_types'] = array( 'cpt' );
+		self::$model->options['post_types'] = array( 'cpt' );
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -99,7 +102,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	function test_programmatically_translated_public_post_type() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -112,28 +115,28 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 
 	function test_untranslated_private_post_type() {
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_translated_private_post_type() {
-		self::$polylang->options['post_types'] = array( 'cpt' );
+		self::$model->options['post_types'] = array( 'cpt' );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_programmatically_translated_private_post_type() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_not_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_untranslated_private_post_type_in_settings() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_untranslated_post_type_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -145,10 +148,10 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_private_post_type_in_settings() {
-		self::$polylang->options['post_types'] = array( 'cpt' );
+		self::$model->options['post_types'] = array( 'cpt' );
 		add_filter( 'pll_get_post_types', array( $this, 'filter_untranslated_post_type_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -161,7 +164,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 
 	function test_untranslated_public_taxonomy() {
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -173,9 +176,9 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_public_taxonomy() {
-		self::$polylang->options['taxonomies'] = array( 'tax' );
+		self::$model->options['taxonomies'] = array( 'tax' );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -189,7 +192,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	function test_programmatically_translated_public_taxonomy() {
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -202,14 +205,14 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 
 	function test_untranslated_private_taxonomy() {
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_translated_private_taxonomy() {
-		self::$polylang->options['taxonomies'] = array( 'tax' );
+		self::$model->options['taxonomies'] = array( 'tax' );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$this->assertEmpty( $module->get_form() );
 	}
@@ -217,14 +220,14 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	function test_programmatically_translated_private_taxonomy() {
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_not_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
 	function test_untranslated_private_taxonomy_in_settings() {
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_untranslated_taxonomy_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );
@@ -236,10 +239,10 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	function test_translated_private_taxonomy_in_settings() {
-		self::$polylang->options['taxonomies'] = array( 'tax' );
+		self::$model->options['taxonomies'] = array( 'tax' );
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_untranslated_taxonomy_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
-		$module = new PLL_Settings_CPT( self::$polylang );
+		$module = new PLL_Settings_CPT( $this->pll_env );
 
 		$doc = new DomDocument();
 		$doc->loadHTML( $module->get_form() );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -21,7 +21,7 @@ class Settings_Test extends PLL_UnitTestCase {
 
 	// bug introduced and fixed in 1.9alpha
 	function test_edit_language() {
-		$lang = self::$polylang->model->get_language( 'fr' );
+		$lang = self::$model->get_language( 'fr' );
 
 		// setup globals
 		$_GET['page'] = 'mlang';
@@ -36,8 +36,9 @@ class Settings_Test extends PLL_UnitTestCase {
 		set_site_transient( 'available_translations', array( 'fr_FR' => '' ) );
 
 		ob_start();
-		self::$polylang = new PLL_Settings( self::$polylang->links_model );
-		self::$polylang->languages_page();
+		$links_model = self::$model->get_links_model();
+		$pll_env = new PLL_Settings( $links_model );
+		$pll_env->languages_page();
 		$out = ob_get_clean();
 		$out = mb_convert_encoding( $out, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
 		$doc = new DomDocument();
@@ -65,7 +66,8 @@ class Settings_Test extends PLL_UnitTestCase {
 		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		set_current_screen();
 
-		self::$polylang = new PLL_Settings( self::$polylang->links_model );
+		$links_model = self::$model->get_links_model();
+		$pll_env = new PLL_Settings( $links_model );
 		do_action( 'load-toplevel_page_mlang' );
 
 		ob_start();
@@ -76,7 +78,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $out );
 
 		ob_start();
-		self::$polylang->model->post->set_language( $id, 'en' );
+		self::$model->post->set_language( $id, 'en' );
 		do_action( 'admin_notices' );
 		$out = ob_get_clean();
 
@@ -90,7 +92,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $out );
 
 		ob_start();
-		self::$polylang->model->term->set_language( $id, 'en' );
+		self::$model->term->set_language( $id, 'en' );
 		do_action( 'admin_notices' );
 		$out = ob_get_clean();
 
@@ -100,10 +102,11 @@ class Settings_Test extends PLL_UnitTestCase {
 	// Bug introduced in 2.1-dev
 	function test_display_settings_errors() {
 		add_settings_error( 'test', 'test', 'ERROR' );
-		self::$polylang = new PLL_Settings( self::$polylang->links_model );
+		$links_model = self::$model->get_links_model();
+		$pll_env = new PLL_Settings( $links_model );
 
 		ob_start();
-		self::$polylang->languages_page();
+		$pll_env->languages_page();
 		$out = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $out, 'ERROR' ) );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -13,14 +13,16 @@ class Slugs_Test extends PLL_UnitTestCase {
 	}
 
 	function test_term_slugs() {
-		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang ); // activate our filters
+		$links_model = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		new PLL_Admin_Filters_Term( $pll_admin ); // activate our filters
 
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $term_id, 'en' );
+		self::$model->term->set_language( $term_id, 'en' );
 
 		$_POST['term_lang_choice'] = 'fr';
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $term_id, 'fr' );
+		self::$model->term->set_language( $term_id, 'fr' );
 
 		$term = get_term( $term_id, 'category' );
 		$this->assertEquals( 'test-fr', $term->slug );

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -20,9 +20,6 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE_formal' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
-
 		// page on front
 		self::$home_en = $en = self::factory()->post->create(
 			array(
@@ -31,7 +28,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 				'post_content' => 'en1<!--nextpage-->en2',
 			)
 		);
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		self::$home_fr = $fr = self::factory()->post->create(
 			array(
@@ -40,7 +37,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 				'post_content' => 'fr1<!--nextpage-->fr2',
 			)
 		);
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		self::$home_de = $de = self::factory()->post->create(
 			array(
@@ -49,26 +46,26 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 				'post_content' => 'de1<!--nextpage-->de2',
 			)
 		);
-		self::$polylang->model->post->set_language( $de, 'de' );
+		self::$model->post->set_language( $de, 'de' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
 
 		// page for posts
 		// intentionally do not create one in German
 		self::$posts_en = $en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		self::$posts_fr = $fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 	}
 
 	function setUp() {
 		parent::setUp();
 
-		self::$polylang->options['hide_default'] = 0;
-		self::$polylang->options['redirect_lang'] = 0;
+		self::$model->options['hide_default'] = 0;
+		self::$model->options['redirect_lang'] = 0;
 
 		global $wp_rewrite;
 
@@ -77,24 +74,25 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$polylang->model->post->register_taxonomy(); // needs this for 'lang' query var
+		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->links_model->init();
+		$this->links_model = self::$model->get_links_model();
+		$this->links_model->init();
 
-		self::$polylang->links = new PLL_Admin_Links( self::$polylang );
-		self::$polylang->static_pages = new PLL_Admin_Static_Pages( self::$polylang );
+		$pll_admin = new PLL_Admin( $this->links_model );
+		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
+		$pll_admin->static_pages = new PLL_Admin_Static_Pages( $pll_admin );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', self::$home_fr );
 		update_option( 'page_for_posts', self::$posts_fr );
 
 		// go to frontend
-		self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-		self::$polylang->init();
+		$this->frontend = new PLL_Frontend( $this->links_model );
+		$this->frontend->init();
 
-		self::$polylang->static_pages = new PLL_Frontend_Static_Pages( self::$polylang );
-		self::$polylang->static_pages->pll_language_defined();
+		$this->frontend->static_pages = new PLL_Frontend_Static_Pages( $this->frontend );
+		$this->frontend->static_pages->pll_language_defined();
 	}
 
 	static function wpTearDownAfterClass() {
@@ -111,7 +109,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_front_page_with_default_options() {
 		global $wp_rewrite;
 
-		self::$polylang->model->clean_languages_cache();
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
@@ -120,12 +118,12 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/en/home/' ), get_permalink( self::$home_en ) );
 		$this->assertEquals( home_url( '/fr/accueil/' ), get_permalink( self::$home_fr ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/accueil/' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/en/home/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/home/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 	}
@@ -133,18 +131,18 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_front_page_with_query() {
 		global $wp_rewrite;
 
-		self::$polylang->model->clean_languages_cache();
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/accueil/?query=1' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/en/home/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/home/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/?query=1' ), false ) );
 	}
@@ -152,28 +150,28 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_paged_front_page() {
 		global $wp_rewrite;
 
-		self::$polylang->model->clean_languages_cache();
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/accueil/page/2/' ) );
 		the_post();
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_paged', 'is_front_page' );
-		$this->assertEquals( home_url( '/en/home/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/home/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( 'fr2', get_the_content() );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/en/home/page/2/' ) );
 		the_post();
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_paged', 'is_front_page' );
-		$this->assertEquals( home_url( '/fr/accueil/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/fr/accueil/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertEquals( 'en2', get_the_content() );
 		$this->assertEmpty( redirect_canonical( home_url( '/en/home/page/2/' ), false ) );
 	}
@@ -181,8 +179,8 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_front_page_with_hide_default() {
 		global $wp_rewrite;
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['hide_default'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
@@ -191,21 +189,21 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/' ), get_permalink( self::$home_en ) );
 		$this->assertEquals( home_url( '/fr/accueil/' ), get_permalink( self::$home_fr ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/accueil/' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/fr/accueil/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/fr/accueil/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertEquals( array( get_post( self::$home_en ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/' ), false ) );
 		$this->assertEquals( home_url( '/' ), redirect_canonical( home_url( '/en/home/' ), false ) );
@@ -218,28 +216,28 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->set_permalink_structure( '' );
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['hide_default'] = 1;
+		$this->frontend->links_model = self::$model->get_links_model();
+		self::$model->clean_languages_cache();
 
 		$this->assertEquals( home_url( '/' ), get_permalink( self::$home_en ) ); // trailing slash kept for home page
 		$this->assertEquals( home_url( '?page_id=' . self::$home_fr . '&lang=fr' ), get_permalink( self::$home_fr ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '?page_id=' . self::$home_fr ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '?page_id=' . self::$home_fr . '&lang=fr' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '?page_id=' . self::$home_fr . '&lang=fr' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertEquals( array( get_post( self::$home_en ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/' ), false ) );
 	}
@@ -250,26 +248,26 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->set_permalink_structure( '' );
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['hide_default'] = 1;
+		$this->frontend->links_model = self::$model->get_links_model();
+		self::$model->clean_languages_cache();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '?page_id=' . self::$home_fr . '&lang=fr&page=2' ) );
 		the_post();
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_paged', 'is_front_page' );
-		$this->assertEquals( home_url( '/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( 'fr2', get_the_content() );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '?page=2' ) );
 		the_post();
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_paged', 'is_front_page' );
-		$this->assertEquals( home_url( '?page_id=' . self::$home_fr . '&lang=fr' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '?page_id=' . self::$home_fr . '&lang=fr' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertEquals( 'en2', get_the_content() );
 		$this->assertEmpty( redirect_canonical( home_url( '?page=2' ), false ) );
 	}
@@ -277,8 +275,8 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
-		self::$polylang->options['redirect_lang'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['redirect_lang'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
@@ -287,35 +285,35 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/en/' ), get_permalink( self::$home_en ) );
 		$this->assertEquals( home_url( '/fr/' ), get_permalink( self::$home_fr ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/' ), false ) );
 	}
 
 	function test_page_for_posts() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/articles/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_posts_page' );
-		$this->assertEquals( home_url( '/en/posts/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/posts/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( $fr ) ), $GLOBALS['wp_query']->posts );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/en/posts/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_posts_page' );
-		$this->assertEquals( home_url( '/fr/articles/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/fr/articles/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
 	}
 
@@ -324,61 +322,61 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 
 		$en = $this->factory->post->create_many( 3 );
 		foreach ( $en as $post_id ) {
-			self::$polylang->model->post->set_language( $post_id, 'en' );
+			self::$model->post->set_language( $post_id, 'en' );
 		}
 
 		$fr = $this->factory->post->create_many( 3 );
 		foreach ( $fr as $post_id ) {
-			self::$polylang->model->post->set_language( $post_id, 'fr' );
+			self::$model->post->set_language( $post_id, 'fr' );
 		}
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/articles/page/2/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_posts_page', 'is_paged' );
-		$this->assertEquals( home_url( '/en/posts/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/posts/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertCount( 1, $GLOBALS['wp_query']->posts );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/en/posts/page/2/' ) );
 
 		$this->assertQueryTrue( 'is_home', 'is_posts_page', 'is_paged' );
-		$this->assertEquals( home_url( '/fr/articles/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/fr/articles/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertCount( 1, $GLOBALS['wp_query']->posts );
 	}
 
 	// bug fixed in 1.8beta3 : non translated posts page always link to the static front page even when they should not
 	function test_untranslated_page_for_posts() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/articles/' ) );
 
-		$this->assertEmpty( self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'de' ) ) );
+		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'de' ) ) );
 	}
 
 	// bug fixed in 1.8.1
 	function test_paged_front_page_with_hide_default() {
 		global $wp_rewrite;
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['hide_default'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/page/2/' ) );
 		the_post();
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_paged', 'is_front_page' );
-		$this->assertEquals( home_url( '/fr/accueil/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'fr' ) ) );
+		$this->assertEquals( home_url( '/fr/accueil/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 		$this->assertEquals( 'en2', get_the_content() );
 		$this->assertEmpty( redirect_canonical( home_url( '/page/2/' ), false ) );
 	}
@@ -387,20 +385,20 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_front_page_with_redirect_lang_and_hide_default() {
 		global $wp_rewrite;
 
-		self::$polylang->options['redirect_lang'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['redirect_lang'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/page/2/' ) );
 		the_post();
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_paged', 'is_front_page' );
-		$this->assertEquals( home_url( '/en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( 'fr2', get_the_content() );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/page/2/' ), false ) );
 	}
@@ -421,10 +419,10 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 
 		// test for standard pages too
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		ob_start();
 		_post_states( get_post( $en ) );
@@ -441,7 +439,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 
 	// Bug fixed in 2.0
 	function test_get_post_type_archive_link_for_posts() {
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$this->assertEquals( 'http://example.org/fr/articles/', get_post_type_archive_link( 'post' ) );
 	}
 
@@ -450,10 +448,10 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
-		self::$polylang->options['redirect_lang'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['redirect_lang'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
@@ -479,17 +477,17 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 
-		self::$polylang->options['post_types'] = array(
+		self::$model->options['post_types'] = array(
 			'trcpt' => 'trcpt',
 		);
 
 		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
 
 		$en = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
-		self::$polylang->options['redirect_lang'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['redirect_lang'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->flush_rules();
 
@@ -518,15 +516,15 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		add_filter( 'query_vars', array( $this, 'extra_query_vars' ) );
 		add_filter( 'root_rewrite_rules', array( $this, 'extra_root_rewrite_rules' ), 1 );
 
-		self::$polylang->options['hide_default'] = 1;
-		self::$polylang->options['redirect_lang'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['hide_default'] = 1;
+		self::$model->options['redirect_lang'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'en' ); // brute force
 		$this->go_to( home_url( '/testing/' ) );
 
 		$this->assertFalse( is_front_page() );
@@ -535,19 +533,19 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	function test_front_page_with_orderby_with_redirect_lang() {
 		global $wp_rewrite;
 
-		self::$polylang->options['redirect_lang'] = 1;
-		self::$polylang->model->clean_languages_cache();
+		self::$model->options['redirect_lang'] = 1;
+		self::$model->clean_languages_cache();
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->flush_rules();
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+		$this->frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 		$this->go_to( home_url( '/fr/?orderby=price' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
-		$this->assertEquals( home_url( '/en/' ), self::$polylang->links->get_translation_url( self::$polylang->model->get_language( 'en' ) ) );
+		$this->assertEquals( home_url( '/en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( self::$home_fr ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/?orderby=price' ), false ) );
 	}

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -21,41 +21,44 @@ class Sync_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
 	function test_copy_taxonomies() {
 		$tag_en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'slug' => 'tag_en' ) );
-		self::$polylang->model->term->set_language( $tag_en, 'en' );
+		self::$model->term->set_language( $tag_en, 'en' );
 
 		$tag_fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'slug' => 'tag_fr' ) );
-		self::$polylang->model->term->set_language( $tag_fr, 'fr' );
+		self::$model->term->set_language( $tag_fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $tag_en, array( 'en' => $tag_en, 'fr' => $tag_fr ) );
+		self::$model->term->save_translations( $tag_en, array( 'en' => $tag_en, 'fr' => $tag_fr ) );
 
 		$untranslated = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $untranslated, 'en' );
+		self::$model->term->set_language( $untranslated, 'en' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 		wp_set_post_terms( $from, array( 'tag_en' ), 'post_tag' ); // Assigned by slug
 		wp_set_post_terms( $from, array( $untranslated, $en ), 'category' ); // Assigned by term_id
 		set_post_format( $from, 'aside' );
 
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		// copy
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		$sync = new PLL_Admin_Sync( $this->pll_admin );
 		$sync->taxonomies->copy( $from, $to, 'fr' ); // copy
 
 		$this->assertEquals( array( $tag_fr ), wp_get_post_terms( $to, 'post_tag', array( 'fields' => 'ids' ) ) );
@@ -63,7 +66,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'aside', get_post_format( $to ) );
 
 		// sync
-		self::$polylang->options['sync'] = array( 'taxonomies' );
+		self::$model->options['sync'] = array( 'taxonomies' );
 		wp_set_post_terms( $from, array( 'tag_en' ), 'post_tag' );
 		wp_set_post_terms( $from, array( $untranslated, $en ), 'category' );
 
@@ -81,28 +84,28 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'aside', get_post_format( $from ) );
 
 		// sync post format
-		self::$polylang->options['sync'] = array( 'post_format' );
+		self::$model->options['sync'] = array( 'post_format' );
 		set_post_format( $to, '' );
 		$this->assertFalse( get_post_format( $from ) );
 	}
 
 	function test_copy_custom_fields() {
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, 'key', 'value' );
 
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		// copy
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		$sync = new PLL_Admin_Sync( $this->pll_admin );
 		$sync->post_metas->copy( $from, $to, 'fr' ); // copy
 		$this->assertEquals( 'value', get_post_meta( $to, 'key', true ) );
 
 		// sync
-		self::$polylang->options['sync'] = array( 'post_meta' );
+		self::$model->options['sync'] = array( 'post_meta' );
 		$this->assertTrue( update_post_meta( $to, 'key', 'new_value' ) );
 		$this->assertEquals( 'new_value', get_post_meta( $from, 'key', true ) );
 
@@ -112,14 +115,14 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_sync_multiple_custom_fields() {
-		self::$polylang->options['sync'] = array( 'post_meta' );
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		self::$model->options['sync'] = array( 'post_meta' );
+		$sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		// Add
 		add_post_meta( $from, 'key', 'value1' );
@@ -129,7 +132,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$sync->post_metas->copy( $from, $to, 'fr', true );
 		$this->assertEqualSets( array( 'value1', 'value2', 'value3' ), get_post_meta( $to, 'key' ) );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		// Delete
 		$this->assertTrue( delete_post_meta( $from, 'key', 'value3' ) );
@@ -155,24 +158,24 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_create_post_translation() {
 		// categories
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		// source post
 		$from = $this->factory->post->create( array( 'post_category' => array( $en ) ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, 'key', 'value' );
 		add_post_meta( $from, '_thumbnail_id', 1234 );
 		set_post_format( $from, 'aside' );
 		stick_post( $from );
 
-		self::$polylang->filters_post = new PLL_Admin_Filters_Post( self::$polylang );
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$_REQUEST = $_GET = array(
 			'from_post' => $from,
@@ -186,7 +189,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['post'] = get_post( $to );
 
 		do_action( 'add_meta_boxes', 'post', $GLOBALS['post'] ); // fires the copy
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
 		$this->assertEquals( 'value', get_post_meta( $to, 'key', true ) );
 		$this->assertEquals( 1234, get_post_thumbnail_id( $to ) );
@@ -197,20 +200,20 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_create_page_translation() {
 		// parent pages
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'fr' ) );
 
 		// source page
 		$from = $this->factory->post->create( array( 'post_type' => 'page', 'menu_order' => 12, 'post_parent' => $en ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, '_wp_page_template', 'full-width.php' );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$_REQUEST = $_GET = array(
 			'from_post' => $from,
@@ -226,14 +229,14 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		do_action( 'add_meta_boxes', 'page', $GLOBALS['post'] ); // fires the copy
 
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
 		$this->assertEquals( 12, $GLOBALS['post']->menu_order );
 		$this->assertEquals( 'full-width.php', get_page_template_slug( $to ) );
 	}
 
 	function test_save_post_with_sync() {
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Attachment for thumbnail
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
@@ -241,27 +244,27 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		// categories
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		// posts
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create( array( 'post_category' => array( $en ), 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		$key = add_post_meta( $from, 'key', 'value' );
 		$metas[ $key ] = array( 'key' => 'key', 'value' => 'value' );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 		$_REQUEST['sticky'] = 'sticky'; // sticky posts not managed by wp_insert_post
 		add_post_meta( $from, '_thumbnail_id', $thumbnail_id );
@@ -276,8 +279,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		); // fires the sync
 		stick_post( $from );
 
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->post->get_translations( $from ) );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
+		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$model->post->get_translations( $from ) );
 		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
 		$this->assertEquals( '2007-09-04', get_the_date( 'Y-m-d', $to ) );
 		$this->assertEquals( array( 'value' ), get_post_meta( $to, 'key' ) );
@@ -295,28 +298,28 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['post_type'] = 'page';
 		add_filter( 'theme_page_templates', array( $this, 'filter_theme_page_templates' ) ); // Allow to test templates with themes without templates
 
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// parent pages
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'fr' ) );
 
 		// pages page
 		$to = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create( array( 'post_type' => 'page', 'menu_order' => 12, 'post_parent' => $en ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		edit_post(
@@ -328,31 +331,31 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$page = get_post( $to );
 
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->post->get_translations( $from ) );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
+		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$model->post->get_translations( $from ) );
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
 		$this->assertEquals( 12, $page->menu_order );
 		$this->assertEquals( 'templates/test.php', get_page_template_slug( $to ) );
 	}
 
 	function test_save_term_with_sync_in_post() {
-		self::$polylang->options['sync'] = array( 'taxonomies' );
+		self::$model->options['sync'] = array( 'taxonomies' );
 
 		$from = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $from, 'en' );
+		self::$model->term->set_language( $from, 'en' );
 
 		// posts
 		$en = $this->factory->post->create( array( 'post_category' => array( $from ) ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		$_REQUEST = $_POST = array(
@@ -362,32 +365,32 @@ class Sync_Test extends PLL_UnitTestCase {
 			'term_tr_lang'     => array( 'en' => $from ),
 		);
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 
 		$to = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->term->get_translations( $from ) );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $to )->slug );
+		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$model->term->get_translations( $from ) );
 		$this->assertTrue( is_object_in_term( $fr, 'category', $to ) );
 	}
 
 	function test_save_term_with_parent_sync() {
 		// Parents
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		// child
 		$from = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $from, 'en' );
+		self::$model->term->set_language( $from, 'en' );
 
-		self::$polylang->filters_term = new PLL_Admin_Filters_Term( self::$polylang );
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		$_REQUEST = $_POST = array(
@@ -399,8 +402,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		);
 
 		$to = $this->factory->term->create( array( 'taxonomy' => 'category', 'parent' => $fr ) );
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $to )->slug );
-		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$polylang->model->term->get_translations( $from ) );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $to )->slug );
+		$this->assertEqualSetsWithIndex( array( 'en' => $from, 'fr' => $to ), self::$model->term->get_translations( $from ) );
 		$this->assertEquals( $fr, get_category( $to )->parent );
 		$this->assertEquals( $en, get_category( $from )->parent );
 	}
@@ -412,26 +415,26 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_child_sync_if_delete_translated_term_parent() {
 		// Children.
 		$child_en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $child_en, 'en' );
+		self::$model->term->set_language( $child_en, 'en' );
 
 		$child_fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $child_fr, 'fr' );
+		self::$model->term->set_language( $child_fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $child_en, array( 'fr' => $child_fr ) );
+		self::$model->term->save_translations( $child_en, array( 'fr' => $child_fr ) );
 
 		// Parents.
 		$parent_en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $parent_en, 'en' );
+		self::$model->term->set_language( $parent_en, 'en' );
 
 		wp_update_term( $child_en, 'category', array( 'parent' => $parent_en ) );
 
 		$parent_fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $parent_fr, 'fr' );
+		self::$model->term->set_language( $parent_fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $parent_en, array( 'fr' => $parent_fr ) );
+		self::$model->term->save_translations( $parent_en, array( 'fr' => $parent_fr ) );
 
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_update_term( $child_fr, 'category', array( 'parent' => $parent_fr ) );
 
 		wp_update_term( $child_fr, 'category', array( 'parent' => 0 ) );
@@ -442,11 +445,11 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_create_post_translation_with_sync_post_date() {
 		// source post
 		$from = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
-		self::$polylang->options['sync'] = array( 'post_date' ); // Sync publish date
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
+		self::$model->options['sync'] = array( 'post_date' ); // Sync publish date
 
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$_REQUEST = $_GET = array(
@@ -466,28 +469,28 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_quick_edit_with_sync_page_parent() {
 		$_REQUEST['post_type'] = 'page';
 
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// parent pages
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'fr' ) );
 
 		// pages page
 		$to = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create( array( 'post_type' => 'page', 'post_parent' => $en ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		wp_update_post( array( 'ID' => $from ) ); // fires the sync
@@ -497,14 +500,14 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_create_post_translation_with_sync_date() {
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// source post
 		$from = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$_REQUEST = $_GET = array(
 			'from_post' => $from,
@@ -520,7 +523,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		do_action( 'add_meta_boxes', 'post', $GLOBALS['post'] ); // fires the copy
 		clean_post_cache( $to ); // Usually WordPress will do it for us when the post will be saved
 
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $to )->slug );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( '2007-09-04 00:00:00', get_post( $to )->post_date );
 	}
 
@@ -530,17 +533,17 @@ class Sync_Test extends PLL_UnitTestCase {
 
 	function test_copy_term_metas() {
 		$from = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $from, 'en' );
+		self::$model->term->set_language( $from, 'en' );
 		add_term_meta( $from, 'key', 'value' );
 
 		$to = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $to, 'fr' );
-		self::$polylang->model->term->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->term->set_language( $to, 'fr' );
+		self::$model->term->save_translations( $from, array( 'fr' => $to ) );
 
 		add_filter( 'pll_copy_term_metas', array( $this, '_add_term_meta_to_copy' ) );
 
 		// copy
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		$sync = new PLL_Admin_Sync( $this->pll_admin );
 		$sync->term_metas->copy( $from, $to, 'fr' ); // copy
 		$this->assertEquals( 'value', get_term_meta( $to, 'key', true ) );
 
@@ -554,15 +557,15 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_sync_multiple_term_metas() {
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		$sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$from = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $from, 'en' );
+		self::$model->term->set_language( $from, 'en' );
 
 		$to = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $to, 'fr' );
+		self::$model->term->set_language( $to, 'fr' );
 
-		self::$polylang->model->term->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->term->save_translations( $from, array( 'fr' => $to ) );
 
 		add_filter( 'pll_copy_term_metas', array( $this, '_add_term_meta_to_copy' ) );
 
@@ -582,16 +585,16 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_sync_post_with_metas_to_remove() {
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Posts
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		add_post_meta( $to, 'key1', 'value' );
 		add_post_meta( $to, 'key2', 'value1' );
@@ -599,8 +602,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		$key = add_post_meta( $from, 'key2', 'value1' );
 		$metas[ $key ] = array( 'key' => 'key2', 'value' => 'value1' );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		edit_post(
@@ -617,21 +620,21 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_source_post_was_sticky_before_sync_was_active() {
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Posts
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		stick_post( $from );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		$_REQUEST['sticky'] = 'sticky'; // sticky posts not managed by wp_insert_post
@@ -646,21 +649,21 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_target_post_was_sticky_before_sync_was_active() {
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Posts
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		stick_post( $to );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		edit_post( array( 'post_ID' => $from ) ); // Fires the sync
@@ -670,27 +673,27 @@ class Sync_Test extends PLL_UnitTestCase {
 
 	// Bug fixed in 2.3.2
 	function test_delete_term() {
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Categories
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		// Posts
 		$post_fr = $this->factory->post->create( array( 'post_category' => array( $fr ) ) );
-		self::$polylang->model->post->set_language( $post_fr, 'fr' );
+		self::$model->post->set_language( $post_fr, 'fr' );
 
 		$post_en = $this->factory->post->create( array( 'post_category' => array( $en ) ) );
-		self::$polylang->model->post->set_language( $post_en, 'en' );
+		self::$model->post->set_language( $post_en, 'en' );
 
-		self::$polylang->model->post->save_translations( $post_en, array( 'fr' => $post_fr ) );
+		self::$model->post->save_translations( $post_en, array( 'fr' => $post_fr ) );
 
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		wp_delete_category( $fr );
 
@@ -701,25 +704,25 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_category_hierarchy() {
 		// Categories
 		$child_en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$child_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		$parent_en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		wp_update_term( $child_en, 'category', array( 'parent' => $parent_en ) );
 
 		$parent_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_update_term( $child_fr, 'category', array( 'parent' => $parent_fr ) );
 
 		$term = get_term( $child_fr );
@@ -734,33 +737,33 @@ class Sync_Test extends PLL_UnitTestCase {
 	function test_sync_category_parent_modification() {
 		// Parent 1
 		$p1en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$p1fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		// Parent 2
 		$p2en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$p2fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
 		// Child
 		$child_en = $en = $this->factory->term->create( array( 'taxonomy' => 'category', 'parent' => $p1en ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$child_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'parent' => $p1fr ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_update_term( $child_fr, 'category', array( 'parent' => $p2fr ) );
 
 		$term = get_term( $child_fr );
@@ -773,7 +776,7 @@ class Sync_Test extends PLL_UnitTestCase {
 
 	function test_if_cannot_synchronize() {
 		add_filter( 'pll_pre_current_user_can_synchronize_post', '__return_null' ); // Enable capability check
-		self::$polylang->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Post format
 		$this->factory->term->create( array( 'taxonomy' => 'post_format', 'name' => 'post-format-aside' ) ); // shouldn't WP do that ?
@@ -784,25 +787,25 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		// Categories
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'fr' ) );
+		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
-		self::$polylang->posts = new PLL_CRUD_Posts( self::$polylang );
-		self::$polylang->sync = new PLL_Admin_Sync( self::$polylang );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		// Posts
 		wp_set_current_user( self::$editor );
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		wp_set_current_user( self::$author );
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->set_language( $from, 'en' );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		// The author cannot override synchronized data
 		wp_update_post( array( 'ID' => $from, 'post_category' => array( $en ), 'post_date' => '2007-09-04 00:00:00' ) );
@@ -836,8 +839,8 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	function test_slashes() {
-		self::$polylang->options['sync'] = array( 'post_meta' );
-		$sync = new PLL_Admin_Sync( self::$polylang );
+		self::$model->options['sync'] = array( 'post_meta' );
+		$sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$key = '\_key';
 		$slash_key = wp_slash( $key );
@@ -847,10 +850,10 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		// Create posts.
 		$to = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $to, 'fr' );
+		self::$model->post->set_language( $to, 'fr' );
 
 		$from = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $from, 'en' );
+		self::$model->post->set_language( $from, 'en' );
 
 		// Test copy().
 		add_post_meta( $from, $slash_key, $slash_2 );
@@ -864,7 +867,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		delete_post_meta( $from, $slash_key );
 		delete_post_meta( $to, $slash_key );
 
-		self::$polylang->model->post->save_translations( $from, array( 'fr' => $to ) );
+		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		// Test add, update, delete.
 		add_post_meta( $from, $slash_key, $slash_2 );

--- a/tests/phpunit/tests/test-terms-list.php
+++ b/tests/phpunit/tests/test-terms-list.php
@@ -19,29 +19,31 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
-		self::$polylang->filters = new PLL_Admin_Filters( self::$polylang ); // To activate the fix_delete_default_category() filter
-		self::$polylang->terms = new PLL_CRUD_Terms( self::$polylang );
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // To activate the fix_delete_default_category() filter
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
 	}
 
 	function test_term_list_with_admin_language_filter() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'enfant', 'parent' => $fr ) );
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $en ) );
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$GLOBALS['taxnow'] = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen();
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );
-		self::$polylang->set_current_language();
+		$this->pll_admin->set_current_language();
 
 		// without filter
 		ob_start();
@@ -55,8 +57,8 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $list, 'enfant' ) );
 
 		// the filter is active
-		self::$polylang->pref_lang = self::$polylang->filter_lang = self::$polylang->model->get_language( 'en' );
-		self::$polylang->set_current_language();
+		$this->pll_admin->pref_lang = $this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		$this->pll_admin->set_current_language();
 
 		ob_start();
 		$wp_list_table->prepare_items();
@@ -73,8 +75,8 @@ class Terms_List_Test extends PLL_UnitTestCase {
 	function test_default_category_in_list_table() {
 		$id = $this->factory->term->create( array( 'taxonomy' => 'category' ) ); // a non default category
 		$default = get_option( 'default_category' );
-		$en = self::$polylang->model->term->get( $default, 'en' );
-		$fr = self::$polylang->model->term->get( $default, 'fr' );
+		$en = self::$model->term->get( $default, 'en' );
+		$fr = self::$model->term->get( $default, 'fr' );
 
 		$GLOBALS['taxnow'] = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -13,11 +13,24 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
-		$GLOBALS['polylang'] = &self::$polylang;
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$GLOBALS['polylang'] = &$this->pll_admin;
+	}
+
+	function tearDown() {
+		parent::tearDown();
+
+		unset( $GLOBALS['polylang'] );
 	}
 
 	protected function add_string_translations( $lang, $translations ) {
-		$language = self::$polylang->model->get_language( $lang );
+		$language = self::$model->get_language( $lang );
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
 		foreach ( $translations as $original => $translation ) {
@@ -28,8 +41,6 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 
 	protected function prepare_option_simple() {
 		add_option( 'my_option', 'val' );
-
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
 		new PLL_Translate_Option( 'my_option' );
 	}
 
@@ -42,16 +53,16 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		}
 
 		// Quick check.
-		self::$polylang->load_strings_translations( 'en' );
+		$this->pll_admin->load_strings_translations( 'en' );
 		$this->assertEquals( 'val_en', get_option( 'my_option' ) );
-		self::$polylang->load_strings_translations( 'fr' );
+		$this->pll_admin->load_strings_translations( 'fr' );
 		$this->assertEquals( 'val_fr', get_option( 'my_option' ) );
 
 		update_option( 'my_option', 'new_val' );
 
-		self::$polylang->load_strings_translations( 'en' );
+		$this->pll_admin->load_strings_translations( 'en' );
 		$this->assertEquals( 'val_en', get_option( 'my_option' ) );
-		self::$polylang->load_strings_translations( 'fr' );
+		$this->pll_admin->load_strings_translations( 'fr' );
 		$this->assertEquals( 'val_fr', get_option( 'my_option' ) );
 	}
 
@@ -60,12 +71,12 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->add_string_translations( 'en', array( 'val' => 'val' ) );
 
 		// Quick check.
-		self::$polylang->load_strings_translations( 'en' );
+		$this->pll_admin->load_strings_translations( 'en' );
 		$this->assertEquals( 'val', get_option( 'my_option' ) );
 
 		update_option( 'my_option', 'new_val' );
 
-		self::$polylang->load_strings_translations( 'en' );
+		$this->pll_admin->load_strings_translations( 'en' );
 		$this->assertEquals( 'new_val', get_option( 'my_option' ) );
 	}
 
@@ -73,10 +84,10 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->prepare_option_simple();
 		$this->add_string_translations( 'en', array( 'val' => 'val_en' ) );
 
-		PLL()->curlang = self::$polylang->model->get_language( 'en' );
+		PLL()->curlang = self::$model->get_language( 'en' );
 		update_option( 'my_option', 'val_en' );
 
-		$language = self::$polylang->model->get_language( 'en' );
+		$language = self::$model->get_language( 'en' );
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
 		$this->assertArrayHasKey( 'val', $mo->entries );
@@ -106,7 +117,6 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			),
 		);
 
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
 		new PLL_Translate_Option( 'my_options', $keys );
 	}
 
@@ -116,7 +126,6 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			'options_*'     => 1,
 		);
 
-		self::$polylang = new PLL_Admin( self::$polylang->links_model );
 		new PLL_Translate_Option( 'my_options', $keys );
 	}
 
@@ -155,7 +164,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 
 		// Quick check.
 		foreach ( $languages as $lang ) {
-			self::$polylang->load_strings_translations( $lang );
+			$this->pll_admin->load_strings_translations( $lang );
 			$options = get_option( 'my_options' );
 			$this->assertEquals( 'val1_' . $lang, $options['option_name_1'] );
 			$this->assertEquals( 'val11_' . $lang, $options['options_group_1']['sub_option_name_11'] );
@@ -164,7 +173,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->update_option_with_new_val( 'ARRAY' );
 
 		foreach ( $languages as $lang ) {
-			self::$polylang->load_strings_translations( $lang );
+			$this->pll_admin->load_strings_translations( $lang );
 			$options = get_option( 'my_options' );
 			$this->assertEquals( 'val1_' . $lang, $options['option_name_1'] );
 			$this->assertEquals( 'val11_' . $lang, $options['options_group_1']['sub_option_name_11'] );
@@ -190,7 +199,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$languages = array( 'en', 'fr' );
 
 		foreach ( $languages as $lang ) {
-			self::$polylang->load_strings_translations( $lang );
+			$this->pll_admin->load_strings_translations( $lang );
 			$options = get_option( 'my_options' );
 			$this->assertEquals( 'val1_' . $lang, $options->option_name_1 );
 			$this->assertEquals( 'val11_' . $lang, $options->options_group_1->sub_option_name_11 );
@@ -222,7 +231,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 
 		$this->update_option_with_new_val( 'ARRAY' );
 
-		self::$polylang->load_strings_translations( 'en' );
+		$this->pll_admin->load_strings_translations( 'en' );
 		$options = get_option( 'my_options' );
 		$this->assertEquals( 'new_val1', $options['option_name_1'] );
 		$this->assertEquals( 'new_val11', $options['options_group_1']['sub_option_name_11'] );
@@ -245,7 +254,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 
 		$this->update_option_with_new_val( 'OBJECT' );
 
-		self::$polylang->load_strings_translations( 'en' );
+		$this->pll_admin->load_strings_translations( 'en' );
 		$options = get_option( 'my_options' );
 		$this->assertEquals( 'new_val1', $options->option_name_1 );
 		$this->assertEquals( 'new_val11', $options->options_group_1->sub_option_name_11 );
@@ -277,10 +286,10 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			$options = json_decode( json_encode( $options ) ); // Recursively converts the arrays to objects.
 		}
 
-		PLL()->curlang = self::$polylang->model->get_language( 'en' );
+		PLL()->curlang = self::$model->get_language( 'en' );
 		update_option( 'my_options', $options );
 
-		$language = self::$polylang->model->get_language( 'en' );
+		$language = self::$model->get_language( 'en' );
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
 		$this->assertArrayHasKey( 'val1', $mo->entries );

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -14,25 +14,28 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		update_option( 'show_on_front', 'page' );
 
-		self::$polylang->static_pages = new PLL_Static_Pages( self::$polylang );
+		$links_model = self::$model->get_links_model();
+		$this->frontend = new PLL_Frontend( $links_model );
+		$this->frontend->init();
+		$this->frontend->static_pages = new PLL_Static_Pages( $this->frontend );
 	}
 
 	public function test_translate_page_for_posts_on_default_language() {
 		// Pages for posts.
 		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		update_option( 'page_for_posts', $en );
 
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$this->frontend->curlang = self::$model->get_language( 'en' );
 
-		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+		$return = $this->frontend->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
 
 		$this->assertEquals( $en, $return );
 	}
@@ -40,18 +43,18 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 	public function test_translate_page_for_posts_on_secondary_language() {
 		// Pages for posts.
 		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		update_option( 'page_for_posts', $en );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+		$return = $this->frontend->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
 
 		$this->assertEquals( $fr, $return );
 
@@ -60,13 +63,13 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 	public function test_translate_page_for_posts_when_page_for_posts_has_no_translations() {
 		// Only one page for posts.
 		$en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		update_option( 'page_for_posts', $en );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-		$return = self::$polylang->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+		$return = $this->frontend->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
 
 		$this->assertEquals( $en, $return );
 	}

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -15,51 +15,51 @@ class Translated_Post_Test extends PLL_UnitTestCase {
 
 	function test_post_language() {
 		$post_id = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $post_id, 'fr' );
+		self::$model->post->set_language( $post_id, 'fr' );
 
-		$this->assertEquals( 'fr', self::$polylang->model->post->get_language( $post_id )->slug );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $post_id )->slug );
 	}
 
 	function test_post_translation() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$de = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $de, 'de' );
+		self::$model->post->set_language( $de, 'de' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
 
-		$this->assertEquals( self::$polylang->model->post->get_translation( $en, 'en' ), $en );
-		$this->assertEquals( self::$polylang->model->post->get_translation( $fr, 'fr' ), $fr );
-		$this->assertEquals( self::$polylang->model->post->get_translation( $fr, 'en' ), $en );
-		$this->assertEquals( self::$polylang->model->post->get_translation( $en, 'fr' ), $fr );
-		$this->assertEquals( self::$polylang->model->post->get_translation( $de, 'fr' ), $fr );
+		$this->assertEquals( self::$model->post->get_translation( $en, 'en' ), $en );
+		$this->assertEquals( self::$model->post->get_translation( $fr, 'fr' ), $fr );
+		$this->assertEquals( self::$model->post->get_translation( $fr, 'en' ), $en );
+		$this->assertEquals( self::$model->post->get_translation( $en, 'fr' ), $fr );
+		$this->assertEquals( self::$model->post->get_translation( $de, 'fr' ), $fr );
 	}
 
 	function test_delete_post_translation() {
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
 		$de = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $de, 'de' );
+		self::$model->post->set_language( $de, 'de' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
-		self::$polylang->model->post->delete_translation( $fr );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->post->delete_translation( $fr );
 
-		$this->assertEquals( self::$polylang->model->post->get_translation( $fr, 'fr' ), $fr );
-		$this->assertEquals( self::$polylang->model->post->get_translation( $en, 'de' ), $de );
-		$this->assertEquals( self::$polylang->model->post->get_translation( $de, 'en' ), $en );
+		$this->assertEquals( self::$model->post->get_translation( $fr, 'fr' ), $fr );
+		$this->assertEquals( self::$model->post->get_translation( $en, 'de' ), $de );
+		$this->assertEquals( self::$model->post->get_translation( $de, 'en' ), $en );
 
-		$this->assertFalse( self::$polylang->model->post->get_translation( $en, 'fr' ) ); // fails
-		$this->assertFalse( self::$polylang->model->post->get_translation( $fr, 'en' ) );
-		$this->assertFalse( self::$polylang->model->post->get_translation( $fr, 'de' ) );
-		$this->assertFalse( self::$polylang->model->post->get_translation( $de, 'fr' ) ); // fails
+		$this->assertFalse( self::$model->post->get_translation( $en, 'fr' ) ); // fails
+		$this->assertFalse( self::$model->post->get_translation( $fr, 'en' ) );
+		$this->assertFalse( self::$model->post->get_translation( $fr, 'de' ) );
+		$this->assertFalse( self::$model->post->get_translation( $de, 'fr' ) ); // fails
 	}
 
 	function test_current_user_can_synchronize() {
@@ -71,49 +71,49 @@ class Translated_Post_Test extends PLL_UnitTestCase {
 		wp_set_current_user( $author );
 
 		$en = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $en ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $fr ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $en ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $fr ) );
 
 		wp_set_current_user( $editor );
 
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $en ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $fr ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $en ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $fr ) );
 
 		$de = $this->factory->post->create();
-		self::$polylang->model->post->set_language( $de, 'de' );
+		self::$model->post->set_language( $de, 'de' );
 
-		self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
 
 		wp_set_current_user( $editor );
 
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $en ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $fr ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_synchronize( $de ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $en ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $fr ) );
+		$this->assertTrue( self::$model->post->current_user_can_synchronize( $de ) );
 
 		wp_set_current_user( $author );
 
-		$this->assertFalse( self::$polylang->model->post->current_user_can_synchronize( $en ) );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_synchronize( $fr ) );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_synchronize( $de ) );
+		$this->assertFalse( self::$model->post->current_user_can_synchronize( $en ) );
+		$this->assertFalse( self::$model->post->current_user_can_synchronize( $fr ) );
+		$this->assertFalse( self::$model->post->current_user_can_synchronize( $de ) );
 	}
 
 	function test_current_user_can_read() {
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
 
 		wp_set_current_user( 0 );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id ) );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id, 'edit' ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id, 'edit' ) );
 
 		wp_set_current_user( 1 );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_read( $post_id, 'edit' ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id ) );
+		$this->assertTrue( self::$model->post->current_user_can_read( $post_id, 'edit' ) );
 
 		$post_id = $this->factory->post->create(
 			array(
@@ -123,21 +123,21 @@ class Translated_Post_Test extends PLL_UnitTestCase {
 		);
 
 		wp_set_current_user( 0 );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id ) );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id, 'edit' ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id, 'edit' ) );
 
 		wp_set_current_user( 1 );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_read( $post_id, 'edit' ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id ) );
+		$this->assertTrue( self::$model->post->current_user_can_read( $post_id, 'edit' ) );
 
 		$post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
 
 		wp_set_current_user( 0 );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id ) );
-		$this->assertFalse( self::$polylang->model->post->current_user_can_read( $post_id, 'edit' ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id ) );
+		$this->assertFalse( self::$model->post->current_user_can_read( $post_id, 'edit' ) );
 
 		wp_set_current_user( 1 );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_read( $post_id ) );
-		$this->assertTrue( self::$polylang->model->post->current_user_can_read( $post_id, 'edit' ) );
+		$this->assertTrue( self::$model->post->current_user_can_read( $post_id ) );
+		$this->assertTrue( self::$model->post->current_user_can_read( $post_id, 'edit' ) );
 	}
 }

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -15,51 +15,51 @@ class Translated_Term_Test extends PLL_UnitTestCase {
 
 	function test_term_language() {
 		$term_id = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $term_id, 'fr' );
+		self::$model->term->set_language( $term_id, 'fr' );
 
-		$this->assertEquals( 'fr', self::$polylang->model->term->get_language( $term_id )->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
 		$this->assertCount( 2, get_terms( 'term_translations' ) ); // 1 translation group per term + 1 for default categories
 	}
 
 	function test_term_translation() {
 		$en = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$de = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $de, 'de' );
+		self::$model->term->set_language( $de, 'de' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr', 'de' ) );
 
-		$this->assertEquals( self::$polylang->model->term->get_translation( $en, 'en' ), $en );
-		$this->assertEquals( self::$polylang->model->term->get_translation( $fr, 'fr' ), $fr );
-		$this->assertEquals( self::$polylang->model->term->get_translation( $fr, 'en' ), $en );
-		$this->assertEquals( self::$polylang->model->term->get_translation( $en, 'fr' ), $fr );
-		$this->assertEquals( self::$polylang->model->term->get_translation( $de, 'fr' ), $fr );
+		$this->assertEquals( self::$model->term->get_translation( $en, 'en' ), $en );
+		$this->assertEquals( self::$model->term->get_translation( $fr, 'fr' ), $fr );
+		$this->assertEquals( self::$model->term->get_translation( $fr, 'en' ), $en );
+		$this->assertEquals( self::$model->term->get_translation( $en, 'fr' ), $fr );
+		$this->assertEquals( self::$model->term->get_translation( $de, 'fr' ), $fr );
 	}
 
 	function test_delete_term_translation() {
 		$en = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $en, 'en' );
+		self::$model->term->set_language( $en, 'en' );
 
 		$fr = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $fr, 'fr' );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$de = $this->factory->term->create();
-		self::$polylang->model->term->set_language( $de, 'de' );
+		self::$model->term->set_language( $de, 'de' );
 
-		self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr', 'de' ) );
-		self::$polylang->model->term->delete_translation( $fr );
+		self::$model->term->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$model->term->delete_translation( $fr );
 
-		$this->assertEquals( self::$polylang->model->term->get_translation( $fr, 'fr' ), $fr );
-		$this->assertEquals( self::$polylang->model->term->get_translation( $en, 'de' ), $de );
-		$this->assertEquals( self::$polylang->model->term->get_translation( $de, 'en' ), $en );
+		$this->assertEquals( self::$model->term->get_translation( $fr, 'fr' ), $fr );
+		$this->assertEquals( self::$model->term->get_translation( $en, 'de' ), $de );
+		$this->assertEquals( self::$model->term->get_translation( $de, 'en' ), $en );
 
-		$this->assertFalse( self::$polylang->model->term->get_translation( $en, 'fr' ) );
-		$this->assertFalse( self::$polylang->model->term->get_translation( $fr, 'en' ) );
-		$this->assertFalse( self::$polylang->model->term->get_translation( $fr, 'de' ) );
-		$this->assertFalse( self::$polylang->model->term->get_translation( $de, 'fr' ) );
+		$this->assertFalse( self::$model->term->get_translation( $en, 'fr' ) );
+		$this->assertFalse( self::$model->term->get_translation( $fr, 'en' ) );
+		$this->assertFalse( self::$model->term->get_translation( $fr, 'de' ) );
+		$this->assertFalse( self::$model->term->get_translation( $de, 'fr' ) );
 	}
 }

--- a/tests/phpunit/tests/test-widgets-calendar.php
+++ b/tests/phpunit/tests/test-widgets-calendar.php
@@ -16,26 +16,27 @@ class Widget_Calendar_Test extends PLL_UnitTestCase {
 		parent::setUp();
 
 		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
-		$GLOBALS['polylang'] = self::$polylang; // We use PLL()
 
-		self::$polylang->options['hide_default'] = 0;
+		self::$model->options['hide_default'] = 0;
 
 		global $wp_rewrite;
 		$wp_rewrite->set_permalink_structure( '' );
 
-		self::$polylang->links_model = self::$polylang->model->get_links_model();
+		$this->links_model = self::$model->get_links_model();
 	}
 
 	function test_get_calendar() {
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$polylang->model->post->set_language( $en, 'en' );
+		self::$model->post->set_language( $en, 'en' );
 
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-05 00:00:00' ) );
-		self::$polylang->model->post->set_language( $fr, 'fr' );
+		self::$model->post->set_language( $fr, 'fr' );
 
-		self::$polylang->filters_links = new PLL_Frontend_Filters_Links( self::$polylang );
+		$frontend = new PLL_Frontend( $this->links_model );
+		$GLOBALS['polylang'] = $frontend; // We use PLL().
+		new PLL_Frontend_Filters_Links( $frontend );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+		$frontend->curlang = self::$model->get_language( 'fr' );
 		$this->go_to( home_url( '/?m=200709&lang=fr' ) );
 		$calendar = PLL_Widget_Calendar::get_calendar( true, false );
 
@@ -43,7 +44,7 @@ class Widget_Calendar_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $calendar, home_url( '/?m=20070904&lang=fr' ) ) ); // no French post on 4th
 		$this->assertNotFalse( strpos( $calendar, home_url( '/?m=20070905&lang=fr' ) ) );
 
-		self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+		$frontend->curlang = self::$model->get_language( 'en' );
 		$this->go_to( home_url( '/?m=200709&lang=en' ) );
 		$calendar = PLL_Widget_Calendar::get_calendar( true, false );
 

--- a/tests/phpunit/tests/themes/test-twenty-fourteen.php
+++ b/tests/phpunit/tests/themes/test-twenty-fourteen.php
@@ -17,7 +17,6 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			self::create_language( 'fr_FR' );
 
 			require_once POLYLANG_DIR . '/include/api.php';
-			$GLOBALS['polylang'] = &self::$polylang;
 
 			self::$stylesheet = get_option( 'stylesheet' ); // save default theme
 			switch_theme( 'twentyfourteen' );
@@ -30,10 +29,11 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			twentyfourteen_setup();
 			Featured_Content::init();
 
-			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-			self::$polylang->init();
-			self::$polylang->featured_content = new PLL_Featured_Content();
-			self::$polylang->featured_content->init();
+			$links_model = self::$model->get_links_model();
+			$this->frontend = new PLL_Frontend( $links_model );
+			$GLOBALS['polylang'] = &$this->frontend;
+			$this->frontend->featured_content = new PLL_Featured_Content();
+			$this->frontend->featured_content->init();
 		}
 
 		static function wpTearDownAfterClass() {
@@ -42,18 +42,25 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			switch_theme( self::$stylesheet );
 		}
 
+		function tearDown() {
+			parent::tearDown();
+
+			unset( $GLOBALS['polylang'] );
+		}
+
 		function test_ephemera_widget() {
+			global $content_width; // The widget accesses this global, no matter what it contains.
 			$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 
 			$en = $this->factory->post->create( array( 'post_content' => 'Test' ) );
 			set_post_format( $en, 'aside' );
-			self::$polylang->model->post->set_language( $en, 'en' );
+			self::$model->post->set_language( $en, 'en' );
 
 			$fr = $this->factory->post->create( array( 'post_content' => 'Essai' ) );
 			set_post_format( $fr, 'aside' );
-			self::$polylang->model->post->set_language( $fr, 'fr' );
+			self::$model->post->set_language( $fr, 'fr' );
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			$this->frontend->curlang = self::$model->get_language( 'fr' );
 
 			require_once get_template_directory() . '/inc/widgets.php';
 			$widget = new Twenty_Fourteen_Ephemera_Widget();
@@ -66,15 +73,17 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 
 			$this->assertFalse( strpos( $out, '<p>Test</p>' ) );
 			$this->assertNotFalse( strpos( $out, '<p>Essai</p>' ) );
+
+			unset( $content_width );
 		}
 
 		function setup_featured_tags() {
 			self::$tag_en = $en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'featured' ) );
-			self::$polylang->model->term->set_language( $en, 'en' );
+			self::$model->term->set_language( $en, 'en' );
 
 			self::$tag_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'en avant' ) );
-			self::$polylang->model->term->set_language( $fr, 'fr' );
-			self::$polylang->model->term->save_translations( $en, compact( 'en', 'fr' ) );
+			self::$model->term->set_language( $fr, 'fr' );
+			self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 			$options = array(
 				'hide-tag' => 1,
@@ -88,11 +97,11 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 		function test_option_featured_content() {
 			$this->setup_featured_tags();
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+			$this->frontend->curlang = self::$model->get_language( 'en' );
 			$settings = Featured_Content::get_setting();
 			$this->assertEquals( self::$tag_en, $settings['tag-id'] );
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			$this->frontend->curlang = self::$model->get_language( 'fr' );
 			$settings = Featured_Content::get_setting();
 			$this->assertEquals( self::$tag_fr, $settings['tag-id'] );
 		}
@@ -101,17 +110,17 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			$this->setup_featured_tags();
 
 			$en = $this->factory->post->create( array( 'tags_input' => array( 'featured' ) ) );
-			self::$polylang->model->post->set_language( $en, 'en' );
+			self::$model->post->set_language( $en, 'en' );
 
 			$fr = $this->factory->post->create( array( 'tags_input' => array( 'en avant' ) ) );
-			self::$polylang->model->post->set_language( $fr, 'fr' );
+			self::$model->post->set_language( $fr, 'fr' );
 
-			do_action_ref_array( 'pll_init', array( &self::$polylang ) ); // to pass the test in PLL_Plugins_Compat::twenty_fourteen_featured_content_ids
+			do_action_ref_array( 'pll_init', array( &$this->frontend ) ); // to pass the test in PLL_Plugins_Compat::twenty_fourteen_featured_content_ids
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'en' );
+			$this->frontend->curlang = self::$model->get_language( 'en' );
 			$this->assertEquals( array( get_post( $en ) ), twentyfourteen_get_featured_posts() );
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' );
+			$this->frontend->curlang = self::$model->get_language( 'fr' );
 			$this->assertEquals( array( get_post( $fr ) ), twentyfourteen_get_featured_posts() );
 		}
 	}

--- a/tests/phpunit/tests/themes/test-twenty-seventeen.php
+++ b/tests/phpunit/tests/themes/test-twenty-seventeen.php
@@ -15,7 +15,6 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyseventee
 			self::create_language( 'fr_FR' );
 
 			require_once POLYLANG_DIR . '/include/api.php';
-			$GLOBALS['polylang'] = &self::$polylang;
 
 			self::$stylesheet = get_option( 'stylesheet' ); // save default theme
 			switch_theme( 'twentyseventeen' );
@@ -42,32 +41,36 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyseventee
 			add_action( 'get_template_part_template-parts/page/content', array( $this, 'get_template_part' ), 10, 2 );
 
 			$en = self::factory()->post->create( array( 'post_title' => 'section 1 EN' ) );
-			self::$polylang->model->post->set_language( $en, 'en' );
+			self::$model->post->set_language( $en, 'en' );
 
 			$fr = self::factory()->post->create( array( 'post_title' => 'section 1 FR' ) );
-			self::$polylang->model->post->set_language( $fr, 'fr' );
+			self::$model->post->set_language( $fr, 'fr' );
 
-			self::$polylang->model->post->save_translations( $en, compact( 'en', 'fr' ) );
+			self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 			set_theme_mod( 'panel_1', $en );
 
-			self::$polylang = new PLL_Frontend( self::$polylang->links_model );
-			self::$polylang->init();
+			$links_model = self::$model->get_links_model();
+			$frontend = new PLL_Frontend( $links_model );
+			$GLOBALS['polylang'] = &$frontend;
+			$frontend->init();
 			do_action( 'pll_init' );
 			$twenty_seventeen = new PLL_Twenty_Seventeen();
 			$twenty_seventeen->init();
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'fr' ); // brute force
+			$frontend->curlang = self::$model->get_language( 'fr' ); // brute force
 
 			ob_start();
 			twentyseventeen_front_page_section( null, 1 );
 			$this->assertNotFalse( strpos( ob_get_clean(), 'section 1 FR' ) );
 
-			self::$polylang->curlang = self::$polylang->model->get_language( 'en' ); // brute force
+			$frontend->curlang = self::$model->get_language( 'en' ); // brute force
 
 			ob_start();
 			twentyseventeen_front_page_section( null, 1 );
 			$this->assertNotFalse( strpos( ob_get_clean(), 'section 1 EN' ) );
+
+			unset( $GLOBALS['polylang'] );
 		}
 	}
 


### PR DESCRIPTION
The main goal of this PR is to stop creating a static `$links_model` and `$polylang` objects which are then shared across all tests of a same class.

This means that, as from now, these instances must be created for each test, possibly in `setUp()`. This is why the PR is so huge.

This should fix some issues of global stat cleaning.

The `PLL_Model` instance is still shared as a static object. We need such object to create the languages (that we must create in `wpSetUpBeforeClass()` for performance reasons). As this object is available and is always of the same class across all tests, I assume this should not cause he same issues we had with the main Polylang object.

The PR also fixes the Twenty Fourteen Ephemera widget test, not working alone and the Twenty Seventeen test which was not running (because the them is no more included in WP 5.6) .