### PR TITLE
Prevent setting a language filter when we should not

### DIFF
--- a/include/query.php
+++ b/include/query.php
@@ -105,6 +105,10 @@ class PLL_Query {
 	 * @return void
 	 */
 	public function set_language( $lang ) {
+		if ( ! $this->can_filter_query() ) {
+			return;
+		}
+
 		// Defining directly the tax_query ( rather than setting 'lang' avoids transforming the query by WP )
 		$lang_query = array(
 			'taxonomy' => 'language',
@@ -174,8 +178,8 @@ class PLL_Query {
 				}
 			}
 		} else {
-			// Do not filter untranslatable post types such as nav_menu_item
-			if ( isset( $qvars['post_type'] ) && ! $this->model->is_translated_post_type( $qvars['post_type'] ) && ( empty( $qvars['tax_query'] ) || ! $this->have_translated_taxonomy( $qvars['tax_query'] ) ) ) {
+			// Do not filter untranslatable post types such as nav_menu_item.
+			if ( ! $this->can_filter_query() ) {
 				unset( $qvars['lang'] );
 			}
 
@@ -184,5 +188,17 @@ class PLL_Query {
 				unset( $qvars['lang'] );
 			}
 		}
+	}
+
+	/**
+	 * Checks if we can filter the query.
+	 *
+	 * @since 3.1
+	 *
+	 * @return bool
+	 */
+	protected function can_filter_query() {
+		$qvars = &$this->query->query_vars;
+		return ! isset( $qvars['post_type'] ) || $this->model->is_translated_post_type( $qvars['post_type'] ) || ( ! empty( $qvars['tax_query'] ) && $this->have_translated_taxonomy( $qvars['tax_query'] ) );
 	}
 }


### PR DESCRIPTION
Related #493, https://github.com/polylang/polylang-pro/pull/486, https://github.com/polylang/polylang-pro/pull/985

This PR introduced `PLL_Query::can_filter_query()` to check if we can add a language filter in the query. This new method is used internally by `set_language()` (new) and `filter_query()` (which was already using the code moved to the new method).

This allows to use boths methods without prior checks and is a better fix for #493.