### PR TITLE
Remove gutenberg widgets screen name

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -172,7 +172,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		 */
 		$scripts = array(
 			'user'    => array( array( 'profile', 'user-edit' ), array( 'jquery' ), 0, 0 ),
-			'widgets' => array( array( 'widgets', 'appearance_page_gutenberg-widgets' ), array( 'jquery' ), 0, 0 ),
+			'widgets' => array( array( 'widgets' ), array( 'jquery' ), 0, 0 ),
 		);
 
 		if ( ! empty( $screen->post_type ) && $this->model->is_translated_post_type( $screen->post_type ) ) {

--- a/admin/admin-filters-widgets-options.php
+++ b/admin/admin-filters-widgets-options.php
@@ -27,7 +27,7 @@ class PLL_Admin_Filters_Widgets_Options extends PLL_Filters_Widgets_Options {
 
 		// Test the Widgets screen and the Customizer to avoid displaying the option in page builders
 		// Saving the widget reloads the form. And curiously the action is in $_REQUEST but neither in $_POST, nor in $_GET.
-		if ( ( isset( $screen ) && in_array( $screen->base, array( 'widgets', 'appearance_page_gutenberg-widgets' ) ) ) || ( isset( $_REQUEST['action'] ) && 'save-widget' === $_REQUEST['action'] ) || isset( $GLOBALS['wp_customize'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ( isset( $screen ) && 'widgets' === $screen->base ) || ( isset( $_REQUEST['action'] ) && 'save-widget' === $_REQUEST['action'] ) || isset( $GLOBALS['wp_customize'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			parent::in_widget_form( $widget, $return, $instance );
 		}
 	}


### PR DESCRIPTION
As we remove the condition to test Gutenberg widgets screen name in [Polylang Pro](https://github.com/polylang/polylang-pro/pull/1026) because it will become the default screen in WP 5.8 with is normal name - widgets - this PR propose to also remove the `appearance_page_gutenberg-widget` screen name from Polylang code