### PR TITLE
Fix PHP notice for legacy widget block type already registered

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -21,6 +21,17 @@ trait PLL_UnitTestCase_Trait {
 		$options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
 		$options['media_support'] = 1; // Force option to pre 3.1 value otherwise phpunit tests break on Travis.
 		self::$model = new PLL_Admin_Model( $options );
+
+		// Since WP 5.8 firing the 'init' action registers the legacy widget block which can be registered only once, so let's clean it up to avoid notices.
+		add_action(
+			'init',
+			function() {
+				if ( class_exists( 'WP_Block_Type_Registry' ) && WP_Block_Type_Registry::get_instance()->is_registered( 'core/legacy-widget' ) ) {
+					unregister_block_type( 'core/legacy-widget' );
+				}
+			},
+			0
+		);
 	}
 
 	/**


### PR DESCRIPTION
Since WP 5.8 a notice is issued if a block type is registered more than once. On the other hand, WP registers the legacy widget block type on 'init' action. This means that the notice is fired each time we fire the 'init' action in tests.

This PR will cleans up the block type if necessary when firing the action 'init', before WordPress attempts to register it again.

This should fix errors reported in https://travis-ci.com/github/polylang/polylang/jobs/512028613, as well as in https://travis-ci.com/github/polylang/polylang-pro/jobs/512022704