### PR TITLE
Add a dialog box to ask a confirmation about a language changing.

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -173,12 +173,12 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 			// Classic editor.
 			if ( ! method_exists( $screen, 'is_block_editor' ) || ! $screen->is_block_editor() ) {
-				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post' ), 0, 1 );
+				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-dialog' ), 0, 1 );
 			}
 
 			// Block editor with legacy metabox in WP 5.0+.
 			if ( method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() && ! pll_use_block_editor_plugin() ) {
-				$scripts['block-editor'] = array( array( 'post' ), array( 'jquery', 'wp-ajax-response', 'wp-api-fetch' ), 0, 1 );
+				$scripts['block-editor'] = array( array( 'post' ), array( 'jquery', 'wp-ajax-response', 'wp-api-fetch', 'jquery-ui-dialog' ), 0, 1 );
 			}
 		}
 
@@ -192,7 +192,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			}
 		}
 
-		wp_enqueue_style( 'polylang_admin', plugins_url( '/css/build/admin' . $suffix . '.css', POLYLANG_BASENAME ), array(), POLYLANG_VERSION );
+		wp_enqueue_style( 'polylang_admin', plugins_url( '/css/build/admin' . $suffix . '.css', POLYLANG_BASENAME ), array( 'wp-jquery-ui-dialog' ), POLYLANG_VERSION );
 
 		$this->localize_scripts();
 	}

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -2,6 +2,12 @@
  * @package Polylang
  */
 
