### PR TITLE
Avoid javascript errors when a plugin define its own editor for translated post types

### DIFF
--- a/js/src/lib/confirmation-modal.js
+++ b/js/src/lib/confirmation-modal.js
@@ -94,6 +94,9 @@ export const initializeConfimationModal = () => {
 }
 
 export const initializeLanguageOldValue = () => {
-	// Keep the old language value to be able to compare to the new one and revert to it if necessary.
-	languagesList.attr( 'data-old-value', languagesList.children( ':selected' )[0].value );
+	// Avoid outputting errors when there is no metabox
+	if ( languagesList.val() ) {
+		// Keep the old language value to be able to compare to the new one and revert to it if necessary.
+		languagesList.attr( 'data-old-value', languagesList.children( ':selected' )[0].value );
+	}
 };

--- a/js/src/lib/confirmation-modal.js
+++ b/js/src/lib/confirmation-modal.js
@@ -29,7 +29,7 @@ export const initializeConfimationModal = () => {
 				switch ( what ) { // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 					case 'yes':
 						// Confirm the new language.
-						languagesList.data( 'old-value', languagesList.children( ':selected' )[0].value );
+						languagesList.data( 'old-value', languagesList.children( ':selected' ).first().val() );
 						confirm();
 						break;
 					case 'no':
@@ -94,9 +94,6 @@ export const initializeConfimationModal = () => {
 }
 
 export const initializeLanguageOldValue = () => {
-	// Avoid outputting errors when there is no metabox
-	if ( languagesList.val() ) {
-		// Keep the old language value to be able to compare to the new one and revert to it if necessary.
-		languagesList.attr( 'data-old-value', languagesList.children( ':selected' )[0].value );
-	}
+	// Keep the old language value to be able to compare to the new one and revert to it if necessary.
+	languagesList.attr( 'data-old-value', languagesList.children( ':selected' ).first().val() );
 };

--- a/modules/wizard/js/languages-step.js
+++ b/modules/wizard/js/languages-step.js
@@ -271,7 +271,7 @@ jQuery(
 						);
 					}
 					// Display language name and flag information in dialog box.
-					$( this ).find( '#dialog-language' ).text( $( '#lang_list' ).children( ':selected' )[0].innerText );
+					$( this ).find( '#dialog-language' ).text( $( '#lang_list' ).children( ':selected' ).first().text() );
 					// language properties come from the select dropdown #lang_list which is built server side and well escaped.
 					// see template view-wizard-step-languages.php.
 					$( this ).find( '#dialog-language-flag' ).empty().prepend( $( '#lang_list' ).children( ':selected' ).data( 'flag-html' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend


### PR DESCRIPTION
## Before

Polylang only loads javascript related to the metabox on an a translated post type editor. However, if a plugin overrides WordPress editors for a translated post type, our script would be loaded, even if the target HTML elements are missing. That's what happened in: https://secure.helpscout.net/conversation/1509819229/15063?folderId=860976

## Changes

Chain jQuery methods instead of accessing directly the properties. If the selected DOM node does not exists at some point of the chain, these methods will return an empty jQuery object, so the chain will continue and only the final result will be `undefined`.

## Going further

- [x] ~~Do we need to adress this in the `initializeConfirmationModal()` function as well? And in other scripts?~~