### PR TITLE
Prevent race condition when deleting images

### DIFF
--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -228,8 +228,7 @@ class PLL_CRUD_Posts {
 	}
 
 	/**
-	 * Prevents WP deleting files when there are still media using them
-	 * Thanks to Bruno "Aesqe" Babic and its plugin file gallery in which I took all the ideas for this function
+	 * Prevents WP deleting files when there are still media using them.
 	 *
 	 * @since 0.9
 	 *
@@ -241,19 +240,20 @@ class PLL_CRUD_Posts {
 
 		$uploadpath = wp_upload_dir();
 
+		// Get the main attached file.
+		$attached_file = substr_replace( $file, '', 0, strlen( trailingslashit( $uploadpath['basedir'] ) ) );
+		$attached_file = preg_replace( '#-\d+x\d+\.([a-z]+)$#', '.$1', $attached_file );
+
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT post_id FROM $wpdb->postmeta
 				WHERE meta_key = '_wp_attached_file' AND meta_value = %s",
-				substr_replace( $file, '', 0, strlen( trailingslashit( $uploadpath['basedir'] ) ) )
+				$attached_file
 			)
 		);
 
 		if ( ! empty( $ids ) ) {
-			// Regenerate intermediate sizes if it's an image ( since we could not prevent WP deleting them before ).
-			require_once ABSPATH . 'wp-admin/includes/image.php'; // In case the file is deleted outside admin.
-			wp_update_attachment_metadata( $ids[0], wp_slash( wp_generate_attachment_metadata( $ids[0], $file ) ) ); // Directly uses update_post_meta, so expects slashed.
-			return ''; // Prevent deleting the main file.
+			return ''; // Prevent deleting the file.
 		}
 
 		return $file;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -58,10 +58,3 @@ parameters:
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: frontend/choose-lang.php
-
-		# False positive due to a probable wrong WordPress doc. See https://core.trac.wordpress.org/ticket/52603
-		-
-			message: "#^Parameter \\#2 \\$data of function wp_update_attachment_metadata expects array, string given\\.$#"
-			count: 1
-			path: include/crud-posts.php
-


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/853

The goal of `PLL_CRUD_Posts::wp_delete_file()` is to prevent WP to delete image files when only a media is deleted and at least one media translation is kept.

The previous method was taken from https://wordpress.org/plugins/file-gallery/. The process was as follows:
1. WP deletes the attachment in database.
2. WP deletes all resized files.
3. WP attempts to deletes the main file.
4. Polylang looks for the attachments using the main file. If it find ones, it re-generates the resized files and tells WP not to delete the main file.

The issue is that when deleting the files from the grid view, media are deleted individually with an ajax request per media. This causes a race condition with a request regenerating the resized files while anoth would have delete them if they had existed.

The new method proposed in this PR is as follows:
1. WP deletes the attachment in database.
2. WP attempts to delete the resized files.
3. Polylang gets the main file name from the resized file name and looks for the attachments using the main file. If it find ones it tells WP not to delete the file.
4. WP attempts to deletes the main file.
5. Polylang looks for the attachments using the main file. If it find ones it tells WP not to delete the file.

