### PR TITLE
Save the correct parent page id when changing the page language

### DIFF
--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -198,11 +198,11 @@ class PLL_CRUD_Posts {
 	 * @return int
 	 */
 	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
-			$lang = $this->model->post->get_language( $post_id );
-			// Dont break the hierarchy in case the post has no language
-			if ( ! empty( $lang ) ) {
-				$post_parent = $this->model->post->get_translation( $post_parent, $lang );
-			}
+		$lang = $this->model->post->get_language( $post_id );
+		// Dont break the hierarchy in case the post has no language
+		if ( ! empty( $lang ) ) {
+			$post_parent = $this->model->post->get_translation( $post_parent, $lang );
+		}
 		return $post_parent;
 	}
 

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -43,7 +43,7 @@ class PLL_CRUD_Posts {
 
 		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
 		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 4 );
-		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 4 );
+		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 2 );
 		add_action( 'before_delete_post', array( $this, 'delete_post' ) );
 
 		// Specific for media
@@ -193,11 +193,9 @@ class PLL_CRUD_Posts {
 	 *
 	 * @param int   $post_parent Post parent ID.
 	 * @param int   $post_id     Post ID.
-	 * @param array $new_postarr Array of parsed post data.
-	 * @param array $postarr     Array of sanitized, but otherwise unmodified post data.
 	 * @return int
 	 */
-	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
+	public function wp_insert_post_parent( $post_parent, $post_id ) {
 		$lang = $this->model->post->get_language( $post_id );
 		// Dont break the hierarchy in case the post has no language
 		if ( ! empty( $lang ) ) {

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -191,8 +191,8 @@ class PLL_CRUD_Posts {
 	 *
 	 * @since 1.8
 	 *
-	 * @param int   $post_parent Post parent ID.
-	 * @param int   $post_id     Post ID.
+	 * @param int $post_parent Post parent ID.
+	 * @param int $post_id     Post ID.
 	 * @return int
 	 */
 	public function wp_insert_post_parent( $post_parent, $post_id ) {

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -187,7 +187,7 @@ class PLL_CRUD_Posts {
 	}
 
 	/**
-	 * Make sure that the post parent is in the correct language when using bulk edit
+	 * Make sure that the post parent is in the correct language.
 	 *
 	 * @since 1.8
 	 *
@@ -198,16 +198,11 @@ class PLL_CRUD_Posts {
 	 * @return int
 	 */
 	public function wp_insert_post_parent( $post_parent, $post_id, $new_postarr, $postarr ) {
-		if ( isset( $postarr['bulk_edit'], $postarr['inline_lang_choice'] ) ) {
-			check_admin_referer( 'bulk-posts' );
-			$lang = -1 == $postarr['inline_lang_choice'] ?
-				$this->model->post->get_language( $post_id ) :
-				$this->model->get_language( $postarr['inline_lang_choice'] );
+			$lang = $this->model->post->get_language( $post_id );
 			// Dont break the hierarchy in case the post has no language
 			if ( ! empty( $lang ) ) {
 				$post_parent = $this->model->post->get_translation( $post_parent, $lang );
 			}
-		}
 		return $post_parent;
 	}
 

--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -1,0 +1,84 @@
+<?php
+
+class Parent_Page_Test extends PLL_UnitTestCase {
+	static $editor;
+
+	static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+
+		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests.
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+
+	}
+
+	public function test_parent_page_with_existing_translation_when_changing_post_language() {
+		// Language set from parent
+		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		self::$model->post->set_language( $en, 'en' );
+
+		$fr = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		self::$model->post->set_language( $fr, 'fr' );
+
+		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+		$child_page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_parent' => $en ) );
+		$this->assertEquals( 'en', self::$model->post->get_language( $child_page_id )->slug );
+
+		// Change the child post language.
+		// Simulate the language is changed.
+		self::$model->post->set_language( $child_page_id, 'fr' );
+		// Before the post is updated.
+		$GLOBALS['post_type'] = 'page';
+		$_REQUEST = $_POST = array(
+			'post_lang_choice' => 'fr',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+			'post_ID'          => $child_page_id,
+		);
+		do_action( 'load-post.php' );
+		edit_post();
+
+		$child_page = get_post( $child_page_id );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $child_page_id )->slug );
+		$this->assertEquals( get_post( $child_page_id )->post_parent, $en );
+
+	}
+
+	public function test_parent_page_with_no_translation_when_changing_post_language() {
+		// Language set from parent
+		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		self::$model->post->set_language( $en, 'en' );
+
+		$child_page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_parent' => $en ) );
+		$this->assertEquals( 'en', self::$model->post->get_language( $child_page_id )->slug );
+
+		// Change the child post language.
+		// Simulate the language is changed.
+		self::$model->post->set_language( $child_page_id, 'fr' );
+		// Before the post is updated.
+		$GLOBALS['post_type'] = 'page';
+		$_REQUEST = $_POST = array(
+			'post_lang_choice' => 'fr',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+			'post_ID'          => $child_page_id,
+		);
+		do_action( 'load-post.php' );
+		edit_post();
+
+		$child_page = get_post( $child_page_id );
+		$this->assertEquals( 'fr', self::$model->post->get_language( $child_page_id )->slug );
+		$this->assertEquals( get_post( $child_page_id )->post_parent, 0 );
+
+	}
+}


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/971

In fact, the parent page id were updated only in a bulk edit context.

This PR propose to update the parent page id in the all contexts.

If the parent page has a translation in the new language the `post_parent` page attribute is updated to the id of the translated parent page otherwise it is reset to 0.