### PR TITLE
Fix second parameter of get_object_taxonomies()

### DIFF
--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -59,7 +59,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 		}
 
 		// Hierarchical taxonomies
-		if ( 'edit' == $screen->base && $taxonomies = get_object_taxonomies( $screen->post_type, 'object' ) ) {
+		if ( 'edit' == $screen->base && $taxonomies = get_object_taxonomies( $screen->post_type, 'objects' ) ) {
 			// Get translated hierarchical taxonomies
 			$hierarchical_taxonomies = array();
 			foreach ( $taxonomies as $taxonomy ) {


### PR DESCRIPTION
See https://developer.wordpress.org/reference/functions/get_object_taxonomies/#parameters
I mark it as an enhancement as the function returns objects for anything else than `'names'`.