### PR TITLE
Fix widget related tests

### DIFF
--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -22,8 +22,9 @@ class Strings_Test extends PLL_UnitTestCase {
 
 	// copied from WP widgets tests
 	function clean_up_global_scope() {
-		global $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
+		global $_wp_sidebars_widgets, $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
+		$_wp_sidebars_widgets = array();
 		$wp_registered_sidebars = array();
 		$wp_registered_widgets = array();
 		$wp_registered_widget_controls = array();
@@ -31,6 +32,24 @@ class Strings_Test extends PLL_UnitTestCase {
 		$wp_widget_factory->widgets = array();
 
 		parent::clean_up_global_scope();
+	}
+
+	function add_widget_search() {
+		update_option(
+			'widget_search',
+			array(
+				2              => array( 'title' => '' ),
+				'_multiwidget' => 1,
+			)
+		);
+
+		update_option(
+			'sidebars_widgets',
+			array(
+				'wp_inactive_widgets' => array(),
+				'sidebar-1'           => array( 'search-2' ),
+			)
+		);
 	}
 
 	function _return_fr_FR() {
@@ -48,6 +67,9 @@ class Strings_Test extends PLL_UnitTestCase {
 	// FIXME: order of nest two tests matters due to static protected strings in PLL_Admin_Strings
 	function test_widget_title_filtered_by_language() {
 		global $wp_registered_widgets;
+
+		$this->add_widget_search();
+
 		wp_widgets_init();
 		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
 
@@ -76,6 +98,9 @@ class Strings_Test extends PLL_UnitTestCase {
 
 	function test_widget_title_in_all_languages() {
 		global $wp_registered_widgets;
+
+		$this->add_widget_search();
+
 		wp_widgets_init();
 		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];
 

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -18,14 +18,23 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 
 		require_once POLYLANG_DIR . '/include/api.php'; // Usually loaded only if an instance of Polylang exists
+
+		update_option(
+			'widget_search',
+			array(
+				2              => array( 'title' => '' ),
+				'_multiwidget' => 1,
+			)
+		);
 	}
 
 	/**
 	 * Copied from WP widgets tests
 	 */
 	function clean_up_global_scope() {
-		global $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
+		global $_wp_sidebars_widgets, $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
+		$_wp_sidebars_widgets = array();
 		$wp_registered_sidebars = array();
 		$wp_registered_widgets = array();
 		$wp_registered_widget_controls = array();
@@ -177,6 +186,14 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 	function test_wp_get_sidebars_widgets() {
 		global $wp_registered_widgets;
+
+		update_option(
+			'sidebars_widgets',
+			array(
+				'wp_inactive_widgets' => array(),
+				'sidebar-1'           => array( 'search-2' ),
+			)
+		);
 
 		wp_widgets_init();
 		$wp_widget_search = $wp_registered_widgets['search-2']['callback'][0];


### PR DESCRIPTION
After https://core.trac.wordpress.org/ticket/53324, the default sidebar is not populated anymore with default widgets. This breaks all widget related tests.

NB: WP tests don't clean up the global `$_wp_sidebars_widgets`. We now need to do it to avoid that `wp_get_sidebars_widgets()` returns the blocks initially stored by WP, instead of our widgets. See https://github.com/WordPress/WordPress/blob/e2104af75e4e4cb8199e40678dd2d73f9747c1a4/wp-includes/widgets.php#L1015-L1017