### PR TITLE
Work around the removal of the wpml-config.xml in Yoast SEO Premium

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -47,8 +47,7 @@ class PLL_WPSEO {
 			add_filter( 'wpseo_frontend_presentation', array( $this, 'frontend_presentation' ) );
 			add_filter( 'wpseo_breadcrumb_indexables', array( $this, 'breadcrumb_indexables' ) );
 		} else {
-			// Primary category
-			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ) );
+			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ), 10, 2 );
 			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
 		}
 	}
@@ -430,14 +429,31 @@ class PLL_WPSEO {
 	}
 
 	/**
-	 * Synchronizes the metas.
+	 * Copies or synchronizes the metas.
 	 *
 	 * @since 2.3.3
 	 *
-	 * @param array $keys List of custom fields names.
+	 * @param string[] $keys List of custom fields names.
+	 * @param bool     $sync True if it is synchronization, false if it is a copy.
 	 * @return array
 	 */
-	public function copy_post_metas( $keys ) {
+	public function copy_post_metas( $keys, $sync ) {
+		if ( ! $sync ) {
+			// Text requiring translation.
+			$keys[] = '_yoast_wpseo_title';
+			$keys[] = '_yoast_wpseo_metadesc';
+			$keys[] = '_yoast_wpseo_bctitle';
+			$keys[] = '_yoast_wpseo_focuskw';
+			$keys[] = '_yoast_wpseo_opengraph-title';
+			$keys[] = '_yoast_wpseo_opengraph-description';
+			$keys[] = '_yoast_wpseo_twitter-title';
+			$keys[] = '_yoast_wpseo_twitter-description';
+
+			// Copy the image urls.
+			$keys[] = '_yoast_wpseo_opengraph-image';
+			$keys[] = '_yoast_wpseo_twitter-image';
+		}
+
 		$keys[] = '_yoast_wpseo_meta-robots-noindex';
 		$keys[] = '_yoast_wpseo_meta-robots-nofollow';
 		$keys[] = '_yoast_wpseo_meta-robots-adv';

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -5,7 +5,7 @@
 
 /**
  * Manages the compatibility with Yoast SEO
- * Version tested: 11.5
+ * Version tested: 15.9.2
  *
  * @since 2.3
  */
@@ -79,6 +79,13 @@ class PLL_WPSEO {
 		);
 
 		new PLL_Translate_Option( 'wpseo_titles', array_fill_keys( $keys, 1 ), array( 'context' => 'wordpress-seo' ) );
+
+		$keys = array(
+			'og_frontpage_title',
+			'og_frontpage_desc',
+		);
+
+		new PLL_Translate_Option( 'wpseo_social', array_fill_keys( $keys, 1 ), array( 'context' => 'wordpress-seo' ) );
 	}
 
 	/**
@@ -363,6 +370,8 @@ class PLL_WPSEO {
 				$presentation->model->permalink = pll_home_url();
 				$presentation->model->title = WPSEO_Options::get( 'title-home-wpseo' );
 				$presentation->model->description = WPSEO_Options::get( 'metadesc-home-wpseo' );
+				$presentation->model->open_graph_title = WPSEO_Options::get( 'og_frontpage_title' );
+				$presentation->model->open_graph_description = WPSEO_Options::get( 'og_frontpage_desc' );
 				break;
 
 			case 'post-type-archive':

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -73,6 +73,9 @@ class PLL_WPSEO {
 			'breadcrumbs-archiveprefix',
 			'breadcrumbs-searchprefix',
 			'breadcrumbs-404crumb',
+			'company_name',
+			'rssbefore',
+			'rssafter',
 		);
 
 		new PLL_Translate_Option( 'wpseo_titles', array_fill_keys( $keys, 1 ), array( 'context' => 'wordpress-seo' ) );

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -54,41 +54,28 @@ class PLL_WPSEO {
 	}
 
 	/**
-	 * Registers custom post types and taxonomy titles for translation.
+	 * Registers options for translation.
 	 *
 	 * @since 2.9
 	 */
 	public function wpseo_translate_options() {
-		$keys = array();
-
-		foreach ( get_post_types( array( 'public' => true, '_builtin' => false ) ) as $t ) {
-			if ( pll_is_translated_post_type( $t ) ) {
-				$keys[] = 'title-' . $t;
-				$keys[] = 'metadesc-' . $t;
-			}
+		if ( method_exists( 'WPSEO_Options', 'clear_cache' ) ) {
+			WPSEO_Options::clear_cache();
 		}
 
-		foreach ( get_post_types( array( 'has_archive' => true, '_builtin' => false ) ) as $t ) {
-			if ( pll_is_translated_post_type( $t ) ) {
-				$keys[] = 'title-ptarchive-' . $t;
-				$keys[] = 'metadesc-ptarchive-' . $t;
-				$keys[] = 'bctitle-ptarchive-' . $t;
-			}
-		}
+		$keys = array(
+			'title-*',
+			'metadesc-*',
+			'bctitle-*',
+			'breadcrumbs-sep',
+			'breadcrumbs-home',
+			'breadcrumbs-prefix',
+			'breadcrumbs-archiveprefix',
+			'breadcrumbs-searchprefix',
+			'breadcrumbs-404crumb',
+		);
 
-		foreach ( get_taxonomies( array( 'public' => true, '_builtin' => false ) ) as $t ) {
-			if ( pll_is_translated_taxonomy( $t ) ) {
-				$keys[] = 'title-tax-' . $t;
-				$keys[] = 'metadesc-tax-' . $t;
-			}
-		}
-
-		if ( ! empty( $keys ) ) {
-			if ( method_exists( 'WPSEO_Options', 'clear_cache' ) ) {
-				WPSEO_Options::clear_cache();
-			}
-			new PLL_Translate_Option( 'wpseo_titles', array_fill_keys( $keys, 1 ), array( 'context' => 'wordpress-seo' ) );
-		}
+		new PLL_Translate_Option( 'wpseo_titles', array_fill_keys( $keys, 1 ), array( 'context' => 'wordpress-seo' ) );
 	}
 
 	/**

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -418,7 +418,7 @@ class PLL_WPSEO {
 	}
 
 	/**
-	 * Synchronize the primary term
+	 * Synchronizes the metas.
 	 *
 	 * @since 2.3.3
 	 *
@@ -426,6 +426,10 @@ class PLL_WPSEO {
 	 * @return array
 	 */
 	public function copy_post_metas( $keys ) {
+		$keys[] = '_yoast_wpseo_meta-robots-noindex';
+		$keys[] = '_yoast_wpseo_meta-robots-nofollow';
+		$keys[] = '_yoast_wpseo_meta-robots-adv';
+
 		$taxonomies = get_taxonomies(
 			array(
 				'hierarchical' => true,


### PR DESCRIPTION
Yoast recently removed (without notice) the `wpml-config.xml` file from Yoast SEO Premium (probably in version 15.8 although I counld not find any information about this in the changelog). As a consequence, all the compatibility relying on this config file (strings translation and custom fields synchronization) is lost. 

This PR aims to work around this issue and handles the strings translations and the custom fields synchronization from our side.

As a complement of the strings translations available in the latest `wpml-config.xml` file, I added:
* The company name (that I found in the options, although I coul dnot succed to display it on front).
* The Facebook title and description. 

As a complement of custom fields copied in the latest `wpml-config.xml` file, I added the Facebook and Twitter title, description and image.