### PR TITLE
Fix test_register_filter_with_custom_priority()

### DIFF
--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -58,11 +58,11 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 		new PLL_Block_Editor_Filter_Preload_Paths( array( $this->spy, '__invoke' ), 50 );
 
 		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
-			$this->arrayHasKey( 'block_editor_preload_paths', $wp_filter );
-			$this->arrayHasKey( 50, $wp_filter['block_editor_preload_paths']['callbacks'] );
+			$this->assertArrayHasKey( 'block_editor_preload_paths', $wp_filter );
+			$this->assertArrayHasKey( 50, $wp_filter['block_editor_preload_paths']->callbacks  );
 		} else {
-			$this->arrayHasKey( 'block_editor_rest_api_preload_paths', $wp_filter );
-			$this->arrayHasKey( 50, $wp_filter['block_editor_rest_api_preload_paths']['callbacks'] );
+			$this->assertArrayHasKey( 'block_editor_rest_api_preload_paths', $wp_filter );
+			$this->assertArrayHasKey( 50, $wp_filter['block_editor_rest_api_preload_paths']->callbacks );
 		}
 
 	}

--- a/tests/phpunit/tests/test-block-editor-preload-paths.php
+++ b/tests/phpunit/tests/test-block-editor-preload-paths.php
@@ -59,7 +59,7 @@ class PLL_Block_Editor_Filter_Preload_Paths_Test extends PLL_UnitTestCase {
 
 		if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha', '<' ) ) {
 			$this->assertArrayHasKey( 'block_editor_preload_paths', $wp_filter );
-			$this->assertArrayHasKey( 50, $wp_filter['block_editor_preload_paths']->callbacks  );
+			$this->assertArrayHasKey( 50, $wp_filter['block_editor_preload_paths']->callbacks );
 		} else {
 			$this->assertArrayHasKey( 'block_editor_rest_api_preload_paths', $wp_filter );
 			$this->assertArrayHasKey( 50, $wp_filter['block_editor_rest_api_preload_paths']->callbacks );


### PR DESCRIPTION
The test is reported as risky in https://travis-ci.com/github/polylang/polylang/jobs/512850432 due to a typo (using `ArrayHasKey()` instead of `assertArrayHasKey()`. Moreover filters are `WP_Hook` objects and not array.

See #854 for the PR introducing the test.