### PR TITLE
Fix RTL display in admin sidebar for translations table title

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -121,7 +121,7 @@ class PLL_Admin_Classic_Editor {
 
 		// NOTE: the class "tags-input" allows to include the field in the autosave $_POST ( see autosave.js )
 		printf(
-			'<p id="pll-metabox-select-language-title"><strong>%1$s</strong></p>
+			'<p><strong>%1$s</strong></p>
 			<label class="screen-reader-text" for="%2$s">%1$s</label>
 			<div id="select-%3$s-language">%4$s</div>',
 			esc_html__( 'Language', 'polylang' ),

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -121,7 +121,7 @@ class PLL_Admin_Classic_Editor {
 
 		// NOTE: the class "tags-input" allows to include the field in the autosave $_POST ( see autosave.js )
 		printf(
-			'<p><strong>%1$s</strong></p>
+			'<p id="pll-metabox-select-language-title"><strong>%1$s</strong></p>
 			<label class="screen-reader-text" for="%2$s">%1$s</label>
 			<div id="select-%3$s-language">%4$s</div>',
 			esc_html__( 'Language', 'polylang' ),

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -187,7 +187,7 @@
 }
 
 /* languages metabox in post.php */
-#pll-metabox-select-language-title {
+#ml_box p {
 	margin-top: 1em;
 }
 

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -187,6 +187,10 @@
 }
 
 /* languages metabox in post.php */
+#post-translations {
+	margin-top: 1em;
+}
+
 #post-translations p {
 	float: left;
 }
@@ -229,6 +233,12 @@
 #select-post-language .pll-select-flag {
 	padding: 4px;
 	margin-right: 10px;
+}
+
+.rtl #select-post-language .pll-select-flag {
+    padding: 4px;
+    margin-right: 0px;
+    margin-left: 10px;
 }
 
 /* specific cases for media */

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -187,12 +187,10 @@
 }
 
 /* languages metabox in post.php */
-#post-translations {
-	margin-top: 1em;
-}
 
 #post-translations p {
 	float: left;
+	margin-top: 1em;
 }
 
 .rtl #post-translations p {

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -187,6 +187,9 @@
 }
 
 /* languages metabox in post.php */
+#pll-metabox-select-language-title {
+	margin-top: 1em;
+}
 
 #post-translations p {
 	float: left;

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -191,6 +191,10 @@
 	float: left;
 }
 
+.rtl #post-translations p {
+	float: right;
+}
+
 #post-translations table {
 	table-layout: fixed;
 	width: 100%;


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1042

## Problem
RTL wasn't handled in the sidebar. Translations table title was displayed on the left for RTL languages.

## Fix
Modify CSS to handle this.