### PR TITLE
Require simplexml in site health if a wpml-config.xml is found

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -62,7 +62,7 @@ class PLL_WPML_Config {
 		$files = $this->get_files();
 
 		if ( ! empty( $files ) ) {
-			add_filter( 'site_status_test_php_modules', array( $this, 'site_status_test_php_modules' ) ); // Require libxml in Site health.
+			add_filter( 'site_status_test_php_modules', array( $this, 'site_status_test_php_modules' ) ); // Require simplexml in Site health.
 
 			// Read all files.
 			if ( extension_loaded( 'simplexml' ) ) {


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/670

This PR reports a missing `simplexml` as critical if a wpml-config.xml should be read. This should then be more obvious to solve issues such as https://wordpress.org/support/topic/string-translations-disappeared-with-php-8-0/