### PR TITLE
Add page for posts label correctly on bulk translate

### DIFF
--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -110,13 +110,15 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 *
 	 * @since 1.8
 	 *
+	 * @since 3.2 Do the same with page for posts
+	 *
 	 * @param int     $post_id      Not used.
 	 * @param WP_Post $post         Not used.
 	 * @param int[]   $translations Translations of the post being saved.
 	 * @return void
 	 */
 	public function pll_save_post( $post_id, $post, $translations ) {
-		if ( in_array( $this->page_on_front, $translations ) ) {
+		if ( in_array( $this->page_on_front, $translations ) || in_array( $this->page_for_posts, $translations ) ) {
 			$this->model->clean_languages_cache();
 		}
 	}

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -33,7 +33,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		// Add post state for translations of the front page and posts page
 		add_filter( 'display_post_states', array( $this, 'display_post_states' ), 10, 2 );
 
-		// Refresh language cache when a static front page has been translated
+		// Refreshes the language cache when a static front page or page for for posts has been translated.
 		add_action( 'pll_save_post', array( $this, 'pll_save_post' ), 10, 3 );
 
 		// Prevents WP resetting the option
@@ -106,11 +106,9 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Refreshes the language cache when a static front page has been translated.
+	 * Refreshes the language cache when a static front page or page for for posts has been translated.
 	 *
 	 * @since 1.8
-	 *
-	 * @since 3.2 Do the same with page for posts
 	 *
 	 * @param int     $post_id      Not used.
 	 * @param WP_Post $post         Not used.


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/868

## Context
The problem occured only with page for posts (not with the homepage).
https://github.com/polylang/polylang-pro/pull/1019 was fixing the case with block editor.

## Problem
The callback for the `'pll_save_post'` action was only verifying the page on front (leaving the page for posts all alone...).

## Solution
Add the page for posts in the condition.

*Note : the corresponding test will be written in PLL-Pro as we bulk translate.*