### PR TITLE
Add a new method to check the modification of function copied from WordPress

### DIFF
--- a/tests/phpunit/includes/check-wp-functions-trait.php
+++ b/tests/phpunit/includes/check-wp-functions-trait.php
@@ -35,4 +35,14 @@ trait PLL_Check_WP_Functions_Trait {
 		}
 		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() has been modified', implode( '::', $args ) ) );
 	}
+
+	/**
+	 * Check if a Polylang function that is duplicated from a WordPress has been modified.
+	 *
+	 * @param string $md5 Expected method md5.
+	 * @param string ...$args Function name or class and method name.
+	 */
+	protected function check_internal_method( $md5, ...$args ) {
+		$this->asserEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() emulates a WordPress function, are you sure that it needs to be modified?', implode( '::', $args ) ) );
+	}
 }

--- a/tests/phpunit/includes/check-wp-functions-trait.php
+++ b/tests/phpunit/includes/check-wp-functions-trait.php
@@ -43,6 +43,6 @@ trait PLL_Check_WP_Functions_Trait {
 	 * @param string ...$args Function name or class and method name.
 	 */
 	protected function check_internal_method( $md5, ...$args ) {
-		$this->asserEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() emulates a WordPress function, are you sure that it needs to be modified?', implode( '::', $args ) ) );
+		$this->assertEquals( $md5, $this->md5( ...$args ), sprintf( 'The function %s() emulates a WordPress function, are you sure that it needs to be modified?', implode( '::', $args ) ) );
 	}
 }


### PR DESCRIPTION
## Before

We used to verify that the WordPress functions we have copied didn't change from one WordPress version to another.

However, we could inadvertedly change from within our files a function that have been copied.

## Changes

Add a test method to check if our copied methods / functions have been changed or not. If we need to indeed change one of these functions, we would then have to update the md5 in the tests.

Need to be merged before https://github.com/polylang/polylang-pro/pull/931