### PR TITLE
enable post search box when create_post capability is disabled

### DIFF
--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -52,13 +52,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				printf(
 					'<label class="screen-reader-text" for="tr_lang_%1$s">%2$s</label>
 					<input type="hidden" name="post_tr_lang[%1$s]" id="htr_lang_%1$s" value="%3$s" />
-					<span lang="%6$s" dir="%7$s"><input type="text" class="tr_lang" id="tr_lang_%1$s" value="%4$s"%5$s /></span>',
+					<span lang="%5$s" dir="%6$s"><input type="text" class="tr_lang" id="tr_lang_%1$s" value="%4$s" /></span>',
 					esc_attr( $language->slug ),
 					/* translators: accessibility text */
 					esc_html__( 'Translation', 'polylang' ),
 					( empty( $value ) ? 0 : esc_attr( $selected->ID ) ),
 					( empty( $value ) ? '' : esc_attr( $selected->post_title ) ),
-					disabled( empty( $link ), true, false ),
 					esc_attr( $language->get_locale( 'display' ) ),
 					( $language->is_rtl ? 'rtl' : 'ltr' )
 				);


### PR DESCRIPTION
Currently it is not possible to link different language versions of Custom Post Types via the interface on the post itself when `create_posts` capabilities are not present for the custom post type. 

The input field is disabled when the add post link is present. That does make sense when you want to add a new translation from inside a post, however if `create_posts` capabilities are disabled, it's likely that they are only added programatically. However it is currently not possible to link the two posts. 

I hope I didn't overlook anything by just removing the disabled option, I tested that the creation of new posts via the interface is still not possible when  `create_posts` capabilities are not present and that the edit links work as expected. 