### PR TITLE
Fix greedy regex which may match all search <form> attributes

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -64,7 +64,7 @@ class PLL_Frontend_Filters_Search {
 				// Take care to modify only the url in the <form> tag.
 				preg_match( '#<form.+>#', $form, $matches );
 				$old = reset( $matches );
-				$new = preg_replace( '#action="(.+)"#', 'action="' . esc_url( $this->curlang->search_url ) . '"', $old );
+				$new = preg_replace( '#action="(.+?)"#', 'action="' . esc_url( $this->curlang->search_url ) . '"', $old );
 				$form = str_replace( $old, $new, $form );
 			} else {
 				$form = str_replace( '</form>', '<input type="hidden" name="lang" value="' . esc_attr( $this->curlang->slug ) . '" /></form>', $form );

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -62,9 +62,9 @@ class PLL_Frontend_Filters_Search {
 		if ( $form ) {
 			if ( $this->links_model->using_permalinks ) {
 				// Take care to modify only the url in the <form> tag.
-				preg_match( '#<form.+>#', $form, $matches );
+				preg_match( '#<form.+?>#', $form, $matches );
 				$old = reset( $matches );
-				$new = preg_replace( '#action="(.+?)"#', 'action="' . esc_url( $this->curlang->search_url ) . '"', $old );
+				$new = preg_replace( '#\saction=("[^"\r\n]+"|\'[^\'\r\n]+\'|[^\'"][^>\s]+)#', ' action="' . esc_url( $this->curlang->search_url ) . '"', $old );
 				$form = str_replace( $old, $new, $form );
 			} else {
 				$form = str_replace( '</form>', '<input type="hidden" name="lang" value="' . esc_attr( $this->curlang->slug ) . '" /></form>', $form );

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -64,6 +64,7 @@ class PLL_Frontend_Filters_Search {
 				// Take care to modify only the url in the <form> tag.
 				preg_match( '#<form.+?>#', $form, $matches );
 				$old = reset( $matches );
+				// Replace action attribute (a text with no space and no closing tag within double quotes or simple quotes or without quotes).
 				$new = preg_replace( '#\saction=("[^"\r\n]+"|\'[^\'\r\n]+\'|[^\'"][^>\s]+)#', ' action="' . esc_url( $this->curlang->search_url ) . '"', $old );
 				$form = str_replace( $old, $new, $form );
 			} else {

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -81,4 +81,14 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$form = apply_filters( 'get_search_form', $form );
 		$this->assertContains( 'action="' . home_url( '/fr/' ) . '"', $form );
 	}
+
+	/**
+	 * PR #780
+	 */
+	function test_search_form_is_not_emptied() {
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
+		$form = '<form action="http://example.org" method="get"><input type="submit" value="Search" /></form>';
+		$form = apply_filters( 'get_search_form', $form );
+		$this->assertEquals( '<form action="http://example.org/fr/" method="get"><input type="submit" value="Search" /></form>', $form );
+	}
 }

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -91,4 +91,24 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$form = apply_filters( 'get_search_form', $form );
 		$this->assertEquals( '<form action="http://example.org/fr/" method="get"><input type="submit" value="Search" /></form>', $form );
 	}
+
+	/**
+	 * PR #780
+	 */
+	function test_search_form_with_simple_quotes_in_html() {
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
+		$form = "<form action='http://example.org' method='get'><input type='submit' value='Search' /></form>";
+		$form = apply_filters( 'get_search_form', $form );
+		$this->assertEquals( "<form action=\"http://example.org/fr/\" method='get'><input type='submit' value='Search' /></form>", $form );
+	}
+
+	/**
+	 * PR #780
+	 */
+	function test_search_form_with_no_quotes_in_html() {
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
+		$form = '<form action=http://example.org method=get><input type=submit value=Search /></form>';
+		$form = apply_filters( 'get_search_form', $form );
+		$this->assertEquals( '<form action="http://example.org/fr/" method=get><input type=submit value=Search /></form>', $form );
+	}
 }


### PR DESCRIPTION
As reported here https://wordpress.org/support/topic/search-form-impact/ , search form is messed up because &lt;form&gt; element is stripped of all attributes except of action attribute, in get_search_form hook.

To fix this issue, replace greedy regex which may match all search &lt;form&gt; attributes with non-greedy regex matching only the action attribute.