### PR TITLE
Add missing script dependencies

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -173,12 +173,12 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 			// Classic editor.
 			if ( ! method_exists( $screen, 'is_block_editor' ) || ! $screen->is_block_editor() ) {
-				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-dialog' ), 0, 1 );
+				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-dialog', 'wp-i18n' ), 0, 1 );
 			}
 
 			// Block editor with legacy metabox in WP 5.0+.
 			if ( method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() && ! pll_use_block_editor_plugin() ) {
-				$scripts['block-editor'] = array( array( 'post' ), array( 'jquery', 'wp-ajax-response', 'wp-api-fetch', 'jquery-ui-dialog' ), 0, 1 );
+				$scripts['block-editor'] = array( array( 'post' ), array( 'jquery', 'wp-ajax-response', 'wp-api-fetch', 'jquery-ui-dialog', 'wp-i18n' ), 0, 1 );
 			}
 		}
 

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -173,7 +173,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 			// Classic editor.
 			if ( ! method_exists( $screen, 'is_block_editor' ) || ! $screen->is_block_editor() ) {
-				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-dialog', 'wp-i18n' ), 0, 1 );
+				$scripts['classic-editor'] = array( array( 'post', 'media', 'async-upload' ), array( 'jquery', 'wp-ajax-response', 'post', 'jquery-ui-dialog', 'wp-i18n', 'wp-media' ), 0, 1 );
 			}
 
 			// Block editor with legacy metabox in WP 5.0+.


### PR DESCRIPTION
It's seems some WordPress scripts aren't always loaded depending on WordPress release when we try to use some of their functions.

- wp-i18n to use the __() function in the new dialog box to confirm language change in the metabox in the classic eidtor and in the legacy metabox in the block editor.
It blocks language change and metabox refresh (no ajax request is launched).
![image](https://user-images.githubusercontent.com/1003778/110604958-ed32d900-8188-11eb-9951-a57bb1c5351e.png)

- wp-media use in this PR https://github.com/polylang/polylang/pull/706 to extend its behaviour
It triggers some javascript error when classic-editor.js is loaded and executed.
![image](https://user-images.githubusercontent.com/1003778/110605343-54508d80-8189-11eb-8482-215f9870df9e.png)



