### PR TITLE
Fix block editor preload path compatibility with WordPress 5.8

### DIFF
--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -22,11 +22,6 @@ class PLL_Admin_Block_Editor {
 	protected $pref_lang;
 
 	/**
-	 * @var PLL_Block_Editor_Filter_Preload_Paths
-	 */
-	private $block_editor_filter_preload_paths;
-
-	/**
 	 * Constructor: setups filters and actions
 	 *
 	 * @since 2.5
@@ -37,7 +32,7 @@ class PLL_Admin_Block_Editor {
 		$this->model     = &$polylang->model;
 		$this->pref_lang = &$polylang->pref_lang;
 
-		$this->block_editor_filter_preload_paths = new PLL_Block_Editor_Filter_Preload_Paths( array( $this, 'preload_paths' ), 10, 2 );
+		new PLL_Block_Editor_Filter_Preload_Paths( array( $this, 'preload_paths' ), 10, 2 );
 	}
 
 	/**

--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -32,7 +32,7 @@ class PLL_Admin_Block_Editor {
 		$this->model     = &$polylang->model;
 		$this->pref_lang = &$polylang->pref_lang;
 
-		add_filter( 'block_editor_preload_paths', array( $this, 'preload_paths' ), 10, 2 );
+		$this->block_editor_filter_preload_paths = new PLL_Block_Editor_Filter_Preload_Paths( array( $this, 'preload_paths' ), 10, 2 );
 	}
 
 	/**

--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -22,6 +22,11 @@ class PLL_Admin_Block_Editor {
 	protected $pref_lang;
 
 	/**
+	 * @var PLL_Block_Editor_Filter_Preload_Paths
+	 */
+	private $block_editor_filter_preload_paths;
+
+	/**
 	 * Constructor: setups filters and actions
 	 *
 	 * @since 2.5

--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -6,8 +6,8 @@
 /**
  * Class PLL_Block_Editor_Filter_Preload_Paths
  */
-class PLL_Block_Editor_Filter_Preload_Paths
-{
+class PLL_Block_Editor_Filter_Preload_Paths {
+
 
 	/**
 	 * @var int
@@ -28,31 +28,28 @@ class PLL_Block_Editor_Filter_Preload_Paths
 	 * @param int      $priority         Priority of execution for the given callback. Default 10.
 	 * @param int      $arguments_number Number of arguments to pass to the callback. Default 1.
 	 */
-	public function __construct( $callback, $priority = 10, $arguments_number = 1 )
-	{
+	public function __construct( $callback, $priority = 10, $arguments_number = 1 ) {
 		$this->callback = $callback;
 		$this->arguments_number = $arguments_number;
 
 		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
 			add_filter( 'block_editor_preload_paths', $callback, $priority, $arguments_number );
 		} else {
-			add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'block_editor_rest_api_preload_paths' ), $priority, 2);
+			add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'block_editor_rest_api_preload_paths' ), $priority, 2 );
 		}
 	}
 
 	/**
-	* Filters the preload REST requests by the current language of the post
-	* Necessary otherwise subsequent REST requests filtered by the language
-	* would not hit the preloaded requests
-	*
- 	* @since 3.1
- 	* @param $preload_paths
-	* @param WP_Block_Editor_Context $block_editor_context The post resource data.
-	* @return array|mixed|string[] (string|string[])[]
-	*
-	*/
-	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context )
-	{
+	 * Filters the preload REST requests by the current language of the post
+	 * Necessary otherwise subsequent REST requests filtered by the language
+	 * would not hit the preloaded requests
+	 *
+	 * @since 3.1
+	 * @param string[]                $preload_paths        The preload paths loaded by the Block Editor.
+	 * @param WP_Block_Editor_Context $block_editor_context The post resource data.
+	 * @return array|mixed|string[] (string|string[])[]
+	 */
+	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context ) {
 		if ( $this->arguments_number > 1 && null === $block_editor_context->post ) {
 			return $preload_paths;
 		}

--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Class PLL_Block_Editor_Filter_Preload_Paths
+ */
+class PLL_Block_Editor_Filter_Preload_Paths
+{
+
+	/**
+	 * @var int
+	 */
+	private $arguments_number;
+
+	/**
+	 * @var callable
+	 */
+	private $callback;
+
+	/**
+	 * PLL_Block_Editor_Filter_Preload_Paths constructor.
+	 *
+	 * @since 3.1
+	 *
+	 * @param callable $callback         Function or method to be executed when the filter is triggered.
+	 * @param int      $priority         Priority of execution for the given callback. Default 10.
+	 * @param int      $arguments_number Number of arguments to pass to the callback. Default 1.
+	 */
+	public function __construct( $callback, $priority = 10, $arguments_number = 1 )
+	{
+		$this->callback = $callback;
+		$this->arguments_number = $arguments_number;
+
+		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
+			add_filter( 'block_editor_preload_paths', $callback, $priority, $arguments_number );
+		} else {
+			add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'block_editor_rest_api_preload_paths' ), $priority, 2);
+		}
+	}
+
+	/**
+	* Filters the preload REST requests by the current language of the post
+	* Necessary otherwise subsequent REST requests filtered by the language
+	* would not hit the preloaded requests
+	*
+ 	* @since 3.1
+ 	* @param $preload_paths
+	* @param WP_Block_Editor_Context $block_editor_context The post resource data.
+	* @return array|mixed|string[] (string|string[])[]
+	*
+	*/
+	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context )
+	{
+		if ( $this->arguments_number > 1 && null === $block_editor_context->post ) {
+			return $preload_paths;
+		}
+
+		// Only two cases: one or two arguments
+		$args = 1 === $this->arguments_number ? array( $preload_paths ) : array( $preload_paths, $block_editor_context->post );
+
+		return call_user_func_array( $this->callback, $args );
+	}
+}

