### PR TITLE
Don't add language columns when editing a term

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -247,10 +247,13 @@ class PLL_Admin_Filters_Columns {
 	 * @return string[] modified List of columns.
 	 */
 	public function add_term_column( $columns ) {
-		if ( empty( $columns ) ) {
-			return $columns;
+		$screen = get_current_screen();
+
+		if ( 'edit-tags' === $screen->base ) { // Don't add our columns when editing a term.
+			return $this->add_column( $columns, 'posts' );
 		}
-		return $this->add_column( $columns, 'posts' );
+
+		return $columns;
 	}
 
 	/**

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -247,7 +247,7 @@ class PLL_Admin_Filters_Columns {
 	 * @return string[] modified List of columns.
 	 */
 	public function add_term_column( $columns ) {
-		if ( empty( $columns ) ){
+		if ( empty( $columns ) ) {
 			return $columns;
 		}
 		return $this->add_column( $columns, 'posts' );

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -247,6 +247,9 @@ class PLL_Admin_Filters_Columns {
 	 * @return string[] modified List of columns.
 	 */
 	public function add_term_column( $columns ) {
+		if ( empty( $columns ) ){
+			return $columns;
+		}
 		return $this->add_column( $columns, 'posts' );
 	}
 

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -88,6 +88,8 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 	}
 
 	function test_term_translations() {
+		set_current_screen( 'edit-tags.php' );
+
 		$en = $this->factory->category->create();
 		self::$model->term->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -212,6 +212,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	function test_add_term_column() {
+		set_current_screen( 'edit-tags.php' );
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
@@ -226,6 +227,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	function test_add_term_column_with_filter() {
+		set_current_screen( 'edit-tags.php' );
 		$this->pll_admin->filter_lang = self::$model->get_language( 'fr' );
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();


### PR DESCRIPTION
Return empty columns to avoid Warning (on WC Brands)