### PR TITLE
Refactor method sidebars_widgets 

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -59,7 +59,7 @@ class PLL_Admin extends PLL_Admin_Base {
 	/**
 	 * @var PLL_Admin_Filters_Widgets_Options
 	 */
-	public $filters_widgets;
+	public $filters_widgets_options;
 
 	/**
 	 * Setups filters and action needed on all admin pages and on plugins page.
@@ -129,7 +129,7 @@ class PLL_Admin extends PLL_Admin_Base {
 	 */
 	public function add_filters() {
 		$this->filters_sanitization = new PLL_Filters_Sanitization( $this->get_locale_for_sanitization() );
-		$this->filters_widgets = new PLL_Admin_Filters_Widgets_Options( $this );
+		$this->filters_widgets_options = new PLL_Admin_Filters_Widgets_Options( $this );
 
 		// All these are separated just for convenience and maintainability
 		$classes = array( 'Filters', 'Filters_Columns', 'Filters_Post', 'Filters_Term', 'Nav_Menu', 'Classic_Editor', 'Block_Editor' );

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -61,7 +61,7 @@ class PLL_Frontend_Filters_Widgets {
 			return $_sidebars_widgets;
 		}
 
-		$sidebars_widgets = $this->filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, array( $this, 'handle_widget_in_sidebar_callback' ) );
+		$sidebars_widgets = $this->filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets );
 
 		$this->cache->set( "sidebars_widgets_{$cache_key}", $sidebars_widgets );
 

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -3,6 +3,11 @@
  * @package Polylang
  */
 
