### PR TITLE
Yoast: fix post type archive title and metadesc not translated

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -84,6 +84,7 @@ class PLL_WPSEO {
 		}
 
 		if ( ! empty( $keys ) ) {
+			WPSEO_Options::clear_cache();
 			new PLL_Translate_Option( 'wpseo_titles', array_fill_keys( $keys, 1 ), array( 'context' => 'wordpress-seo' ) );
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/855

1. The Yoast SEO options are cached after they are read from `get_option()`.
2. We wait for `wp_loaded` to determine the post type archives for which we need to translat the title and metadesc. This is too late as the options are already in the cache and the `option_{$option_name}` filters are not executed anymore.

Fortunately, Yoast SEO allows to clear the options cache which allows us to execute our filters once done.  