### PR TITLE
Add clean build folders before build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -733,14 +733,6 @@
         "domhandler": "^4.0.0",
         "domutils": "^2.4.3",
         "nth-check": "^2.0.0"
-      },
-      "dependencies": {
-        "css-what": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
-          "dev": true
-        }
       }
     },
     "css-tree": {
@@ -752,6 +744,12 @@
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       }
+    },
+    "css-what": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+      "dev": true
     },
     "cssesc": {
       "version": "3.0.0",
@@ -2238,6 +2236,15 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "webpack --mode production",
-    "build:dev": "webpack --mode development",
-    "dev": "webpack --mode development --watch",
+    "build": "npm run clean && webpack --mode production",
+    "build:dev": "npm run clean && webpack --mode development",
+    "dev": "npm run clean && webpack --mode development --watch",
+		"clean": "rimraf js/build css/build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "preinstall": "npx npm-force-resolutions"
   },
@@ -44,6 +45,7 @@
     "css-minimizer-webpack-plugin": "^3.0.1",
     "mini-css-extract-plugin": "^1.4.0",
     "postcss": "^8.2.15",
+    "rimraf": "^3.0.2",
     "terser-webpack-plugin": "^5.1.1",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run clean && webpack --mode production",
     "build:dev": "npm run clean && webpack --mode development",
     "dev": "npm run clean && webpack --mode development --watch",
-		"clean": "rimraf js/build css/build",
+    "clean": "rimraf js/build css/build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "preinstall": "npx npm-force-resolutions"
   },


### PR DESCRIPTION
Simply add a clean up step before the build process to ensure not to mix files version each time we build the project.

Add a new npm command `npm run clean` automatically launch when we run the build commands `npm run build`, `npm run build:dev` or `npm run dev`