### PR TITLE
Validate the redirect links before redirecting on frontend

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -261,7 +261,7 @@ abstract class PLL_Choose_Lang {
 			if ( $redirect = apply_filters( 'pll_redirect_home', $redirect ) ) {
 				$this->maybe_setcookie();
 				header( 'Vary: Accept-Language' );
-				wp_safe_redirect( $redirect, 302, POLYLANG );
+				wp_redirect( $redirect, 302, POLYLANG );
 				exit;
 			}
 		}

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -258,10 +258,11 @@ abstract class PLL_Choose_Lang {
 			 *
 			 * @param string $redirect the url the visitor will be redirected to
 			 */
-			if ( $redirect = apply_filters( 'pll_redirect_home', $redirect ) ) {
+			$redirect = apply_filters( 'pll_redirect_home', $redirect );
+			if ( $redirect && wp_validate_redirect( $redirect ) ) {
 				$this->maybe_setcookie();
 				header( 'Vary: Accept-Language' );
-				wp_redirect( $redirect, 302, POLYLANG );
+				wp_safe_redirect( $redirect, 302, POLYLANG );
 				exit;
 			}
 		}

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -468,8 +468,8 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		// The language is not correctly set so let's redirect to the correct url for this object
 		if ( $do_redirect ) {
 			// Protect against chained redirects.
-			if ( $redirect_url && $requested_url != $redirect_url && $redirect_url === $this->check_canonical_url( $redirect_url, false ) ) {
-				wp_redirect( $redirect_url, 301, POLYLANG );
+			if ( $redirect_url && $requested_url != $redirect_url && $redirect_url === $this->check_canonical_url( $redirect_url, false ) && wp_validate_redirect( $redirect_url ) ) {
+				wp_safe_redirect( $redirect_url, 301, POLYLANG );
 				exit;
 			} else {
 				return;

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -469,7 +469,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		if ( $do_redirect ) {
 			// Protect against chained redirects.
 			if ( $redirect_url && $requested_url != $redirect_url && $redirect_url === $this->check_canonical_url( $redirect_url, false ) ) {
-				wp_safe_redirect( $redirect_url, 301, POLYLANG );
+				wp_redirect( $redirect_url, 301, POLYLANG );
 				exit;
 			} else {
 				return;


### PR DESCRIPTION
In 58dd54e4b3112141ce8c028e348349e0c74fb190 (version 2.6) we replaced all usages of `wp_redirect()` by `wp_safe_redirect()` as per WPCS recommendation (`WordPress.Security.SafeRedirect` sniff).

On the other hand,  we sometimes have reports of Polylang redirecting to `/wp-admin/`. It's quite difficult to explain to users that the root cause of this issue is not Polylang redirecting to `/wp-admin/` (because of our usage of `wp_safe_redirect()`) but the underlying redirect link which was not validated by WordPress because of the usage of an unknown host.

My first intention was to ignore the WordPress sniff and use `wp_redirect()` on frontend. I however now propose to validate the redirect link before calling `wp_safe_redirect()`. That way, if the redirect link is not valid, then no redirects is made by Polylang. And we still use `wp_safe_redirect()` to avoid open redirects and please WPCS.

The only downside I see in this proposal is that `wp_validate_redirect()` is called twice, once directly and once by `wp_safe_redirect()`.