+import {
+	initializeLanguageOldValue,
+	initializeConfimationModal,
+	bypassConfirmation
+} from './lib/confirmation-modal';
+
 /**
  * Filter REST API requests to add the language in the request
  *
@@ -50,6 +56,10 @@ function getCurrentLanguage() {
  */
 jQuery(
 	function( $ ) {
+		// Initialize current language to be able to compare if it changes.
+		initializeLanguageOldValue();
+
+
 		// Ajax for changing the post's language in the languages metabox
 		$( '.post_lang_choice' ).on(
 			'change',
@@ -57,49 +67,66 @@ jQuery(
 				const select = wp.data.select;
 				const dispatch = wp.data.dispatch;
 				const subscribe = wp.data.subscribe;
-				const title = select( 'core/editor' ).getEditedPostAttribute( 'title' );
-				const content = select( 'core/editor' ).getEditedPostAttribute( 'content' );
-				const excerpt = select( 'core/editor' ).getEditedPostAttribute( 'excerpt' );
+				const emptyPost = bypassConfirmation();
+
+				// Initialize the confirmation dialog box.
+				const { dialogContainer : dialog, dialogResult } = initializeConfimationModal();
+				// The selected option in the dropdown list.
+				const selectedOption = event.target;
 
 				// Specific case for empty posts.
 				// Place at the beginning because window.location changing triggers automatically page reloading.
-				if ( location.pathname.match( /post-new.php/gi ) && '' === title && '' === content && '' === excerpt ) {
-					reloadPageForEmptyPost( this.value );
+				if ( location.pathname.match( /post-new.php/gi ) && emptyPost ) {
+					reloadPageForEmptyPost( selectedOption.value );
 				}
 
 				// Otherwise send an ajax request to refresh the legacy metabox and set the post language with the new language.
+				// It needs a confirmation of the user before changing the language.
 				// Need to wait the ajax response before triggering the block editor post save action.
-				var data = {
-					action:     'post_lang_choice',
-					lang:       event.target.value,
-					post_type:  $( '#post_type' ).val(),
-					post_id:    $( '#post_ID' ).val(),
-					_pll_nonce: $( '#_pll_nonce' ).val()
+				if ( $( this ).data( 'old-value' ) !== selectedOption.value && ! emptyPost ) {
+					dialog.dialog( 'open' );
+				} else {
+					// Block editor doesn't allow to save an empty post.
+					// So we must revert the language to the old one because the browser asks if we want to quit the page if we trigger its reloading.
+					selectedOption.value = $( this ).data( 'old-value' );
 				}
 
-				$.post(
-					ajaxurl,
-					data,
-					function( response ) {
-						var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-						$.each(
-							res.responses,
-							function() {
-								switch ( this.what ) {
-									case 'translations': // Translations fields
-										// Data is built and come from server side and is well escaped when necessary
-										$( '.translations' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-										init_translations();
-									break;
-									case 'flag': // Flag in front of the select dropdown
-										// Data is built and come from server side and is well escaped when necessary
-										$( '.pll-select-flag' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-									break;
-								}
+				dialogResult.then(
+					() => {
+						var data = {
+							action:     'post_lang_choice',
+							lang:       selectedOption.value,
+							post_type:  $( '#post_type' ).val(),
+							post_id:    $( '#post_ID' ).val(),
+							_pll_nonce: $( '#_pll_nonce' ).val()
+						}
+
+						$.post(
+							ajaxurl,
+							data,
+							function( response ) {
+								var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+								$.each(
+									res.responses,
+									function() {
+										switch ( this.what ) {
+											case 'translations': // Translations fields
+												// Data is built and come from server side and is well escaped when necessary
+												$( '.translations' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												init_translations();
+											break;
+											case 'flag': // Flag in front of the select dropdown
+												// Data is built and come from server side and is well escaped when necessary
+												$( '.pll-select-flag' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+											break;
+										}
+									}
+								);
+								blockEditorSavePostAndReloadPage();
 							}
 						);
-						blockEditorSavePostAndReloadPage();
-					}
+					},
+					() => {} // Do nothing when promise is rejected by clicking the Cancel dialog button.
 				);
 
 				/**
@@ -123,7 +150,7 @@ jQuery(
 				/**
 				 * Triggers block editor post save and reload the block editor page when everything is ok.
 				 */
-				blockEditorSavePostAndReloadPage = function() {
+				 function blockEditorSavePostAndReloadPage() {
 
 					let unsubscribe = null;
 

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -93,7 +93,7 @@ jQuery(
 
 				dialogResult.then(
 					() => {
-						var data = {
+						var data = { // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 							action:     'post_lang_choice',
 							lang:       selectedOption.value,
 							post_type:  $( '#post_type' ).val(),
@@ -150,7 +150,7 @@ jQuery(
 				/**
 				 * Triggers block editor post save and reload the block editor page when everything is ok.
 				 */
-				 function blockEditorSavePostAndReloadPage() {
+				function blockEditorSavePostAndReloadPage() {
 
 					let unsubscribe = null;
 

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -4,8 +4,7 @@
 
 import {
 	initializeLanguageOldValue,
-	initializeConfimationModal,
-	bypassConfirmation
+	initializeConfimationModal
 } from './lib/confirmation-modal';
 
 // tag suggest in metabox
@@ -104,7 +103,6 @@ jQuery(
 		$( '.post_lang_choice' ).on(
 			'change',
 			function( event ) {
-				const emptyPost = bypassConfirmation();
 				// Initialize the confirmation dialog box.
 				const confirmationModal = initializeConfimationModal();
 				const { dialogContainer: dialog } = confirmationModal;
@@ -112,7 +110,7 @@ jQuery(
 				// The selected option in the dropdown list.
 				const selectedOption = event.target;
 
-				if ( $( this ).data( 'old-value' ) !== selectedOption.value && ! emptyPost ) {
+				if ( $( this ).data( 'old-value' ) !== selectedOption.value && ! isEmptyPost() ) {
 					dialog.dialog( 'open' );
 				} else {
 					dialogResult = Promise.resolve();
@@ -201,6 +199,14 @@ jQuery(
 					() => {} // Do nothing when promise is rejected by clicking the Cancel dialog button.
 				);
 				// phpcs:enable PEAR.Functions.FunctionCallSignature.EmptyLine
+
+				function isEmptyPost() {
+					const title = jQuery( 'input#title' ).val();
+					const content = jQuery( 'textarea#content' ).val();
+					const excerpt = jQuery( 'textarea#excerpt' ).val();
+
+					return ! title && ! content && ! excerpt;
+				}
 			}
 		);
 

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -201,9 +201,9 @@ jQuery(
 				// phpcs:enable PEAR.Functions.FunctionCallSignature.EmptyLine
 
 				function isEmptyPost() {
-					const title = jQuery( 'input#title' ).val();
-					const content = jQuery( 'textarea#content' ).val();
-					const excerpt = jQuery( 'textarea#excerpt' ).val();
+					const title = $( 'input#title' ).val();
+					const content = $( 'textarea#content' ).val();
+					const excerpt = $( 'textarea#excerpt' ).val();
 
 					return ! title && ! content && ! excerpt;
 				}

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -2,6 +2,12 @@
  * @package Polylang
  */
 
+import {
+	initializeLanguageOldValue,
+	initializeConfimationModal,
+	bypassConfirmation
+} from './lib/confirmation-modal';
+
 // tag suggest in metabox
 jQuery(
 	function( $ ) {
@@ -91,83 +97,107 @@ jQuery(
 			}
 		);
 
-		// ajax for changing the post's language in the languages metabox
-		$( '.post_lang_choice' ).change(
-			function() {
-				var value = $( this ).val();
-				var lang  = $( this ).children( 'option[value="' + value + '"]' ).attr( 'lang' );
-				var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
+		// Initialize current language to be able to compare if it changes.
+		initializeLanguageOldValue();
 
-				var data = {
-					action:     'post_lang_choice',
-					lang:       value,
-					post_type:  $( '#post_type' ).val(),
-					taxonomies: taxonomies,
-					post_id:    $( '#post_ID' ).val(),
-					_pll_nonce: $( '#_pll_nonce' ).val()
+		// ajax for changing the post's language in the languages metabox
+		$( '.post_lang_choice' ).on(
+			'change',
+			function( event ) {
+				const emptyPost = bypassConfirmation();
+				// Initialize the confirmation dialog box.
+				const confirmationModal = initializeConfimationModal();
+				const { dialogContainer: dialog } = confirmationModal;
+				let { dialogResult } = confirmationModal;
+				// The selected option in the dropdown list.
+				const selectedOption = event.target;
+
+				if ( $( this ).data( 'old-value' ) !== selectedOption.value && ! emptyPost ) {
+					dialog.dialog( 'open' );
+				} else {
+					dialogResult = Promise.resolve();
 				}
 
-				$.post(
-					ajaxurl,
-					data,
-					function( response ) {
-						var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
-						$.each(
-							res.responses,
-							function() {
-								switch ( this.what ) {
-									case 'translations': // translations fields
-										// Data is built and come from server side and is well escaped when necessary
-										$( '.translations' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-										init_translations();
-									break;
-									case 'taxonomy': // categories metabox for posts
-										var tax = this.data;
-										// @see wp_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L175
-										// @see https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/class-walker-category-checklist.php#L89-L111
-										$( '#' + tax + 'checklist' ).html( this.supplemental.all ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-										// @see wp_popular_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L236
-										$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-										// @see wp_dropdown_categories https://github.com/WordPress/WordPress/blob/5.5.1/wp-includes/category-template.php#L336
-										// which is called by PLL_Admin_Classic_Editor::post_lang_choice to generate supplemental.dropdown
-										$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
-										$( '#' + tax + '-lang' ).val( $( '.post_lang_choice' ).val() ); // hidden field
-									break;
-									case 'pages': // parent dropdown list for pages
-										// @see wp_dropdown_pages https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/post-template.php#L1186-L1208
-										// @see https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/class-walker-page-dropdown.php#L88
-										$( '#parent_id' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-									break;
-									case 'flag': // flag in front of the select dropdown
-										// Data is built and come from server side and is well escaped when necessary
-										$( '.pll-select-flag' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-									break;
-									case 'permalink': // Sample permalink
-										var div = $( '#edit-slug-box' );
-										if ( '-1' != this.data && div.children().length ) {
-											// @see get_sample_permalink_html https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/post.php#L1425-L1454
-											div.html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+				dialogResult.then(
+					() => {
+						var lang  = selectedOption.options[selectedOption.options.selectedIndex].lang;
+						var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
+
+						var data = {
+							action:     'post_lang_choice',
+							lang:       selectedOption.value,
+							post_type:  $( '#post_type' ).val(),
+							taxonomies: taxonomies,
+							post_id:    $( '#post_ID' ).val(),
+							_pll_nonce: $( '#_pll_nonce' ).val()
+						}
+
+						$.post(
+							ajaxurl,
+							data,
+							function( response ) {
+								var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+								$.each(
+									res.responses,
+									function() {
+										switch ( this.what ) {
+											case 'translations': // translations fields
+												// Data is built and come from server side and is well escaped when necessary
+												$( '.translations' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												init_translations();
+											break;
+											case 'taxonomy': // categories metabox for posts
+												var tax = this.data;
+												// @see wp_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L175
+												// @see https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/class-walker-category-checklist.php#L89-L111
+												$( '#' + tax + 'checklist' ).html( this.supplemental.all ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												// @see wp_popular_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L236
+												$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												// @see wp_dropdown_categories https://github.com/WordPress/WordPress/blob/5.5.1/wp-includes/category-template.php#L336
+												// which is called by PLL_Admin_Classic_Editor::post_lang_choice to generate supplemental.dropdown
+												$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+												$( '#' + tax + '-lang' ).val( $( '.post_lang_choice' ).val() ); // hidden field
+											break;
+											case 'pages': // parent dropdown list for pages
+												// @see wp_dropdown_pages https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/post-template.php#L1186-L1208
+												// @see https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/class-walker-page-dropdown.php#L88
+												$( '#parent_id' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+											break;
+											case 'flag': // flag in front of the select dropdown
+												// Data is built and come from server side and is well escaped when necessary
+												$( '.pll-select-flag' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+											break;
+											case 'permalink': // Sample permalink
+												var div = $( '#edit-slug-box' );
+												if ( '-1' != this.data && div.children().length ) {
+													// @see get_sample_permalink_html https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/post.php#L1425-L1454
+													div.html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												}
+											break;
 										}
-									break;
-								}
+									}
+								);
+
+								// Update the old language with the new one to be able to compare it in the next changing.
+								initializeLanguageOldValue();
+								// modifies the language in the tag cloud
+								$( '.tagcloud-link' ).each(
+									function() {
+										var id = $( this ).attr( 'id' );
+										tagBox.get( id );
+									}
+								);
+
+								// Modifies the text direction
+								$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
+								$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
+								$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
+
+								pll.media.resetAllAttachmentsCollections();
 							}
-						);
-
-						// modifies the language in the tag cloud
-						$( '.tagcloud-link' ).each(
-							function() {
-								var id = $( this ).attr( 'id' );
-								tagBox.get( id );
-							}
-						);
-
-						// Modifies the text direction
-						$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
-						$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
-						$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
-
-						pll.media.resetAllAttachmentsCollections();
-					}
+						)
+					},
+					() => {} // Do nothing when promise is rejected by clicking the Cancel dialog button.
 				);
 			}
 		);
@@ -216,21 +246,21 @@ jQuery(
 
 /**
  * @since 3.0
- * 
+ *
  * @namespace pll
  */
 var pll = window.pll || {};
 
 /**
  * @since 3.0
- * 
+ *
  * @namespace pll.media
  */
 _.extend( pll, { media: {} } );
 
 /**
  * @since 3.0
- * 
+ *
  * @alias pll.media
  * @memberOf pll
  * @namespace
@@ -247,7 +277,7 @@ var media = _.extend(
 
 		/**
 		 * Imitates { @see wp.media.query } but log all Attachments collections created.
-		 * 
+		 *
 		 * @param {Object} [props]
 		 * @return {wp.media.model.Attachments}
 		 */
@@ -264,7 +294,7 @@ var media = _.extend(
 				function( attachmentsCollection ) {
 					/**
 					 * First reset the { @see wp.media.model.Attachments } collection.
-					 * Then, if it is mirroring a { @see wp.media.model.Query } collection, 
+					 * Then, if it is mirroring a { @see wp.media.model.Query } collection,
 					 * refresh this one too, so it will fetch new data from the server,
 					 * and then the wp.media.model.Attachments collection will syncrhonize with the new data.
 					 */
@@ -281,7 +311,7 @@ var media = _.extend(
 
 /**
  * @since 3.0
- * 
+ *
  * @memberOf pll.media
  */
 media.query = _.extend(

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -118,12 +118,13 @@ jQuery(
 					dialogResult = Promise.resolve();
 				}
 
+				// phpcs:disable PEAR.Functions.FunctionCallSignature.EmptyLine
 				dialogResult.then(
 					() => {
-						var lang  = selectedOption.options[selectedOption.options.selectedIndex].lang;
-						var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' );
+						var lang  = selectedOption.options[selectedOption.options.selectedIndex].lang; // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
+						var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' ); // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 
-						var data = {
+						var data = {  // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 							action:     'post_lang_choice',
 							lang:       selectedOption.value,
 							post_type:  $( '#post_type' ).val(),
@@ -199,6 +200,7 @@ jQuery(
 					},
 					() => {} // Do nothing when promise is rejected by clicking the Cancel dialog button.
 				);
+				// phpcs:enable PEAR.Functions.FunctionCallSignature.EmptyLine
 			}
 		);
 

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -6,7 +6,7 @@
 // Classic editor underscore is loaded, Block editor lodash is loaded.
 const { __ } = wp.i18n;
 
-const languagesList = jQuery( '#post_lang_choice' );
+const languagesList = jQuery( '.post_lang_choice' );
 
 // Dialog box for alerting the user about a risky changing.
 export const initializeConfimationModal = () => {

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -6,7 +6,7 @@
 // Classic editor underscore is loaded, Block editor lodash is loaded.
 const { __ } = wp.i18n;
 
-const languagesList = jQuery( '#post_lang_choice');
+const languagesList = jQuery( '#post_lang_choice' );
 
 export const bypassConfirmation = () => {
 	let title = jQuery( 'input#title' ).val();
@@ -34,12 +34,13 @@ export const initializeConfimationModal = () => {
 	).text( __( 'Are you sure you want to change the language of the current content?', 'polylang' ) );
 
 	// Put it after languages list dropdown.
-	languagesList.after( dialogContainer );
+	// PHPCS ignore dialogContainer is a new safe HTML code generated above.
+	languagesList.after( dialogContainer ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
 
 	const dialogResult = new Promise(
 		( confirm, cancel ) => {
-			const confirmDialog = ( what ) => {
-				switch ( what ) {
+			const confirmDialog = ( what ) => { // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
+				switch ( what ) { // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 					case 'yes':
 						// Confirm the new language.
 						languagesList.data( 'old-value', languagesList.children( ':selected' )[0].value );
@@ -47,12 +48,12 @@ export const initializeConfimationModal = () => {
 						break;
 					case 'no':
 						// Revert to the old language.
-						languagesList.val( languagesList.data( 'old-value') );
+						languagesList.val( languagesList.data( 'old-value' ) );
 						cancel( 'Cancel' );
 						break;
 				}
-				dialogContainer.dialog( 'close' );
-			}
+				dialogContainer.dialog( 'close' ); // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
+			} // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 
 			// Initialize dialog box in the case a language is selected but not added in the list.
 			dialogContainer.dialog(

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -1,0 +1,101 @@
+/**
+ * @package Polylang
+ */
+
+// We can't use underscore or lodash in this common code because it depends of the context classic or block editor.
+// Classic editor underscore is loaded, Block editor lodash is loaded.
+const { __ } = wp.i18n;
+
+const languagesList = jQuery( '#post_lang_choice');
+
+export const bypassConfirmation = () => {
+	let title = jQuery( 'input#title' ).val();
+	let content = jQuery( 'textarea#content' ).val();
+	let excerpt = jQuery( 'textarea#excerpt' ).val();
+	// Block editor case
+	if ( document.getElementById( 'editor' ) && 'undefined' !== typeof wp.data ) {
+		const editor = wp.data.select( 'core/editor' );
+		title = editor.getEditedPostAttribute( 'title' ).trim();
+		content = editor.getEditedPostAttribute( 'content' ).trim();
+		excerpt = editor.getEditedPostAttribute( 'excerpt' ).trim();
+	}
+	return ! title && ! content && ! excerpt;
+}
+
+// Dialog box for alerting the user about a risky changing.
+export const initializeConfimationModal = () => {
+	// Create dialog container.
+	const dialogContainer = jQuery(
+		'<div/>',
+		{
+			id: 'pll-dialog',
+			style: 'display:none;'
+		}
+	).text( __( 'Are you sure you want to change the language of the current content?', 'polylang' ) );
+
+	// Put it after languages list dropdown.
+	languagesList.after( dialogContainer );
+
+	const dialogResult = new Promise(
+		( confirm, cancel ) => {
+			const confirmDialog = ( what ) => {
+				switch ( what ) {
+					case 'yes':
+						// Confirm the new language.
+						languagesList.data( 'old-value', languagesList.children( ':selected' )[0].value );
+						confirm();
+						break;
+					case 'no':
+						// Revert to the old language.
+						languagesList.val( languagesList.data( 'old-value') );
+						cancel( 'Cancel' );
+						break;
+				}
+				dialogContainer.dialog( 'close' );
+			}
+
+			// Initialize dialog box in the case a language is selected but not added in the list.
+			dialogContainer.dialog(
+				{
+					autoOpen: false,
+					modal: true,
+					draggable: false,
+					resizable: false,
+					title: __( 'Change language', 'polylang' ),
+					minWidth: 600,
+					maxWidth: '100%',
+					open: function( event, ui ) {
+						// Change dialog box position for rtl language
+						// if ( $( 'body' ).hasClass( 'rtl' ) ) {
+						// 	$( this ).parent().css(
+						// 		{
+						// 			right: $( this ).parent().css( 'left' ),
+						// 			left: 'auto'
+						// 		}
+						// 	);
+						// }
+					},
+					buttons: [
+					{
+						text: __( 'OK', 'polylang' ),
+						click: function( event ) {
+							confirmDialog( 'yes' );
+						}
+					},
+					{
+						text: __( 'Cancel', 'polylang' ),
+						click: function( event ) {
+							confirmDialog( 'no' );
+						}
+					}				]
+				}
+			);
+		}
+	);
+	return { dialogContainer, dialogResult };
+}
+
+export const initializeLanguageOldValue = () => {
+	// Keep the old language value to be able to compare to the new one and revert to it if necessary.
+	languagesList.attr( 'data-old-value', languagesList.children( ':selected' )[0].value );
+};

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -8,20 +8,6 @@ const { __ } = wp.i18n;
 
 const languagesList = jQuery( '#post_lang_choice' );
 
-export const bypassConfirmation = () => {
-	let title = jQuery( 'input#title' ).val();
-	let content = jQuery( 'textarea#content' ).val();
-	let excerpt = jQuery( 'textarea#excerpt' ).val();
-	// Block editor case
-	if ( document.getElementById( 'editor' ) && 'undefined' !== typeof wp.data ) {
-		const editor = wp.data.select( 'core/editor' );
-		title = editor.getEditedPostAttribute( 'title' ).trim();
-		content = editor.getEditedPostAttribute( 'content' ).trim();
-		excerpt = editor.getEditedPostAttribute( 'excerpt' ).trim();
-	}
-	return ! title && ! content && ! excerpt;
-}
-
 // Dialog box for alerting the user about a risky changing.
 export const initializeConfimationModal = () => {
 	// Create dialog container.

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -67,14 +67,14 @@ export const initializeConfimationModal = () => {
 					maxWidth: '100%',
 					open: function( event, ui ) {
 						// Change dialog box position for rtl language
-						// if ( $( 'body' ).hasClass( 'rtl' ) ) {
-						// 	$( this ).parent().css(
-						// 		{
-						// 			right: $( this ).parent().css( 'left' ),
-						// 			left: 'auto'
-						// 		}
-						// 	);
-						// }
+						if ( jQuery( 'body' ).hasClass( 'rtl' ) ) {
+							jQuery( this ).parent().css(
+								{
+									right: jQuery( this ).parent().css( 'left' ),
+									left: 'auto'
+								}
+							);
+						}
 					},
 					buttons: [
 					{


### PR DESCRIPTION
This PR propose to fix https://github.com/polylang/polylang-pro/issues/240 part needed by the classic editor:
- classic editor
- legacy metabox in block editor ( Polylang or by using PLL_USE_BLOCK_EDITOR_PLUGIN constant)

To display the dialog box we're using the jQuery UI dialog widget with its WordPress default style.
As we can take advantage of how our javascript code is now built, the part of the dialog management is developed in its own script and shared in the the 2 cases quoted above.

This PR also fix https://github.com/polylang/polylang/issues/741 because we forgot one bind `change` function during our [jQuery migration project](https://github.com/orgs/polylang/projects/1)

This PR doesn't look at the media case. In fact, it seems to me that nothing is done for this metabox. Indeed, the metabox isn't refreshed after a language changing because the `change` handler is attached to `post_lang_choice` id instead of `attachments[n][language]` where `n` is the post id
