### PR TITLE
Fix legacy widget dropdown preview

### DIFF
--- a/include/widget-languages.php
+++ b/include/widget-languages.php
@@ -37,7 +37,7 @@ class PLL_Widget_Languages extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		// Sets a unique id for dropdown.
-		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $args['widget_id'];
+		$instance['dropdown'] = empty( $instance['dropdown'] ) ? 0 : $this->id;
 
 		if ( $list = pll_the_languages( array_merge( $instance, array( 'echo' => 0 ) ) ) ) {
 			$title = empty( $instance['title'] ) ? '' : $instance['title'];


### PR DESCRIPTION
### Before
The language switcher of the legacy widget displayed a list when the dropdown was selected. 

### After
It now displays a dropdown.

### Fix

The `$args['widget_id']` does not exist during the preview request, so we set the id of the current widget.
( Even if it's not the right one, it doesn't bother for the preview, it allows to not have a dropdown with 0 )