### PR TITLE
Correct body border in wizard to override WordPress install styles

### DIFF
--- a/modules/wizard/css/wizard.css
+++ b/modules/wizard/css/wizard.css
@@ -3,7 +3,8 @@ body {
 	margin: 65px auto 24px;
 	box-shadow: none;
 	background: #f1f1f1;
-	padding: 0
+	padding: 0;
+	border: 0; /* fix-pro #856 override WP install.css */
 }
 
 #pll-logo {


### PR DESCRIPTION
All is in the PR title 

Fix https://github.com/polylang/polylang-pro/issues/856

/!\ Need to be tested with Polylang first because the correction is inside Polylang.