### PR TITLE
Add Yoast SEO columns when updating the post list table rows

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -46,6 +46,10 @@ class PLL_WPSEO {
 		} else {
 			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ), 10, 2 );
 			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
+
+			if ( filter_input( INPUT_POST, 'action' ) === 'pll_update_post_rows' ) {
+				$GLOBALS['wpseo_meta_columns'] = new WPSEO_Meta_Columns();
+			}
 		}
 	}
 

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -48,7 +48,7 @@ class PLL_WPSEO {
 			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
 
 			// Yoast SEO adds the columns hooks only for the 'inline-save' action. We need them for 'pll_update_post_rows' too.
-			if ( filter_input( INPUT_POST, 'action' ) === 'pll_update_post_rows' ) {
+			if ( doing_ajax() && isset( $_POST['action'] ) && 'pll_update_post_rows' === $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$GLOBALS['wpseo_meta_columns'] = new WPSEO_Meta_Columns();
 			}
 		}

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -48,7 +48,7 @@ class PLL_WPSEO {
 			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
 
 			// Yoast SEO adds the columns hooks only for the 'inline-save' action. We need them for 'pll_update_post_rows' too.
-			if ( doing_ajax() && isset( $_POST['action'] ) && 'pll_update_post_rows' === $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( wp_doing_ajax() && isset( $_POST['action'] ) && 'pll_update_post_rows' === $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$GLOBALS['wpseo_meta_columns'] = new WPSEO_Meta_Columns();
 			}
 		}

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -47,6 +47,7 @@ class PLL_WPSEO {
 			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ), 10, 2 );
 			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
 
+			// Yoast SEO adds the columns hooks only for the 'inline-save' action. We need them for 'pll_update_post_rows' too.
 			if ( filter_input( INPUT_POST, 'action' ) === 'pll_update_post_rows' ) {
 				$GLOBALS['wpseo_meta_columns'] = new WPSEO_Meta_Columns();
 			}


### PR DESCRIPTION
When quick editing a post, the columns added by Yoast SEO are not drawn correctly. It's because the relevant hooks are not added for ajax actions, except the `inline-save` action used by WordPress. We need to add the hooks for our action `pll_update_post_rows` too.

See also https://github.com/polylang/polylang/issues/928#issuecomment-989883330