--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -5,14 +5,10 @@
 
 /**
  * Class PLL_Block_Editor_Filter_Preload_Paths
+ *
+ * @since 3.1
  */
 class PLL_Block_Editor_Filter_Preload_Paths {
-
-
-	/**
-	 * @var int
-	 */
-	private $arguments_number;
 
 	/**
 	 * @var callable

--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -30,12 +30,11 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	 */
 	public function __construct( $callback, $priority = 10, $arguments_number = 1 ) {
 		$this->callback = $callback;
-		$this->arguments_number = $arguments_number;
 
-		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
-			add_filter( 'block_editor_preload_paths', $callback, $priority, $arguments_number );
+		if ( class_exists( 'WP_Block_Editor_Context' ) ) {
+			add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'block_editor_rest_api_preload_paths' ), $priority, $arguments_number );
 		} else {
-			add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'block_editor_rest_api_preload_paths' ), $priority, 2 );
+			add_filter( 'block_editor_preload_paths', $callback, $priority, $arguments_number );
 		}
 	}
 
@@ -49,13 +48,8 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	 * @param WP_Block_Editor_Context $block_editor_context The post resource data.
 	 * @return array|mixed|string[] (string|string[])[]
 	 */
-	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context ) {
-		if ( $this->arguments_number > 1 && null === $block_editor_context->post ) {
-			return $preload_paths;
-		}
-
-		// Only two cases: one or two arguments
-		$args = 1 === $this->arguments_number ? array( $preload_paths ) : array( $preload_paths, $block_editor_context->post );
+	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context = null ) {
+		$args = null === $block_editor_context ? array( $preload_paths ) : array( $preload_paths, $block_editor_context->post );
 
 		return call_user_func_array( $this->callback, $args );
 	}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -68,5 +68,5 @@ parameters:
 		# Will not be an issue after WordPress 5.8 release
 		-
 			message: "#^Access to property \\$post on an unknown class WP_Block_Editor_Context\\.$#"