+/**
+ * Filters widgets by language on frontend
+ *
+ * @since 3.1
+ */
 class PLL_Frontend_Filters_Widgets {
 	/**
 	 * Internal non persistent cache object.
@@ -89,10 +94,9 @@ class PLL_Frontend_Filters_Widgets {
 	 *
 	 * @param  array $sidebars_widgets       An associative array of sidebars and their widgets
 	 * @param  array $wp_registered_widgets  Array of all registered widgets.
-	 * @param  array $callback               Array of the callback function to call.
 	 * @return array                         An associative array of sidebars and their widgets
 	 */
-	public function filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, $callback ) {
+	public function filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets ) {
 		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
 			if ( 'wp_inactive_widgets' === $sidebar || empty( $widgets ) ) {
 				continue;
@@ -105,12 +109,6 @@ class PLL_Frontend_Filters_Widgets {
 
 				$widget_data = $this->get_widget_data( $wp_registered_widgets, $widget );
 
-				$args = array(
-					$widget_data,
-					$sidebars_widgets,
-					$sidebar,
-					$key,
-				);
 				$sidebars_widgets = $this->handle_widget_in_sidebar_callback( $widget_data, $sidebars_widgets, $sidebar, $key );
 			}
 		}
@@ -130,10 +128,10 @@ class PLL_Frontend_Filters_Widgets {
 		// Nothing can be done if the widget is created using pre WP2.8 API :(
 		// There is no object, so we can't access it to get the widget options
 		return isset( $wp_registered_widgets[ $widget ]['callback'] ) &&
-		       is_array( $wp_registered_widgets[ $widget ]['callback'] ) &&
-		       isset( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
-		       is_object( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
-		       method_exists( $wp_registered_widgets[ $widget ]['callback'][0], 'get_settings' );
+				is_array( $wp_registered_widgets[ $widget ]['callback'] ) &&
+				isset( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
+				is_object( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
+				method_exists( $wp_registered_widgets[ $widget ]['callback'][0], 'get_settings' );
 	}
 
 	/**

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+class PLL_Frontend_Filters_Widgets {
+	/**
+	 * Internal non persistent cache object.
+	 *
+	 * @var PLL_Cache
+	 */
+	public $cache;
+
+	/**
+	 * Current language.
+	 *
+	 * @var PLL_Language
+	 */
+	public $curlang;
+
+	/**
+	 * Constructor: setups filters and actions
+	 *
+	 * @since 1.2
+	 *
+	 * @param object $polylang
+	 */
+	public function __construct( &$polylang ) {
+		$this->curlang = &$polylang->curlang;
+		$this->cache = new PLL_Cache();
+
+		add_filter( 'sidebars_widgets', array( $this, 'sidebars_widgets' ) );
+	}
+
+	/**
+	 * Remove widgets from sidebars if they are not visible in the current language
+	 * Needed to allow is_active_sidebar() to return false if all widgets are not for the current language. See #54
+	 *
+	 * @since 2.1
+	 * @since 2.4 The result is cached as the function can be very expensive in case there are a lot of widgets
+	 *
+	 * @param array $sidebars_widgets An associative array of sidebars and their widgets
+	 * @return array
+	 */
+	public function sidebars_widgets( $sidebars_widgets ) {
+		global $wp_registered_widgets;
+
+		if ( empty( $wp_registered_widgets ) ) {
+			return $sidebars_widgets;
+		}
+
+		$cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
+		$_sidebars_widgets = $this->cache->get( "sidebars_widgets_{$cache_key}" );
+
+		if ( false !== $_sidebars_widgets ) {
+			return $_sidebars_widgets;
+		}
+
+		$sidebars_widgets = $this->filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, array( $this, 'handle_widget_in_sidebar_callback' ) );
+
+		$this->cache->set( "sidebars_widgets_{$cache_key}", $sidebars_widgets );
+
+		return $sidebars_widgets;
+	}
+
+	/**
+	 * Method that handles the removal of widgets in the sidebars depending on their display language.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array  $widget_data      An array containing the widget data
+	 * @param array  $sidebars_widgets An associative array of sidebars and their widgets
+	 * @param string $sidebar          Sidebar name
+	 * @param int    $key              Widget number
+	 * @return array                   An associative array of sidebars and their widgets
+	 */
+	public function handle_widget_in_sidebar_callback( $widget_data, $sidebars_widgets, $sidebar, $key ) {
+		// Remove the widget if not visible in the current language
+		if ( ! empty( $widget_data['settings'][ $widget_data['number'] ]['pll_lang'] ) && $widget_data['settings'][ $widget_data['number'] ]['pll_lang'] !== $this->curlang->slug ) {
+			unset( $sidebars_widgets[ $sidebar ][ $key ] );
+		}
+		return $sidebars_widgets;
+	}
+
+	/**
+	 * Browse the widgets sidebars and sort the ones that should be displayed or not.
+	 *
+	 * @since 3.1
+	 *
+	 * @param  array $sidebars_widgets       An associative array of sidebars and their widgets
+	 * @param  array $wp_registered_widgets  Array of all registered widgets.
+	 * @param  array $callback               Array of the callback function to call.
+	 * @return array                         An associative array of sidebars and their widgets
+	 */
+	public function filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, $callback ) {
+		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
+			if ( 'wp_inactive_widgets' === $sidebar || empty( $widgets ) ) {
+				continue;
+			}
+
+			foreach ( $widgets as $key => $widget ) {
+				if ( ! $this->is_widget_object( $wp_registered_widgets, $widget ) ) {
+					continue;
+				}
+
+				$widget_data = $this->get_widget_data( $wp_registered_widgets, $widget );
+
+				$args = array(
+					$widget_data,
+					$sidebars_widgets,
+					$sidebar,
+					$key,
+				);
+				$sidebars_widgets = $this->handle_widget_in_sidebar_callback( $widget_data, $sidebars_widgets, $sidebar, $key );
+			}
+		}
+		return $sidebars_widgets;
+	}
+
+	/**
+	 * Test if the widget is an object.
+	 *
+	 * @since 3.1
+	 *
+	 * @param  array  $wp_registered_widgets Array of all registered widgets.
+	 * @param  string $widget                String that identifies the widget.
+	 * @return bool                          True if object, false otherwise.
+	 */
+	protected function is_widget_object( $wp_registered_widgets, $widget ) {
+		// Nothing can be done if the widget is created using pre WP2.8 API :(
+		// There is no object, so we can't access it to get the widget options
+		return isset( $wp_registered_widgets[ $widget ]['callback'] ) &&
+		       is_array( $wp_registered_widgets[ $widget ]['callback'] ) &&
+		       isset( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
+		       is_object( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
+		       method_exists( $wp_registered_widgets[ $widget ]['callback'][0], 'get_settings' );
+	}
+
+	/**
+	 * Get widgets settings and number.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array  $wp_registered_widgets Array of all registered widgets.
+	 * @param string $widget                String that identifies the widget.
+	 * @return array An array containing the widget settings and number.
+	 */
+	protected function get_widget_data( $wp_registered_widgets, $widget ) {
+		$widget_settings = $wp_registered_widgets[ $widget ]['callback'][0]->get_settings();
+		$number          = $wp_registered_widgets[ $widget ]['params'][0]['number'];
+
+		return array(
+			'settings' => $widget_settings,
+			'number'   => $number,
+		);
+	}
+}

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -237,9 +237,9 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 *
 	 * @since 3.1
 	 *
-	 * @param array $sidebars_widgets An associative array of sidebars and their widgets
+	 * @param array $sidebars_widgets        An associative array of sidebars and their widgets
 	 * @param  array $wp_registered_widgets  Array of all registered widgets.
-	 * @return array|null             An associative array of sidebars and their widgets or nothing.
+	 * @return array|null                    An associative array of sidebars and their widgets or nothing.
 	 */
 	public function init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets ) {
 		if ( empty( $wp_registered_widgets ) ) {

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -10,13 +10,6 @@
  */
 class PLL_Frontend_Filters extends PLL_Filters {
 	/**
-	 * Internal non persistent cache object.
-	 *
-	 * @var PLL_Cache
-	 */
-	public $cache;
-
-	/**
 	 * Constructor: setups filters and actions
 	 *
 	 * @since 1.2
@@ -25,8 +18,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 */
 	public function __construct( &$polylang ) {
 		parent::__construct( $polylang );
-
-		$this->cache = new PLL_Cache();
 
 		// Filters the WordPress locale
 		add_filter( 'locale', array( $this, 'get_locale' ) );

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -173,7 +173,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 
 		$sidebars_widgets = $this->sort_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, array( $this, 'handle_widget_in_sidebar_callback' ) );
 
-		$this->set_sidebars_widgets_cache( $sidebars_widgets );
+		$this->cache->set( "sidebars_widgets_{$this->cache_key}", $sidebars_widgets );
 
 		return $sidebars_widgets;
 	}
@@ -237,17 +237,20 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 *
 	 * @since 3.1
 	 *
-	 * @param array $sidebars_widgets        An associative array of sidebars and their widgets
-	 * @param  array $wp_registered_widgets  Array of all registered widgets.
+	 * @param  array  $sidebars_widgets      An associative array of sidebars and their widgets
+	 * @param  array  $wp_registered_widgets Array of all registered widgets.
+	 * @param  object $instance              Instance of class that handles widgets blocks filters.
 	 * @return array|null                    An associative array of sidebars and their widgets or nothing.
 	 */
-	public function init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets ) {
+	public function init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets, $instance = null ) {
 		if ( empty( $wp_registered_widgets ) ) {
 			return $sidebars_widgets;
 		}
 
-		$this->cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
-		$_sidebars_widgets = $this->cache->get( "sidebars_widgets_{$this->cache_key}" );
+		$instance = $instance ? $instance : $this;
+
+		$instance->cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
+		$_sidebars_widgets = $instance->cache->get( "sidebars_widgets_{$instance->cache_key}" );
 
 		if ( false !== $_sidebars_widgets ) {
 			return $_sidebars_widgets;
@@ -294,18 +297,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 			'settings' => $widget_settings,
 			'number'   => $number,
 		);
-	}
-
-	/**
-	 * Add the sidebars widgets in cache.
-	 *
-	 * @since 3.1
-	 *
-	 * @param array $sidebars_widgets An associative array of sidebars and their widgets
-	 * @return void
-	 */
-	public function set_sidebars_widgets_cache( $sidebars_widgets ) {
-		$this->cache->set( "sidebars_widgets_{$this->cache_key}", $sidebars_widgets );
 	}
 
 	/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -166,9 +166,15 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	public function sidebars_widgets( $sidebars_widgets ) {
 		global $wp_registered_widgets;
 
-		$existing_sidebars_widgets = $this->init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets );
-		if ( $existing_sidebars_widgets ) {
-			return $existing_sidebars_widgets;
+		if ( empty( $wp_registered_widgets ) ) {
+			return $sidebars_widgets;
+		}
+
+		$this->cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
+		$_sidebars_widgets = $this->cache->get( "sidebars_widgets_{$this->cache_key}" );
+
+		if ( false !== $_sidebars_widgets ) {
+			return $_sidebars_widgets;
 		}
 
 		$sidebars_widgets = $this->sort_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, array( $this, 'handle_widget_in_sidebar_callback' ) );
@@ -230,32 +236,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 			}
 		}
 		return $sidebars_widgets;
-	}
-
-	/**
-	 * Init widgets sidebars, checks if they already exist in the cache to use them later.
-	 *
-	 * @since 3.1
-	 *
-	 * @param  array  $sidebars_widgets      An associative array of sidebars and their widgets
-	 * @param  array  $wp_registered_widgets Array of all registered widgets.
-	 * @param  object $instance              Instance of class that handles widgets blocks filters.
-	 * @return array|null                    An associative array of sidebars and their widgets or nothing.
-	 */
-	public function init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets, $instance = null ) {
-		if ( empty( $wp_registered_widgets ) ) {
-			return $sidebars_widgets;
-		}
-
-		$instance = $instance ? $instance : $this;
-
-		$instance->cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
-		$_sidebars_widgets = $instance->cache->get( "sidebars_widgets_{$instance->cache_key}" );
-
-		if ( false !== $_sidebars_widgets ) {
-			return $_sidebars_widgets;
-		}
-		return null;
 	}
 
 	/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -40,7 +40,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 
 		// Filters the widgets according to the current language
 		add_filter( 'widget_display_callback', array( $this, 'widget_display_callback' ) );
