### PR TITLE
Use use_block_editor_for_post filter instead of rest_api_init

### DIFF
--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -88,12 +88,20 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return bool
 	 */
 	public function new_post_translation( $is_block_editor, $post ) {
+		static $done = array();
+
 		if ( isset( $GLOBALS['pagenow'], $_GET['from_post'], $_GET['new_lang'] ) && 'post-new.php' === $GLOBALS['pagenow'] && $this->model->is_translated_post_type( $post->post_type ) ) {
 			check_admin_referer( 'new-post-translation' );
 
 			// Capability check already done in post-new.php
 			$from_post_id = (int) $_GET['from_post'];
 			$lang         = $this->model->get_language( sanitize_key( $_GET['new_lang'] ) );
+
+			if ( ! $from_post_id || ! $lang || ! empty( $done[ $from_post_id ] ) ) {
+				return $is_block_editor;
+			}
+
+			$done[ $from_post_id ] = true; // Avoid a second duplication in the block editor. Using an array only to allow multiple phpunit tests.
 
 			$this->taxonomies->copy( $from_post_id, $post->ID, $lang->slug );
 			$this->post_metas->copy( $from_post_id, $post->ID, $lang->slug );

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -90,7 +90,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 		global $post;
 		static $done = array();
 
-		if ( isset( $GLOBALS['pagenow'], $_GET['from_post'], $_GET['new_lang'] ) && 'post-new.php' === $GLOBALS['pagenow'] && $this->model->is_translated_post_type( $post->post_type ) ) {
+		if ( ! empty( $post ) && isset( $GLOBALS['pagenow'], $_GET['from_post'], $_GET['new_lang'] ) && 'post-new.php' === $GLOBALS['pagenow'] && $this->model->is_translated_post_type( $post->post_type ) ) {
 			check_admin_referer( 'new-post-translation' );
 
 			// Capability check already done in post-new.php

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -22,8 +22,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 
 		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 3 );
 		add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ) );
-		add_action( 'rest_api_init', array( $this, 'new_post_translation' ) ); // Block editor
-		add_action( 'add_meta_boxes', array( $this, 'new_post_translation' ), 5 ); // Classic editor, before Types which populates custom fields in same hook with priority 10
+		add_filter( 'use_block_editor_for_post', array( $this, 'new_post_translation' ), 10, 2 );
 	}
 
 	/**
@@ -82,11 +81,13 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * Copy post metas, and taxonomies when using "Add new" ( translation )
 	 *
 	 * @since 2.5
+	 * @since 3.1 Use of use_block_editor_for_post filter instead of rest_api_init which is triggered too early in WP 5.8.
 	 *
-	 * @return void
+	 * @param bool    $is_block_editor Whether the post can be edited or not.
+	 * @param WP_Post $post             The post being checked.
+	 * @return bool
 	 */
