### PR TITLE
FIx category feed not redirected when the language code is wrong

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -394,7 +394,11 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		elseif ( $this->links_model->using_permalinks && is_category() && ! empty( $this->wp_query()->query['cat'] ) ) {
 			// When we receive a plain permaling with a cat query var, we need to redirect to the pretty permalink.
-			extract( $this->get_queried_term_language( true ) );
+			$language = $this->get_queried_term_language();
+			if ( $language ) {
+				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
+				$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
+			}
 		}
 
 		elseif ( is_category() || is_tag() || is_tax() ) {
@@ -419,13 +423,13 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 			if ( is_feed() && empty( $obj ) ) { 
 				// Allows to replace the language correctly in a category feed query.
-				extract( $this->get_queried_term_language() );
+				$language = $this->get_queried_term_language();
 			}
 		}
 
 		elseif ( is_404() && ! empty( $this->wp_query()->tax_query ) ) {
 			// When a wrong language is passed through a pretty permalink, we just need to switch the language.
-			extract( $this->get_queried_term_language() );
+			$language = $this->get_queried_term_language();
 		}
 
 		elseif ( $this->links_model->using_permalinks && $this->wp_query()->is_posts_page && ! empty( $this->wp_query()->query['page_id'] ) && $id = get_query_var( 'page_id' ) ) {
@@ -567,23 +571,15 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	}
 
 	/**
-	 * Get the language and the redirect URL corresponding to the queried term.
+	 * Get the language corresponding to the queried term.
 	 * 
-	 * @param bool $need_url optionnal, whether or not it should return the redirect URL.
-	 * 
-	 * @return array an associative array containing the langugage and the redirect URL as keys.
+	 * @return PLL_Language|false the language object or false.
 	 */
-	public function get_queried_term_language( $need_url = false ) {
+	public function get_queried_term_language() {
 		if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
 			$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
-			return array(
-				'language'     => $this->model->term->get_language( $term_id ),
-				'redirect_url' => $need_url ? $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) ) : false,
-			);
+			return $this->model->term->get_language( $term_id );
 		}
-		return array(
-			'language'     => false,
-			'redirect_url' => false,
-		);
+		return false;
 	}
 }

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -411,6 +411,13 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					}
 				}
 			}
+
+			if ( is_feed() && empty( $obj ) ) { // Allows to replace the language correctly in a category feed query.
+				if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
+					$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
+					$language = $this->model->term->get_language( $term_id );
+				}
+			}
 		}
 
 		elseif ( is_404() && ! empty( $this->wp_query()->tax_query ) ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -412,7 +412,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 				}
 			}
 
-			if ( is_feed() && empty( $obj ) ) { 
+			if ( is_feed() && empty( $obj ) ) {
 				// Allows to replace the language correctly in a category feed query.
 				$language = $this->get_queried_term_language();
 			}
@@ -563,8 +563,10 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 	/**
 	 * Get the language corresponding to the queried term.
-	 * 
-	 * @return PLL_Language|false the language object or false.
+	 *
+	 * @since 3.2
+	 *
+	 * @return PLL_Language|false The language object or false.
 	 */
 	public function get_queried_term_language() {
 		if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -392,15 +392,6 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( $this->links_model->using_permalinks && is_category() && ! empty( $this->wp_query()->query['cat'] ) ) {
-			// When we receive a plain permaling with a cat query var, we need to redirect to the pretty permalink.
-			$language = $this->get_queried_term_language();
-			if ( $language ) {
-				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
-				$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
-			}
-		}
-
 		elseif ( is_category() || is_tag() || is_tax() ) {
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
 				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
@@ -411,7 +402,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 					}
-					$language = $this->model->term->get_language( $term_id );
+					$language = $this->get_queried_term_language();
 				} else {
 					// We need to switch the language when there is no language provided in a pretty permalink.
 					$obj = get_queried_object();

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -471,4 +471,26 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public function test_plain_tag_feed() {
 		$this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
 	}
+	
+	public function test_category_feed() {
+		// Create an untranslated category.
+		$cat_id = $this->factory->category->create(
+			array(
+				'name' => 'Test Category',
+				'slug' => 'test-category',
+				)
+		);
+		self::$model->term->set_language( $cat_id, 'en' );
+		// Create a post with the previous category.
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'test',
+				'post_type'  => 'page',
+				'category'   => $cat_id,
+			)
+		);
+		self::$model->post->set_language( $post_id, 'en' );
+
+		$this->assertCanonical( '/fr/category/test-category/feed/', '/en/category/test-category/feed/' );
+	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -471,26 +471,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public function test_plain_tag_feed() {
 		$this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
 	}
-	
-	public function test_category_feed() {
-		// Create an untranslated category.
-		$cat_id = $this->factory->category->create(
-			array(
-				'name' => 'Test Category',
-				'slug' => 'test-category',
-			)
-		);
-		self::$model->term->set_language( $cat_id, 'en' );
-		// Create a post with the previous category.
-		$post_id = $this->factory->post->create(
-			array(
-				'post_title' => 'test',
-				'post_type'  => 'page',
-				'category'   => $cat_id,
-			)
-		);
-		self::$model->post->set_language( $post_id, 'en' );
-
-		$this->assertCanonical( '/fr/category/test-category/feed/', '/en/category/test-category/feed/' );
+		
+	public function test_untranslated_category_feed() {
+		$this->assertCanonical( '/fr/category/parent/feed/', '/en/category/parent/feed/' );
 	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -478,7 +478,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 			array(
 				'name' => 'Test Category',
 				'slug' => 'test-category',
-				)
+			)
 		);
 		self::$model->term->set_language( $cat_id, 'en' );
 		// Create a post with the previous category.


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/819

## Problem 
*Context : two language created (`en` and `fr`) with one category in english but not translated in french, containing some posts*

When requesting a untranslated category feed (for instance `/fr/category/uncategorized/feed/` ), no redirection is made toward the correct feed (i.e. with the correct language slug, like `/en/category/uncategorized/feed/` ).

## Solution
If no post is found for the wrong URL and if the query is for a category feed (`is_category()` and `is_feed()`), we can set the language to the language corresponding to requested category. So, later in `PLL_Frontend_Filters_Links::check_canonical_url()`, the `pll_check_canonical_url` filter will set the correct language slug in the redirect url.