### PR TITLE
Filter attachments query with original arguments

### DIFF
--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -318,21 +318,24 @@ var media = _.extend(
 	}
 );
 
-/**
- * @since 3.0
- *
- * @memberOf pll.media
- */
-media.query = _.extend(
-	media.query, /** @lends pll.media.query prototype */
-	{
-		/**
-		 * @type Function References WordPress { @see wp.media.query } constructor
-		 */
-		delegate: wp.media.query
-	}
-)
+if ( 'undefined' !== typeof wp && 'undefined' !== typeof wp.media ) {
 
-// Substitute WordPress media query shortcut with our decorated function.
-wp.media.query = media.query
+	/**
+	 * @since 3.0
+	 *
+	 * @memberOf pll.media
+	 */
+	media.query = _.extend(
+		media.query, /** @lends pll.media.query prototype */
+		{
+			/**
+			 * @type Function References WordPress { @see wp.media.query } constructor
+			 */
+			delegate: wp.media.query
+		}
+	)
 
+	// Substitute WordPress media query shortcut with our decorated function.
+	wp.media.query = media.query
+
+}

--- a/js/classic-editor.js
+++ b/js/classic-editor.js
@@ -291,7 +291,7 @@ var media = _.extend(
 		 * @return {wp.media.model.Attachments}
 		 */
 		query: function( props ) {
-			var attachments = pll.media.query.delegate();
+			var attachments = pll.media.query.delegate( props );
 
 			pll.media.attachmentsCollections.push( attachments );
 


### PR DESCRIPTION
## Before

PR #706 override WordPress `pll.media.query()` to filter attachments by language. But the original query used to be filtered by several other arguments.

## Changes

Pass the arguments to the query through our decorated function.

Fixes https://github.com/polylang/polylang-pro/issues/907