### PR TITLE
Improve rss feed support with plain permalinks

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -392,8 +392,18 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( $this->links_model->using_permalinks && is_category() && ! empty( $this->wp_query()->query['cat'] ) ) {
-			// When we receive a plain permaling with a cat query var, we need to redirect to the pretty permalink.
+		elseif ( is_feed() && ( is_category() || is_tag() || is_tax() ) ) {
+			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
+				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
+				$language = $this->model->term->get_language( $term_id );
+				if ( $this->links_model->using_permalinks ) {
+					$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term_id, '' ) );
+				}
+			}
+		}
+
+		elseif ( $this->links_model->using_permalinks && ( is_category() || is_tag() || is_tax() ) && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] )) ) {
+			// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
 				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
 				$language = $this->model->term->get_language( $term_id );

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -402,7 +402,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( $this->links_model->using_permalinks && ( is_category() || is_tag() || is_tax() ) && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] )) ) {
+		elseif ( $this->links_model->using_permalinks && ( is_category() || is_tag() || is_tax() ) && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
 			// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
 				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -392,26 +392,18 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			}
 		}
 
-		elseif ( is_feed() && ( is_category() || is_tag() || is_tax() ) ) {
+		elseif ( is_category() || is_tag() || is_tax() ) {
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
-				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
-				$language = $this->model->term->get_language( $term_id );
-				if ( $this->links_model->using_permalinks ) {
-					$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term_id, '' ) );
+				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
+					// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
+					$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
+					if( is_feed() ) {
+						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term_id, '' ) );
+					} else {
+						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
+					}
 				}
 			}
-		}
-
-		elseif ( $this->links_model->using_permalinks && ( is_category() || is_tag() || is_tax() ) && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
-			// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
-			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
-				$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
-				$language = $this->model->term->get_language( $term_id );
-				$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
-			}
-		}
-
-		elseif ( is_category() || is_tag() || is_tax() ) {
 			// We need to switch the language when there is no language provided in a pretty permalink.
 			$obj = get_queried_object();
 			if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -410,7 +410,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 						$language = $this->model->term->get_language( (int) $obj->term_id );
 					}
 				}
-				}
+			}
 		}
 
 		elseif ( is_404() && ! empty( $this->wp_query()->tax_query ) ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -397,7 +397,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
 					// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
 					$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
-					if( is_feed() ) {
+					if ( is_feed() ) {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term_id, '' ) );
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -402,13 +402,15 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 					}
+					$language = $this->model->term->get_language( $term_id );
+				} else {
+					// We need to switch the language when there is no language provided in a pretty permalink.
+					$obj = get_queried_object();
+					if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
+						$language = $this->model->term->get_language( (int) $obj->term_id );
+					}
 				}
