### PR TITLE
Fix wp screen notice

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -249,11 +249,12 @@ class PLL_Admin_Filters_Columns {
 	public function add_term_column( $columns ) {
 		$screen = get_current_screen();
 
-		if ( 'edit-tags' === $screen->base ) { // Don't add our columns when editing a term.
-			return $this->add_column( $columns, 'posts' );
+		// Avoid displaying languages in screen options when editing a term.
+		if ( $screen instanceof WP_Screen && 'term' === $screen->base ) {
+			return $columns;
 		}
 
-		return $columns;
+		return $this->add_column( $columns, 'posts' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -88,8 +88,6 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 	}
 
 	function test_term_translations() {
-		set_current_screen( 'edit-tags.php' );
-
 		$en = $this->factory->category->create();
 		self::$model->term->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -34,6 +34,14 @@ class Columns_Test extends PLL_UnitTestCase {
 		parent::tearDown();
 	}
 
+	/**
+	 * This must be the first test due to the static variable in get_culumn_headers().
+	 */
+	function test_no_screen_options_in_term_screen() {
+		set_current_screen( 'term.php' );
+		$this->assertEmpty( get_column_headers( get_current_screen() ) );
+	}
+
 	function test_post_with_no_language() {
 		$post_id = $this->factory->post->create();
 


### PR DESCRIPTION
#850 introduced a regression when adding or quick editing a term. Languages columns for the added or edited term are not displayed correctly and we get this notice: 
```
PHP Notice:  Trying to get property 'base' of non-object in /polylang-pro/vendor/wpsyntex/polylang/admin/admin-filters-columns.php on line 252
PHP Stack trace:
PHP   1. {main}() /wp-admin/admin-ajax.php:0
PHP   2. do_action() /wp-admin/admin-ajax.php:187
PHP   3. WP_Hook->do_action() /wp-includes/plugin.php:484
PHP   4. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:316
PHP   5. wp_ajax_inline_save_tax() /wp-includes/class-wp-hook.php:292
PHP   6. WP_Terms_List_Table->single_row() /wp-admin/includes/ajax-actions.php:2148
PHP   7. WP_Terms_List_Table->single_row_columns() /wp-admin/includes/class-wp-terms-list-table.php:357
PHP   8. WP_Terms_List_Table->get_column_info() /wp-admin/includes/class-wp-list-table.php:1410
PHP   9. get_column_headers() /wp-admin/includes/class-wp-list-table.php:1124
PHP  10. apply_filters() /wp-admin/includes/screen.php:37
PHP  11. WP_Hook->apply_filters() /wp-includes/plugin.php:212
PHP  12. PLL_Admin_Filters_Columns->add_term_column() /wp-includes/class-wp-hook.php:292
```

This occurs because no screen is set for ajax requests. We however need our columns to be added in such circumstances.

In this PR I inverted the logic compared to #850 and don't add the columns only for the term screen.
I fix the ajax test in which I wrongly set a screen object.
I add a new test for the term screen to check that no screen options are added. This test must be placed first due to a static variable in `get_column_headers()`.   