### PR TITLE
Link translations to script files

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -189,6 +189,9 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		foreach ( $scripts as $script => $v ) {
 			if ( in_array( $screen->base, $v[0] ) && ( $v[2] || $this->model->get_languages_list() ) ) {
 				wp_enqueue_script( 'pll_' . $script, plugins_url( '/js/build/' . $script . $suffix . '.js', POLYLANG_BASENAME ), $v[1], POLYLANG_VERSION, $v[3] );
+				if ( 'classic-editor' === $script || 'block-editor' === $script ) {
+					wp_set_script_translations( 'pll_' . $script, 'polylang' );
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the part of the issue #https://github.com/polylang/polylang-pro/issues/908 for Polylang (  classic editor and legacy language metabox in block editor )

Note that because we now manage backward compatibilty with WP 5.1 I don't test `wp_set_script_translations` function existence as in it was done in Polylang Pro
https://github.com/polylang/polylang-pro/blob/master/modules/block-editor/block-editor-plugin.php#L169-L171 