### PR TITLE
Test the correct post_parent value after changing the child post language

### DIFF
--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -51,7 +51,7 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 
 		$child_page = get_post( $child_page_id );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $child_page_id )->slug );
-		$this->assertEquals( get_post( $child_page_id )->post_parent, $en );
+		$this->assertEquals( get_post( $child_page_id )->post_parent, $fr );
 
 	}
 


### PR DESCRIPTION
To follow up #911 I tested locally the test correctly failed but I wrongly pushed the code.
This PR fix the test by testing the right expected value in the assertion.