-			count: 2
+			count: 1
 			path: admin/block-editor-filter-preload-paths.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -58,3 +58,15 @@ parameters:
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: frontend/choose-lang.php
+
+		# Will not be an issue after WordPress 5.8 release
+		-
+			message: "#^Parameter \\$block_editor_context of method PLL_Block_Editor_Filter_Preload_Paths::block_editor_rest_api_preload_paths\\(\\) has invalid typehint type WP_Block_Editor_Context\\.$#"
+			count: 1
+			path: admin/block-editor-filter-preload-paths.php
+
+		# Will not be an issue after WordPress 5.8 release
+		-
+			message: "#^Access to property \\$post on an unknown class WP_Block_Editor_Context\\.$#"
+			count: 2
+			path: admin/block-editor-filter-preload-paths.php

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -1,0 +1,133 @@
+<?php
+
+
+class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
+{
+	/**
+	 * @var PLL_Admin_Block_Editor
+	 */
+	private $admin_block_editor;
+
+	/**
+	 * @var
+	 */
+	private $pll_admin;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory )
+	{
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+	}
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$options = PLL_Install::get_default_options();
+		$model = new PLL_Admin_Model( $options );
+		$links_model = new PLL_Links_Default( $model );
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->admin_block_editor = new PLL_Admin_Block_Editor( $this->pll_admin );
+	}
+
+	public function test_do_not_set_language_parameter_to_root_URL() {
+		$post = $this->factory()->post->create_and_get();
+		$this->pll_admin->model->post->set_language( $post->ID, 'en' );
+
+		$preload_paths = $this->preload_paths( $post );
+
+		$this->assertContains( '/', $preload_paths );
+	}
+
+	public function test_do_not_set_language_to_preload_paths_for_untranslated_post_type() {
+		register_post_type( 'custom' );
+		$post = $this->factory()->post->create_and_get(
+			array(
+				'post_type' => 'custom'
+			)
+		);
+
+		$preload_paths = $this->preload_paths( $post );
+
+		$this->assertNotEmpty( $preload_paths );
+		foreach( $preload_paths as $preload_path ) {
+			$this->assertFalse(
+				is_string( $preload_path ) &&
+				stripos( $preload_path, 'lang' )
+			);
+		}
+	}
+
+	public function test_set_preferred_language_as_parameter_to_preload_paths_for_a_post_without_language() {
+		$this->pll_admin->pref_lang = $this->pll_admin->model->get_language( 'en' );
+		$post = $this->factory()->post->create_and_get();
+
+		$preload_paths = $this->preload_paths( $post );
+
+		$this->assertNotEmpty( $preload_paths );
+		foreach( $preload_paths as $preload_path ) {
+			$this->assertTrue(
+				is_array( $preload_path ) ||
+				'/' === $preload_path ||
+				str_ends_with( $preload_path, 'en' )
+			);
+		}
+	}
+
+	public function test_set_post_language_as_parameter_to_preload_paths_for_a_post_with_a_language() {
+		$post = $this->factory()->post->create_and_get();
+		$this->pll_admin->model->post->set_language( $post->ID, 'fr' );
+
+		$preload_paths = $this->preload_paths( $post );
+
+		$this->assertNotEmpty( $preload_paths );
+		foreach( $preload_paths as $preload_path ) {
+			$this->assertTrue(
+				is_array( $preload_path ) ||
+				'/' === $preload_path ||
+				str_ends_with( $preload_path, 'fr' )
+			);
+		}
+	}
+
+	/**
+	 * Filters the preload paths with the correct function depending on WordPress version.
+	 *
+	 * @param WP_Post|mixed $post Represents the post being edited. Or a preload path without if no post is being edited.
+	 * @return mixed
+	 */
+	protected function preload_paths( $post )
+	{
+		$preload_paths = array (
+			0 => '/',
+			1 => '/wp/v2/types?context=edit',
+			2 => '/wp/v2/taxonomies?per_page=-1&context=edit',
+			3 => '/wp/v2/themes?status=active',
+			4 => "/wp/v2/posts/{$post->ID}?context=edit",
+			5 => "/wp/v2/types/{$post->post_type}?context=edit",
+			6 => "/wp/v2/users/me?post_type={$post->post_type}&context=edit",
+			7 =>
+				array (
+					0 => '/wp/v2/media',
+					1 => 'OPTIONS',
+				),
+			8 =>
+				array (
+					0 => '/wp/v2/blocks',
+					1 => 'OPTIONS',
+				),
+			9 => "/wp/v2/posts/{$post->ID}/autosaves?context=edit",
+		);
+
+		if (version_compare($GLOBALS['wp_version'], '5.8-alpha', '>=')) {
+			$preload_paths = block_editor_rest_api_preload_paths( $preload_paths, new WP_Block_Editor_Context(array('post' => $post)));
+		} else {
+			$preload_paths = apply_filters('block_editor_preload_paths', $preload_paths, $post);
+		}
+		return $preload_paths;
+	}
+
+
+}

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -1,28 +1,26 @@
 <?php
 
 
