### PR TITLE
Let filter block_editor_rest_api_preload_paths unchanged when no post is provided

### DIFF
--- a/admin/block-editor-filter-preload-paths.php
+++ b/admin/block-editor-filter-preload-paths.php
@@ -39,8 +39,7 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 	/**
 	 * Filters the array of REST API paths that will be used to preloaded common data to use with the block editor.
 	 *
-	 * Converts the WP_Block_Editor_Context object to a WP_Post when the second parameter if used.
-	 * Bails if the WP_Block_Editor_Context object is passed without post.
+	 * Converts the WP_Block_Editor_Context object to a WP_Post if provided in the context.
 	 *
 	 * @since 3.1
 	 *
@@ -55,6 +54,6 @@ class PLL_Block_Editor_Filter_Preload_Paths {
 			return call_user_func_array( $this->callback, array( $preload_paths, $block_editor_context->post ) );
 		}
 
-		return $preload_paths;
+		return call_user_func_array( $this->callback, array( $preload_paths, $block_editor_context ) );
 	}
 }

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -40,8 +40,12 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 			$this->markTestSkipped( 'block_editor_preload_paths is not called without a WP_Post as argument' );
 		}
 
-		$this->spy->expects( $this->never() )
-			->method( '__invoke' );
+		$this->spy->expects( $this->once() )
+			->method( '__invoke' )
+			->with(
+				$this->isType( 'array' ),
+				$this->isInstanceOf( WP_Block_Editor_Context::class )
+			);
 
 		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 10, 2 );
 


### PR DESCRIPTION
in #858, we decided not to propagate the filter when `block_editor_rest_api_preload_paths` is used with 2 parameters and no post is provided in the context. This introduces a limitation for https://github.com/polylang/polylang-pro/pull/1010 where we are not able to correctly differentiate the widget screen and the post editor with an untranslated post type.

I then appears better to propagate the filter with all the parameters allowing us to test the context.