### PR TITLE
Add composer commands to launch all our tools the same way

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
 		]
 	},
 	"scripts": {
-		"test":"phpunit",
-		"cs":"phpcs",
-		"stan": "phpstan analyze --memory-limit=400M",
+		"test":"vendor/bin/phpunit",
+		"cs":"vendor/bin/phpcs",
+		"stan": "vendor/bin/phpstan analyze --memory-limit=400M",
 		"lint": [
 			"@cs",
 			"@stan"

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,24 @@
 			"modules/",
 			"settings/"
 		]
+	},
+	"scripts": {
+		"test":"phpunit",
+		"cs":"phpcs",
+		"stan": "phpstan analyze --memory-limit=400M",
+		"lint": [
+			"@cs",
+			"@stan"
+		],
+		"build": "bin/build.sh",
+		"dist": "bin/distribute.sh"
+	},
+	"scripts-descriptions": {
+		"test":"Runs PHPUnit tests.",
+		"cs":"Runs PHPCS linter.",
+		"stan": "Runs PHPStan analysis.",
+		"lint": "Runs both PHPCS and PHPStan.",
+		"build": "Builds the project.",
+		"dist": "Make the zip file to distibute the project release."
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ The simplest way is to clone locally this repository and build it directly in yo
 2. Clone there the polylang repository (or your fork) from GitHub:<br/>
 `git clone https://github.com/polylang/polylang.git`
 3. Go to your local Polylang clone folder from there: `cd polylang`
-4. Run the bash script: `./bin/build.sh`
+4. Run the composer command: `composer build`
 5. Activate Polylang as if you had installed it from WordPress.org:<br/>
 See <https://wordpress.org/plugins/polylang/#installation>
 


### PR DESCRIPTION
The goal of this PR is to propose composer commands to launch each of our tools the same way:

| Tool | Command | Description
| -------- | ---- | ----- |
| PHPUnit | composer test | Runs PHPUnit tests. |
| PHPCS | composer cs | Runs PHPCS linter. |
| PHPStan | composer stan | Runs PHPStan analysis. |
| PHPCS & PHPStan | composer lint | Runs both PHPCS and PHPStan. |
| Build project | composer build | Builds the project. |
| Distribute project | composer dist | Make the zip file to distibute the project release. |

**Note** 
1. It is possible to pass parameters to the tool by using the `--` separator between the composer command and the tool parameter.

For example:

- to run PHPUnit only on one class or method:
  - `composer test -- --filter Admin_Test`
  - `composer test -- --filter Admin_Test::test_admin_bar_menu`
- to run PHPCS only on a folder or file
  -  `composer cs -- admin/`
  - `composer cs -- admin/admin-base.php`

2. the `readme.md` file has been updated to take in account the new `composer build` command.