### PR TITLE
Fix Canonical_Test::test_plain_tag_feed 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ js/build/
 *.min.js
 *.min.css
 composer.lock
+.phpunit.result.cache

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -398,9 +398,11 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
 					// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
 					if ( is_feed() ) {
+						// Backward compatibility with WP < 5.9 due to change in how get_term_feed_link() works.
+						// @see https://github.com/WordPress/wordpress-develop/commit/a8485376d27b5b3348a68963f6fd38200b6e64cf
 						global $wp_version;
 						if ( version_compare( $wp_version, '5.9-alpha', '>=' ) ) {
-							$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term ) );
+							$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term ) ); // @phpstan-ignore-line
 						} else {
 							$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term->term_id, $term->taxonomy ) );
 						}

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -393,26 +393,30 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 
 		elseif ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
 				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
 					// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
-					$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
 					if ( is_feed() ) {
-						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term_id, '' ) );
+						global $wp_version;
+						if ( version_compare( $wp_version, '5.9-alpha', '>=' ) ) {
+							$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term ) );
+						} else {
+							$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_feed_link( $term->term_id, $term->taxonomy ) );
+						}
 					} else {
-						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
+						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term ) );
 					}
 					$language = $this->get_queried_term_language();
 				} else {
 					// We need to switch the language when there is no language provided in a pretty permalink.
-					$obj = get_queried_object();
-					if ( ! empty( $obj ) && $this->model->is_translated_taxonomy( $obj->taxonomy ) ) {
-						$language = $this->model->term->get_language( (int) $obj->term_id );
+					if ( ! empty( $term ) && $this->model->is_translated_taxonomy( $term->taxonomy ) ) {
+						$language = $this->model->term->get_language( (int) $term->term_id );
 					}
 				}
 			}
 
-			if ( is_feed() && empty( $obj ) ) {
+			if ( is_feed() && empty( $term ) ) {
 				// Allows to replace the language correctly in a category feed query.
 				$language = $this->get_queried_term_language();
 			}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1132

## Problem

Since WordPress 5.9-alpha, `get_term_feed_link()` first parameter type changed. Prior to 5.9-alpha, the previous function accept only the `term_id`. Now it allow both `term_id` and `WP_Term`. BUT when passing a `term_id`, the `taxonomy` is set to a default value `category`.

See https://github.com/WordPress/wordpress-develop/commit/a8485376d27b5b3348a68963f6fd38200b6e64cf  

## Changes

Check the WordPress version before getting the term feed link.
If WP > 5.9, then use a `WP_Term` object.

*Note : the use of `WP_term` seems to increase performance. See the link above.*

⚠️  *This [PR](https://github.com/WordPress/wordpress-develop/pull/1945) should fix the broken backward compatibility in WordPress, if so this PR would be useless.*
See https://core.trac.wordpress.org/ticket/50225#comment:27