### PR TITLE
Add a CSS class on jQuery UI dialog widget

### DIFF
--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -51,6 +51,9 @@ export const initializeConfimationModal = () => {
 					title: __( 'Change language', 'polylang' ),
 					minWidth: 600,
 					maxWidth: '100%',
+					classes: {
+						'ui-dialog': 'pll-confirmation-modal',
+					},
 					open: function( event, ui ) {
 						// Change dialog box position for rtl language
 						if ( jQuery( 'body' ).hasClass( 'rtl' ) ) {


### PR DESCRIPTION
Add a CSS class on jQuery UI dialog widget to be able to easily override styles for confirmation-modal.

It could be interesting when some other plugins adds jQuery UI styles in the admin as WooCommerce does in it product admin page and overrides WordPress default styles.

This PR prepare correction of https://github.com/polylang/polylang-wc/issues/333