-			}
-			// We need to switch the language when there is no language provided in a pretty permalink.
-			$obj = get_queried_object();
-			if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
-				$language = $this->model->term->get_language( (int) $obj->term_id );
-			}
+				}
 		}
 
 		elseif ( is_404() && ! empty( $this->wp_query()->tax_query ) ) {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -7,6 +7,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	private static $page_id;
 	private static $custom_post_id;
 	private static $term_en;
+	private static $tag_en;
 	private static $page_for_posts_en;
 	private static $page_for_posts_fr;
 
@@ -53,6 +54,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$model->term->set_language( self::$term_en, 'en' );
+
+		self::$tag_en = $factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test-tag' ) );
+		self::$model->term->set_language( self::$tag_en, 'en' );
 
 		$en = self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$model->post->set_language( self::$page_for_posts_en, 'en' );
@@ -461,46 +465,10 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public function test_plain_cat_feed() {
-		// Create a category.
-		$cat_id = $this->factory->category->create(
-			array(
-				'name' => 'Test Category',
-				'slug' => 'test-category',
-			)
-		);
-		self::$model->term->set_language( $cat_id, 'en' );
-		// Create a post with the previous category.
-		$post_id = $this->factory->post->create(
-			array(
-				'post_title' => 'test',
-				'post_type'  => 'page',
-				'category'   => $cat_id,
-			)
-		);
-		self::$model->post->set_language( $post_id, 'en' );
-
-		$this->assertCanonical( '/?cat=' . $cat_id . '&feed=rss2', '/en/category/test-category/feed/' );
+		$this->assertCanonical( '/?cat=' . self::$term_en . '&feed=rss2', '/en/category/parent/feed/' );
 	}
 
 	public function test_plain_tag_feed() {
-		// Create a tag.
-		$tag_id = $this->factory->tag->create(
-			array(
-				'name' => 'Test Tag',
-				'slug' => 'test-tag',
-			)
-		);
-		self::$model->term->set_language( $tag_id, 'en' );
-		// Create a post with the previous tag.
-		$post_id = $this->factory->post->create(
-			array(
-				'post_title' => 'test',
-				'post_type'  => 'page',
-				'tag'        => $tag_id,
-			)
-		);
-		self::$model->post->set_language( $post_id, 'en' );
-
 		$this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
 	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -503,20 +503,4 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		$this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
 	}
-
-	public function test_custom_post_type_from_plain_permalink() {
-		$this->assertCanonical( '?pllcanonical=' . self::$custom_post_id, '/en/pllcanonical/custom-post/' );
-	}
-
-	public function test_custom_post_type_feed_with_incorrect_language() {
-		$this->assertCanonical( '/fr/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
-	}
-
-	public function test_custom_post_type_feed_without_language() {
-		$this->assertCanonical( '/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
-	}
-
-	public function test_custom_post_type_feed_from_plain_permalink() {
-		$this->assertCanonical( '?feed=rss&pllcanonical=' . self::$custom_post_id, '/en/pllcanonical/custom-post/feed/' );
-	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -459,4 +459,64 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 			)
 		);
 	}
+
+	public function test_plain_cat_feed() {
+		// Create a category.
+		$cat_id = $this->factory->category->create(
+			array(
+				'name' => 'Test Category',
+				'slug' => 'test-category',
+			)
+		);
+		self::$model->term->set_language( $cat_id, 'en' );
+		// Create a post with the previous category.
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'test',
+				'post_type'  => 'page',
+				'category'   => $cat_id,
+			)
+		);
+		self::$model->post->set_language( $post_id, 'en' );
+
+		$this->assertCanonical( '/?cat=' . $cat_id . '&feed=rss2', '/en/category/test-category/feed/' );
+	}
+
+	public function test_plain_tag_feed() {
+		// Create a tag.
+		$tag_id = $this->factory->tag->create(
+			array(
+				'name' => 'Test Tag',
+				'slug' => 'test-tag',
+			)
+			);
+		self::$model->term->set_language( $tag_id, 'en' );
+		// Create a post with the previous tag.
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'test',
+				'post_type'  => 'page',
+				'tag'        => $tag_id,
+			)
+		);
+		self::$model->post->set_language( $post_id, 'en' );
+
+		$this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
+	}
+
+	public function test_custom_post_type_from_plain_permalink() {
+		$this->assertCanonical( '?pllcanonical=' . self::$custom_post_id, '/en/pllcanonical/custom-post/' );
+	}
+
+	public function test_custom_post_type_feed_with_incorrect_language() {
+		$this->assertCanonical( '/fr/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
+	}
+
+	public function test_custom_post_type_feed_without_language() {
+		$this->assertCanonical( '/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
+	}
+
+	public function test_custom_post_type_feed_from_plain_permalink() {
+		$this->assertCanonical( '?feed=rss&pllcanonical=' . self::$custom_post_id, '/en/pllcanonical/custom-post/feed/' );
+	}
 }

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -489,7 +489,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				'name' => 'Test Tag',
 				'slug' => 'test-tag',
 			)
-			);
+		);
 		self::$model->term->set_language( $tag_id, 'en' );
 		// Create a post with the previous tag.
 		$post_id = $this->factory->post->create(


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1031

## Changes

In a feed request context, set the language to retrieve the archive of the translated taxonomy. If pretty permalinks option is used, then redirect to the pretty link corresponding to the desired taxonomy feed. Also redirect to pretty link for tag request but no feed.