### PR TITLE
Remove update_post_meta_cache() call in the pages list table

### DIFF
--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -90,7 +90,26 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		// Hierarchical post types
 		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
 			$pages = get_pages( array( 'sort_column' => 'menu_order, post_title' ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
-			update_post_caches( $pages, $screen->post_type );
+
+			/**
+			 * Allow to retrieve the taxonomy during update_post_caches().
+			 *
+			 * @since 3.1
+			 *
+			 * @param bool $filter_term true to retrieve taxonomy terms.
+			 */
+			$filter_term = apply_filters( 'pll_update_post_filter_term', true );
+
+			/**
+			 * Allow to retrieve the postmeta during update_post_caches().
+			 *
+			 * @since 3.1
+			 *
+			 * @param bool $filter_meta true to retrieve postmeta.
+			 */
+			$filter_meta = apply_filters( 'pll_update_post_filter_meta', true );
+
+			update_post_caches( $pages, $screen->post_type, $filter_term, $filter_meta );
 
 			$page_languages = array();
 

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -91,16 +91,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
 			$pages = get_pages( array( 'sort_column' => 'menu_order, post_title' ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
 
-			/**
-			 * Allow to retrieve the postmeta during update_post_caches().
-			 *
-			 * @since 3.1
-			 *
-			 * @param bool $filter_meta true to retrieve postmeta.
-			 */
-			$filter_meta = apply_filters( 'pll_update_post_filter_meta', true );
-
-			update_post_caches( $pages, $screen->post_type, true, $filter_meta );
+			update_post_caches( $pages, $screen->post_type, true, false );
 
 			$page_languages = array();
 

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -92,15 +92,6 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			$pages = get_pages( array( 'sort_column' => 'menu_order, post_title' ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
 
 			/**
-			 * Allow to retrieve the taxonomy during update_post_caches().
-			 *
-			 * @since 3.1
-			 *
-			 * @param bool $filter_term true to retrieve taxonomy terms.
-			 */
-			$filter_term = apply_filters( 'pll_update_post_filter_term', true );
-
-			/**
 			 * Allow to retrieve the postmeta during update_post_caches().
 			 *
 			 * @since 3.1
@@ -109,7 +100,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			 */
 			$filter_meta = apply_filters( 'pll_update_post_filter_meta', true );
 
-			update_post_caches( $pages, $screen->post_type, $filter_term, $filter_meta );
+			update_post_caches( $pages, $screen->post_type, true, $filter_meta );
 
 			$page_languages = array();
 


### PR DESCRIPTION
In the pages list table, the post meta cache is uselessly updated due to the 4th parameter of `update_post_caches()` being true by default. This PR sets it to false.
Related to Helpsout ticket https://secure.helpscout.net/conversation/1476825775/14628
 