### PR TITLE
Fix Trying to get property 'term_taxonomy_id' of non-object

### DIFF
--- a/include/filters.php
+++ b/include/filters.php
@@ -123,7 +123,11 @@ class PLL_Filters {
 			}
 		}
 
-		return array( $this->curlang );
+		if ( ! empty( $this->curlang ) ) {
+			array( $this->curlang );
+		}
+
+		return array();
 	}
 
 	/**

--- a/include/filters.php
+++ b/include/filters.php
@@ -124,7 +124,7 @@ class PLL_Filters {
 		}
 
 		if ( ! empty( $this->curlang ) ) {
-			array( $this->curlang );
+			return array( $this->curlang );
 		}
 
 		return array();


### PR DESCRIPTION
In #840, we introduced a PHP notice when querying comments without language param in REST API. 

Indeed, in this case, no current language is defined and we return `array( null )` in https://github.com/polylang/polylang/pull/840/files#diff-0a65d816bf89ff2e4a745c64cbc99c2e486354842cf98980e9b78824012c5483R126, later passing null to `PLL_Translated_Post::where_clause()`, thus causing the error reported in Polylang Pro test `REST_API_Test::test_get_comments()`. See https://travis-ci.com/github/polylang/polylang-pro/jobs/511686527