### PR TITLE
Do not build WP_Styles global instance before add_theme_support() is called

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -97,7 +97,9 @@ abstract class PLL_Choose_Lang {
 		$this->curlang = ( $curlang instanceof PLL_Language ) ? $curlang : $this->model->get_language( $this->options['default_lang'] );
 
 		$GLOBALS['text_direction'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
-		add_action( 'wp_default_styles', array( $this, 'set_styles_text_direction' ) );
+		if ( did_action( 'wp_default_styles' ) ) {
+			wp_styles()->text_direction = $GLOBALS['text_direction'];
+		}
 
 		/**
 		 * Fires when the current language is defined.
@@ -108,21 +110,6 @@ abstract class PLL_Choose_Lang {
 		 * @param PLL_Language $curlang Current language object.
 		 */
 		do_action( 'pll_language_defined', $this->curlang->slug, $this->curlang );
-	}
-
-	/**
-	 * Overrides the theme text direction with the correct text direction for the language.
-	 *
-	 * @param mixed $styles
-	 *
-	 * @return WP_Styles
-	 */
-	public function set_styles_text_direction( $styles ) {
-		if ( WP_Styles::class !== get_class( $styles ) ) {
-			$styles = wp_styles();
-		}
-		$styles->text_direction = $GLOBALS['text_direction'];
-		return $styles;
 	}
 
 	/**

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -96,8 +96,8 @@ abstract class PLL_Choose_Lang {
 		// See https://wordpress.org/support/topic/detect-browser-language-sometimes-setting-null-language
 		$this->curlang = ( $curlang instanceof PLL_Language ) ? $curlang : $this->model->get_language( $this->options['default_lang'] );
 
-		$GLOBALS['text_direction']  = $this->curlang->is_rtl ? 'rtl' : 'ltr';
-		wp_styles()->text_direction = $GLOBALS['text_direction'];
+		$GLOBALS['text_direction'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
+		add_action( 'wp_default_styles', array( $this, 'set_styles_text_direction' ) );
 
 		/**
 		 * Fires when the current language is defined.
@@ -108,6 +108,21 @@ abstract class PLL_Choose_Lang {
 		 * @param PLL_Language $curlang Current language object.
 		 */
 		do_action( 'pll_language_defined', $this->curlang->slug, $this->curlang );
+	}
+
+	/**
+	 * Overrides the theme text direction with the correct text direction for the language.
+	 *
+	 * @param mixed $styles
+	 *
+	 * @return WP_Styles
+	 */
+	public function set_styles_text_direction( $styles ) {
+		if ( WP_Styles::class !== get_class( $styles ) ) {
+			$styles = wp_styles();
+		}
+		$styles->text_direction = $GLOBALS['text_direction'];
+		return $styles;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -190,4 +190,22 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->go_to( home_url( '?year=2007' ) );
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
+
+	/**
+	 * @see https://github.com/polylang/polylang/issues/356
+	 */
+	public function test_update_stylesheet_text_direction_when_language_is_set_by_content() {
+		self::create_language( 'ar' );
+		$this->frontend->init();
+
+		// Usually happens on 'setup_theme'
+		wp_style_add_data( 'default', 'key', 'value' );
+
+		// Happens on 'wp'
+		$set_language = new ReflectionMethod( PLL_Choose_Lang::class, 'set_language' );
+		$set_language->setAccessible( true );
+		$set_language->invokeArgs( $this->frontend->choose_lang, array( $this->frontend->model->get_language( 'ar' ) ) );
+
+		$this->assertEquals( 'rtl', wp_styles()->text_direction );
+	}
 }


### PR DESCRIPTION
## Before

Calling `wp_syles()` will create a global instance of [WP_Styles](https://developer.wordpress.org/reference/classes/wp_styles/) if none exists. But the `WP_Styles` constructor calls to `current_theme_supports()` and so need to be called only after the themes could have called `add_theme_support()`.

## Changes

Set the languages direction on the `wp_default_styles` hook that is called only when the `WP_Styles` is instantiated globally.
Fixes #775 

## Going further

Which Polylang / Polylang Pro feature should be investigated to prevent regression?