### PR TITLE
Fix passing null arguments to legacy preload paths filters

### DIFF
--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -4,7 +4,9 @@
  */
 
 /**
- * Class PLL_Block_Editor_Filter_Preload_Paths
+ * This class handles the deprecated filter 'block_editor_preload_paths'
+ * to replace it by the new filter 'block_editor_rest_api_preload_paths'
+ * and is used for backward compatibility with WP < 5.8.
  *
  * @since 3.1
  */
@@ -27,7 +29,7 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	public function __construct( $callback, $priority = 10, $arguments_number = 1 ) {
 		$this->callback = $callback;
 
-		if ( class_exists( 'WP_Block_Editor_Context' ) ) {
+		if ( class_exists( 'WP_Block_Editor_Context' ) ) { // Since WP 5.8.
 			add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'block_editor_rest_api_preload_paths' ), $priority, $arguments_number );
 		} else {
 			add_filter( 'block_editor_preload_paths', $callback, $priority, $arguments_number );
@@ -35,11 +37,13 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	}
 
 	/**
-	 * Filters the preload REST requests by the current language of the post
-	 * Necessary otherwise subsequent REST requests filtered by the language
-	 * would not hit the preloaded requests
+	 * Filters the array of REST API paths that will be used to preloaded common data to use with the block editor.
+	 *
+	 * Converts the WP_Block_Editor_Context object to a WP_Post when the second parameter if used.
+	 * Bails if the WP_Block_Editor_Context object is passed without post.
 	 *
 	 * @since 3.1
+	 *
 	 * @param string[]                $preload_paths        The preload paths loaded by the Block Editor.
 	 * @param WP_Block_Editor_Context $block_editor_context The post resource data.
 	 * @return array|mixed|string[] (string|string[])[]
@@ -47,10 +51,10 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context = null ) {
 		if ( null === $block_editor_context ) {
 			return call_user_func( $this->callback, $preload_paths );
-		} elseif ( null === $block_editor_context->post ) {
-			return $preload_paths;
-		} else {
+		} elseif ( ! empty( $block_editor_context->post ) ) {
 			return call_user_func_array( $this->callback, array( $preload_paths, $block_editor_context->post ) );
 		}
+
+		return $preload_paths;
 	}
 }

--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -45,8 +45,12 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	 * @return array|mixed|string[] (string|string[])[]
 	 */
 	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context = null ) {
-		$args = null === $block_editor_context ? array( $preload_paths ) : array( $preload_paths, $block_editor_context->post );
-
-		return call_user_func_array( $this->callback, $args );
+		if ( null === $block_editor_context ) {
+			return call_user_func( $this->callback, $preload_paths );
+		} else if ( null === $block_editor_context->post ) {
+			return $preload_paths;
+		} else {
+			return call_user_func_array( $this->callback, array( $preload_paths, $block_editor_context->post ) );
+		}
 	}
 }

--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -47,7 +47,7 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	public function block_editor_rest_api_preload_paths( $preload_paths, $block_editor_context = null ) {
 		if ( null === $block_editor_context ) {
 			return call_user_func( $this->callback, $preload_paths );
-		} else if ( null === $block_editor_context->post ) {
+		} elseif ( null === $block_editor_context->post ) {
 			return $preload_paths;
 		} else {
 			return call_user_func_array( $this->callback, array( $preload_paths, $block_editor_context->post ) );

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -68,5 +68,5 @@ parameters:
 		# Will not be an issue after WordPress 5.8 release
 		-
 			message: "#^Access to property \\$post on an unknown class WP_Block_Editor_Context\\.$#"
-			count: 1
+			count: 2
 			path: admin/block-editor-filter-preload-paths.php

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -35,6 +35,19 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 		}
 	}
 
+	public function test_do_not_invoke_callback_with_no_post_in_context() {
+		if ( ! class_exists( WP_Block_Editor_Context::class ) ) {
+			$this->markTestSkipped( 'block_editor_preload_paths is not called without a WP_Post as argument' );
+		}
+
+		$this->spy->expects( $this->never() )
+			->method( '__invoke' );
+
+		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 10, 2 );
+
+		block_editor_rest_api_preload( array( '/' ), new WP_Block_Editor_Context() );
+	}
+
 	public function test_register_filter_with_custom_priority() {
 		global $wp_filter;
 

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -64,7 +64,7 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_transform_block_editor_context_into_related_post() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
+		if ( ! class_exists( WP_Block_Editor_Context::class ) ) {
 			$this->markTestSkipped( 'This test needs WordPress version 5.8+' );
 		} else {
 			new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 10, 2 );
@@ -81,7 +81,7 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_honor_backward_compatibility() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '>=' ) ) {
+		if ( class_exists( WP_Block_Editor_Context::class ) ) {
 			$this->markTestSkipped( 'This test needs WordPress version < 5.8' );
 		} else {
 			new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 10, 2 );

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -19,14 +19,14 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 	public function test_invoke_filter_with_one_argument() {
 		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ) );
 
-		$fail_if_more_than_one_argument = function (...$args) {
-			if ( count( $args ) > 1) {
+		$fail_if_more_than_one_argument = function ( ...$args ) {
+			if ( count( $args ) > 1 ) {
 				$this->fail( 'Filter registered with one parameter is expected to be called with one argument.' );
 			}
 		};
 		$this->spy->expects( $this->once() )
 			->method( '__invoke' )
-			->willReturnCallback( $fail_if_more_than_one_argument	);
+			->willReturnCallback( $fail_if_more_than_one_argument );
 
 		if ( class_exists( WP_Block_Editor_Context::class ) ) {
 			block_editor_rest_api_preload( array( '/' ), new WP_Block_Editor_Context( array( 'post' => new WP_Post( new stdClass() ) ) ) );

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -19,16 +19,19 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 	public function test_invoke_filter_with_one_argument() {
 		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ) );
 
+		$fail_if_more_than_one_argument = function (...$args) {
+			if ( count( $args ) > 1) {
+				$this->fail( 'Filter registered with one parameter is expected to be called with one argument.' );
+			}
+		};
 		$this->spy->expects( $this->once() )
 			->method( '__invoke' )
-			->with(
-				$this->isType( 'array' )
-			);
+			->willReturnCallback( $fail_if_more_than_one_argument	);
 
-		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
-			apply_filters( 'block_editor_preload_paths', array( '/' ), new WP_Post( new stdClass() ) );
-		} else {
+		if ( class_exists( WP_Block_Editor_Context::class ) ) {
 			block_editor_rest_api_preload( array( '/' ), new WP_Block_Editor_Context( array( 'post' => new WP_Post( new stdClass() ) ) ) );
+		} else {
+			apply_filters( 'block_editor_preload_paths', array( '/' ), new WP_Post( new stdClass() ) );
 		}
 	}
 


### PR DESCRIPTION
## Before

The filters we set on the deprecated `block_editor_preload_paths` hook either wait for a WP_Post as second parameter, or for no second parameter.

In WordPress 5.8  the `block_editor_rest_api_preload_paths`, only calls to the deprecated `block_editor_preload_paths` filter if it can  find a WP_Post: https://github.com/WordPress/gutenberg/blob/fb481b7e32917d50021332d6e713642993ffaac0/lib/compat/wordpress-5.8/block-editor.php#L328

## Changes

- Update test case for calling the legacy filter with only one parameter (this should fail if more than one parameter is passed now).
- Modify the new filters to not call to the legacy ones if no `WP_Post` can be find in the `WP_Block_Editor_Context` instance.
- Update the other tests to use the same detection than the production code (class WP_Block_Editor_Context exists instead of WordPress version number).