### PR TITLE
jQuery: replace deprecated shorthand functions and syntax

### DIFF
--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -46,7 +46,8 @@ jQuery(
 					// @see code from WordPress core https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/js/tags-box.js#L291
 					// @see wp_generate_tag_cloud function which generate the escaped HTML https://github.com/WordPress/WordPress/blob/a02b5cc2a8eecb8e076fbb7cf4de7bd2ec8a8eb1/wp-includes/category-template.php#L966-L975
 					r = $( '<div />' ).addClass( 'the-tagcloud' ).attr( 'id', 'tagcloud-' + tax ).html( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-					$( 'a', r ).click(
+					$( 'a', r ).on(
+						'click',
 						function(){
 							tagBox.flushTags( $( this ).closest( '.inside' ).children( '.tagsdiv' ), this );
 							return false;
@@ -72,7 +73,7 @@ jQuery(
 );
 
 jQuery(
-	function ( $ ) {
+	function( $ ) {
 		// collect taxonomies - code partly copied from WordPress
 		var taxonomies = new Array();
 		$( '.categorydiv' ).each(

--- a/js/nav-menu.js
+++ b/js/nav-menu.js
@@ -6,7 +6,7 @@
 
 jQuery( document ).ready(
 	function( $ ) {
-		$( '#update-nav-menu' ).bind(
+		$( '#update-nav-menu' ).on(
 			'click',
 			function( e ) {
 				if ( e.target && e.target.className && -1 != e.target.className.indexOf( 'item-edit' ) ) {

--- a/js/nav-menu.js
+++ b/js/nav-menu.js
@@ -85,7 +85,8 @@ jQuery(
 							$.each(
 								options,
 								function( i, v ) {
-									$( '#edit-menu-item-show_' + v + id ).change(
+									$( '#edit-menu-item-show_' + v + id ).on(
+										'change',
 										function() {
 											if ( true != $( this ).prop( 'checked' ) ) {
 												$( '#edit-menu-item-show_' + options[ 1 - i ] + id ).prop( 'checked', true );

--- a/js/nav-menu.js
+++ b/js/nav-menu.js
@@ -4,7 +4,7 @@
  * @package Polylang
  */
 
-jQuery( document ).ready(
+jQuery(
 	function( $ ) {
 		$( '#update-nav-menu' ).on(
 			'click',

--- a/js/post.js
+++ b/js/post.js
@@ -41,7 +41,8 @@ jQuery(
 						filter_pages( lang ); // initial filter for parent dropdown
 
 						// modify category checklist an parent dropdown on language change
-						select.change(
+						select.on(
+							'change',
 							function() {
 								filter_terms( $( this ).val() );
 								filter_pages( $( this ).val() );

--- a/js/term.js
+++ b/js/term.js
@@ -164,7 +164,8 @@ jQuery(
 		init_translations();
 
 		// ajax for changing the term's language
-		$( '#term_lang_choice' ).change(
+		$( '#term_lang_choice' ).on(
+			'change',
 			function() {
 				var value = $( this ).val();
 				var lang  = $( this ).children( 'option[value="' + value + '"]' ).attr( 'lang' );

--- a/js/user.js
+++ b/js/user.js
@@ -4,7 +4,7 @@
  * @package Polylang
  */
 
-jQuery( document ).ready(
+jQuery(
 	function( $ ) {
 		// biography
 		// FIXME there is probably a more efficient way to do this


### PR DESCRIPTION
Fix #741 reopened again after the latest comments.
And some other deprecated binds which aren't catched too.