### PR TITLE
Fix selectmenu breaking changes

### DIFF
--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -120,6 +120,8 @@
 	white-space: nowrap;
 	vertical-align: top;
 	padding: 0;
+	line-height: normal; /* Override WC Bookings styles with WP < 5.6 */
+	height: 28px; /* Override WC Bookings styles with WP < 5.6 */
 }
 
 .ui-selectmenu-button span.ui-icon {

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -141,6 +141,7 @@
 }
 
 
+.ui-selectmenu-button.ui-widget span.ui-selectmenu-text, /* Override WC Bookings styles with WP < 5.6 */
 .ui-selectmenu-button span.ui-selectmenu-text {
 	text-align: left;
 	padding: 0.1em 2.1em 0.2em 2em;

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -157,6 +157,7 @@
 
 .ui-widget-content,
 .ui-state-default,
+.ui-selectmenu-button.ui-state-default, /* Override WC Bookings styles with WP < 5.6 */
 .ui-button.ui-selectmenu-button-closed, /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 .ui-button.ui-selectmenu-button-open, /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */
 .ui-widget-content .ui-state-default,
@@ -198,6 +199,9 @@
 	margin: 0;
 }
 
+.ui-selectmenu-open .ui-widget-content .ui-state-hover, /* Override WC Bookings styles with WP < 5.6 */
+.ui-selectmenu-open .ui-widget-content .ui-state-focus, /* Override WC Bookings styles with WP < 5.6 */
+.ui-selectmenu-open .ui-widget-content .ui-state-active, /* Override WC Bookings styles with WP < 5.6 */
 .pll-selectmenu-menu .ui-widget-content .ui-state-hover,
 .pll-selectmenu-menu .ui-widget-content .ui-state-focus,
 .pll-selectmenu-menu .ui-widget-content .ui-state-active { /* To be compatible jQuery UI 1.12.1 since WordPress 5.6 */

--- a/css/selectmenu.css
+++ b/css/selectmenu.css
@@ -109,6 +109,7 @@
 	display: block;
 }
 
+.ui-selectmenu-button, /* jQuery UI 1.11.4 - WP < 5.6 */
 .ui-selectmenu-button.ui-button {
 	display: inline-block;
 	overflow: hidden;


### PR DESCRIPTION
With the PR https://github.com/polylang/polylang/pull/753 I proposed to correct the https://github.com/polylang/polylang-pro/issues/333 issue.

It works fine with WP >= 5.6 but the PR introduced breaking changes and didn't fix some conflicts with WP < 5.6

Most of them are:
- in Languages settings screen
![image](https://user-images.githubusercontent.com/1003778/110306328-00656d80-7ffe-11eb-829d-ce75ccb538fb.png)

- in wizard languages step
![image](https://user-images.githubusercontent.com/1003778/110306977-b6c95280-7ffe-11eb-9c2d-8224efffde34.png)

So this PR propose to complete the initial PR and fixes https://github.com/polylang/polylang-pro/issues/333 issue for WP < 5.6
