### PR TITLE
Fix site title not translated in email change confirmation email

### DIFF
--- a/include/base.php
+++ b/include/base.php
@@ -61,6 +61,7 @@ abstract class PLL_Base {
 		// User defined strings translations
 		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
 		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
+		add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
 
 		// Switch_to_blog
 		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );
@@ -115,7 +116,7 @@ abstract class PLL_Base {
 	 */
 	public function load_strings_translations( $locale = '' ) {
 		if ( empty( $locale ) ) {
-			$locale = get_locale();
+			$locale = ( is_admin() && ! Polylang::is_ajax_on_front() ) ? get_user_locale() : get_locale();
 		}
 
 		$language = $this->model->get_language( $locale );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -354,7 +354,6 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	function test_site_title_in_email_change_confirmation_email() {
-		// Important to use a language available in DIR_TESTDATA . '/languages/', otherwise switch_to_locale() doesn't switch.
 		$language = self::$model->get_language( 'es' );
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -353,6 +353,34 @@ class Filters_Test extends PLL_UnitTestCase {
 		reset_phpmailer_instance();
 	}
 
+	function test_site_title_in_email_change_confirmation_email() {
+		// Important to use a language available in DIR_TESTDATA . '/languages/', otherwise switch_to_locale() doesn't switch.
+		$language = self::$model->get_language( 'es' );
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );
+		$_mo->export_to_db( $language );
+
+		reset_phpmailer_instance();
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, 'locale', 'es_ES' );
+		wp_set_current_user( $user_id );
+		set_current_screen( 'profile.php' );
+
+		$pll_env = new PLL_Admin( $this->frontend->links_model );
+		$pll_env->init();
+
+		$_POST = array(
+			'user_id' => $user_id,
+			'email'   => 'my_new_email@example.org',
+		);
+		do_action( 'personal_options_update', $user_id );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi sitio' ) );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi sitio' ) );
+		reset_phpmailer_instance();
+	}
+
 	function _action_pre_get_posts() {
 		$terms = get_terms( 'post_tag', array( 'hide_empty' => false ) );
 		$language = self::$model->term->get_language( $terms[0]->term_id );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/92

Strings translations are usually not loaded on admin side. We however need to make an exception when emails are sent. This PR loads the strings translations when the user profile is saved in case the email change confirmation email is sent.