### PR TITLE
Fix accept language parameter

### DIFF
--- a/frontend/accept-language.php
+++ b/frontend/accept-language.php
@@ -49,7 +49,7 @@ class PLL_Accept_Language {
 	 */
 	public function __construct( $subtags, $quality = 1.0 ) {
 		$this->subtags = $subtags;
-		$this->quality = $quality;
+		$this->quality = is_numeric( $quality ) ? floatval( $quality ) : 1.0;
 	}
 
 	/**

--- a/frontend/accept-language.php
+++ b/frontend/accept-language.php
@@ -45,7 +45,7 @@ class PLL_Accept_Language {
 	 * @since 3.0
 	 *
 	 * @param string[] $subtags With subtag name as keys and subtag values as names.
-	 * @param float    $quality
+	 * @param mixed    $quality Floating point value from 0.0 to 1.0. Higher values indicates a user's preference.
 	 */
 	public function __construct( $subtags, $quality = 1.0 ) {
 		$this->subtags = $subtags;

--- a/frontend/accept-language.php
+++ b/frontend/accept-language.php
@@ -65,7 +65,7 @@ class PLL_Accept_Language {
 			array_keys( array_slice( self::SUBTAG_PATTERNS, 0, count( $matches ) - 1 ) ),
 			array_slice( $matches, 1, count( self::SUBTAG_PATTERNS ) )
 		);
-		$quality = count( $matches ) === 9 ? floatval( $matches[8] ) : 1.0;
+		$quality = count( $matches ) === 9 ? $matches[8] : 1.0;
 
 		return new PLL_Accept_Language( $subtags, $quality );
 	}

--- a/frontend/accept-languages-collection.php
+++ b/frontend/accept-languages-collection.php
@@ -74,12 +74,6 @@ class PLL_Accept_Languages_Collection {
 		);
 
 		if ( $n = count( $k ) ) {
-			// Set default to 1 for any without q factor.
-			foreach ( $v as $key => $val ) {
-				if ( '' === $val || (float) $val > 1 ) {
-					$v[ $key ] = 1;
-				}
-			}
 
 			if ( $n > 1 ) {
 				for ( $i = 2; $i <= $n; $i++ ) {

--- a/tests/phpunit/tests/test-accept-language.php
+++ b/tests/phpunit/tests/test-accept-language.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Test a single {@see PLL_Aceept_Language} instance.
+ */
+class Accept_Language_Test extends PHPUnit_Framework_TestCase {
+
+	public function test_it_should_have_1_dot_0_as_default_quality_value() {
+		$accept_language = new PLL_Accept_Language( array( 'language' => 'en' ), '' );
+
+		$this->assertSame( 1.0, $accept_language->get_quality() );
+	}
+}

--- a/tests/phpunit/tests/test-accept-language.php
+++ b/tests/phpunit/tests/test-accept-language.php
@@ -25,8 +25,8 @@ class Accept_Language_Test extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider numeric_values_provider
-	 * @param $arg
-	 * @param $expected
+	 * @param mixed $arg Class consturctor argument.
+	 * @param float $expected Expected quality.
 	 */
 	public function test_it_should_always_use_a_float_as_quality_value( $arg, $expected ) {
 		$accept_language = new PLL_Accept_Language( array( 'language' => 'en' ), $arg );

--- a/tests/phpunit/tests/test-accept-language.php
+++ b/tests/phpunit/tests/test-accept-language.php
@@ -5,9 +5,40 @@
  */
 class Accept_Language_Test extends PHPUnit_Framework_TestCase {
 
-	public function test_it_should_have_1_dot_0_as_default_quality_value() {
-		$accept_language = new PLL_Accept_Language( array( 'language' => 'en' ), '' );
+	/**
+	 * @dataProvider default_values_provider
+	 * @param mixed $arg Class constructor argument.
+	 */
+	public function test_it_should_have_1_dot_0_as_default_quality_value( $arg ) {
+		$accept_language = new PLL_Accept_Language( array( 'language' => 'en' ), $arg );
 
 		$this->assertSame( 1.0, $accept_language->get_quality() );
+	}
+
+	public function default_values_provider() {
+		return array(
+			array( 'something else' ),
+			array( '' ),
+			array( null ),
+		);
+	}
+
+	/**
+	 * @dataProvider numeric_values_provider
+	 * @param $arg
+	 * @param $expected
+	 */
+	public function test_it_should_always_use_a_float_as_quality_value( $arg, $expected ) {
+		$accept_language = new PLL_Accept_Language( array( 'language' => 'en' ), $arg );
+
+		$this->assertSame( $expected, $accept_language->get_quality() );
+	}
+
+	public function numeric_values_provider() {
+		return array(
+			array( '0.8', 0.8 ),
+			array( 1, 1.0 ),
+			array( 0.5, 0.5 ),
+		);
 	}
 }


### PR DESCRIPTION
## Before

PHPStan reported a 'useless strict comparison' because our code documentation indicated that `PLL_Accept_Language::get_quality()` would always return a float value.

## Changes

- Make sure that `PLL_Accept_Language::get_quality()` would always return a float value.
- Use default value in `PLL_Accept_Language` constructor instead that having to override it after it is read.

Fixes https://github.com/polylang/polylang-pro/issues/906