### PR TITLE
Support session cookie with the pll_cookie_expiration filter

### DIFF
--- a/include/cookie.php
+++ b/include/cookie.php
@@ -10,7 +10,7 @@
  */
 class PLL_Cookie {
 	/**
-	 * Parses the cookie parameters
+	 * Parses the cookie parameters.
 	 *
 	 * @since 2.9
 	 *
@@ -19,17 +19,19 @@ class PLL_Cookie {
 	 */
 	protected static function parse_args( $args ) {
 		/**
-		 * Filter the Polylang cookie duration
-		 * /!\ this filter may be fired *before* the theme is loaded
+		 * Filters the Polylang cookie duration.
+		 *
+		 * If a cookie duration of 0 is specified, a session cookie will be set.
+		 * /!\ This filter may be fired *before* the theme is loaded.
 		 *
 		 * @since 1.8
 		 *
-		 * @param int $duration cookie duration in seconds
+		 * @param int $duration Cookie duration in seconds.
 		 */
 		$expiration = apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS );
 
 		$defaults = array(
-			'expires'  => time() + $expiration,
+			'expires'  => $expiration > 0 ? time() + $expiration : 0,
 			'path'     => COOKIEPATH,
 			'domain'   => COOKIE_DOMAIN, // Cookie domain must be set to false for localhost ( default value for COOKIE_DOMAIN ) thanks to Stephen Harris.
 			'secure'   => is_ssl(),

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -42,21 +42,30 @@ class PLL_Cache_Compat {
 		$domain   = ( 2 === PLL()->options['force_lang'] ) ? wp_parse_url( PLL()->links_model->home, PHP_URL_HOST ) : COOKIE_DOMAIN;
 		$samesite = ( 3 === PLL()->options['force_lang'] ) ? 'None' : 'Lax';
 
+		/** This filter is documented in include/cookie.php */
+		$expiration = apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS );
+
+		if ( $expiration > 0 ) {
+			$format = 'var expirationDate = new Date();
+				expirationDate.setTime( expirationDate.getTime() + %7$d * 1000 );
+				document.cookie = "%1$s=%2$s; expires=" + expirationDate.toUTCString() + "; path=%3$s%4$s%5$s%6$s";';
+		} else {
+			$format = 'document.cookie = "%1$s=%2$s; path=%3$s%4$s%5$s%6$s";';
+		}
+
 		$js = sprintf(
-			'(function() {
-				var expirationDate = new Date();
-				expirationDate.setTime( expirationDate.getTime() + %d * 1000 );
-				document.cookie = "%s=%s; expires=" + expirationDate.toUTCString() + "; path=%s%s%s%s";
-			}());',
-			esc_js( apply_filters( 'pll_cookie_expiration', YEAR_IN_SECONDS ) ),
+			"(function() {
+				{$format}
+			}());\n",
 			esc_js( PLL_COOKIE ),
 			esc_js( pll_current_language() ),
 			esc_js( COOKIEPATH ),
 			$domain ? '; domain=' . esc_js( $domain ) : '',
 			is_ssl() ? '; secure' : '',
-			'; SameSite=' . $samesite
+			'; SameSite=' . $samesite,
+			esc_js( $expiration )
 		);
-		echo '<script type="text/javascript">' . $js . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput
+		echo "<script type='text/javascript'>\n" . $js . "</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
 	/**


### PR DESCRIPTION
Fixes #834

This PR allows to pass 0 to the `pll_cookie_expiration` filter, thus setting a session cookie instead of persistent cookie.