### PR TITLE
Fix fatal error in PHPunit tests

### DIFF
--- a/tests/phpunit/tests/plugins/test-duplicate-post.php
+++ b/tests/phpunit/tests/plugins/test-duplicate-post.php
@@ -2,7 +2,7 @@
 
 if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 	require_once DIR_TESTROOT . '/../duplicate-post/duplicate-post.php';
-	require_once DIR_TESTROOT . '/../duplicate-post/duplicate-post-admin.php';
+	require_once DIR_TESTROOT . '/../duplicate-post/admin-functions.php';
 
 	class Duplicate_Post_Test extends PLL_UnitTestCase {
 


### PR DESCRIPTION
... following the renaming of a file from the duplicate-post plugin.

See https://github.com/Yoast/duplicate-post/pull/156