### PR TITLE
Fix confirmation modal with WooCommerce and WordPress < 5.6

### DIFF
--- a/css/dialog.css
+++ b/css/dialog.css
@@ -14,6 +14,7 @@
 	background: #fff;
 	border: 0;
 	color: #444;
+	border-radius: 0; /* Override WooCommerce dialog styles - jQuery UI 1.11.4 - WP < 5.6 */
 }
 .ui-dialog.pll-confirmation-modal .ui-dialog-titlebar {
 	background: #fcfcfc;
@@ -44,6 +45,8 @@
 	right: 0;
 	width: 36px;
 	height: 36px;
+	border: 0; /* Override WooCommerce dialog styles - jQuery UI 1.11.4 - WP < 5.6 */
+	background: none; /* Override WooCommerce dialog styles - jQuery UI 1.11.4 - WP < 5.6 */
 }
 .ui-dialog.pll-confirmation-modal .ui-dialog-content {
 	border: 0;

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -42,34 +42,30 @@ export const initializeConfimationModal = () => {
 			} // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 
 			// Initialize dialog box in the case a language is selected but not added in the list.
-			dialogContainer.dialog(
-				{
-					autoOpen: false,
-					modal: true,
-					draggable: false,
-					resizable: false,
-					title: __( 'Change language', 'polylang' ),
-					minWidth: 600,
-					maxWidth: '100%',
-					classes: {
-						'ui-dialog': 'pll-confirmation-modal',
-					},
-					open: function( event, ui ) {
-						// Change dialog box position for rtl language
-						if ( jQuery( 'body' ).hasClass( 'rtl' ) ) {
-							jQuery( this ).parent().css(
-								{
-									right: jQuery( this ).parent().css( 'left' ),
-									left: 'auto'
-								}
-							);
-						}
-					},
-					close: function( event, ui ) {
-						// When we're closing the dialog box we need to cancel the language change as we click on Cancel button.
-						confirmDialog( 'no' );
-					},
-					buttons: [
+			const dialogOptions = {
+				autoOpen: false,
+				modal: true,
+				draggable: false,
+				resizable: false,
+				title: __( 'Change language', 'polylang' ),
+				minWidth: 600,
+				maxWidth: '100%',
+				open: function( event, ui ) {
+					// Change dialog box position for rtl language
+					if ( jQuery( 'body' ).hasClass( 'rtl' ) ) {
+						jQuery( this ).parent().css(
+							{
+								right: jQuery( this ).parent().css( 'left' ),
+								left: 'auto'
+							}
+						);
+					}
+				},
+				close: function( event, ui ) {
+					// When we're closing the dialog box we need to cancel the language change as we click on Cancel button.
+					confirmDialog( 'no' );
+				},
+				buttons: [
 					{
 						text: __( 'OK', 'polylang' ),
 						click: function( event ) {
@@ -81,9 +77,15 @@ export const initializeConfimationModal = () => {
 						click: function( event ) {
 							confirmDialog( 'no' );
 						}
-					}				]
-				}
-			);
+					}
+				]
+			};
+			if ( jQuery.ui.version >= '1.12.0' ) {
+				Object.assign( dialogOptions, { classes: { 'ui-dialog': 'pll-confirmation-modal' } } );
+			} else {
+				Object.assign( dialogOptions, { dialogClass: 'pll-confirmation-modal' } ); // jQuery UI 1.11.4 - WP < 5.6
+			}
+			dialogContainer.dialog( dialogOptions );
 		}
 	);
 	return { dialogContainer, dialogResult };

--- a/js/lib/confirmation-modal.js
+++ b/js/lib/confirmation-modal.js
@@ -80,11 +80,13 @@ export const initializeConfimationModal = () => {
 					}
 				]
 			};
+
 			if ( jQuery.ui.version >= '1.12.0' ) {
 				Object.assign( dialogOptions, { classes: { 'ui-dialog': 'pll-confirmation-modal' } } );
 			} else {
-				Object.assign( dialogOptions, { dialogClass: 'pll-confirmation-modal' } ); // jQuery UI 1.11.4 - WP < 5.6
+			Object.assign( dialogOptions, { dialogClass: 'pll-confirmation-modal' } ); // jQuery UI 1.11.4 - WP < 5.6
 			}
+
 			dialogContainer.dialog( dialogOptions );
 		}
 	);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -144,6 +144,15 @@
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
+	<!-- PHPCS cannot correctly parse JavaScript syntax -->
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<exclude-pattern>*/*.js</exclude-pattern>
+	</rule>
+
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<exclude-pattern>*/*.js</exclude-pattern>
+	</rule>
+	
 	<exclude-pattern>js/*.min.js</exclude-pattern>
 	<exclude-pattern>js/build</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>


### PR DESCRIPTION
The PR #755  seems incomplete.
It fixed issue https://github.com/polylang/polylang-wc/issues/333 with WP >= 5.6 but we still have issue with WP < 5.6.

![image](https://user-images.githubusercontent.com/1003778/111496298-7d03f480-8740-11eb-8cab-11eab3238976.png)

## What happens
In PR #755 we used a new CSS class `pll-confirmation-modal` introduced by the jQuery UI dialog wiget `classes` option
See https://api.jqueryui.com/dialog/#option-classes and be able to override styles for our specific dialog box.
But this option doesn't exist in jQuery UI 1.11.4 used by WP < 5.6
See https://api.jqueryui.com/1.11/dialog/

## Solution
In jQuery UI 1.11 it exists the `dialogClass` option which does the same thing as jQuery UI `classes` option.
However  `dialogClass` option is deprecated in favor of the jQuery.
See https://api.jqueryui.com/dialog/#option-dialogClass
So I decided to chose which one to use in function of the jQuery UI version.

Some of CSS properties have also been added to fully override the WooCommerce ones.

## What we should obtain
![image](https://user-images.githubusercontent.com/1003778/111495588-d3bcfe80-873f-11eb-9c89-6c5d2d087cef.png)

## In addition
Add some phpcs general rules to ignore some coding standards errors in javascript files as it was made in Polylang Pro
https://github.com/polylang/polylang-pro/blob/master/phpcs.xml.dist#L141-L148