### PR TITLE
Add a travis job to test the deve version of WP with PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,17 @@ jobs:
       php: "7.2"
       env: "WP_VERSION=latest WP_MULTISITE=1"
 
+    - name: "WP nightly - PHP 5.6"
+      php: "5.6"
+      env: "WP_VERSION=nightly WP_MULTISITE=0"
+
     - name: "WP nightly - PHP 8.0"
       php: "8.0"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
   allow_failures:
+    - php: "5.6"
+      env: "WP_VERSION=nightly WP_MULTISITE=0"
+
     - php: "8.0"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 


### PR DESCRIPTION
After #764, it seems useful not to only run our tests for the nightly version of WP with the latest PHP version but also with the oldest, in the hope that this will help to catch more issues.