### PR TITLE
An empty search should not display the homepage anymore

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -305,16 +305,13 @@ abstract class PLL_Choose_Lang {
 		if ( $lang = apply_filters( 'pll_set_language_from_query', false, $query ) ) {
 			$this->set_language( $lang );
 			$this->set_curlang_in_query( $query );
-		}
-
-		// sets is_home on translated home page when it displays posts
-		// is_home must be true on page 2, 3... too
-		// as well as when searching an empty string: http://wordpress.org/support/topic/plugin-polylang-polylang-breaks-search-in-spun-theme
-		elseif ( ( count( $query->query ) == 1 || ( is_paged() && count( $query->query ) == 2 ) || ( isset( $query->query['s'] ) && ! $query->query['s'] ) ) && $lang = get_query_var( 'lang' ) ) {
+		} elseif ( ( count( $query->query ) == 1 || ( is_paged() && count( $query->query ) == 2 ) ) && $lang = get_query_var( 'lang' ) ) {
+			// Set is_home on translated home page when it displays posts. It must be true on page 2, 3... too.
 			$lang = $this->model->get_language( $lang );
-			$this->set_language( $lang ); // sets the language now otherwise it will be too late to filter sticky posts !
+			$this->set_language( $lang ); // Set the language now otherwise it will be too late to filter sticky posts!
 			$query->is_home = true;
-			$query->is_archive = $query->is_tax = false;
+			$query->is_tax = false;
+			$query->is_archive = false;
 		}
 	}
 

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -364,6 +364,22 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/?s=test' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
+	/**
+	 * After https://core.trac.wordpress.org/ticket/11330 an empty search doesn't return the homepage anymore.
+	 */
+	function test_empty_search() {
+		$this->go_to( home_url( '/fr/?s=' ) );
+		$this->assertQueryTrue( 'is_search' );
+	}
+
+	/**
+	 * Issue #937.
+	 */
+	function test_invalid_search() {
+		$this->go_to( home_url( '/fr/random/?s=' ) );
+		$this->assertQueryTrue( 'is_404' );
+	}
+
 	function test_search_in_category() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );


### PR DESCRIPTION
Fix #937 

WordPress used to display the homepage as the result of an empty search. We aimed to reproduce this behavior since  https://wordpress.org/support/topic/plugin-polylang-polylang-breaks-search-in-spun-theme. However, the behavior of WordPress has been modified since https://core.trac.wordpress.org/ticket/11330 has been fixed in WP 4.0.

Moreover our fix didn't handle correctly empty searches when the query had additional query vars (see #937).

This PR removes the "fix" added in v1.1.1 to display the homepage for an empty search. It adds tests to check that we reproduce the current behavior for empty searches with or without additional query vars.