### PR TITLE
WPSEO: Use dynamic permalinks

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -423,6 +423,10 @@ class PLL_WPSEO {
 				$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
 				$indexable->breadcrumb_title = pll__( $breadcrumb_title );
 			}
+
+			if ( 'term' === $indexable->object_type && pll_is_translated_taxonomy( $indexable->object_sub_type ) ) {
+				$indexable->permalink = get_term_link( $indexable->object_id );
+			}
 		}
 
 		return $indexables;

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -17,6 +17,7 @@ class PLL_WPSEO {
 	 */
 	public function init() {
 		add_action( 'wp_loaded', array( $this, 'wpseo_translate_options' ) );
+		add_filter( 'wpseo_dynamic_permalinks_enabled', '__return_true', 999 );
 
 		if ( PLL() instanceof PLL_Frontend ) {
 			// Filters sitemap queries to remove inactive language or to get
@@ -366,7 +367,6 @@ class PLL_WPSEO {
 	public function frontend_presentation( $presentation ) {
 		switch ( $presentation->model->object_type ) {
 			case 'home-page':
-				$presentation->model->permalink = pll_home_url();
 				$presentation->model->title = WPSEO_Options::get( 'title-home-wpseo' );
 				$presentation->model->description = WPSEO_Options::get( 'metadesc-home-wpseo' );
 				$presentation->model->open_graph_title = WPSEO_Options::get( 'og_frontpage_title' );
@@ -375,14 +375,9 @@ class PLL_WPSEO {
 
 			case 'post-type-archive':
 				if ( pll_is_translated_post_type( $presentation->model->object_sub_type ) ) {
-					$presentation->model->permalink = get_post_type_archive_link( $presentation->model->object_sub_type );
 					$presentation->model->title = WPSEO_Options::get( 'title-ptarchive-' . $presentation->model->object_sub_type );
 					$presentation->model->description = WPSEO_Options::get( 'metadesc-ptarchive-' . $presentation->model->object_sub_type );
 				}
-				break;
-
-			case 'user':
-				$presentation->model->permalink = get_author_posts_url( $presentation->model->object_id );
 				break;
 
 			case 'system-page':

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -407,24 +407,18 @@ class PLL_WPSEO {
 	 */
 	public function breadcrumb_indexables( $indexables ) {
 		foreach ( $indexables as &$indexable ) {
-			// Handles both when the front page displays the list of posts or a static page.
 			if ( 'home-page' === $indexable->object_type || ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_on_front' ) === $indexable->object_id ) ) {
+				// Handles both when the front page displays the list of posts or a static page.
 				$indexable->permalink = pll_home_url();
 				$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
-			}
-
-			if ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_for_posts' ) === $indexable->object_id ) {
+			} elseif ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_for_posts' ) === $indexable->object_id ) {
 				$indexable->permalink = get_permalink( $indexable->object_id );
-			}
-
-			if ( 'post-type-archive' === $indexable->object_type && pll_is_translated_post_type( $indexable->object_sub_type ) ) {
+			} elseif ( 'post-type-archive' === $indexable->object_type && pll_is_translated_post_type( $indexable->object_sub_type ) ) {
 				$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
 				$breadcrumb_title = WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type );
 				$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
 				$indexable->breadcrumb_title = pll__( $breadcrumb_title );
-			}
-
-			if ( 'term' === $indexable->object_type && pll_is_translated_taxonomy( $indexable->object_sub_type ) ) {
+			} elseif ( 'term' === $indexable->object_type && pll_is_translated_taxonomy( $indexable->object_sub_type ) ) {
 				$indexable->permalink = get_term_link( $indexable->object_id );
 			}
 		}

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -396,29 +396,32 @@ class PLL_WPSEO {
 	}
 
 	/**
-	 * Fixes the breadcrumb links and strings stored in the indexable table since Yoast SEO 14.0
+	 * Fixes the breadcrumb links and strings stored in the indexable table since Yoast SEO 14.0.
+	 *
+	 * In version 17.0, the breadcrumb links do not honor the filter `wpseo_dynamic_permalinks_enabled`.
 	 *
 	 * @since 2.8.3
 	 *
 	 * @param array $indexables An array of Indexable objects.
-	 * @return object
+	 * @return array
 	 */
 	public function breadcrumb_indexables( $indexables ) {
 		foreach ( $indexables as &$indexable ) {
-			switch ( $indexable->object_type ) {
-				case 'home-page':
-					$indexable->permalink = pll_home_url();
-					$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
-					break;
+			// Handles both when the front page displays the list of posts or a static page.
+			if ( 'home-page' === $indexable->object_type || ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_on_front' ) === $indexable->object_id ) ) {
+				$indexable->permalink = pll_home_url();
+				$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
+			}
 
-				case 'post-type-archive':
-					if ( pll_is_translated_post_type( $indexable->object_sub_type ) ) {
-						$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
-						$breadcrumb_title = WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type );
-						$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
-						$indexable->breadcrumb_title = pll__( $breadcrumb_title );
-					}
-					break;
+			if ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_for_posts' ) === $indexable->object_id ) ) {
+				$indexable->permalink = get_permalink( $indexable->object_id );
+			}
+
+			if ( 'post-type-archive' === $indexable->object_type && pll_is_translated_post_type( $indexable->object_sub_type ) ) {
+				$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
+				$breadcrumb_title = WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type );
+				$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
+				$indexable->breadcrumb_title = pll__( $breadcrumb_title );
 			}
 		}
 

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -407,11 +407,13 @@ class PLL_WPSEO {
 		foreach ( $indexables as &$indexable ) {
 			switch ( $indexable->object_type ) {
 				case 'home-page':
+					$indexable->permalink = pll_home_url();
 					$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
 					break;
 
 				case 'post-type-archive':
 					if ( pll_is_translated_post_type( $indexable->object_sub_type ) ) {
+						$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
 						$breadcrumb_title = WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type );
 						$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
 						$indexable->breadcrumb_title = pll__( $breadcrumb_title );

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -413,7 +413,7 @@ class PLL_WPSEO {
 				$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
 			}
 
-			if ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_for_posts' ) === $indexable->object_id ) ) {
+			if ( 'post' === $indexable->object_type && 'page' === $indexable->object_sub_type && get_option( 'page_for_posts' ) === $indexable->object_id ) {
 				$indexable->permalink = get_permalink( $indexable->object_id );
 			}
 

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -407,13 +407,11 @@ class PLL_WPSEO {
 		foreach ( $indexables as &$indexable ) {
 			switch ( $indexable->object_type ) {
 				case 'home-page':
-					$indexable->permalink = pll_home_url();
 					$indexable->breadcrumb_title = pll__( WPSEO_Options::get( 'breadcrumbs-home' ) );
 					break;
 
 				case 'post-type-archive':
 					if ( pll_is_translated_post_type( $indexable->object_sub_type ) ) {
-						$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
 						$breadcrumb_title = WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type );
 						$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
 						$indexable->breadcrumb_title = pll__( $breadcrumb_title );


### PR DESCRIPTION
I luckily discovered the filter `wpseo_dynamic_permalinks_enabled` introduced in Yoast SEO 15.1. This is more or less what I asked for just before the indexables were introduced in the version 14.0.

This PR asks Yoast SEO to use dynamic permalinks. Overriding them should thus not be useful anymore. Hopefully using this filter should fix all permalinks issues once for all.

Unfortunately Yoast SEO doesn't honor the filter for breadcrumb links, so we still need to override them.

Moreover more tests demonstrate a bug for the static front page and blog page breadcrumbs which are also fixed by this PR.

Fixes #882 
Fixes https://github.com/polylang/polylang-pro/issues/1039