### PR TITLE
Bump min WP version to 5.4 and remove useless checks in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: "WP oldest - PHP 7.2"
       php: "7.2"
-      env: "WP_VERSION=5.1 WP_MULTISITE=0"
+      env: "WP_VERSION=5.3.1 WP_MULTISITE=0"
       script:
         - "vendor/bin/phpunit --verbose"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: "WP oldest - PHP 7.2"
       php: "7.2"
-      env: "WP_VERSION=5.3.1 WP_MULTISITE=0"
+      env: "WP_VERSION=5.4 WP_MULTISITE=0"
       script:
         - "vendor/bin/phpunit --verbose"
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,8 @@
 
 	<file>.</file>
 
+	<config name="minimum_supported_wp_version" value="5.3.1"/>
+
 	<rule ref="PHPCompatibilityWP">
 		<config name="testVersion" value="5.6-"/>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
 
 	<file>.</file>
 
-	<config name="minimum_supported_wp_version" value="5.3.1"/>
+	<config name="minimum_supported_wp_version" value="5.4"/>
 
 	<rule ref="PHPCompatibilityWP">
 		<config name="testVersion" value="5.6-"/>

--- a/polylang.php
+++ b/polylang.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://polylang.pro
  * Description:       Adds multilingual capability to WordPress
  * Version:           3.1-dev
- * Requires at least: 5.1
+ * Requires at least: 5.3.1
  * Requires PHP:      5.6
  * Author:            WP SYNTEX
  * Author URI:        https://polylang.pro
@@ -54,7 +54,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 } else {
 	// Go on loading the plugin
 	define( 'POLYLANG_VERSION', '3.1-dev' );
-	define( 'PLL_MIN_WP_VERSION', '5.1' );
+	define( 'PLL_MIN_WP_VERSION', '5.3.1' );
 	define( 'PLL_MIN_PHP_VERSION', '5.6' );
 
 	define( 'POLYLANG_FILE', __FILE__ );

--- a/polylang.php
+++ b/polylang.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://polylang.pro
  * Description:       Adds multilingual capability to WordPress
  * Version:           3.1-dev
- * Requires at least: 5.3.1
+ * Requires at least: 5.4
  * Requires PHP:      5.6
  * Author:            WP SYNTEX
  * Author URI:        https://polylang.pro
@@ -54,7 +54,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 } else {
 	// Go on loading the plugin
 	define( 'POLYLANG_VERSION', '3.1-dev' );
-	define( 'PLL_MIN_WP_VERSION', '5.3.1' );
+	define( 'PLL_MIN_WP_VERSION', '5.4' );
 	define( 'PLL_MIN_PHP_VERSION', '5.6' );
 
 	define( 'POLYLANG_FILE', __FILE__ );

--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -79,30 +79,22 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 	}
 
 	function test_upload_dir() {
-		// hack $_SERVER
+		// Hack $_SERVER.
 		$server = $_SERVER;
 		$_SERVER['REQUEST_URI'] = '/test/';
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->hosts['fr'], PHP_URL_HOST );
-		if ( function_exists( 'wp_get_upload_dir' ) ) {
-			$uploads = wp_get_upload_dir(); // Since WP 4.5
-		} else {
-			$uploads = wp_upload_dir( null, false );
-		}
+		$uploads = wp_get_upload_dir(); // Since WP 4.5.
 
 		$this->assertContains( $this->hosts['fr'], $uploads['url'] );
 		$this->assertContains( $this->hosts['fr'], $uploads['baseurl'] );
 
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->hosts['en'], PHP_URL_HOST );
-		if ( function_exists( 'wp_get_upload_dir' ) ) {
-			$uploads = wp_get_upload_dir(); // Since WP 4.5
-		} else {
-			$uploads = wp_upload_dir( null, false );
-		}
+		$uploads = wp_get_upload_dir(); // Since WP 4.5.
 
 		$this->assertContains( $this->hosts['en'], $uploads['url'] );
 		$this->assertContains( $this->hosts['en'], $uploads['baseurl'] );
 
-		// clean up
+		// Clean up.
 		$_SERVER = $server;
 	}
 }

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( version_compare( $GLOBALS['wp_version'], '5.2', '>=' ) && file_exists( DIR_TESTROOT . '/../jetpack/jetpack.php' ) ) {
+if ( file_exists( DIR_TESTROOT . '/../jetpack/jetpack.php' ) ) {
 
 	require_once DIR_TESTROOT . '/../jetpack/functions.opengraph.php';
 

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( file_exists( DIR_TESTROOT . '/../jetpack/jetpack.php' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], '5.6', '>=' ) && file_exists( DIR_TESTROOT . '/../jetpack/jetpack.php' ) ) {
 
 	require_once DIR_TESTROOT . '/../jetpack/functions.opengraph.php';
 

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -77,10 +77,6 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	function test_use_block_editor_for_post() {
-		if ( ! function_exists( 'use_block_editor_for_post' ) ) {
-			$this->markTestSkipped( 'This test requires WP 5.0+' );
-		}
-
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -92,14 +92,11 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertCount( 1, $languages );
 		$this->assertNotEmpty( $languages['fr'] );
 
-		// test orderby and order only in WP 4.7+
-		if ( function_exists( 'wp_list_sort' ) ) {
-			$languages = apply_filters( 'wpml_active_languages', null, 'orderby=code&order=asc' );
-			$this->assertEqualSetsWithIndex( array( 'de', 'en', 'fr' ), array_keys( $languages ) );
+		$languages = apply_filters( 'wpml_active_languages', null, 'orderby=code&order=asc' );
+		$this->assertEqualSetsWithIndex( array( 'de', 'en', 'fr' ), array_keys( $languages ) );
 
-			$languages = apply_filters( 'wpml_active_languages', null, 'orderby=code&order=desc' );
-			$this->assertEqualSetsWithIndex( array( 'fr', 'en', 'de' ), array_keys( $languages ) );
-		}
+		$languages = apply_filters( 'wpml_active_languages', null, 'orderby=code&order=desc' );
+		$this->assertEqualSetsWithIndex( array( 'fr', 'en', 'de' ), array_keys( $languages ) );
 	}
 
 	function test_wpml_current_language() {


### PR DESCRIPTION
~~Following our policy of support of ol WP versions, I propose to bump the minimum required WP version to 5.3.1.
I propose 5.3.1 instead of 5.3 due to the functions that were introduced in this version and that we are using in Polylang Pro.~~
The PR also removes some checks that are now useless for all supported versions.

Edit: I updated the check for min WP version with Jetpack which just bumped its min WP version requirement to 5.6. Done in this PR to avoid a merge conflict.

Edit: We have finally decided to bump the min version to 5.4