### PR TITLE
Let's require WP 5.5 as min version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ jobs:
         - "vendor/bin/phpcs -s --extensions=php,js ./"
         - "vendor/bin/phpstan analyze --memory-limit=512M"
 
-    - name: "WP oldest - PHP 7.2"
+    - name: "WP 5.5 - PHP 7.2"
       php: "7.2"
-      env: "WP_VERSION=5.4 WP_MULTISITE=0"
+      env: "WP_VERSION=5.5 WP_MULTISITE=0"
       script:
         - "vendor/bin/phpunit --verbose"
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
 
 	<file>.</file>
 
-	<config name="minimum_supported_wp_version" value="5.4"/>
+	<config name="minimum_supported_wp_version" value="5.5"/>
 
 	<rule ref="PHPCompatibilityWP">
 		<config name="testVersion" value="5.6-"/>
@@ -154,7 +154,7 @@
 	<rule ref="Generic.WhiteSpace.ScopeIndent">
 		<exclude-pattern>*/*.js</exclude-pattern>
 	</rule>
-	
+
 	<exclude-pattern>js/*.min.js</exclude-pattern>
 	<exclude-pattern>js/build</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>

--- a/polylang.php
+++ b/polylang.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://polylang.pro
  * Description:       Adds multilingual capability to WordPress
  * Version:           3.2-dev
- * Requires at least: 5.4
+ * Requires at least: 5.5
  * Requires PHP:      5.6
  * Author:            WP SYNTEX
  * Author URI:        https://polylang.pro
@@ -54,7 +54,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 } else {
 	// Go on loading the plugin
 	define( 'POLYLANG_VERSION', '3.2-dev' );
-	define( 'PLL_MIN_WP_VERSION', '5.4' );
+	define( 'PLL_MIN_WP_VERSION', '5.5' );
 	define( 'PLL_MIN_PHP_VERSION', '5.6' );
 
 	define( 'POLYLANG_FILE', __FILE__ );

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ If you are not a developer, we recommend to [download Polylang](https://wordpres
 
 Before starting, make sure that you have the following software installed and working on your computer:
 
-1. A local [WordPress](https://wordpress.org/support/article/how-to-install-wordpress/) (5.4 or later) instance
+1. A local [WordPress](https://wordpress.org/support/article/how-to-install-wordpress/) (5.5 or later) instance
 2. [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) to clone the Polylang repository (or your fork of the Polylang repository).
 3. [Node.js](https://nodejs.org/en/download/) which provides [NPM](https://docs.npmjs.com/). They are both required by [Webpack](https://webpack.js.org/guides/getting-started/) that Polylang uses to build and minify CSS and javascript files. We recommend to install Node.js LTS version.
 4. [Composer](https://getcomposer.org/doc/00-intro.md) because Polylang uses its autoloader to work and it is required to install development tools such as PHP CodeSniffer that ensures your code follows coding standards.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Chouby, manooweb, raaaahman, marianne38, sebastienserre
 Donate link: https://polylang.pro
 Tags: multilingual, bilingual, translate, translation, language, multilanguage, international, localization
-Requires at least: 5.4
+Requires at least: 5.5
 Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 3.1.2

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ Don't hesitate to [give your feedback](http://wordpress.org/support/view/plugin-
 
 == Installation ==
 
-1. Make sure you are using WordPress 5.1 or later and that your server is running PHP 5.6 or later (same requirement as WordPress itself)
+1. Make sure you are using WordPress 5.5 or later and that your server is running PHP 5.6 or later (same requirement as WordPress itself)
 1. If you tried other multilingual plugins, deactivate them before activating Polylang, otherwise, you may get unexpected results!
 1. Install and activate the plugin as usual from the 'Plugins' menu in WordPress.
 1. Go to the languages settings page and create the languages you need

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -74,10 +74,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public function init_for_sitemaps() {
-		if ( ! function_exists( 'wp_get_sitemap_providers' ) ) {
-			self::markTestSkipped( 'This test requires WP 5.5+' );
-		}
-
 		add_action(
 			'pll_init',
 			function ( $polylang ) {

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -5,11 +5,6 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		// Sitemaps were introduced in WP 5.5.
-		if ( ! function_exists( 'wp_get_sitemap_providers' ) ) {
-			self::markTestSkipped( 'These tests require WP 5.5+' );
-		}
-
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );


### PR DESCRIPTION
- Updates the readme and plugin header accordingly.
- Updates the Travis config
- Removes skipped tests for WP < 5.5