### PR TITLE
Fix radio button display for small screen

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -30,11 +30,6 @@
 	content: "\25cf";
 }
 
-.form-field input[type="radio"] {
-	width: auto;
-	margin-right: 2px;
-}
-
 /* about Polylang metabox */
 #pll-about-box p,
 #pll-recommended p {


### PR DESCRIPTION
## Problem
Radio button wasn't well displayed on small screen. See :
![screenshot-trunk-test com-2021 07 07-11_15_50](https://user-images.githubusercontent.com/69580439/124737966-c27b4600-df18-11eb-8d6b-0e254ff9f529.png)

## Solution
Remove the rules concerning radio button. Also, WP seems to have a default style for [them](https://github.com/WordPress/WordPress/blob/473295ab123b35ed54104b599f12f9e8b5e97283/wp-admin/css/forms.css#L1417).