### PR TITLE
Use the language custom block attribute to be able to filter blocks on frontend

### DIFF
--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -191,6 +191,15 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				if ( ! empty( $widget_settings[ $number ]['pll_lang'] ) && $widget_settings[ $number ]['pll_lang'] !== $this->curlang->slug ) {
 					unset( $sidebars_widgets[ $sidebar ][ $key ] );
 				}
+
+				// Remove the widget if not visible in the current language (blocks in legacy widget).
+				if ( ! empty( $widget_settings[ $number ]['content'] ) ) {
+					preg_match( "/{\"pll_lang\":\"([a-z]*)\"}/", $widget_settings[ $number ]['content' ], $matches );
+					$lang_should_be_displayed = $matches[1];
+					if ( $this->curlang->slug !== $lang_should_be_displayed ) {
+						unset( $sidebars_widgets[ $sidebar ][ $key ] );
+					}
+				}
 			}
 		}
 

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -194,10 +194,20 @@ class PLL_Frontend_Filters extends PLL_Filters {
 
 				// Remove the widget if not visible in the current language (blocks in legacy widget).
 				if ( ! empty( $widget_settings[ $number ]['content'] ) ) {
-					preg_match( "/{\"pll_lang\":\"([a-z]*)\"}/", $widget_settings[ $number ]['content' ], $matches );
-					$lang_should_be_displayed = $matches[1];
-					if ( $this->curlang->slug !== $lang_should_be_displayed ) {
-						unset( $sidebars_widgets[ $sidebar ][ $key ] );
+					$parser = new WP_Block_Parser();
+					$parser->parse( $widget_settings[ $number ]['content'] );
+					if ( is_array( $parser->output ) ) {
+						foreach ( $parser->output as $output ) {
+							if ( isset( $output['attrs'] ) ) {
+								if ( array_key_exists( 'pll_lang', $output['attrs'] ) ) {
+									$lang_to_be_displayed = $output['attrs']['pll_lang'];
+
+									if ( $this->curlang->slug !== $lang_to_be_displayed ) {
+										unset( $sidebars_widgets[ $sidebar ][ $key ] );
+									}
+								}
+							}
+						}
 					}
 				}
 			}

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -111,8 +111,8 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 		$_POST = array(
 			'widget-block' => array(
-				$wp_registered_widgets['block-1']['params'][0]['number'] => array( 'content' => '<!-- wp:latest-posts {"pll_lang":"en"} /-->' )
-			)
+				$wp_registered_widgets['block-1']['params'][0]['number'] => array( 'content' => '<!-- wp:latest-posts {"pll_lang":"en"} /-->' ),
+			),
 		);
 		$wp_widget_block->update_callback();
 


### PR DESCRIPTION
- Displays the block widget only if the current language is the selected language for displaying the widget.
- Adds a test that checks if the widget would display in the sidebar if the current language is the selected language for displaying the widget.

Fixes https://github.com/polylang/polylang-pro/issues/860