### PR TITLE
Remove unused filter for WP_Widget::display_callback()

### DIFF
--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -39,7 +39,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		add_filter( 'getarchives_where', array( $this, 'getarchives_where' ), 10, 2 );
 
 		// Filters the widgets according to the current language
-		add_filter( 'widget_display_callback', array( $this, 'widget_display_callback' ) );
 		add_filter( 'sidebars_widgets', array( $this, 'sidebars_widgets' ) );
 
 		if ( $this->options['media_support'] ) {
@@ -132,20 +131,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 */
 	public function getarchives_where( $sql, $r ) {
 		return ! empty( $r['post_type'] ) && $this->model->is_translated_post_type( $r['post_type'] ) ? $sql . $this->model->post->where_clause( $this->curlang ) : $sql;
-	}
-
-	/**
-	 * Filters the widgets according to the current language
-	 * Don't display if a language filter is set and this is not the current one
-	 *
-	 * @since 0.3
-	 *
-	 * @param array $instance Widget settings
-	 * @return bool|array false if we hide the widget, unmodified $instance otherwise
-	 */
-	public function widget_display_callback( $instance ) {
-		// FIXME it looks like this filter is useless, now the we use the filter sidebars_widgets
-		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] != $this->curlang->slug ? false : $instance;
 	}
 
 	/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -39,6 +39,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		add_filter( 'getarchives_where', array( $this, 'getarchives_where' ), 10, 2 );
 
 		// Filters the widgets according to the current language
+		add_filter( 'widget_display_callback', array( $this, 'widget_display_callback' ) );
 		add_filter( 'sidebars_widgets', array( $this, 'sidebars_widgets' ) );
 
 		if ( $this->options['media_support'] ) {
@@ -131,6 +132,20 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 */
 	public function getarchives_where( $sql, $r ) {
 		return ! empty( $r['post_type'] ) && $this->model->is_translated_post_type( $r['post_type'] ) ? $sql . $this->model->post->where_clause( $this->curlang ) : $sql;
+	}
+
+	/**
+	 * Filters the widgets according to the current language
+	 * Don't display if a language filter is set and this is not the current one
+	 *
+	 * @since 0.3
+	 *
+	 * @param array $instance Widget settings
+	 * @return bool|array false if we hide the widget, unmodified $instance otherwise
+	 */
+	public function widget_display_callback( $instance ) {
+		// FIXME it looks like this filter is useless, now the we use the filter sidebars_widgets
+		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] != $this->curlang->slug ? false : $instance;
 	}
 
 	/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -137,6 +137,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	/**
 	 * Filters the widgets according to the current language
 	 * Don't display if a language filter is set and this is not the current one
+	 * Needed for {@see https://developer.wordpress.org/reference/functions/the_widget/ the_widget()}.
 	 *
 	 * @since 0.3
 	 *
@@ -144,7 +145,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @return bool|array false if we hide the widget, unmodified $instance otherwise
 	 */
 	public function widget_display_callback( $instance ) {
-		// FIXME it looks like this filter is useless, now the we use the filter sidebars_widgets
 		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] != $this->curlang->slug ? false : $instance;
 	}
 

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -66,6 +66,51 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$widget->update_callback();
 	}
 
+	function test_display_with_filter() {
+		global $wp_registered_widgets;
+
+		wp_widgets_init();
+		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
+		$this->update_lang_choice( $wp_widget_search, 'en' );
+
+		$frontend = new PLL_Frontend( $this->links_model );
+		new PLL_Frontend_Filters( $frontend );
+
+		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
+		$frontend->curlang = self::$model->get_language( 'en' );
+		ob_start();
+		$wp_widget_search->display_callback( $args, 2 );
+		$this->assertNotEmpty( ob_get_clean() );
+
+		$frontend->curlang = self::$model->get_language( 'fr' );
+		ob_start();
+		$wp_widget_search->display_callback( $args, 2 );
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	function test_display_with_no_filter() {
+		global $wp_registered_widgets;
+
+		wp_widgets_init();
+		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
+		$this->update_lang_choice( $wp_widget_search, 0 );
+
+		$frontend = new PLL_Frontend( $this->links_model );
+		new PLL_Frontend_Filters( $frontend );
+
+		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
+		$frontend->curlang = self::$model->get_language( 'en' );
+		ob_start();
+		$wp_widget_search->display_callback( $args, 2 );
+		$this->assertNotEmpty( ob_get_clean() );
+
+		$frontend->curlang = self::$model->get_language( 'fr' );
+		ob_start();
+		$wp_widget_search->display_callback( $args, 2 );
+		$this->assertNotEmpty( ob_get_clean() );
+	}
+
+
 	function test_widget_media_image() {
 		self::$model->options['media_support'] = 1;
 		$pll_admin = new PLL_Admin( $this->links_model );

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -66,51 +66,6 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$widget->update_callback();
 	}
 
-	function test_display_with_filter() {
-		global $wp_registered_widgets;
-
-		wp_widgets_init();
-		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
-		$this->update_lang_choice( $wp_widget_search, 'en' );
-
-		$frontend = new PLL_Frontend( $this->links_model );
-		new PLL_Frontend_Filters( $frontend );
-
-		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
-		$frontend->curlang = self::$model->get_language( 'en' );
-		ob_start();
-		$wp_widget_search->display_callback( $args, 2 );
-		$this->assertNotEmpty( ob_get_clean() );
-
-		$frontend->curlang = self::$model->get_language( 'fr' );
-		ob_start();
-		$wp_widget_search->display_callback( $args, 2 );
-		$this->assertEmpty( ob_get_clean() );
-	}
-
-	function test_display_with_no_filter() {
-		global $wp_registered_widgets;
-
-		wp_widgets_init();
-		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
-		$this->update_lang_choice( $wp_widget_search, 0 );
-
-		$frontend = new PLL_Frontend( $this->links_model );
-		new PLL_Frontend_Filters( $frontend );
-
-		$args = array( 'before_title' => '', 'after_title' => '', 'before_widget' => '', 'after_widget' => '' );
-		$frontend->curlang = self::$model->get_language( 'en' );
-		ob_start();
-		$wp_widget_search->display_callback( $args, 2 );
-		$this->assertNotEmpty( ob_get_clean() );
-
-		$frontend->curlang = self::$model->get_language( 'fr' );
-		ob_start();
-		$wp_widget_search->display_callback( $args, 2 );
-		$this->assertNotEmpty( ob_get_clean() );
-	}
-
-
 	function test_widget_media_image() {
 		self::$model->options['media_support'] = 1;
 		$pll_admin = new PLL_Admin( $this->links_model );


### PR DESCRIPTION
## Changes

~~It appears that this filter is not used anymore, because the widgets are already filtered on `sidebars_widgets`.~~

EDIT: Widgets can be displayed as template tag by [the_widget()](https://developer.wordpress.org/reference/functions/the_widget/) function.

In this case, we will need the display callback.