### PR TITLE
Fix margin for labels in add language form

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -8,8 +8,12 @@
 }
 
 .pll-legend {
-	margin: 0.35em 0 0.5em;
+	display: block;
 	padding: 2px 0;
+	color: #1d2327;
+	font-weight: 400;
+	text-shadow: none;
+	margin: 0.35em 0 0.5em;
 }
 
 .column-locale,

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -7,6 +7,11 @@
 	margin: 0.35em 0 0.5em;
 }
 
+.pll-legend {
+	margin: 0.35em 0 0.5em;
+	padding: 2px 0;
+}
+
 .column-locale,
 .languages .column-slug {
 	width : 15%

--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -3,6 +3,10 @@
 	width: 95%;
 }
 
+#add-lang label {
+	margin: 0.35em 0 0.5em;
+}
+
 .column-locale,
 .languages .column-slug {
 	width : 15%

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -107,7 +107,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</div>
 
 					<div class="form-field"><fieldset>
-						<legend><?php esc_html_e( 'Text direction', 'polylang' ); ?></legend>
+						<legend class="pll-legend"><?php esc_html_e( 'Text direction', 'polylang' ); ?></legend>
 						<?php
 						printf(
 							'<label><input name="rtl" type="radio" value="0" %s /> %s</label>',


### PR DESCRIPTION
## Problem
Lack of margin for the labels.
<img width="460" alt="Capture d’écran 2021-07-08 à 11 15 49" src="https://user-images.githubusercontent.com/69580439/124897112-464b3600-dfde-11eb-8676-641aecd1967d.png">

## Changes
For consistency with other forms (export string translations form for instance), add the same margin that WP apply to its forms ([cf](https://github.com/WordPress/WordPress/blob/473295ab123b35ed54104b599f12f9e8b5e97283/wp-admin/css/forms.css#L777)) . See the display now :
<img width="459" alt="Capture d’écran 2021-07-08 à 11 46 24" src="https://user-images.githubusercontent.com/69580439/124901323-2f0e4780-dfe2-11eb-83b1-54a84758ec16.png">


*Note that the margin is applied to all `<label>` in the form and not only these with a radio button.*