### PR TITLE
Fix switcher block not working in a post retrieved in REST API

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -29,11 +29,8 @@
  * @return string|array Either the html markup of the switcher or the raw elements to build a custom language switcher.
  */
 function pll_the_languages( $args = array() ) {
-	if ( PLL() instanceof PLL_Frontend ) {
-		$switcher = new PLL_Switcher();
-		return $switcher->the_languages( PLL()->links, $args );
-	}
-	return '';
+	$switcher = new PLL_Switcher();
+	return $switcher->the_languages( PLL()->links, $args );
 }
 
 /**

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -11,6 +11,11 @@
 class PLL_Switcher {
 
 	/**
+	 * @var PLL_Links
+	 */
+	protected $links;
+
+	/**
 	 * Returns options available for the language switcher - menu or widget
 	 * either strings to display the options or default values
 	 *
@@ -37,22 +42,21 @@ class PLL_Switcher {
 	 *
 	 * @since 1.2
 	 *
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
-	 * @param array              $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @param array $args  Arguments passed to {@see PLL_Switcher::the_languages()}.
 	 * @return array Language switcher elements.
 	 */
-	protected function get_elements( $links, $args ) {
+	protected function get_elements( $args ) {
 		$first = true;
 		$out   = array();
 
-		foreach ( $links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
+		foreach ( $this->links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			$id = (int) $language->term_id;
 			$order = (int) $language->term_group;
 			$slug = $language->slug;
 			$locale = $language->get_locale( 'display' );
 			$classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
 			$url = null; // Avoids potential notice
-			$curlang = 0 === $args['admin_render'] ? $links->curlang->slug : $args['admin_current_lang'];
+			$curlang = 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
 			$current_lang = $curlang == $slug;
 
 			if ( $current_lang ) {
@@ -63,10 +67,10 @@ class PLL_Switcher {
 				}
 			}
 
-			if ( null !== $args['post_id'] && ( $tr_id = $links->model->post->get( $args['post_id'], $language ) ) && $links->model->post->current_user_can_read( $tr_id ) ) {
+			if ( null !== $args['post_id'] && ( $tr_id = $this->links->model->post->get( $args['post_id'], $language ) ) && $this->links->model->post->current_user_can_read( $tr_id ) ) {
 				$url = get_permalink( $tr_id );
 			} elseif ( null === $args['post_id'] && 0 === $args['admin_render'] ) {
-				$url = $links->get_translation_url( $language );
+				$url = $this->links->get_translation_url( $language );
 			}
 
 			if ( $no_translation = empty( $url ) ) {
@@ -89,7 +93,7 @@ class PLL_Switcher {
 				continue;
 			}
 
-			$url = empty( $url ) || $args['force_home'] ? $links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
+			$url = empty( $url ) || $args['force_home'] ? $this->links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
 			$flag = $args['raw'] && ! $args['show_flags'] ? $language->get_display_flag_url() : ( $args['show_flags'] ? $language->get_display_flag() : '' );
@@ -111,8 +115,8 @@ class PLL_Switcher {
 	 *
 	 * @since 0.1
 	 *
-	 * @param PLL_Frontend_Links $links Instance of PLL_Frontend_Links.
-	 * @param array              $args {
+	 * @param Links $links Instance of PLL_Links.
+	 * @param array $args {
 	 *   Optional array of arguments.
 	 *
 	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.
@@ -133,6 +137,8 @@ class PLL_Switcher {
 	 * @return string|array either the html markup of the switcher or the raw elements to build a custom language switcher
 	 */
 	public function the_languages( $links, $args = array() ) {
+		$this->links = $links;
+
 		$defaults = array(
 			'dropdown'               => 0, // display as list and not as dropdown
 			'echo'                   => 1, // echoes the list
@@ -166,7 +172,7 @@ class PLL_Switcher {
 			$args['show_names'] = 1;
 		}
 
-		$elements = $this->get_elements( $links, $args );
+		$elements = $this->get_elements( $args );
 
 		if ( $args['raw'] ) {
 			return $elements;
@@ -175,7 +181,7 @@ class PLL_Switcher {
 		if ( $args['dropdown'] ) {
 			$args['name'] = 'lang_choice_' . $args['dropdown'];
 			$walker = new PLL_Walker_Dropdown();
-			$args['selected'] = 0 === $args['admin_render'] ? $links->curlang->slug : $args['admin_current_lang'];
+			$args['selected'] = 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
 		}
 		else {
 			$walker = new PLL_Walker_List();

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -62,7 +62,15 @@ class PLL_Switcher {
 	 * @return string
 	 */
 	protected function get_current_language( $args ) {
-		return 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
+		if ( $args['admin_current_lang'] ) {
+			return $args['admin_current_lang'];
+		}
+
+		if ( isset( $this->links->curlang ) ) {
+			return $this->links->curlang->slug;
+		}
+
+		return $this->links->options['default_lang'];
 	}
 
 	/**

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -94,7 +94,7 @@ class PLL_Switcher {
 		}
 
 		// If we are on frontend.
-		if ( $this->links instanceof PLL_Frontend ) {
+		if ( $this->links instanceof PLL_Frontend_Links ) {
 			return $this->links->get_translation_url( $language );
 		}
 

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -9,6 +9,22 @@
  * @since 1.2
  */
 class PLL_Switcher {
+	const DEFAULTS = array(
+		'dropdown'               => 0, // Display as list and not as dropdown.
+		'echo'                   => 1, // Echoes the list.
+		'hide_if_empty'          => 1, // Hides languages with no posts (or pages).
+		'show_flags'             => 0, // Don't show flags.
+		'show_names'             => 1, // Show language names.
+		'display_names_as'       => 'name', // Display the language name.
+		'force_home'             => 0, // Tries to find a translation.
+		'hide_if_no_translation' => 0, // Don't hide the link if there is no translation.
+		'hide_current'           => 0, // Don't hide the current language.
+		'post_id'                => null, // Link to the translations of the current page.
+		'raw'                    => 0, // Build the language switcher.
+		'item_spacing'           => 'preserve', // Preserve whitespace between list items.
+		'admin_render'           => 0, // Make the switcher in a frontend context.
+		'admin_current_lang'     => null, // Use the global current language.
+	);
 
 	/**
 	 * @var PLL_Links
@@ -152,25 +168,7 @@ class PLL_Switcher {
 	 */
 	public function the_languages( $links, $args = array() ) {
 		$this->links = $links;
-
-		$defaults = array(
-			'dropdown'               => 0, // display as list and not as dropdown
-			'echo'                   => 1, // echoes the list
-			'hide_if_empty'          => 1, // hides languages with no posts ( or pages )
-			'menu'                   => 0, // not for nav menu ( this argument is deprecated since v1.1.1 )
-			'show_flags'             => 0, // don't show flags
-			'show_names'             => 1, // show language names
-			'display_names_as'       => 'name', // valid options are slug and name
-			'force_home'             => 0, // tries to find a translation
-			'hide_if_no_translation' => 0, // don't hide the link if there is no translation
-			'hide_current'           => 0, // don't hide current language
-			'post_id'                => null, // if not null, link to translations of post defined by post_id
-			'raw'                    => 0, // set this to true to build your own custom language switcher
-			'item_spacing'           => 'preserve', // 'preserve' or 'discard' whitespace between list items
-			'admin_render'           => 0, // make the switcher in an frontend context
-			'admin_current_lang'     => null, // use when admin_render is set to 1, if not null use it instead of the current language
-		);
-		$args = wp_parse_args( $args, $defaults );
+		$args = wp_parse_args( $args, self::DEFAULTS );
 
 		/**
 		 * Filter the arguments of the 'pll_the_languages' template tag

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -38,6 +38,27 @@ class PLL_Switcher {
 	}
 
 	/**
+	 * Returns the link for a given language.
+	 *
+	 * @since 3.0
+	 *
+	 * @param PLL_Language $language Language.
+	 * @param array        $args     Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @return string|null
+	 */
+	protected function get_link( $language, $args ) {
+		$url = null;
+
+		if ( null !== $args['post_id'] && ( $tr_id = $this->links->model->post->get( $args['post_id'], $language ) ) && $this->links->model->post->current_user_can_read( $tr_id ) ) {
+			$url = get_permalink( $tr_id );
+		} elseif ( null === $args['post_id'] && 0 === $args['admin_render'] ) {
+			$url = $this->links->get_translation_url( $language );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Get the language elements for use in a walker
 	 *
 	 * @since 1.2
@@ -55,7 +76,6 @@ class PLL_Switcher {
 			$slug = $language->slug;
 			$locale = $language->get_locale( 'display' );
 			$classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
-			$url = null; // Avoids potential notice
 			$curlang = 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
 			$current_lang = $curlang == $slug;
 
@@ -67,12 +87,6 @@ class PLL_Switcher {
 				}
 			}
 
-			if ( null !== $args['post_id'] && ( $tr_id = $this->links->model->post->get( $args['post_id'], $language ) ) && $this->links->model->post->current_user_can_read( $tr_id ) ) {
-				$url = get_permalink( $tr_id );
-			} elseif ( null === $args['post_id'] && 0 === $args['admin_render'] ) {
-				$url = $this->links->get_translation_url( $language );
-			}
-
 			if ( $no_translation = empty( $url ) ) {
 				$classes[] = 'no-translation';
 			}
@@ -82,11 +96,11 @@ class PLL_Switcher {
 			 *
 			 * @since 0.7
 			 *
-			 * @param string $url    the link
-			 * @param string $slug   language code
-			 * @param string $locale language locale
+			 * @param string|null $url    The link, null if no translation was found.
+			 * @param string      $slug   The language code.
+			 * @param string      $locale The language locale
 			 */
-			$url = apply_filters( 'pll_the_language_link', $url, $slug, $language->locale );
+			$url = apply_filters( 'pll_the_language_link', $this->get_link( $language, $args ), $slug, $language->locale );
 
 			// Hide if no translation exists
 			if ( empty( $url ) && $args['hide_if_no_translation'] ) {

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -54,6 +54,18 @@ class PLL_Switcher {
 	}
 
 	/**
+	 * Returns the current language code.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $args Arguments passed to {@see PLL_Switcher::the_languages()}.
+	 * @return string
+	 */
+	protected function get_current_language( $args ) {
+		return 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
+	}
+
+	/**
 	 * Returns the link for a given language.
 	 *
 	 * @since 3.0
@@ -92,8 +104,7 @@ class PLL_Switcher {
 			$slug = $language->slug;
 			$locale = $language->get_locale( 'display' );
 			$classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
-			$curlang = 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
-			$current_lang = $curlang == $slug;
+			$current_lang = $this->get_current_language( $args ) === $slug;
 
 			if ( $current_lang ) {
 				if ( $args['hide_current'] && ! ( $args['dropdown'] && ! $args['raw'] ) ) {
@@ -193,9 +204,8 @@ class PLL_Switcher {
 		if ( $args['dropdown'] ) {
 			$args['name'] = 'lang_choice_' . $args['dropdown'];
 			$walker = new PLL_Walker_Dropdown();
-			$args['selected'] = 0 === $args['admin_render'] ? $this->links->curlang->slug : $args['admin_current_lang'];
-		}
-		else {
+			$args['selected'] = $this->get_current_language( $args );
+		} else {
 			$walker = new PLL_Walker_List();
 		}
 

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -179,8 +179,8 @@ class PLL_Switcher {
 	 *
 	 * @since 0.1
 	 *
-	 * @param Links $links Instance of PLL_Links.
-	 * @param array $args {
+	 * @param PLL_Links $links Instance of PLL_Links.
+	 * @param array     $args {
 	 *   Optional array of arguments.
 	 *
 	 *   @type int    $dropdown               The list is displayed as dropdown if set, defaults to 0.

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -137,6 +137,8 @@ class PLL_Switcher {
 				}
 			}
 
+			$url = $this->get_link( $language, $args );
+
 			if ( $no_translation = empty( $url ) ) {
 				$classes[] = 'no-translation';
 			}
@@ -150,7 +152,7 @@ class PLL_Switcher {
 			 * @param string      $slug   The language code.
 			 * @param string      $locale The language locale
 			 */
-			$url = apply_filters( 'pll_the_language_link', $this->get_link( $language, $args ), $slug, $language->locale );
+			$url = apply_filters( 'pll_the_language_link', $url, $slug, $language->locale );
 
 			// Hide if no translation exists
 			if ( empty( $url ) && $args['hide_if_no_translation'] ) {

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -94,7 +94,7 @@ class PLL_Switcher {
 		}
 
 		// If we are on frontend.
-		if ( method_exists( $this->links, 'get_translation_url' ) ) {
+		if ( $this->links instanceof PLL_Frontend ) {
 			return $this->links->get_translation_url( $language );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/892

The PR clarifies the `PLL_Switcher` by introducing a constant for the default arguments of `the_languages()` and 2 new methods `get_current_language()` and `get_link()`.

The parameter passed as current language is prioritized over the gloabal current language. It defaults to the default language in case no current language is found.

The `get_link()` method now checks the instance of `$this->links` to avoid a fatal error in case it is not a `PLL_Frontend_Links`.
A new way to get the link, based on the global post is introduced to make the language switcher functionnal in REST API.

The parameter `admin_render` is kept to control the output of the javascript for dropdowns.