### PR TITLE
Consistent margin between flag and select for post and media

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -214,16 +214,16 @@
 	padding: 2px;
 }
 
+#post-translations p {
+	margin: 1em 0;
+}
+
 #post-translations .spinner,
 #term-translations .spinner {
 	float: none;
 	margin: 0;
 	background-position: center;
 	width: auto;
-}
-
-.pll-column-icon {
-	text-align: center;
 }
 
 #select-post-language .pll-select-flag {

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -228,7 +228,7 @@
 
 #select-post-language .pll-select-flag {
 	padding: 4px;
-	margin-right: 32px;
+	margin-right: 10px;
 }
 
 /* specific cases for media */

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -214,10 +214,6 @@
 	padding: 2px;
 }
 
-#post-translations p {
-	margin: 1em 0;
-}
-
 #post-translations .spinner,
 #term-translations .spinner {
 	float: none;


### PR DESCRIPTION
## Problem

The margin between the flag and the `select` wasn't consistent in post edit and media edit. The theses [lines](https://github.com/polylang/polylang/blob/2dab3ad9997a5d1f302078d535ce5fecfed08fcc/css/src/admin.css#L229).

## Changes

Set the same margin for both post and media. Note that I added margin for the `p` inside the translation title because it wasn't handle automatically by Wordpress (like in Classic Editor, [see](https://github.com/WordPress/WordPress/blob/473295ab123b35ed54104b599f12f9e8b5e97283/wp-admin/css/common.css#L307)) in the block editor. See bellow the original display :

<img width="280" alt="Capture d’écran 2021-07-02 à 15 20 07" src="https://user-images.githubusercontent.com/69580439/124280533-1832a580-db49-11eb-975e-e2584e4682f0.png">
