### PR TITLE
PHP Notice: Trying to get property 'post_type' of non-object

### DIFF
--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -47,7 +47,7 @@ class PLL_Admin_Block_Editor {
 	 * @return (string|string[])[]
 	 */
 	public function preload_paths( $preload_paths, $post ) {
-		if ( $this->model->is_translated_post_type( $post->post_type ) ) {
+		if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
 			$lang = $this->model->post->get_language( $post->ID );
 
 			if ( ! $lang ) {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1012
Related #854, #858, #860

With the deprecation of the filter `block_editor_preload_paths`, we must now check the instance of the object received in the second parameter of `PLL_Admin_Block_Editor::preload_paths()`