### PR TITLE
Delay the copy of terms and post metas

### DIFF
--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -22,7 +22,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 
 		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 3 );
 		add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ) );
-		add_filter( 'use_block_editor_for_post', array( $this, 'new_post_translation' ) );
+		add_filter( 'use_block_editor_for_post', array( $this, 'new_post_translation' ), 5000 ); // After content duplication.
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up of #884 and necessary for https://github.com/polylang/polylang-pro/pull/1040 to have all actions fired in the correct order. 