### PR TITLE
Insert pll_ajax_backend parameter in a new empty object

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -317,7 +317,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 										addPolylangParametersAsString();
 									} else {
 										// Otherwise options.data is probably an object.
-										options.data = Object.assign( options.data, <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?> );
+										options.data = Object.assign( options.data || {} , <?php echo $arr; // phpcs:ignore WordPress.Security.EscapeOutput ?> );
 									}
 								}
 							}


### PR DESCRIPTION
This PR fixes the [HS #14681 ticket](https://secure.helpscout.net/conversation/1481323694/14681?folderId=860979) (private)

options.data could be undefined when it come from [jQuery Form plugin](https://github.com/jquery-form/form) espacially when it is used to upload a file because [processData](https://github.com/jquery-form/form/blob/v4.3.0/src/jquery.form.js#L396) is set to false and [data to null](https://github.com/jquery-form/form/blob/v4.3.0/src/jquery.form.js#L424)

So we need to insert pll_ajax_backend parameter in a new empty object instead to avoid the javascript error which blocks the uploading process.

**Note** that by [jQuery Form plugin implementation](https://github.com/jquery-form/form/blob/v4.3.0/src/jquery.form.js#L430-L434) the pll_ajax_backend parameter will be never sent to the server