-	public function new_post_translation() {
-		global $post;
+	public function new_post_translation( $is_block_editor, $post ) {
 		static $done = array();
 
 		if ( isset( $GLOBALS['pagenow'], $_GET['from_post'], $_GET['new_lang'] ) && 'post-new.php' === $GLOBALS['pagenow'] && $this->model->is_translated_post_type( $post->post_type ) ) {
@@ -97,7 +98,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 			$lang         = $this->model->get_language( sanitize_key( $_GET['new_lang'] ) );
 
 			if ( ! $from_post_id || ! $lang || ! empty( $done[ $from_post_id ] ) ) {
-				return;
+				return $is_block_editor;
 			}
 
 			$done[ $from_post_id ] = true; // Avoid a second duplication in the block editor. Using an array only to allow multiple phpunit tests.
@@ -109,6 +110,8 @@ class PLL_Admin_Sync extends PLL_Sync {
 				stick_post( $post->ID );
 			}
 		}
+
+		return $is_block_editor;
 	}
 
 	/**

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -22,7 +22,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 
 		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 3 );
 		add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ) );
-		add_filter( 'use_block_editor_for_post', array( $this, 'new_post_translation' ), 10, 2 );
+		add_filter( 'use_block_editor_for_post', array( $this, 'new_post_translation' ) );
 	}
 
 	/**
@@ -84,10 +84,10 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @since 3.1 Use of use_block_editor_for_post filter instead of rest_api_init which is triggered too early in WP 5.8.
 	 *
 	 * @param bool    $is_block_editor Whether the post can be edited or not.
-	 * @param WP_Post $post             The post being checked.
 	 * @return bool
 	 */
-	public function new_post_translation( $is_block_editor, $post ) {
+	public function new_post_translation( $is_block_editor ) {
+		global $post;
 		static $done = array();
 
 		if ( isset( $GLOBALS['pagenow'], $_GET['from_post'], $_GET['new_lang'] ) && 'post-new.php' === $GLOBALS['pagenow'] && $this->model->is_translated_post_type( $post->post_type ) ) {

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -88,20 +88,12 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return bool
 	 */
 	public function new_post_translation( $is_block_editor, $post ) {
-		static $done = array();
-
 		if ( isset( $GLOBALS['pagenow'], $_GET['from_post'], $_GET['new_lang'] ) && 'post-new.php' === $GLOBALS['pagenow'] && $this->model->is_translated_post_type( $post->post_type ) ) {
 			check_admin_referer( 'new-post-translation' );
 
 			// Capability check already done in post-new.php
 			$from_post_id = (int) $_GET['from_post'];
 			$lang         = $this->model->get_language( sanitize_key( $_GET['new_lang'] ) );
-
-			if ( ! $from_post_id || ! $lang || ! empty( $done[ $from_post_id ] ) ) {
-				return $is_block_editor;
-			}
-
-			$done[ $from_post_id ] = true; // Avoid a second duplication in the block editor. Using an array only to allow multiple phpunit tests.
 
 			$this->taxonomies->copy( $from_post_id, $post->ID, $lang->slug );
 			$this->post_metas->copy( $from_post_id, $post->ID, $lang->slug );

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -83,7 +83,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @since 2.5
 	 * @since 3.1 Use of use_block_editor_for_post filter instead of rest_api_init which is triggered too early in WP 5.8.
 	 *
-	 * @param bool    $is_block_editor Whether the post can be edited or not.
+	 * @param bool $is_block_editor Whether the post can be edited or not.
 	 * @return bool
 	 */
 	public function new_post_translation( $is_block_editor ) {

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -188,7 +188,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$GLOBALS['post'] = get_post( $to );
 
-		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
@@ -228,7 +228,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$GLOBALS['post'] = get_post( $to );
 
-		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -188,7 +188,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$GLOBALS['post'] = get_post( $to );
 
-		apply_filters( 'use_block_editor_for_post', false ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
@@ -228,7 +228,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$GLOBALS['post'] = get_post( $to );
 
-		apply_filters( 'use_block_editor_for_post', false ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -188,7 +188,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$GLOBALS['post'] = get_post( $to );
 
-		do_action( 'add_meta_boxes', 'post', $GLOBALS['post'] ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
+
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
 		$this->assertEquals( 'value', get_post_meta( $to, 'key', true ) );
@@ -227,7 +228,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$GLOBALS['post'] = get_post( $to );
 
-		do_action( 'add_meta_boxes', 'page', $GLOBALS['post'] ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1030

## Explanations
WordPress 5.8 introduces the new block pattern feature.
A part of this feature is hooked on the `current_screen` hook in [`default-filters.php`](https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php#L335) which is fired by [`admin.php`](https://github.com/WordPress/WordPress/blob/master/wp-admin/admin.php#L212) require in [`post-new.php`](https://github.com/WordPress/WordPress/blob/master/wp-admin/post-new.php#L10) and call the new `[_load_remote_block_patterns()](https://github.com/WordPress/WordPress/blob/master/wp-includes/block-patterns.php#L54)` function.

This function execute a [REST API request ](https://github.com/WordPress/WordPress/blob/master/wp-includes/block-patterns.php#L74) and then the [REST API server initialization](https://github.com/WordPress/WordPress/blob/09fda454d08417f64c34ba410ff93a1d0e96e118/wp-includes/rest-api.php#L509) which fires the [`rest_api_init`](https://github.com/WordPress/WordPress/blob/09fda454d08417f64c34ba410ff93a1d0e96e118/wp-includes/rest-api.php#L537) action only the first time i.e. if the REST API server hasn't been initialized yet.

As our code is hooked on [`rest_api_init`](https://github.com/polylang/polylang/blob/3.0-beta1/modules/sync/admin-sync.php#L25) the [`PLL_Admin_Sync::new_post_translation()` method](https://github.com/polylang/polylang/blob/3.0-beta1/modules/sync/admin-sync.php#L88) is fired before the post [is initialized](https://github.com/WordPress/WordPress/blob/master/wp-admin/post-new.php#L66) which causes the PHP notice and that [the taxonomies and post metas copies](https://github.com/polylang/polylang/blob/3.0-beta1/modules/sync/admin-sync.php#L105-L106) aren't done.

We could think that the [`preload_paths`](https://github.com/WordPress/WordPress/blob/master/wp-admin/edit-form-blocks.php#L68) process should fire our code as before on the [first request to preload](https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api.php#L2832). But as we saw above the REST API server is already initialized in the same process and the `rest_api_init` action isn't fired a new time and then our code never executed before the UI is displayed with the preloaded post datas.

We also could think that the metaboxes process should do the job because it is really executed, fired by https://github.com/WordPress/WordPress/blob/master/wp-admin/edit-form-blocks.php#L256. At the opposite of the case above it is fired after the post is preloaded and thus too late even if the datas are really saved in the database.

## Beta2 and Beta3 differences

In the beta2 release the code of the `_load_remote_block_patterns()` function used a transient.

```
$patterns = get_transient( 'wp_remote_block_patterns' );
if ( ! $patterns ) {
	$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
	$core_keyword_id = 11; // 11 is the ID for "core".
	$request->set_param( 'keyword', $core_keyword_id );
	$response = rest_do_request( $request );
	if ( $response->is_error() ) {
		return;
	}
	$patterns = $response->get_data();
	set_transient( 'wp_remote_block_patterns', $patterns, HOUR_IN_SECONDS );
}

```
If the transient already exist in the database, It explain why the REST API server isn't initialized at this step because the REST API request isn't exceuted and thus why all work as before i.e. correctly fired on the `rest_api_init` hook during the post preloading process.

## Fix
As we can see, our code need to be executed after the post variable is initialized and no matter the editor used .
So this PR propose to execute our code after the post is initialized and before the UI is loaded.

The use of the `use_block_editor_for_post` implemented in [`use_block_editor_for_post()`](https://github.com/WordPress/WordPress/blob/09fda454d08417f64c34ba410ff93a1d0e96e118/wp-admin/includes/post.php#L2124) function seems relevant to use because [fired just after the post initialization and use to choose which editor to use](https://github.com/WordPress/WordPress/blob/master/wp-admin/post-new.php#L71). So our code is executed the same way no matter the editor used.


## Going further
- the `Sync_Test::test_create_page_translation()` test fails when it runs alone. It was already the case before the issue and this PR doesn't fix this. It fails the comparison on the post `menu_order` property.
- With the issue, if we save the new translated post and refresh the page the copied datas are correctly displayed. It is due to the fact that the `add_meta_boxes` hook fires the `PLL_Admin_Sync::new_post_translation()` but does the database updates too late.
- Duplicate content Polylang Pro feature seems to be implemented the same way by using [`block_editor_rest_api_preload_paths`](https://github.com/polylang/polylang-pro/blob/3.1-beta1/modules/duplicate/duplicate-rest.php#L27) for the post block editor and [`add_meta_boxes`](https://github.com/polylang/polylang-pro/blob/3.1-beta1/modules/duplicate/duplicate.php#L35) for the classic editor
Maybe there is also something to simplify here.