### PR TITLE
Fix wizard deactivate license

### DIFF
--- a/modules/wizard/view-wizard-page.php
+++ b/modules/wizard/view-wizard-page.php
@@ -74,7 +74,7 @@ if ( is_rtl() ) {
 		<div class="pll-wizard-content">
 			<form method="post" class="<?php echo esc_attr( "{$this->step}-step" ); ?>">
 				<?php
-				wp_nonce_field( 'pll-wizard', '_pll_nonce' );
+				wp_nonce_field( 'pll-wizard', '_pll_wizard_nonce' );
 
 				if ( ! empty( $this->steps[ $this->step ]['view'] ) ) {
 					call_user_func( $this->steps[ $this->step ]['view'], $this );

--- a/modules/wizard/view-wizard-step-licenses.php
+++ b/modules/wizard/view-wizard-step-licenses.php
@@ -10,6 +10,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
+wp_nonce_field( 'pll_options', '_pll_nonce' ); // Specific nonce to be able to deactivate licenses {@see js/src/admin.js} in ajax call context.
 
 $licenses = apply_filters( 'pll_settings_licenses', array() );
 $is_error = isset( $_GET['activate_error'] ) && 'i18n_license_key_error' === sanitize_key( $_GET['activate_error'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -362,9 +362,6 @@ class PLL_Wizard {
 	 * @return array List of steps updated.
 	 */
 	public function add_step_licenses( $steps ) {
-		// Add ajax action on deactivate button in licenses step.
-		add_action( 'wp_ajax_pll_deactivate_license', array( $this, 'deactivate_license' ) );
-
 		// Be careful pll_admin script is enqueued here without depedency except jquery because only code useful for deactivate license button is needed.
 		// To be really loaded the script need to be passed to the $steps['licenses']['scripts'] array below with the same handle than in wp_enqueue_script().
 		wp_enqueue_script( 'pll_admin', plugins_url( '/js/build/admin' . $this->get_suffix() . '.js', POLYLANG_ROOT_FILE ), array( 'jquery' ), POLYLANG_VERSION, true );
@@ -423,37 +420,6 @@ class PLL_Wizard {
 
 		wp_safe_redirect( esc_url_raw( $redirect ) );
 		exit;
-	}
-
-	/**
-	 * Ajax method to deactivate a license
-	 *
-	 * @since 2.7
-	 *
-	 * @return void
-	 */
-	public function deactivate_license() {
-		check_ajax_referer( 'pll-wizard', '_pll_nonce' );
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( -1 );
-		}
-
-		if ( ! isset( $_POST['id'] ) ) {
-			wp_die( 0 );
-		}
-
-		$id = substr( sanitize_text_field( wp_unslash( $_POST['id'] ) ), 11 );
-		$licenses = apply_filters( 'pll_settings_licenses', array() );
-		$license = $licenses[ $id ];
-		$license->deactivate_license();
-
-		wp_send_json(
-			array(
-				'id'   => $id,
-				'html' => $license->get_form_field(),
-			)
-		);
 	}
 
 	/**

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -401,7 +401,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function save_step_licenses() {
-		check_admin_referer( 'pll-wizard', '_pll_nonce' );
+		check_admin_referer( 'pll-wizard', '_pll_wizard_nonce' );
 
 		$redirect = $this->get_next_step_link();
 		$licenses = apply_filters( 'pll_settings_licenses', array() );
@@ -523,7 +523,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function save_step_languages() {
-		check_admin_referer( 'pll-wizard', '_pll_nonce' );
+		check_admin_referer( 'pll-wizard', '_pll_wizard_nonce' );
 
 		$existing_languages = $this->model->get_languages_list();
 
@@ -635,7 +635,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function save_step_media() {
-		check_admin_referer( 'pll-wizard', '_pll_nonce' );
+		check_admin_referer( 'pll-wizard', '_pll_wizard_nonce' );
 
 		$media_support = isset( $_POST['media_support'] ) ? sanitize_key( $_POST['media_support'] ) === 'yes' : false;
 
@@ -692,7 +692,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function save_step_untranslated_contents() {
-		check_admin_referer( 'pll-wizard', '_pll_nonce' );
+		check_admin_referer( 'pll-wizard', '_pll_wizard_nonce' );
 
 		$lang = isset( $_POST['language'] ) ? sanitize_text_field( wp_unslash( $_POST['language'] ) ) : false;
 
@@ -760,7 +760,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function save_step_home_page() {
-		check_admin_referer( 'pll-wizard', '_pll_nonce' );
+		check_admin_referer( 'pll-wizard', '_pll_wizard_nonce' );
 
 		$languages = $this->model->get_languages_list();
 
@@ -856,7 +856,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function save_step_last() {
-		check_admin_referer( 'pll-wizard', '_pll_nonce' );
+		check_admin_referer( 'pll-wizard', '_pll_wizard_nonce' );
 
 		wp_safe_redirect( esc_url_raw( $this->get_next_step_link() ) );
 		exit;


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1082

## What happens?

In fact when a deactivation license is requested an ajax call is done and it's not the wizard context which is loaded but the Polylang settings one.
Thus it's the `wp_ajax_pll_deactivate_license` hook defined in PLL_Settings_Licenses which is really called https://github.com/polylang/polylang/blob/master/settings/settings-licenses.php#L47 and not this one which is defined in the wizard https://github.com/polylang/polylang/blob/master/modules/wizard/wizard.php#L366

In addition the nonce action (`pll_options`) value expected to verify in `PLL_Settings_Licenses` https://github.com/polylang/polylang/blob/master/settings/settings-licenses.php#L98
isn't the same as in the wizard steps https://github.com/polylang/polylang/blob/master/modules/wizard/wizard.php#L404

## What changes?

So to fix the issue this PR propose:

- to add the right `pll_options` nonce only in the licenses step
- to rename the specific wizard nonce name to avoid conflicts with the `_pll_nonce` used in the settings context
- remove the useless `wp_ajax_pll_deactivate_license` hook which is never call
