### PR TITLE
FIx the default category displayed in the Categories

### DIFF
--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -63,7 +63,7 @@ class PLL_Admin_Default_Term {
 		foreach ( $this->taxonomies as $taxonomy ) {
 			if ( 'category' === $taxonomy ) {
 				// Allows to get the default terms in all languages
-				add_filter( 'option_default' . $taxonomy, array( $this, 'option_default_term' ) );
+				add_filter( 'option_default_' . $taxonomy, array( $this, 'option_default_term' ) );
 				add_action( 'update_option_default_' . $taxonomy, array( $this, 'update_option_default_term' ), 10, 2 );
 
 				// Adds the language column in the 'Terms' table.

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -142,7 +142,6 @@ class Default_Term_Test extends PLL_UnitTestCase {
 
 	function test_get_option_default_category() {
 		$this->pll_admin->pref_lang = self::$model->get_language( 'es' );
-		$this->pll_admin->set_current_language();
 
 		$option = get_option( 'default_category' );
 		$option_lang = self::$model->term->get_language( $option );

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -139,4 +139,14 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $list, 'edit-tags.php?action=delete&amp;taxonomy=category&amp;tag_ID=' . $fr . '&amp;' ) );
 		$this->assertNotFalse( strpos( $list, 'edit-tags.php?action=delete&amp;taxonomy=category&amp;tag_ID=' . $id . '&amp;' ) );
 	}
+
+	function test_get_option_default_category() {
+		$this->pll_admin->pref_lang = self::$model->get_language( 'es' );
+		$this->pll_admin->set_current_language();
+
+		$option = get_option( 'default_category' );
+		$option_lang = self::$model->term->get_language( $option );
+
+		$this->assertEquals( 'es', $option_lang->slug );
+	}
 }

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -141,6 +141,11 @@ class Default_Term_Test extends PLL_UnitTestCase {
 	}
 
 	function test_get_option_default_category() {
+		$option = get_option( 'default_category' );
+		$option_lang = self::$model->term->get_language( $option );
+
+		$this->assertEquals( 'en', $option_lang->slug );
+
 		$this->pll_admin->pref_lang = self::$model->get_language( 'es' );
 
 		$option = get_option( 'default_category' );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1036

There was a **missing** `_`.

So the filter called was `option_defaultcategory` instead of `option_default_category`.
So we never pass in `option_default_term` method which return the default category in the filtered language.