### PR TITLE
Rewrite how to add polylang parameters in all admin ajax requests

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -269,8 +269,6 @@ abstract class PLL_Admin_Base extends PLL_Base {
 					function( $ ){
 						$.ajaxPrefilter( function ( options, originalOptions, jqXHR ) {
 							if ( -1 != options.url.indexOf( ajaxurl ) || -1 != ajaxurl.indexOf( options.url ) ) {
-								console.log( 'pll', '$str = <?php echo $str; ?>');
-								console.log( 'pll', '$arr <?php echo $arr; ?>');
 
 								function addStringParamaters() {
 									if ( 'undefined' === typeof options.data || '' === options.data ) {
@@ -279,6 +277,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 										options.data = options.data + '&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
 									}
 								}
+
 								// options.processData set to true is the default jQuery process where the data is converted in a query string by using jQuery.param().
 								// This step is done before applying filters. Thus here the options.data is already a string in this case.
 								// @See https://github.com/jquery/jquery/blob/3.5.1/src/ajax.js#L563-L569 jQuery ajax function.
@@ -298,7 +297,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 						});
 					}
 				);
-			}
+			}q
 		</script>
 		<?php
 	}

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -297,7 +297,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 						});
 					}
 				);
-			}q
+			}
 		</script>
 		<?php
 	}

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -284,7 +284,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 								 * @See https://github.com/jquery/jquery/blob/3.5.1/src/ajax.js#L563-L569 jQuery ajax function.
 								 */
 								if ( options.processData ) {
-									addStringParamaters();
+									addStringParameters();
 								} else {
 									/*
 									 * If options.processData is set to false data could be undefined or pass as a string.

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -270,7 +270,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 						$.ajaxPrefilter( function ( options, originalOptions, jqXHR ) {
 							if ( -1 != options.url.indexOf( ajaxurl ) || -1 != ajaxurl.indexOf( options.url ) ) {
 
-								function addStringParamaters() {
+								function addStringParameters() {
 									if ( 'undefined' === typeof options.data || '' === options.data ) {
 										options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
 									} else {
@@ -278,14 +278,18 @@ abstract class PLL_Admin_Base extends PLL_Base {
 									}
 								}
 
-								// options.processData set to true is the default jQuery process where the data is converted in a query string by using jQuery.param().
-								// This step is done before applying filters. Thus here the options.data is already a string in this case.
-								// @See https://github.com/jquery/jquery/blob/3.5.1/src/ajax.js#L563-L569 jQuery ajax function.
+								/*
+								 * options.processData set to true is the default jQuery process where the data is converted in a query string by using jQuery.param().
+								 * This step is done before applying filters. Thus here the options.data is already a string in this case.
+								 * @See https://github.com/jquery/jquery/blob/3.5.1/src/ajax.js#L563-L569 jQuery ajax function.
+								 */
 								if ( options.processData ) {
 									addStringParamaters();
 								} else {
-									// If options.processData is set to false data could be undefined or pass as a string.
-									// So data as to be processed as if options.processData is set to true.
+									/*
+									 * If options.processData is set to false data could be undefined or pass as a string.
+									 * So data as to be processed as if options.processData is set to true.
+									 */
 									if ( 'undefined' === typeof options.data || 'string' === typeof options.data ) {
 										addStringParameters();
 									} else {

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -266,27 +266,32 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		<script type="text/javascript">
 			if (typeof jQuery != 'undefined') {
 				jQuery(
-					function($){
-						$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+					function( $ ){
+						$.ajaxPrefilter( function ( options, originalOptions, jqXHR ) {
 							if ( -1 != options.url.indexOf( ajaxurl ) || -1 != ajaxurl.indexOf( options.url ) ) {
-								if ( 'undefined' === typeof options.data ) {
-									options.data = ( 'get' === options.type.toLowerCase() ) ? '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>' : <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?>;
-								} else {
-									if ( 'string' === typeof options.data ) {
-										if ( '' === options.data && 'get' === options.type.toLowerCase() ) {
-											options.url = options.url+'&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
-										} else {
-											try {
-												var o = JSON.parse(options.data);
-												o = $.extend(o, <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?>);
-												options.data = JSON.stringify(o);
-											}
-											catch(e) {
-												options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>&'+options.data;
-											}
-										}
+								console.log( 'pll', '$str = <?php echo $str; ?>');
+								console.log( 'pll', '$arr <?php echo $arr; ?>');
+
+								function addStringParamaters() {
+									if ( 'undefined' === typeof options.data || '' === options.data ) {
+										options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
 									} else {
-										options.data = $.extend(options.data, <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?>);
+										options.data = options.data + '&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
+									}
+								}
+								// options.processData set to true is the default jQuery process where the data is converted in a query string by using jQuery.param().
+								// This step is done before applying filters. Thus here the options.data is already a string in this case.
+								// @See https://github.com/jquery/jquery/blob/3.5.1/src/ajax.js#L563-L569 jQuery ajax function.
+								if ( options.processData ) {
+									addStringParamaters();
+								} else {
+									// If options.processData is set to false data could be undefined or pass as a string.
+									// So data as to be processed as if options.processData is set to true.
+									if ( 'undefined' === typeof options.data || 'string' === typeof options.data ) {
+										addStringParameters();
+									} else {
+										// Otherwise options.data is probably an object.
+										options.data = Object.assign( options.data, <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?> );
 									}
 								}
 							}


### PR DESCRIPTION
fixes #744 and fixes https://github.com/polylang/polylang-pro/issues/821

To correctly understand, refer to my latest comment on https://github.com/polylang/polylang-pro/issues/821 https://github.com/polylang/polylang-pro/issues/821#issuecomment-779915122 and we need to know how [jQuery ajax](https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings) function works. Especially that `processData` option is set to true by default and then `ajaxPrefilter` is done after [jQuery.param()](https://api.jquery.com/jQuery.param/#jQuery-param-obj) which converts data as an object into a string.
https://github.com/jquery/jquery/blob/main/src/ajax.js#L566-L571

So `processData` option is really the right method to know what kind of data we receive in `ajaxPrefilter` function:

- `true`: always a string, set by the user or convert by` jQuery.param()`
- `false`: could also be a string  set by the user and need to be processed as when `processData` is set to `true` or anything else probably an object

Thus, in most cases, we have a string to process and we want to add the Polylang parameters.
So we have to test to cases:
- undefined or empty data string: fully override the value by the Polylang parameters.
- otherwise concatenate the Polylang parameters to the data string

If processData is enforce to false and data send as an object the polylang parameters are added as properties of this data object.

We consider that the user know what it does and how the data need to be retrieved server side to be process. 
Any way it is a borderline case.

## Further more
I tested the cases that I thought about and described above on codepen https://codepen.io/manooweb/pen/abBENbx and by using the webservice https://httpbin.org/