-class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
-{
+class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase {
+
 	/**
 	 * @var PLL_Admin_Block_Editor
 	 */
 	private $admin_block_editor;
 
 	/**
-	 * @var
+	 * @var PLL_Admin
 	 */
 	private $pll_admin;
 
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory )
-	{
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 	}
 
-	public function setUp()
-	{
+	public function setUp() {
 		parent::setUp();
 
 		$options = PLL_Install::get_default_options();
@@ -45,14 +43,14 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 		register_post_type( 'custom' );
 		$post = $this->factory()->post->create_and_get(
 			array(
-				'post_type' => 'custom'
+				'post_type' => 'custom',
 			)
 		);
 
 		$preload_paths = $this->preload_paths( $post );
 
 		$this->assertNotEmpty( $preload_paths );
-		foreach( $preload_paths as $preload_path ) {
+		foreach ( $preload_paths as $preload_path ) {
 			$this->assertFalse(
 				is_string( $preload_path ) &&
 				stripos( $preload_path, 'lang' )
@@ -67,7 +65,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 		$preload_paths = $this->preload_paths( $post );
 
 		$this->assertNotEmpty( $preload_paths );
-		foreach( $preload_paths as $preload_path ) {
+		foreach ( $preload_paths as $preload_path ) {
 			$this->assertTrue(
 				is_array( $preload_path ) ||
 				'/' === $preload_path ||
@@ -83,7 +81,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 		$preload_paths = $this->preload_paths( $post );
 
 		$this->assertNotEmpty( $preload_paths );
-		foreach( $preload_paths as $preload_path ) {
+		foreach ( $preload_paths as $preload_path ) {
 			$this->assertTrue(
 				is_array( $preload_path ) ||
 				'/' === $preload_path ||
@@ -98,9 +96,8 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 	 * @param WP_Post|mixed $post Represents the post being edited. Or a preload path without if no post is being edited.
 	 * @return mixed
 	 */
-	protected function preload_paths( $post )
-	{
-		$preload_paths = array (
+	protected function preload_paths( $post ) {
+		$preload_paths = array(
 			0 => '/',
 			1 => '/wp/v2/types?context=edit',
 			2 => '/wp/v2/taxonomies?per_page=-1&context=edit',
@@ -108,23 +105,21 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 			4 => "/wp/v2/posts/{$post->ID}?context=edit",
 			5 => "/wp/v2/types/{$post->post_type}?context=edit",
 			6 => "/wp/v2/users/me?post_type={$post->post_type}&context=edit",
-			7 =>
-				array (
-					0 => '/wp/v2/media',
-					1 => 'OPTIONS',
-				),
-			8 =>
-				array (
-					0 => '/wp/v2/blocks',
-					1 => 'OPTIONS',
-				),
+			7 => array(
+				0 => '/wp/v2/media',
+				1 => 'OPTIONS',
+			),
+			8 => array(
+				0 => '/wp/v2/blocks',
+				1 => 'OPTIONS',
+			),
 			9 => "/wp/v2/posts/{$post->ID}/autosaves?context=edit",
 		);
 
-		if (version_compare($GLOBALS['wp_version'], '5.8-alpha', '>=')) {
-			$preload_paths = block_editor_rest_api_preload( $preload_paths, new WP_Block_Editor_Context(array('post' => $post)));
+		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '>=' ) ) {
+			$preload_paths = block_editor_rest_api_preload( $preload_paths, new WP_Block_Editor_Context( array( 'post' => $post ) ) );
 		} else {
-			$preload_paths = apply_filters('block_editor_preload_paths', $preload_paths, $post);
+			$preload_paths = apply_filters( 'block_editor_preload_paths', $preload_paths, $post );
 		}
 		return $preload_paths;
 	}

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -116,13 +116,6 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase {
 			9 => "/wp/v2/posts/{$post->ID}/autosaves?context=edit",
 		);
 
-		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '>=' ) ) {
-			$preload_paths = block_editor_rest_api_preload( $preload_paths, new WP_Block_Editor_Context( array( 'post' => $post ) ) );
-		} else {
-			$preload_paths = apply_filters( 'block_editor_preload_paths', $preload_paths, $post );
-		}
-		return $preload_paths;
+		return $this->admin_block_editor->preload_paths( $preload_paths, $post );
 	}
-
-
 }

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -71,7 +71,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 			$this->assertTrue(
 				is_array( $preload_path ) ||
 				'/' === $preload_path ||
-				str_ends_with( $preload_path, 'en' )
+				preg_match( '#lang=en#', $preload_path )
 			);
 		}
 	}
@@ -87,7 +87,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 			$this->assertTrue(
 				is_array( $preload_path ) ||
 				'/' === $preload_path ||
-				str_ends_with( $preload_path, 'fr' )
+				preg_match( '#lang=fr#', $preload_path )
 			);
 		}
 	}

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -122,7 +122,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase
 		);
 
 		if (version_compare($GLOBALS['wp_version'], '5.8-alpha', '>=')) {
-			$preload_paths = block_editor_rest_api_preload_paths( $preload_paths, new WP_Block_Editor_Context(array('post' => $post)));
+			$preload_paths = block_editor_rest_api_preload( $preload_paths, new WP_Block_Editor_Context(array('post' => $post)));
 		} else {
 			$preload_paths = apply_filters('block_editor_preload_paths', $preload_paths, $post);
 		}

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Class PLL_Block_Editor_Filter_Preload_Paths_Test
+ */
+class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->spy = $this->getMockBuilder( stdClass::class )
+			->setMethods( array( '__invoke' ) )
+			->getMock();
+	}
+
+	public function test_invoke_filter_with_one_argument() {
+		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ) );
+
+		$this->spy->expects( $this->once() )
+			->method( '__invoke' )
+			->with(
+				$this->isType( 'array' )
+			);
+
+		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
+			apply_filters( 'block_editor_preload_paths', array( '/' ), new WP_Post( new stdClass() ) );
+		} else {
+			block_editor_rest_api_preload( array( '/' ), new WP_Block_Editor_Context( array( 'post' => new WP_Post( new stdClass() ) ) ) );
+		}
+	}
+
+	public function test_register_filter_with_custom_priority() {
+		global $wp_filter;
+
+		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 50 );
+
+		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
+			$this->arrayHasKey( 'block_editor_preload_paths', $wp_filter );
+			$this->arrayHasKey( 50, $wp_filter['block_editor_preload_paths']['callbacks'] );
+		} else {
+			$this->arrayHasKey( 'block_editor_rest_api_preload_paths', $wp_filter );
+			$this->arrayHasKey( 50, $wp_filter['block_editor_rest_api_preload_paths']['callbacks'] );
+		}
+
+	}
+
+	public function test_transform_block_editor_context_into_related_post() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
+			$this->markTestSkipped( 'This test needs WordPress version 5.8+' );
+		} else {
+			new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 10, 2 );
+
+			$this->spy->expects( $this->once() )
+				->method( '__invoke' )
+				->with(
+					$this->isType( 'array' ),
+					$this->isInstanceOf( WP_Post::class )
+				);
+
+			block_editor_rest_api_preload( array( '/' ), new WP_Block_Editor_Context( array( 'post' => new WP_Post( new stdClass() ) ) ) );
+		}
+	}
+
+	public function test_honor_backward_compatibility() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '>=' ) ) {
+			$this->markTestSkipped( 'This test needs WordPress version < 5.8' );
+		} else {
+			new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 10, 2 );
+
+			$this->spy->expects( $this->once() )
+				->method( '__invoke' )
+				->with(
+					$this->isType( 'array' ),
+					$this->isInstanceOf( WP_Post::class )
+				);
+
+			apply_filters( 'block_editor_preload_paths', array( '/' ), new WP_Post( new stdClass() ) );
+		}
+	}
+}


### PR DESCRIPTION
## Before

We hooked a filter on `block_editor_preload_paths` to preload languages data during Block Editor loading. This hook has been deprecated in WordPress 5.8 alpha.

## Changes

- Create a wrapper for the preload paths filters that check on WordPress version and read the arguments accordingly.
    - Register our filter on the correct hook depending on WordPress version.
    - Transform the arguments received by the filters from a `WP_Block_Editor_Context` (new argument) into a `WP_Post` (used in our legacy filters).
    - Is used several times inside Polylang Pro (see https://github.com/polylang/polylang-pro/pull/1005)
- Replace filter registration in `PLL_Admin_Block`
- Add tests for the `PLL_Admin_Block::preload_paths()` method.
- Tests the `PLL_Block_Editor_Preload_Paths` class independently, so we don't have to change the tests in Polylang Pro.