### PR TITLE
Add styles to override jQuery UI dialog widget styles of WooCommerce

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -192,7 +192,8 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			}
 		}
 
-		wp_enqueue_style( 'polylang_admin', plugins_url( '/css/build/admin' . $suffix . '.css', POLYLANG_BASENAME ), array( 'wp-jquery-ui-dialog' ), POLYLANG_VERSION );
+		wp_register_style( 'polylang_admin', plugins_url( '/css/build/admin' . $suffix . '.css', POLYLANG_BASENAME ), array( 'wp-jquery-ui-dialog' ), POLYLANG_VERSION );
+		wp_enqueue_style( 'polylang_dialog', plugins_url( '/css/build/dialog' . $suffix . '.css', POLYLANG_BASENAME ), array( 'polylang_admin' ), POLYLANG_VERSION );
 
 		$this->localize_scripts();
 	}

--- a/css/dialog.css
+++ b/css/dialog.css
@@ -1,0 +1,82 @@
+/*  By default Polylang dialog box use WordPress jQuery UI dialog styles.
+	However WooCommerce loads its own jQuery UI dialog styles and we need to override them by ours
+	to revert to the default WordPress ones.
+*/
+.pll-confirmation-modal.ui-widget,
+.pll-confirmation-modal.ui-widget .ui-widget,
+.pll-confirmation-modal .ui-widget {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+}
+.pll-confirmation-modal.ui-dialog {
+	padding: 0;
+	z-index: 100102;
+	background: #fff;
+	border: 0;
+	color: #444;
+}
+.ui-dialog.pll-confirmation-modal .ui-dialog-titlebar {
+	background: #fcfcfc;
+	border-radius: 0;
+	border: 0;
+	border-bottom: 1px solid #dfdfdf;
+	height: 36px;
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 2;
+	padding: 0 36px 0 16px;
+	color: #444;
+	position: static;
+}
+.ui-dialog.pll-confirmation-modal .ui-dialog-title {
+	float: none;
+	width: auto;
+	margin: 0;
+}
+.pll-confirmation-modal .ui-widget-header .ui-icon {
+	background: none;
+	position: static;
+}
+.pll-confirmation-modal .ui-button.ui-dialog-titlebar-close {
+	padding: 0;
+	margin: 0;
+	top: 0;
+	right: 0;
+	width: 36px;
+	height: 36px;
+}
+.ui-dialog.pll-confirmation-modal .ui-dialog-content {
+	border: 0;
+	padding: 16px;
+	color: #444;
+	position: static;
+	box-sizing: border-box;
+}
+.ui-dialog.pll-confirmation-modal .ui-dialog-buttonpane{
+	margin: 0;
+	padding: 16px;
+	border: 0;
+	background: #fcfcfc;
+	border-top: 1px solid #dfdfdf;
+}
+.ui-dialog.pll-confirmation-modal .ui-dialog-buttonpane .ui-button{
+	margin: 0 0 0 16px;
+	padding: 0 10px 1px;
+	background: #f7f7f7;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	position: static;
+	line-height: 2;
+	vertical-align: top;
+}
+.ui-dialog.pll-confirmation-modal .ui-button:hover,
+.ui-dialog.pll-confirmation-modal .ui-button:focus {
+	background: #fafafa;
+	border-color: #999;
+	color: #23282d;
+}
+.pll-confirmation-modal + .ui-widget-overlay {
+	background: #000;
+	opacity: 0.7;
+	z-index: 100101;
+}


### PR DESCRIPTION
This PR propose to fix https://github.com/polylang/polylang-wc/issues/333 by targeting specifically the polylang confirmation dialog box - see https://github.com/polylang/polylang/pull/752 - and revert styles to the jQuery UI Dialog WordPress default ones on the WooCommerce admin product page.

We should have with this PR as with Polylang only

![image](https://user-images.githubusercontent.com/1003778/107759476-a9cf8100-6d28-11eb-8d4b-a454e965bf63.png)

So we enqueue a new dialog.css file with a dependency on the admin.css existing one.

**Notice** that because the enqueue is done all the time, the new file is also loaded on post editing page. I noticed nothing wrong because the styles should be the same.

It is exactly the equivalent of the [PR proposed initially on Polylang for WooCommerce repository](https://github.com/polylang/polylang-wc/pull/338) but it makes more sense to put it in Polylang to avoid future incompatibilities with other plugins.