-		add_filter( 'sidebars_widgets', array( $this, 'sidebars_widgets' ) );
 
 		if ( $this->options['media_support'] ) {
 			add_filter( 'widget_media_image_instance', array( $this, 'widget_media_instance' ), 1 ); // Since WP 4.8
@@ -146,129 +145,6 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 */
 	public function widget_display_callback( $instance ) {
 		return ! empty( $instance['pll_lang'] ) && $instance['pll_lang'] != $this->curlang->slug ? false : $instance;
-	}
-
-	/**
-	 * Remove widgets from sidebars if they are not visible in the current language
-	 * Needed to allow is_active_sidebar() to return false if all widgets are not for the current language. See #54
-	 *
-	 * @since 2.1
-	 * @since 2.4 The result is cached as the function can be very expensive in case there are a lot of widgets
-	 *
-	 * @param array $sidebars_widgets An associative array of sidebars and their widgets
-	 * @return array
-	 */
-	public function sidebars_widgets( $sidebars_widgets ) {
-		global $wp_registered_widgets;
-
-		if ( empty( $wp_registered_widgets ) ) {
-			return $sidebars_widgets;
-		}
-
-		$cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
-		$_sidebars_widgets = $this->cache->get( "sidebars_widgets_{$cache_key}" );
-
-		if ( false !== $_sidebars_widgets ) {
-			return $_sidebars_widgets;
-		}
-
-		$sidebars_widgets = $this->filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, array( $this, 'handle_widget_in_sidebar_callback' ) );
-
-		$this->cache->set( "sidebars_widgets_{$cache_key}", $sidebars_widgets );
-
-		return $sidebars_widgets;
-	}
-
-	/**
-	 * Callback method that handles the removal of widgets in the sidebars depending on their display language.
-	 *
-	 * @since 3.1
-	 *
-	 * @param array  $widget_data      An array containing the widget data
-	 * @param array  $sidebars_widgets An associative array of sidebars and their widgets
-	 * @param string $sidebar          Sidebar name
-	 * @param int    $key              Widget number
-	 * @return array                   An associative array of sidebars and their widgets
-	 */
-	public function handle_widget_in_sidebar_callback( $widget_data, $sidebars_widgets, $sidebar, $key ) {
-		// Remove the widget if not visible in the current language
-		if ( ! empty( $widget_data['settings'][ $widget_data['number'] ]['pll_lang'] ) && $widget_data['settings'][ $widget_data['number'] ]['pll_lang'] !== $this->curlang->slug ) {
-			unset( $sidebars_widgets[ $sidebar ][ $key ] );
-		}
-		return $sidebars_widgets;
-	}
-
-	/**
-	 * Browse the widgets sidebars and sort the ones that should be displayed or not.
-	 *
-	 * @since 3.1
-	 *
-	 * @param  array $sidebars_widgets       An associative array of sidebars and their widgets
-	 * @param  array $wp_registered_widgets  Array of all registered widgets.
-	 * @param  array $callback               Array of the callback function to call.
-	 * @return array                         An associative array of sidebars and their widgets
-	 */
-	public function filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, $callback ) {
-		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
-			if ( 'wp_inactive_widgets' === $sidebar || empty( $widgets ) ) {
-				continue;
-			}
-
-			foreach ( $widgets as $key => $widget ) {
-				if ( ! $this->is_widget_object( $wp_registered_widgets, $widget ) ) {
-					continue;
-				}
-
-				$widget_data = $this->get_widget_data( $wp_registered_widgets, $widget );
-
-				$args = array(
-					$widget_data,
-					$sidebars_widgets,
-					$sidebar,
-					$key,
-				);
-				$sidebars_widgets = call_user_func_array( $callback, $args );
-			}
-		}
-		return $sidebars_widgets;
-	}
-
-	/**
-	 * Test if the widget is an object.
-	 *
-	 * @since 3.1
-	 *
-	 * @param  array  $wp_registered_widgets Array of all registered widgets.
-	 * @param  string $widget                String that identifies the widget.
-	 * @return bool                          True if object, false otherwise.
-	 */
-	protected function is_widget_object( $wp_registered_widgets, $widget ) {
-		// Nothing can be done if the widget is created using pre WP2.8 API :(
-		// There is no object, so we can't access it to get the widget options
-		return isset( $wp_registered_widgets[ $widget ]['callback'] ) &&
-			is_array( $wp_registered_widgets[ $widget ]['callback'] ) &&
-			isset( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
-			is_object( $wp_registered_widgets[ $widget ]['callback'][0] ) &&
-			method_exists( $wp_registered_widgets[ $widget ]['callback'][0], 'get_settings' );
-	}
-
-	/**
-	 * Get widgets settings and number.
-	 *
-	 * @since 3.1
-	 *
-	 * @param array  $wp_registered_widgets Array of all registered widgets.
-	 * @param string $widget                String that identifies the widget.
-	 * @return array An array containing the widget settings and number.
-	 */
-	protected function get_widget_data( $wp_registered_widgets, $widget ) {
-		$widget_settings = $wp_registered_widgets[ $widget ]['callback'][0]->get_settings();
-		$number          = $wp_registered_widgets[ $widget ]['params'][0]['number'];
-
-		return array(
-			'settings' => $widget_settings,
-			'number'   => $number,
-		);
 	}
 
 	/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -238,9 +238,9 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 *
 	 * @since 3.1
 	 *
-	 * @param array  $wp_registered_widgets Array of all registered widgets.
-	 * @param string $widget                String that identifies the widget.
-	 * @return bool                         True if object, false otherwise.
+	 * @param  array  $wp_registered_widgets Array of all registered widgets.
+	 * @param  string $widget                String that identifies the widget.
+	 * @return bool                          True if object, false otherwise.
 	 */
 	protected function is_widget_object( $wp_registered_widgets, $widget ) {
 		// Nothing can be done if the widget is created using pre WP2.8 API :(

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -166,7 +166,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	public function sidebars_widgets( $sidebars_widgets ) {
 		global $wp_registered_widgets;
 
-		$existing_sidebars_widgets = $this->init_sidebars_widgets( $sidebars_widgets );
+		$existing_sidebars_widgets = $this->init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets );
 		if ( $existing_sidebars_widgets ) {
 			return $existing_sidebars_widgets;
 		}
@@ -238,9 +238,10 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @since 3.1
 	 *
 	 * @param array $sidebars_widgets An associative array of sidebars and their widgets
+	 * @param  array $wp_registered_widgets  Array of all registered widgets.
 	 * @return array|null             An associative array of sidebars and their widgets or nothing.
 	 */
-	public function init_sidebars_widgets( $sidebars_widgets ) {
+	public function init_sidebars_widgets( $sidebars_widgets, $wp_registered_widgets ) {
 		if ( empty( $wp_registered_widgets ) ) {
 			return $sidebars_widgets;
 		}

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -166,7 +166,10 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	public function sidebars_widgets( $sidebars_widgets ) {
 		global $wp_registered_widgets;
 
-		$this->init_sidebars_widgets( $sidebars_widgets );
+		$existing_sidebars_widgets = $this->init_sidebars_widgets( $sidebars_widgets );
+		if ( $existing_sidebars_widgets ) {
+			return $existing_sidebars_widgets;
+		}
 
 		$sidebars_widgets = $this->sort_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets, array( $this, 'handle_widget_in_sidebar_callback' ) );
 
@@ -235,7 +238,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @since 3.1
 	 *
 	 * @param array $sidebars_widgets An associative array of sidebars and their widgets
-	 * @return mixed|void
+	 * @return array|null             An associative array of sidebars and their widgets or nothing.
 	 */
 	public function init_sidebars_widgets( $sidebars_widgets ) {
 		if ( empty( $wp_registered_widgets ) ) {
@@ -248,6 +251,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		if ( false !== $_sidebars_widgets ) {
 			return $_sidebars_widgets;
 		}
+		return null;
 	}
 
 	/**

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -59,6 +59,11 @@ class PLL_Frontend extends PLL_Base {
 	public $static_pages;
 
 	/**
+	 * @var PLL_Frontend_Filters_Widgets
+	 */
+	public $filters_widgets;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.2
@@ -119,6 +124,7 @@ class PLL_Frontend extends PLL_Base {
 		$this->filters_links = new PLL_Frontend_Filters_Links( $this );
 		$this->filters = new PLL_Frontend_Filters( $this );
 		$this->filters_search = new PLL_Frontend_Filters_Search( $this );
+		$this->filters_widgets = new PLL_Frontend_Filters_Widgets( $this );
 
 		// Auto translate for Ajax
 		if ( ( ! defined( 'PLL_AUTO_TRANSLATE' ) || PLL_AUTO_TRANSLATE ) && wp_doing_ajax() ) {

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -38,7 +38,7 @@ class PLL_REST_Request extends PLL_Base {
 	/**
 	 * @var PLL_Filters_Widgets_Options
 	 */
-	public $filters_widgets;
+	public $filters_widgets_options;
 
 	/**
 	 * Setup filters.
@@ -57,7 +57,7 @@ class PLL_REST_Request extends PLL_Base {
 
 			$this->filters_links = new PLL_Filters_Links( $this );
 			$this->filters = new PLL_Filters( $this );
-			$this->filters_widgets = new PLL_Filters_Widgets_Options( $this );
+			$this->filters_widgets_options = new PLL_Filters_Widgets_Options( $this );
 
 			// Static front page and page for posts.
 			if ( 'page' === get_option( 'show_on_front' ) ) {

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -183,11 +183,11 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->update_lang_choice( $wp_widget_search, 'en' );
 
 		$frontend = new PLL_Frontend( $this->links_model );
-		$frontend->filters = new PLL_Frontend_Filters( $frontend );
+		$frontend->filters_widgets = new PLL_Frontend_Filters_Widgets( $frontend );
 		$frontend->curlang = self::$model->get_language( 'en' );
 
-		$frontend->filters->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		$frontend->filters->cache->method( 'get' )->willReturn( false );
+		$frontend->filters_widgets->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
+		$frontend->filters_widgets->cache->method( 'get' )->willReturn( false );
 
 		$sidebars = wp_get_sidebars_widgets();
 		$this->assertTrue( in_array( 'search-2', $sidebars['sidebar-1'] ) );


### PR DESCRIPTION
Refactor method `sidebars_widgets` to separate it into several methods in order to re-use them in `widget-editor-language-attribute.php` to avoid duplicated code.

See : https://github.com/polylang/polylang-pro/pull/922#discussion_r597571113

Link to this PR : https://github.com/polylang/polylang-pro/pull/922 and so issue https://github.com/polylang/polylang-pro/issues/860
