### PR TITLE
WPML Compatibility: Check the type of the string before registering it

### DIFF
--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -103,6 +103,10 @@ class PLL_WPML_Compat {
 	 * @return void
 	 */
 	public function register_string( $context, $name, $string ) {
+		if ( ! $string || ! is_scalar( $string ) ) {
+			return;
+		}
+
 		// If a string has already been registered with the same name and context, let's replace it.
 		$exist_string = $this->get_string_by_context_and_name( $context, $name );
 		if ( $exist_string && $exist_string !== $string ) {
@@ -122,7 +126,7 @@ class PLL_WPML_Compat {
 
 		// Registers the string if it does not exist yet (multiline as in WPML).
 		$to_register = array( 'context' => $context, 'name' => $name, 'string' => $string, 'multiline' => true, 'icl' => true );
-		if ( ! in_array( $to_register, self::$strings ) && $to_register['string'] ) {
+		if ( ! in_array( $to_register, self::$strings ) ) {
 			$key = md5( "$context | $name" );
 			self::$strings[ $key ] = $to_register;
 			update_option( 'polylang_wpml_strings', self::$strings );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1144
This is to avoid warnings in the case that a 3rd party plugin would register for example an array.
See also f96d4c4d0c314ab6b72b7f89b8ab748fe85955dc which was the same for strings registered with `pll_register_string()`.