### PR TITLE
Fix array_flip warning when a language is corrupted

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -187,15 +187,13 @@ class PLL_Language {
 	 * @param WP_Term       $term_language Corresponding 'term_language' term.
 	 */
 	public function __construct( $language, $term_language = null ) {
-		// Build the object from all properties stored as an array.
-		if ( is_array( $language ) ) {
+		if ( empty( $term_language ) ) {
+			// Build the object from all properties stored as an array.
 			foreach ( $language as $prop => $value ) {
 				$this->$prop = $value;
 			}
-		}
-
-		// Build the object from taxonomy terms.
-		elseif ( ! empty( $term_language ) ) {
+		} else {
+			// Build the object from taxonomy terms.
 			$this->term_id = (int) $language->term_id;
 			$this->name = $language->name;
 			$this->slug = $language->slug;


### PR DESCRIPTION
Since v3.0, some users reported this error:
```
PHP Warning:  array_flip(): Can only flip STRING and INTEGER values! in polylang/include/translated-object.php on line 258
```

In some circumstances database cleaning tools may delete the `term_language` term. In such case, the `PLL_Language` constructor gets an empty `$term_language` param. Since 3.0, this creates a `PLL_Language` object with null properties, whereas in older versions, this created an incomplete  `PLL_Language` object. See [this commit](https://github.com/polylang/polylang/commit/b16720ebd5d24b0463990de4cf68116d379cfe7d#diff-15448452fcf2eda2e4d5c61d73ff632a908cfa35d6fb0ce7b0162654dd0c658eR198).

The warning itself occurs when we want to array_flip the array with a null value (instead of the language slug).

This PR restores the old behavior to keep an incomplete language rather than a language with null properties. This doesn't however restore the old code, to keep PHPStan happy.