### PR TITLE
Don't disable the translations input fields for terms

### DIFF
--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -71,13 +71,12 @@ else {
 				printf(
 					'<label class="screen-reader-text" for="tr_lang_%1$s">%2$s</label>
 					<input type="hidden" class="htr_lang" name="term_tr_lang[%1$s]" id="htr_lang_%1$s" value="%3$s" />
-					<span lang="%6$s" dir="%7$s"><input type="text" class="tr_lang" id="tr_lang_%1$s" value="%4$s"%5$s /></span>',
+					<span lang="%5$s" dir="%6$s"><input type="text" class="tr_lang" id="tr_lang_%1$s" value="%4$s" /></span>',
 					esc_attr( $language->slug ),
 					/* translators: accessibility text */
 					esc_html__( 'Translation', 'polylang' ),
 					( empty( $translation ) ? 0 : esc_attr( $translation->term_id ) ),
 					( empty( $translation ) ? '' : esc_attr( $translation->name ) ),
-					disabled( empty( $disabled ), false, false ),
 					esc_attr( $language->get_locale( 'display' ) ),
 					( $language->is_rtl ? 'rtl' : 'ltr' )
 				);


### PR DESCRIPTION
This PR is the equivalent of #841 for terms.

Let's imagine that a user doesn't have the right to edit the content in German. This doesn't mean that he/she should be unable to link an existing German term with the English term being edited.