### PR TITLE
Move __ function declaration from the global scope to a local scope

### DIFF
--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -2,14 +2,14 @@
  * @package Polylang
  */
 
-// We can't use underscore or lodash in this common code because it depends of the context classic or block editor.
-// Classic editor underscore is loaded, Block editor lodash is loaded.
-const { __ } = wp.i18n;
-
 const languagesList = jQuery( '.post_lang_choice' );
 
 // Dialog box for alerting the user about a risky changing.
 export const initializeConfimationModal = () => {
+	// We can't use underscore or lodash in this common code because it depends of the context classic or block editor.
+	// Classic editor underscore is loaded, Block editor lodash is loaded.
+	const { __ } = wp.i18n;
+
 	// Create dialog container.
 	const dialogContainer = jQuery(
 		'<div/>',


### PR DESCRIPTION
The goal is to avoid conflict with other codes which could also declare the wp.i18n.__ function in the global scope.

Note I saw that backward compatibility with older WordPress releases doesn't work but it isn't taken in charge by this PR which is focused to fixes #779 issue.