### PR TITLE
Make the legacy widget language filter field correctly saved in the new block-based widget screen

### DIFF
--- a/admin/admin-filters-widgets-options.php
+++ b/admin/admin-filters-widgets-options.php
@@ -32,24 +32,4 @@ class PLL_Admin_Filters_Widgets_Options extends PLL_Filters_Widgets_Options {
 		}
 	}
 
-	/**
-	 * Called when widget options are saved.
-	 * Saves the language associated to the widget.
-	 *
-	 * @since 3.0
-	 *
-	 * @param array     $instance The current Widget's options.
-	 * @param array     $new_instance The new Widget's options.
-	 * @param array     $old_instance Not used.
-	 * @param WP_Widget $widget The Widget object.
-	 * @return array The processed Widget options.
-	 */
-	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
-		$key = $this->get_language_key( $widget );
-		if ( ! empty( $_POST[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$new_instance[ $key ] = sanitize_key( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.NonceVerification
-		}
-		return parent::widget_update_callback( $instance, $new_instance, $old_instance, $widget );
-	}
-
 }

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -81,7 +81,8 @@ class PLL_Filters_Widgets_Options {
 	 * @return array Widget options.
 	 */
 	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
-		if ( ! empty( $new_instance[ 'lang_choice' ] ) && $lang = $this->model->get_language( $new_instance[ 'lang_choice' ] ) ) {
+		if ( ( ! empty( $new_instance[ 'lang_choice' ] ) && $lang = $this->model->get_language( $new_instance[ 'lang_choice' ] ) ) || // For legacy widget screen and when updating the widget language field in the block-based widget screen.
+			 ( ! empty( $new_instance[ 'pll_lang' ] ) && $lang = $this->model->get_language( $new_instance[ 'pll_lang' ] ) ) ) { // When updating the block-based widget screen the real widget setting name is passed to the new widget instance.
 			$instance['pll_lang'] = $lang->slug;
 		} else {
 			unset( $instance['pll_lang'] );

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -35,7 +35,8 @@ class PLL_Filters_Widgets_Options {
 	/**
 	 * Add the language filter field to the widgets options form.
 	 *
-	 * @since 3.0 Moved PLL_Admin_Filters
+	 * @since 3.0 Moved PLL_Admin_Filters.
+	 * @since 3.1 Rename lang_choice field name and id to pll_lang as the widget setting.
 	 *
 	 * @param WP_Widget $widget
 	 * @param null      $return
@@ -72,15 +73,15 @@ class PLL_Filters_Widgets_Options {
 	 * Saves the language associated to the widget.
 	 *
 	 * @since 0.3
-	 * @since 3.0 Moved from PLL_Admin_Filters
+	 * @since 3.0 Moved from PLL_Admin_Filters.
+	 * @since 3.1 Retrieve pll_lang widget setting from widget new instance instead of $_POST global variable.
+	 *            Remove unused $old_instance and $widget parameters.
 	 *
-	 * @param array     $instance The current Widget's options.
-	 * @param array     $new_instance The new Widget's options.
-	 * @param array     $old_instance Not used.
-	 * @param WP_Widget $widget WP_Widget object.
+	 * @param array $instance The current Widget's options.
+	 * @param array $new_instance The new Widget's options.
 	 * @return array Widget options.
 	 */
-	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
+	public function widget_update_callback( $instance, $new_instance ) {
 		if ( ! empty( $new_instance['pll_lang'] ) && $lang = $this->model->get_language( $new_instance['pll_lang'] ) ) {
 			$instance['pll_lang'] = $lang->slug;
 		} else {

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -52,7 +52,8 @@ class PLL_Filters_Widgets_Options {
 			),
 			-1,
 			array(
-				'name' => $this->get_language_key( $widget ),
+				'id' => $widget->get_field_id( 'lang_choice' ),
+				'name' => $widget->get_field_name( 'lang_choice' ),
 				'class' => 'tags-input pll-lang-choice',
 				'selected' => empty( $instance['pll_lang'] ) ? '' : $instance['pll_lang'],
 			)
@@ -60,7 +61,7 @@ class PLL_Filters_Widgets_Options {
 
 		printf(
 			'<p><label for="%1$s">%2$s %3$s</label></p>',
-			esc_attr( $this->get_language_key( $widget ) ),
+			esc_attr( $widget->get_field_id( 'lang_choice' ) ),
 			esc_html__( 'The widget is displayed for:', 'polylang' ),
 			$dropdown_html // phpcs:ignore WordPress.Security.EscapeOutput
 		);

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -81,7 +81,7 @@ class PLL_Filters_Widgets_Options {
 	 * @return array Widget options.
 	 */
 	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
-		if ( ! empty( $new_instance[ 'pll_lang' ] ) && $lang = $this->model->get_language( $new_instance[ 'pll_lang' ] ) ) {
+		if ( ! empty( $new_instance['pll_lang'] ) && $lang = $this->model->get_language( $new_instance['pll_lang'] ) ) {
 			$instance['pll_lang'] = $lang->slug;
 		} else {
 			unset( $instance['pll_lang'] );

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -81,9 +81,7 @@ class PLL_Filters_Widgets_Options {
 	 * @return array Widget options.
 	 */
 	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
-		$key = $this->get_language_key( $widget );
-
-		if ( ! empty( $new_instance[ $key ] ) && $lang = $this->model->get_language( $new_instance[ $key ] ) ) {
+		if ( ! empty( $new_instance[ 'lang_choice' ] ) && $lang = $this->model->get_language( $new_instance[ 'lang_choice' ] ) ) {
 			$instance['pll_lang'] = $lang->slug;
 		} else {
 			unset( $instance['pll_lang'] );

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -52,8 +52,8 @@ class PLL_Filters_Widgets_Options {
 			),
 			-1,
 			array(
-				'id' => $widget->get_field_id( 'lang_choice' ),
-				'name' => $widget->get_field_name( 'lang_choice' ),
+				'id' => $widget->get_field_id( 'pll_lang' ),
+				'name' => $widget->get_field_name( 'pll_lang' ),
 				'class' => 'tags-input pll-lang-choice',
 				'selected' => empty( $instance['pll_lang'] ) ? '' : $instance['pll_lang'],
 			)
@@ -61,7 +61,7 @@ class PLL_Filters_Widgets_Options {
 
 		printf(
 			'<p><label for="%1$s">%2$s %3$s</label></p>',
-			esc_attr( $widget->get_field_id( 'lang_choice' ) ),
+			esc_attr( $widget->get_field_id( 'pll_lang' ) ),
 			esc_html__( 'The widget is displayed for:', 'polylang' ),
 			$dropdown_html // phpcs:ignore WordPress.Security.EscapeOutput
 		);
@@ -81,8 +81,7 @@ class PLL_Filters_Widgets_Options {
 	 * @return array Widget options.
 	 */
 	public function widget_update_callback( $instance, $new_instance, $old_instance, $widget ) {
-		if ( ( ! empty( $new_instance[ 'lang_choice' ] ) && $lang = $this->model->get_language( $new_instance[ 'lang_choice' ] ) ) || // For legacy widget screen and when updating the widget language field in the block-based widget screen.
-			 ( ! empty( $new_instance[ 'pll_lang' ] ) && $lang = $this->model->get_language( $new_instance[ 'pll_lang' ] ) ) ) { // When updating the block-based widget screen the real widget setting name is passed to the new widget instance.
+		if ( ! empty( $new_instance[ 'pll_lang' ] ) && $lang = $this->model->get_language( $new_instance[ 'pll_lang' ] ) ) {
 			$instance['pll_lang'] = $lang->slug;
 		} else {
 			unset( $instance['pll_lang'] );

--- a/include/filters-widgets-options.php
+++ b/include/filters-widgets-options.php
@@ -90,15 +90,4 @@ class PLL_Filters_Widgets_Options {
 		return $instance;
 	}
 
-	/**
-	 * Returns the key used by Polylang to pass language data.
-	 *
-	 * @since 3.0
-	 *
-	 * @param WP_Widget $widget
-	 * @return string
-	 */
-	protected function get_language_key( $widget ) {
-		return $widget->id . '_lang_choice';
-	}
 }

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -85,10 +85,9 @@ class Strings_Test extends PLL_UnitTestCase {
 		);
 
 		$_POST['widget-search'][2] = array(
-			'title' => 'My Title',
+			'title'    => 'My Title',
+			'pll_lang' => 'en',
 		);
-
-		$_POST['search-2_lang_choice'] = 'en';
 
 		$wp_widget_search->update_callback();
 		$strings = PLL_Admin_Strings::get_strings();

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -56,7 +56,8 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 		ob_start();
 		$wp_widget_search->form_callback( 2 );
-		$this->assertNotFalse( strpos( ob_get_clean(), 'search-2_lang_choice' ) );
+		$form = ob_get_clean();
+		$this->assertNotFalse( strpos( $form, 'widget-search-2-pll_lang' ) );
 	}
 
 	function update_lang_choice( $widget, $lang ) {
@@ -71,7 +72,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 			'multi_number'  => '',
 		);
 
-		$_POST[ $widget->id . '_lang_choice' ] = $lang;
+		$_POST[ 'widget-' . $widget->id_base ][2]['pll_lang'] = $lang;
 		$widget->update_callback();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/986

In fact the language filter widget field wasn't saved correctly in the widget block editor context because the name of this field doesn't respect the widget naming standard for a long time in Polylang and explains why we should need to retrieve the field value in the `$_POST` global variable instead of `$new_instance` widget parameter

See in 1.9.x branch
https://github.com/polylang/polylang-pro/blob/master/modules/block-editor/block-editor-plugin.php#L188-L196
and
https://github.com/polylang/polylang/blob/1.9.x/admin/admin-filters.php#L77

It also wasn't consistent with all the other checkbox fields which respect the widget naming standard.
See https://github.com/polylang/polylang/blob/1.9.x/include/widget-languages.php#L95

Also See the `WP_Widget::get_field_name()` and `WP_Widget::get_field_id()` methods
https://github.com/WordPress/WordPress/blob/5.7.2/wp-includes/class-wp-widget.php#L209-L216
and
https://github.com/WordPress/WordPress/blob/5.7.2/wp-includes/class-wp-widget.php#L230-L232

And how these field values are retrieved in the WP_Widget::update_callback() method to set the $new_instance widget parameter passed to the `widget_update_callback` filter
https://github.com/WordPress/WordPress/blob/5.7.2/wp-includes/class-wp-widget.php#L423-L424
and
https://github.com/WordPress/WordPress/blob/5.7.2/wp-includes/class-wp-widget.php#L432-L469

So this PR propose to also use the two methods `WP_Widget::get_field_name()` and `WP_Widget::get_field_id()` for the language filter widget fields and make it work correctly without using the `$_POST` global variable.

