### PR TITLE
Extract language selection to context classes.

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -467,7 +467,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * @param array $args
 	 * @return PLL_Language
 	 */
-	public function get_requested_language( $args ) {
+	public function get_requested_language( $args = array() ) {
 		// On tags page, everything should be filtered according to the admin language filter except the parent dropdown
 		if ( 'edit-tags.php' === $GLOBALS['pagenow'] && empty( $args['class'] ) ) {
 			return $this->filter_lang;

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -460,4 +460,17 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			);
 		}
 	}
+
+	/**
+	 * @param array $args
+	 * @return PLL_Language
+	 */
+	public function get_requested_language( $args ) {
+		// On tags page, everything should be filtered according to the admin language filter except the parent dropdown
+		if ( 'edit-tags.php' === $GLOBALS['pagenow'] && empty( $args['class'] ) ) {
+			return $this->filter_lang;
+		}
+
+		return $this->curlang;
+	}
 }

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -462,6 +462,8 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	}
 
 	/**
+	 * Returns the language matching the request.
+	 *
 	 * @param array $args
 	 * @return PLL_Language
 	 */

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -228,6 +228,12 @@ class PLL_Frontend extends PLL_Base {
 		}
 	}
 
+	/**
+	 * Returns the language matching the request.
+	 *
+	 * @param array $args
+	 * @return PLL_Language
+	 */
 	public function get_requested_language( $args ) {
 		return $this->curlang;
 	}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -227,4 +227,8 @@ class PLL_Frontend extends PLL_Base {
 			$this->load_strings_translations();
 		}
 	}
+
+	public function get_requested_language( $args ) {
+		return $this->curlang;
+	}
 }

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -234,7 +234,7 @@ class PLL_Frontend extends PLL_Base {
 	 * @param array $args
 	 * @return PLL_Language
 	 */
-	public function get_requested_language( $args ) {
+	public function get_requested_language( $args = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->curlang;
 	}
 }

--- a/include/base.php
+++ b/include/base.php
@@ -166,12 +166,4 @@ abstract class PLL_Base {
 		 */
 		return $new_blog_id !== $prev_blog_id && in_array( POLYLANG_BASENAME, $plugins ) && get_option( 'polylang' );
 	}
-
-	/**
-	 * Returns the language matching the request.
-	 *
-	 * @param array $args
-	 * @return PLL_Language
-	 */
-	abstract public function get_requested_language( $args );
 }

--- a/include/base.php
+++ b/include/base.php
@@ -166,4 +166,12 @@ abstract class PLL_Base {
 		 */
 		return $new_blog_id !== $prev_blog_id && in_array( POLYLANG_BASENAME, $plugins ) && get_option( 'polylang' );
 	}
+
+	/**
+	 * Returns the language matching the request.
+	 *
+	 * @param array $args
+	 * @return PLL_Language
+	 */
+	abstract public function get_requested_language( $args );
 }

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -23,13 +23,6 @@ class PLL_CRUD_Terms {
 	public $curlang;
 
 	/**
-	 * Language selected in the admin language filter.
-	 *
-	 * @var PLL_Language
-	 */
-	public $filter_lang;
-
-	/**
 	 * Preferred language to assign to new contents.
 	 *
 	 * @var PLL_Language
@@ -51,9 +44,9 @@ class PLL_CRUD_Terms {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
+		$this->polylang = $polylang;
 		$this->model = &$polylang->model;
 		$this->curlang = &$polylang->curlang;
-		$this->filter_lang = &$polylang->filter_lang;
 		$this->pref_lang = &$polylang->pref_lang;
 
 		// Saving terms
@@ -153,12 +146,7 @@ class PLL_CRUD_Terms {
 			return $args['lang'];
 		}
 
-		// On tags page, everything should be filtered according to the admin language filter except the parent dropdown
-		if ( 'edit-tags.php' === $GLOBALS['pagenow'] && empty( $args['class'] ) ) {
-			return $this->filter_lang;
-		}
-
-		return $this->curlang;
+		return $this->polylang->get_requested_language( $args );
 	}
 
 	/**

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -37,11 +37,18 @@ class PLL_CRUD_Terms {
 	private $tax_query_lang;
 
 	/**
+	 * The Polylang context.
+	 *
+	 * @var PLL_Base
+	 */
+	private $polylang;
+
+	/**
 	 * Constructor
 	 *
 	 * @since 2.4
 	 *
-	 * @param object $polylang
+	 * @param PLL_Base $polylang
 	 */
 	public function __construct( &$polylang ) {
 		$this->polylang = $polylang;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -39,7 +39,7 @@ class PLL_CRUD_Terms {
 	/**
 	 * The Polylang context.
 	 *
-	 * @var PLL_Base
+	 * @var PLL_Frontend|PLL_Admin_Base
 	 */
 	private $polylang;
 
@@ -48,7 +48,7 @@ class PLL_CRUD_Terms {
 	 *
 	 * @since 2.4
 	 *
-	 * @param PLL_Base $polylang
+	 * @param PLL_Frontend|PLL_Admin_Base $polylang
 	 */
 	public function __construct( &$polylang ) {
 		$this->polylang = $polylang;


### PR DESCRIPTION
## Before

`PLL_CRUD_Terms::get_queried_language()` checked the value of `$GLOBALS['pagenow']`, which is a global variable available in the admin context only, whereas `PLL_CRUD_Terms` is used in both admin and frontend contexts (REST?).

`PLL_CRUD_Terms` did also read the `$filter_lang` property of whichever context class was passed, but this property only exists in `PLL_Admin_Base` and its child classes.

## Changes

Extract the method that returns the correct language to use, and move it to the context classes.

Fixes [Polylang Pro #884](https://github.com/polylang/polylang-pro/issues/884)

## Going Further

- The `get_requested_language()` method could belong to a specialized class, `PLL_Request`, that we could use to carry other information from the global variables to the modules.
- The `get_requested_language()` method could belong to the `PLL_Query` class instead.

