### PR TITLE
Add a CSS classes on jQuery UI selectmenu widget elements

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -111,7 +111,13 @@ jQuery(
 		 */
 
 		// Selectmenu widget options
-		var selectmenuOptions = { width: defaultSelectmenuWidth };
+		var selectmenuOptions = {
+			width: defaultSelectmenuWidth,
+			classes: {
+				'ui-selectmenu-menu': 'pll-selectmenu-menu',
+				'ui-selectmenu-button': 'pll-selectmenu-button',
+			}
+		};
 
 		// Selectmenu widget callbacks
 		var selectmenuFlagListCallbacks = {};


### PR DESCRIPTION
 Add a CSS classes on jQuery UI selectmenu widget elements to be able to easily override styles for languages and flags lists dropdown.
 
 It could be interesting when some other plugins adds jQuery UI styles everywhere in the admin as WooCommerce Booking does and overrides WordPress default styles.

See code of WC Bookings in class-wc-bookings-admin.php

``` 
add_action( 'admin_enqueue_scripts', array( $this, 'styles_and_scripts' ) );
```
and

``` 
wp_enqueue_style( 'jquery-ui-style', '//ajax.googleapis.com/ajax/libs/jqueryui/' . $jquery_version . '/themes/smoothness/jquery-ui.min.css' );
```
 without any condition to load it where it's only needed.

 This PR prepare correction of https://github.com/polylang/polylang-pro/issues/333