### PR TITLE
Fix user description escaping

### DIFF
--- a/admin/admin-filters.php
+++ b/admin/admin-filters.php
@@ -66,15 +66,13 @@ class PLL_Admin_Filters extends PLL_Filters {
 	public function personal_options( $profileuser ) {
 		foreach ( $this->model->get_languages_list() as $lang ) {
 			$meta = $lang->slug == $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
-
-			/** This filter is documented in wp-includes/user.php */
-			$description = apply_filters( 'user_description', get_user_meta( $profileuser->ID, $meta, true ) ); // Applies WP default filter wp_kses_data
+			$description = get_user_meta( $profileuser->ID, $meta, true );
 
 			printf(
 				'<input type="hidden" class="biography" name="%s___%s" value="%s" />',
 				esc_attr( $lang->slug ),
 				esc_attr( $lang->name ),
-				esc_attr( $description )
+				sanitize_user_field( 'description', $description, $profileuser->ID, 'edit' )
 			);
 		}
 	}


### PR DESCRIPTION
Fix #933 

When displaying the user edit form, we used to apply directly the filter 'user_description' as well as `esc_attr()` to escape the user description in the text area.

This was a mistake as the filter is adapted to the 'display' context (see https://github.com/WordPress/WordPress/blob/5.8.1/wp-includes/user.php#L1524) but not to the 'edit' context and thus is too aggressive.

I propose to use `sanitize_user_field()` with the 'edit' context exactly [as WordPress does](https://github.com/WordPress/WordPress/blob/5.8.1/wp-includes/class-wp-user.php#L326).

This is equivalent to [a call to `esc_html()`](https://github.com/WordPress/WordPress/blob/5.8.1/wp-includes/user.php#L1482) which, in a default WP install is equivalent to the previous `esc_attr()`.

This PR intentionnally doesn't handle https://github.com/polylang/polylang-pro/issues/1124 which doesn't seem to have a visble impact.

Note: `sanitize_user_field()` intentionnally uses `esc_html()` instead of `esc_textarea()` to escape the user description. See: https://core.trac.wordpress.org/ticket/15454#comment:17