### PR TITLE
Add Polylang parameters in ajax request datas sent in JSON string format

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -278,7 +278,16 @@ abstract class PLL_Admin_Base extends PLL_Base {
 										// Only Polylang data need to be send. So it could be as a simple query string.
 										options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
 									} else {
-										options.data = options.data + '&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
+										/*
+										 * In some cases data could be a JSON string like in third party plugins.
+										 * So we need not to break their process by adding polylang parameters as valid JSON datas.
+										 */
+										try {
+											options.data = JSON.stringify( Object.assign( JSON.parse( options.data ), <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?> ) );
+										} catch( exception ) {
+											// Add Polylang data to the existing query string.
+											options.data = options.data + '&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
+										}
 									}
 								}
 

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -273,7 +273,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 						$.ajaxPrefilter( function ( options, originalOptions, jqXHR ) {
 							if ( -1 != options.url.indexOf( ajaxurl ) || -1 != ajaxurl.indexOf( options.url ) ) {
 
-								function addStringParameters() {
+								function addPolylangParametersAsString() {
 									if ( 'undefined' === typeof options.data || '' === options.data.trim() ) {
 										// Only Polylang data need to be send. So it could be as a simple query string.
 										options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
@@ -291,14 +291,14 @@ abstract class PLL_Admin_Base extends PLL_Base {
 								 * @See https://api.jquery.com/jquery.param/ jQuery param function.
 								 */
 								if ( options.processData ) {
-									addStringParameters();
+									addPolylangParametersAsString();
 								} else {
 									/*
 									 * If options.processData is set to false data could be undefined or pass as a string.
 									 * So data as to be processed as if options.processData is set to true.
 									 */
 									if ( 'undefined' === typeof options.data || 'string' === typeof options.data ) {
-										addStringParameters();
+										addPolylangParametersAsString();
 									} else {
 										// Otherwise options.data is probably an object.
 										options.data = Object.assign( options.data, <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?> );

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -275,6 +275,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 								function addStringParameters() {
 									if ( 'undefined' === typeof options.data || '' === options.data.trim() ) {
+										// Only Polylang data need to be send. So it could be as a simple query string.
 										options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
 									} else {
 										options.data = options.data + '&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
@@ -285,6 +286,9 @@ abstract class PLL_Admin_Base extends PLL_Base {
 								 * options.processData set to true is the default jQuery process where the data is converted in a query string by using jQuery.param().
 								 * This step is done before applying filters. Thus here the options.data is already a string in this case.
 								 * @See https://github.com/jquery/jquery/blob/3.5.1/src/ajax.js#L563-L569 jQuery ajax function.
+								 * It is the most case WordPress send ajax request this way however third party plugins or themes could be send JSON string.
+								 * Use JSON format is recommended in jQuery.param() documentation to be able to send complex data structures.
+								 * @See https://api.jquery.com/jquery.param/ jQuery param function.
 								 */
 								if ( options.processData ) {
 									addStringParameters();

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -274,7 +274,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 							if ( -1 != options.url.indexOf( ajaxurl ) || -1 != ajaxurl.indexOf( options.url ) ) {
 
 								function addStringParameters() {
-									if ( 'undefined' === typeof options.data || '' === options.data ) {
+									if ( 'undefined' === typeof options.data || '' === options.data.trim() ) {
 										options.data = '<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';
 									} else {
 										options.data = options.data + '&<?php echo $str; // phpcs:ignore WordPress.Security.EscapeOutput ?>';


### PR DESCRIPTION
Fixes #798

After this PR https://github.com/polylang/polylang/pull/768 it seems we breaks ajax request in third party plugins because they are using JSON string to send datas.

## What happens
In the PR mentioned we removed the code that takes in charge this kind of datas.
https://github.com/polylang/polylang/blob/2.9.2/admin/admin-base.php#L230-L235

As it is mentioned in the jQuery.param() function documentation , it is recommended to use JSON string for more complex data structures
See https://api.jquery.com/jquery.param/

For example with the `Hubspot` plugin mentioned https://github.com/polylang/polylang/issues/798#issuecomment-801086300 it breaks the registration and the connection with the hubspot platform because it breaks how the datas is retrieved from the request.
https://plugins.trac.wordpress.org/browser/leadin/trunk/src/admin/api/class-registrationapi.php#L25

![image](https://user-images.githubusercontent.com/1003778/111620065-8ba4e700-87e6-11eb-888f-fe749668bf72.png)

and we still stay on the connection screen
![image](https://user-images.githubusercontent.com/1003778/111620277-ca3aa180-87e6-11eb-97d8-abd127610be0.png)

## What changes
- rename the `addStringParameters()`  function to a more explicit one `addPolylangParametersAsString()` to take in account jQuery.param()/query string and JSON string formats.
- Reintroduce the code which has been removed to be able to process JSON string.
- Better comment the code to remember what it is for.

## Going further
- It seems using `JSON.parse()` function inside a try/catch statement is a good and simplier solution to validate JSON string
See the mozilla javascript documentation itself https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
- A the opposite of the #798 proposition, I preferred to put the code inside the `addPolylangParametersAsString()` which process all the string cases and not to use the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) in favor of the `Object.assign()` function not to create a new object but to directly add our Polylang datas in the `options.data` parsed object.

