### PR TITLE
Display translation icon in old widget editor when no language is selected for a widget

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -463,3 +463,8 @@
 		line-height: 20px !important;
 	}
 }
+
+/* manage translation icon in widget title for old screen */
+.widget-title h3 .dashicons-translation {
+	margin: -5px 6px -5px auto;
+}

--- a/js/src/widgets.js
+++ b/js/src/widgets.js
@@ -43,7 +43,7 @@ jQuery(
 				}
 				$( '.dashicons-translation', title ).remove(); // Remove potential translation icon.
 			} else {
-				if ( ! $( '<span />', title ).hasClass( 'dashicons-translation' ) ) {
+				if ( $( '.dashicons-translation', title ).length === 0 ) {
 					translationIcon = $( '<span />' ).addClass( 'dashicons dashicons-translation' );
 					title.prepend( translationIcon );
 					$( '.pll-lang', title ).remove(); // Remove potential language icon.

--- a/js/src/widgets.js
+++ b/js/src/widgets.js
@@ -41,15 +41,13 @@ jQuery(
 					// See the comment above about the icon which is safe. So it is also safe to prepend flag which uses icon.
 					title.prepend( flag ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 				}
-				$( '.dashicons-translation', title ).remove();
+				$( '.dashicons-translation', title ).remove(); // Remove potential translation icon.
 			} else {
-				if ( $( '<span />', title ).hasClass( 'dashicons-translation' )   ) {
-					$( '.dashicons-translation', title ).remove();
+				if ( ! $( '<span />', title ).hasClass( 'dashicons-translation' ) ) {
+					translationIcon = $( '<span />' ).addClass( 'dashicons dashicons-translation' );
+					title.prepend( translationIcon );
+					$( '.pll-lang', title ).remove(); // Remove potential language icon.
 				}
-				translationIcon = $( '<span />' ).addClass( 'dashicons dashicons-translation' );  // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
-				// See the comment above about the icon which is safe. So it is also safe to prepend flag which uses icon.
-				title.prepend( translationIcon ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
-				$( '.pll-lang', title ).remove();
 			}
 		}
 
@@ -121,6 +119,12 @@ jQuery(
 				add_flag( $( this ).parents( '.widget' ) );
 			}
 		);
+
+		// Add translation icon to added widgets as all languages is selected by default.
+		// @link https://core.trac.wordpress.org/changeset/27969 for wp event.
+		$( document ).on( 'widget-added', function(event, widget) {
+			add_flag( widget );
+		});
 
 		function pll_toggle( a, test ) {
 			test ? a.show() : a.hide();

--- a/js/src/widgets.js
+++ b/js/src/widgets.js
@@ -41,7 +41,14 @@ jQuery(
 					// See the comment above about the icon which is safe. So it is also safe to prepend flag which uses icon.
 					title.prepend( flag ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 				}
+				$( '.dashicons-translation', title ).remove();
 			} else {
+				if ( $( '<span />', title ).hasClass( 'dashicons-translation' )   ) {
+					$( '.dashicons-translation', title ).remove();
+				}
+				translationIcon = $( '<span />' ).addClass( 'dashicons dashicons-translation' );  // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+				// See the comment above about the icon which is safe. So it is also safe to prepend flag which uses icon.
+				title.prepend( translationIcon ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 				$( '.pll-lang', title ).remove();
 			}
 		}

--- a/js/src/widgets.js
+++ b/js/src/widgets.js
@@ -45,7 +45,7 @@ jQuery(
 			} else {
 				if ( $( '.dashicons-translation', title ).length === 0 ) {
 					translationIcon = $( '<span />' ).addClass( 'dashicons dashicons-translation' );
-					title.prepend( translationIcon );
+					title.prepend( translationIcon ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 					$( '.pll-lang', title ).remove(); // Remove potential language icon.
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,7 +729,7 @@
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "5.0.1",
+        "css-what": "^4.0.0",
         "domhandler": "^4.0.0",
         "domutils": "^2.4.3",
         "nth-check": "^2.0.0"
@@ -738,7 +738,8 @@
         "css-what": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
+          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+          "dev": true
         }
       }
     },
@@ -751,12 +752,6 @@
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       }
-    },
-    "css-what": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
-      "dev": true
     },
     "cssesc": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,7 +729,7 @@
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^4.0.0",
+        "css-what": "5.0.1",
         "domhandler": "^4.0.0",
         "domutils": "^2.4.3",
         "nth-check": "^2.0.0"
@@ -738,8 +738,7 @@
         "css-what": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
-          "dev": true
+          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
         }
       }
     },
@@ -752,6 +751,12 @@
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       }
+    },
+    "css-what": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+      "dev": true
     },
     "cssesc": {
       "version": "3.0.0",


### PR DESCRIPTION
Related to https://github.com/polylang/polylang-pro/issues/926

## Enhancement 
Add a translation icon when no language is selected. See bellow.
![Capture d’écran 2021-06-24 à 14 54 04](https://user-images.githubusercontent.com/69580439/123266198-168b3100-d4fc-11eb-8cec-3e4fc12a1afe.png)

## Process
Add the dashicon for translation when no language is selected in `widget.js`. It needs a bit of margin in `admin.css` to be consistent with the flags.

*Note that is works with live preview in WP customizer with those modifications*