### PR TITLE
Set curlang as current post language when cleaning the post cache

### DIFF
--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -24,6 +24,8 @@ class PLL_Cache_Compat {
 		if ( ! defined( 'WP_ROCKET_VERSION' ) || version_compare( WP_ROCKET_VERSION, '3.0.5', '<' ) ) {
 			add_action( 'wp', array( $this, 'do_not_cache_site_home' ) );
 		}
+
+		add_action( 'clean_post_cache', array( $this, 'clean_post_cache' ), 1 );
 	}
 
 	/**
@@ -68,6 +70,22 @@ class PLL_Cache_Compat {
 	public function do_not_cache_site_home() {
 		if ( ! defined( 'DONOTCACHEPAGE' ) && PLL()->options['browser'] && PLL()->options['hide_default'] && is_front_page() && pll_current_language() === pll_default_language() ) {
 			define( 'DONOTCACHEPAGE', true );
+		}
+	}
+
+	/**
+	 * Defines the current language as the current post language when cleaning the post cache.
+	 *
+	 * This allows cache plugins to clean the right post type archive cache.
+	 *
+	 * @since 3.0.5
+	 *
+	 * @param int $post_id Post id.
+	 */
+	public function clean_post_cache( $post_id ) {
+		$lang = PLL()->model->post->get_language( $post_id );
+		if ( $lang ) {
+			PLL()->curlang = $lang;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #828 

When a custom post is published, cache plugins purge the post cache but also the post type archive cache.
See for examples:
* WP Rocket: https://github.com/wp-media/wp-rocket/blob/v3.8.8/inc/common/purge.php#L63
* Cache enabler: https://github.com/keycdn/cache-enabler/blob/1.7.1/inc/cache_enabler.class.php#L1217 

Our [`post_type_archive_link` filter](https://github.com/polylang/polylang/blob/3.0.4/include/filters-links.php#L198) uses `$curlang` to evaluate the language of the link. So we thus must ensure that `PLL()->curlang` is equal to the language of the post being published.

In this PR, I propose to set `PLL()->curlang` in a method hooked to `clean_post_cache`. WP Rocket uses this hook and it is expected that other cache plugins uses this hook too. Note that Cache enabler uses `save_post`, but this shouldn't be an issue as this hooked is fired after `clean_post_cache`.