### PR TITLE
Allow to query comments by multiple languages

### DIFF
--- a/include/filters.php
+++ b/include/filters.php
@@ -98,7 +98,7 @@ class PLL_Filters {
 	 * @since 2.0
 	 *
 	 * @param WP_Comment_Query $query  WP_Comment_Query object.
-	 * @return PLL_Language|false The language to use in the filter, false otherwise.
+	 * @return PLL_Language|string|false The language to use in the filter, false otherwise.
 	 */
 	protected function get_comments_queried_language( $query ) {
 		// Don't filter comments if comment ids or post ids are specified.
@@ -113,7 +113,12 @@ class PLL_Filters {
 			return false;
 		}
 
-		return empty( $query->query_vars['lang'] ) ? $this->curlang : $this->model->get_language( $query->query_vars['lang'] );
+		// If comments are queried with a 'lang' parameter.
+		if ( isset( $query->query_vars['lang'] ) ) {
+			return $query->query_vars['lang'];
+		}
+
+		return $this->curlang;
 	}
 
 	/**
@@ -129,7 +134,8 @@ class PLL_Filters {
 	public function parse_comment_query( $query ) {
 		$lang = $this->get_comments_queried_language( $query );
 		if ( $lang ) {
-			$key = '_' . $lang->slug;
+			$lang = is_string( $lang ) && strpos( $lang, ',' ) ? explode( ',', $lang ) : $lang;
+			$key = '_' . ( is_array( $lang ) ? implode( ',', $lang ) : $this->model->get_language( $lang )->slug );
 			$query->query_vars['cache_domain'] = empty( $query->query_vars['cache_domain'] ) ? 'pll' . $key : $query->query_vars['cache_domain'] . $key;
 		}
 	}

--- a/include/filters.php
+++ b/include/filters.php
@@ -99,7 +99,7 @@ class PLL_Filters {
 	 * @since 3.1 Always returns an array. Renamed from get_comments_queried_language().
 	 *
 	 * @param WP_Comment_Query $query WP_Comment_Query object.
-	 * @return string[] The languages to use in the filter.
+	 * @return PLL_Language[] The languages to use in the filter.
 	 */
 	protected function get_comments_queried_languages( $query ) {
 		// Don't filter comments if comment ids or post ids are specified.
@@ -119,12 +119,11 @@ class PLL_Filters {
 			$languages = is_string( $query->query_vars['lang'] ) ? explode( ',', $query->query_vars['lang'] ) : $query->query_vars['lang'];
 			if ( is_array( $languages ) ) {
 				$languages = array_map( array( $this->model, 'get_language' ), $languages );
-				$languages = array_filter( $languages );
-				return wp_list_pluck( $languages, 'slug' );
+				return array_filter( $languages );
 			}
 		}
 
-		return array( $this->curlang->slug );
+		return array( $this->curlang );
 	}
 
 	/**
@@ -140,6 +139,7 @@ class PLL_Filters {
 	public function parse_comment_query( $query ) {
 		$lang = $this->get_comments_queried_languages( $query );
 		if ( ! empty( $lang ) ) {
+			$lang = wp_list_pluck( $lang, 'slug' );
 			$key = '_' . implode( ',', $lang );
 			$query->query_vars['cache_domain'] = empty( $query->query_vars['cache_domain'] ) ? 'pll' . $key : $query->query_vars['cache_domain'] . $key;
 		}
@@ -161,6 +161,8 @@ class PLL_Filters {
 		$lang = $this->get_comments_queried_languages( $query );
 
 		if ( ! empty( $lang ) ) {
+			$lang = wp_list_pluck( $lang, 'slug' );
+
 			// If this clause is not already added by WP.
 			if ( ! strpos( $clauses['join'], '.ID' ) ) {
 				$clauses['join'] .= " JOIN $wpdb->posts ON $wpdb->posts.ID = $wpdb->comments.comment_post_ID";

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -143,16 +143,24 @@ class Filters_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $fr, 'fr' );
 		$fr = $this->factory->comment->create( array( 'comment_post_ID' => $fr, 'comment_approved' => '1' ) );
 
+		$de = $this->factory->post->create();
+		self::$model->post->set_language( $de, 'de' );
+		$de = $this->factory->comment->create( array( 'comment_post_ID' => $de, 'comment_approved' => '1' ) );
+
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		new PLL_Frontend_Filters( $this->frontend );
 		$comments = get_comments();
 		$this->assertCount( 1, $comments );
-		$this->assertEquals( get_comment( $fr )->comment_ID, reset( $comments )->comment_ID );
+		$this->assertEquals( $fr, reset( $comments )->comment_ID );
 
 		// don't use the same default args as above to avoid hitting the cache
 		$comments = get_comments( array( 'fields' => 'ids', 'lang' => 'en' ) );
 		$this->assertCount( 1, $comments );
-		$this->assertEquals( get_comment( $en )->comment_ID, reset( $comments ) );
+		$this->assertEquals( $en, reset( $comments ) );
+
+		$comments = get_comments( array( 'fields' => 'ids', 'lang' => 'en,fr' ) );
+		$this->assertCount( 2, $comments );
+		$this->assertEqualSets( array( $en, $fr ), $comments );
 	}
 
 	function test_get_terms() {


### PR DESCRIPTION
Unlike posts and terms, it was not possible to query comments by multiple languages. This PR solves this using the same way used for terms.