### PR TITLE
Cancel language change when we're closing the confirmation dialog box.

### DIFF
--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -65,6 +65,10 @@ export const initializeConfimationModal = () => {
 							);
 						}
 					},
+					close: function( event, ui ) {
+						// When we're closing the dialog box we need to cancel the language change as we click on Cancel button.
+						confirmDialog( 'no' );
+					},
 					buttons: [
 					{
 						text: __( 'OK', 'polylang' ),


### PR DESCRIPTION
When we added a confirmation dialog box to ask the user to confirm the language change in the PR #746 we forgot to cancel the change when we're closing the dialog box by using the cross icon in the top right corner of the dialog box.

![image](https://user-images.githubusercontent.com/1003778/107763568-1ea5b980-6d2f-11eb-90c1-a9c0f2f97339.png)

So this propose to fix this issue.