### PR TITLE
Improve coding standards in tests

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -134,10 +134,6 @@
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Scope.MethodScope" >
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-
 	<rule ref="WordPress.PHP.NoSilencedErrors.Discouraged" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
@@ -154,7 +150,7 @@
 	<rule ref="Generic.WhiteSpace.ScopeIndent">
 		<exclude-pattern>*/*.js</exclude-pattern>
 	</rule>
-	
+
 	<exclude-pattern>js/*.min.js</exclude-pattern>
 	<exclude-pattern>js/build</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -94,10 +94,6 @@
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="PSR2.Classes.PropertyDeclaration.ScopeMissing" >
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-
 	<rule ref="Squiz.Commenting.ClassComment.Missing" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
@@ -127,10 +123,6 @@
 	</rule>
 
 	<rule ref="Squiz.PHP.CommentedOutCode.Found" >
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-
-	<rule ref="Squiz.Scope.MemberVarScope.Missing" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -110,15 +110,7 @@
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.FunctionComment.WrongStyle" >
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-
 	<rule ref="Squiz.Commenting.VariableComment.Missing" >
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-
-	<rule ref="Squiz.Commenting.VariableComment.WrongStyle" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -102,10 +102,6 @@
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.FunctionComment.EmptyThrows" >
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-
 	<rule ref="Squiz.Commenting.FunctionComment.Missing" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>

--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -18,45 +18,45 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 		self::create_language( 'de_DE' );
 	}
 
-	static function wpTearDownAfterClass() {
+	public static function wpTearDownAfterClass() {
 		parent::wpTearDownAfterClass();
 
 		$_SERVER = self::$server;
 	}
 
-	function test_add_language_to_link() {
+	public function test_add_language_to_link() {
 		$url = $this->hosts['en'] . '/test/';
 
 		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_double_add_language_to_link() {
+	public function test_double_add_language_to_link() {
 		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->add_language_to_link( $this->hosts['fr'] . '/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_remove_language_from_link() {
+	public function test_remove_language_from_link() {
 		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->remove_language_from_link( $this->hosts['en'] . '/test/' ) );
 		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->remove_language_from_link( $this->hosts['fr'] . '/test/' ) );
 	}
 
-	function test_switch_language_in_link() {
+	public function test_switch_language_in_link() {
 		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->switch_language_in_link( $this->hosts['fr'] . '/test/', self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->hosts['de'] . '/test/', $this->links_model->switch_language_in_link( $this->hosts['fr'] . '/test/', self::$model->get_language( 'de' ) ) );
 		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->switch_language_in_link( $this->hosts['en'] . '/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_add_paged_to_link() {
+	public function test_add_paged_to_link() {
 		$this->assertEquals( $this->hosts['en'] . '/test/page/2/', $this->links_model->add_paged_to_link( $this->hosts['en'] . '/test/', 2 ) );
 		$this->assertEquals( $this->hosts['fr'] . '/test/page/2/', $this->links_model->add_paged_to_link( $this->hosts['fr'] . '/test/', 2 ) );
 	}
 
-	function test_remove_paged_from_link() {
+	public function test_remove_paged_from_link() {
 		$this->assertEquals( $this->hosts['en'] . '/test/', $this->links_model->remove_paged_from_link( $this->hosts['en'] . '/test/page/2/' ) );
 		$this->assertEquals( $this->hosts['fr'] . '/test/', $this->links_model->remove_paged_from_link( $this->hosts['fr'] . '/test/page/2/' ) );
 	}
 
-	function test_get_language_from_url() {
+	public function test_get_language_from_url() {
 		// hack $_SERVER
 		$server = $_SERVER;
 		$_SERVER['REQUEST_URI'] = '/test/';
@@ -67,18 +67,18 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 		$_SERVER = $server;
 	}
 
-	function test_home_url() {
+	public function test_home_url() {
 		$this->assertEquals( $this->hosts['en'] . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->hosts['fr'] . '/', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_allowed_redirect_hosts() {
+	public function test_allowed_redirect_hosts() {
 		$hosts = str_replace( 'http://', '', array_values( $this->hosts ) );
 		$this->assertEquals( $hosts, $this->links_model->allowed_redirect_hosts( array() ) );
 		$this->assertEquals( $this->hosts['fr'], wp_validate_redirect( $this->hosts['fr'] ) );
 	}
 
-	function test_upload_dir() {
+	public function test_upload_dir() {
 		// Hack $_SERVER.
 		$server = $_SERVER;
 		$_SERVER['REQUEST_URI'] = '/test/';

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -16,7 +16,7 @@ trait PLL_UnitTestCase_Trait {
 	 *
 	 * @param WP_UnitTest_Factory $factory WP_UnitTest_Factory object.
 	 */
-	static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		$options = PLL_Install::get_default_options();
 		$options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
 		$options['media_support'] = 1; // Force option to pre 3.1 value otherwise phpunit tests break on Travis.
@@ -26,14 +26,14 @@ trait PLL_UnitTestCase_Trait {
 	/**
 	 * Deletes all languages after all tests have run.
 	 */
-	static function wpTearDownAfterClass() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function wpTearDownAfterClass() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		self::delete_all_languages();
 	}
 
 	/**
 	 * Empties the languages cache after all tests
 	 */
-	function tear_down() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function tear_down() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		self::$model->clean_languages_cache(); // We must do it before database ROLLBACK otherwhise it is impossible to delete the transient
 
 		$globals = array( 'current_screen', 'hook_suffix', 'wp_settings_errors', 'post_type', 'wp_scripts', 'wp_styles' );
@@ -53,7 +53,7 @@ trait PLL_UnitTestCase_Trait {
 	 * @param array  $args   Allows to optionnally override the default values for the language.
 	 * @throws InvalidArgumentException If language is not created.
 	 */
-	static function create_language( $locale, $args = array() ) {
+	public static function create_language( $locale, $args = array() ) {
 		$languages = include POLYLANG_DIR . '/settings/languages.php';
 		$values    = $languages[ $locale ];
 
@@ -78,7 +78,7 @@ trait PLL_UnitTestCase_Trait {
 	/**
 	 * Deletes all languages
 	 */
-	static function delete_all_languages() {
+	public static function delete_all_languages() {
 		$languages = self::$model->get_languages_list();
 		if ( is_array( $languages ) ) {
 			// Delete the default categories first.

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -9,7 +9,7 @@ trait PLL_UnitTestCase_Trait {
 	 *
 	 * @var object
 	 */
-	static $model;
+	protected static $model;
 
 	/**
 	 * Initialization before all tests run.

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -9,7 +9,7 @@ trait PLL_UnitTestCase_Trait {
 	 *
 	 * @var object
 	 */
-	protected static $model;
+	public static $model;
 
 	/**
 	 * Initialization before all tests run.

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -6,7 +6,7 @@
 class PLL_UnitTestCase extends WP_UnitTestCase {
 	use PLL_UnitTestCase_Trait;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.

--- a/tests/phpunit/includes/wp-screen-mock.php
+++ b/tests/phpunit/includes/wp-screen-mock.php
@@ -19,8 +19,6 @@ class Wp_Screen_Mock {
 
 	/**
 	 * Wp_Screen_Mock constructor.
-	 *
-	 * @throws ReflectionException
 	 */
 	public function __construct() {
 		$this->screen = new ReflectionClass( WP_Screen::class );

--- a/tests/phpunit/tests/plugins/test-duplicate-post.php
+++ b/tests/phpunit/tests/plugins/test-duplicate-post.php
@@ -21,7 +21,7 @@ if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 			PLL_Integrations::instance()->duplicate_post->init();
 		}
 
-		function test_exclude_post_translations() {
+		public function test_exclude_post_translations() {
 			$en = $this->factory->post->create();
 			self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -15,7 +15,7 @@ if ( version_compare( $GLOBALS['wp_version'], '5.6', '>=' ) && file_exists( DIR_
 			self::create_language( 'fr_FR' );
 		}
 
-		function set_up() {
+		public function set_up() {
 			parent::set_up();
 
 			require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
@@ -27,7 +27,7 @@ if ( version_compare( $GLOBALS['wp_version'], '5.6', '>=' ) && file_exists( DIR_
 			$GLOBALS['polylang'] = &$this->frontend; // we still use the global $polylang
 		}
 
-		function test_opengraph() {
+		public function test_opengraph() {
 			// create posts to get something  on home page
 			$en = $this->factory->post->create();
 			self::$model->post->set_language( $en, 'en' );

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -4,7 +4,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress-importer/wordpress-importer.php'
 
 	class WP_Importer_Test extends PLL_UnitTestCase {
 
-		function set_up() {
+		public function set_up() {
 			parent::set_up();
 
 			require_once POLYLANG_DIR . '/include/api.php';
@@ -34,7 +34,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress-importer/wordpress-importer.php'
 			$GLOBALS['polylang'] = &$pll_admin;
 		}
 
-		function tear_down() {
+		public function tear_down() {
 			unset( $GLOBALS['polylang'] );
 			self::delete_all_languages();
 
@@ -75,7 +75,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress-importer/wordpress-importer.php'
 			$_POST = array();
 		}
 
-		function test_simple_import() {
+		public function test_simple_import() {
 			$this->_import_wp( dirname( __FILE__ ) . '/../../data/test-import.xml' );
 
 			// languages

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -41,7 +41,15 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress-importer/wordpress-importer.php'
 			parent::tear_down();
 		}
 
-		// mostly copied from WP_Import_UnitTestCase
+		/**
+		 * Import a WXR file.
+		 *
+		 * Mostly copied from WP_Import_UnitTestCase.
+		 *
+		 * @param string $filename    Full path of the file to import.
+		 * @param array  $users       User import settings.
+		 * @param bool   $fetch_files Whether or not do download remote attachments.
+		 */
 		protected function _import_wp( $filename, $users = array(), $fetch_files = true ) {
 			$importer = new PLL_WP_Import(); // Change to our importer
 			$file = realpath( $filename );

--- a/tests/phpunit/tests/plugins/test-yarpp.php
+++ b/tests/phpunit/tests/plugins/test-yarpp.php
@@ -2,7 +2,7 @@
 
 class YARPP_Test extends PLL_UnitTestCase {
 	// bug introduced in 1.8 and fixed in 1.8.2
-	function test_yarpp_support() {
+	public function test_yarpp_support() {
 		define( 'YARPP_VERSION', '1.0' ); // Fake.
 		do_action( 'plugins_loaded' );
 		do_action( 'init' );

--- a/tests/phpunit/tests/plugins/test-yarpp.php
+++ b/tests/phpunit/tests/plugins/test-yarpp.php
@@ -1,7 +1,9 @@
 <?php
 
 class YARPP_Test extends PLL_UnitTestCase {
-	// bug introduced in 1.8 and fixed in 1.8.2
+	/**
+	 * Bug introduced in 1.8 and fixed in 1.8.2.
+	 */
 	public function test_yarpp_support() {
 		define( 'YARPP_VERSION', '1.0' ); // Fake.
 		do_action( 'plugins_loaded' );

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -1,7 +1,7 @@
 <?php
 
 class Admin_Filters_Post_Test extends PLL_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -19,7 +19,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
@@ -33,7 +33,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
 	}
 
-	function test_default_language() {
+	public function test_default_language() {
 		// User preferred language
 		$this->pll_admin->pref_lang = self::$model->get_language( 'fr' );
 		$post_id = $this->factory->post->create();
@@ -51,7 +51,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'es', self::$model->post->get_language( $post_id )->slug );
 	}
 
-	function test_save_post_from_metabox() {
+	public function test_save_post_from_metabox() {
 		$GLOBALS['post_type'] = 'post';
 
 		$_REQUEST = $_POST = array(
@@ -78,7 +78,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( compact( 'en', 'fr' ), self::$model->post->get_translations( $en ) );
 	}
 
-	function test_save_post_from_bulk_edit() {
+	public function test_save_post_from_bulk_edit() {
 		$posts = $this->factory->post->create_many( 2 );
 		self::$model->post->set_language( $posts[0], 'en' );
 		self::$model->post->set_language( $posts[1], 'fr' );
@@ -105,7 +105,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->post->get_language( $posts[1] )->slug );
 	}
 
-	function test_quickdraft() {
+	public function test_quickdraft() {
 		$_REQUEST = array(
 			'action'   => 'post-quickdraft-save',
 			'_wpnonce' => wp_create_nonce( 'add-post' ),
@@ -116,7 +116,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->post->get_language( $post_id )->slug );
 	}
 
-	function test_save_post_with_categories() {
+	public function test_save_post_with_categories() {
 		$en = $this->factory->category->create();
 		self::$model->term->set_language( $en, 'en' );
 
@@ -146,7 +146,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_object_in_term( $post_id, 'category', $fr2 ) );
 	}
 
-	function test_save_post_with_tags() {
+	public function test_save_post_with_tags() {
 		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
 
 		$en = $this->factory->tag->create( array( 'name' => 'test' ) );
@@ -172,7 +172,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->term->get_language( $new->term_id )->slug );
 	}
 
-	function test_delete_post() {
+	public function test_delete_post() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -192,7 +192,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 2, $group->count ); // Count updated
 	}
 
-	function test_page_attributes_meta_box() {
+	public function test_page_attributes_meta_box() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -223,7 +223,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $out, 'essai' ) );
 	}
 
-	function test_languages_meta_box_for_new_post() {
+	public function test_languages_meta_box_for_new_post() {
 		global $post_ID;
 
 		$lang = $this->pll_admin->pref_lang = self::$model->get_language( 'en' );
@@ -242,7 +242,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'selected', $option->item( 0 )->getAttribute( 'selected' ) );
 	}
 
-	function test_languages_meta_box_for_new_translation() {
+	public function test_languages_meta_box_for_new_translation() {
 		global $post_ID;
 
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
@@ -273,7 +273,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'test', $input->item( 0 )->getAttribute( 'value' ) );
 	}
 
-	function test_languages_meta_box_for_existing_post_with_translations() {
+	public function test_languages_meta_box_for_existing_post_with_translations() {
 		global $post_ID;
 
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
@@ -319,7 +319,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '', $input->item( 0 )->getAttribute( 'value' ) );
 	}
 
-	function test_languages_meta_box_for_media() {
+	public function test_languages_meta_box_for_media() {
 		global $post_ID;
 
 		$this->pll_admin->options['media_support'] = 1;
@@ -355,7 +355,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $form, 'Add a translation in Deutsch' ) );
 	}
 
-	function test_get_posts_language_filter() {
+	public function test_get_posts_language_filter() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -381,7 +381,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $en, $fr, $de ), $posts );
 	}
 
-	function test_get_posts_with_query_var() {
+	public function test_get_posts_with_query_var() {
 		$this->pll_admin->options['taxonomies'] = array(
 			'trtax' => 'trtax',
 		);
@@ -432,7 +432,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $fr, reset( $posts ) );
 	}
 
-	function test_categories_script_data_in_footer() {
+	public function test_categories_script_data_in_footer() {
 		$hook_suffix = $GLOBALS['hook_suffix'] = 'edit.php';
 		set_current_screen( 'edit' );
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
@@ -453,7 +453,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $term_id, $matches[1] );
 	}
 
-	function test_parent_pages_script_data_in_footer() {
+	public function test_parent_pages_script_data_in_footer() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -1,7 +1,7 @@
 <?php
 
 class Admin_Filters_Term_Test extends PLL_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -17,7 +17,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
@@ -29,7 +29,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
 	}
 
-	function test_default_language() {
+	public function test_default_language() {
 		// User preferred language
 		$this->pll_admin->pref_lang = self::$model->get_language( 'fr' );
 		$term_id = $this->factory->category->create();
@@ -42,7 +42,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'de', self::$model->term->get_language( $term_id )->slug );
 	}
 
-	function test_save_term_from_edit_tags() {
+	public function test_save_term_from_edit_tags() {
 		$_REQUEST = $_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'en',
@@ -64,7 +64,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( compact( 'en', 'fr' ), self::$model->term->get_translations( $en ) );
 	}
 
-	function test_create_term_from_categories_metabox() {
+	public function test_create_term_from_categories_metabox() {
 		$_REQUEST = $_POST = array(
 			'action'                   => 'add-category',
 			'term_lang_choice'         => 'fr',
@@ -75,7 +75,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
 	}
 
-	function test_save_term_from_quick_edit() {
+	public function test_save_term_from_quick_edit() {
 		$term_id = $en = $this->factory->category->create();
 		self::$model->term->set_language( $en, 'en' );
 
@@ -113,7 +113,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'de' => $term_id ), self::$model->term->get_translations( $term_id ) );
 	}
 
-	function test_create_term_from_post_bulk_edit() {
+	public function test_create_term_from_post_bulk_edit() {
 		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin ); // We need this too
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
 
@@ -175,7 +175,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $new_fr, $test_fr, $third ), $tags );
 	}
 
-	function test_delete_term() {
+	public function test_delete_term() {
 		$en = $this->factory->category->create();
 		self::$model->term->set_language( $en, 'en' );
 
@@ -196,7 +196,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 2, $group->count ); // Count updated
 	}
 
-	function get_edit_term_form( $tag_ID, $taxonomy ) {
+	protected function get_edit_term_form( $tag_ID, $taxonomy ) {
 		// Prepare all needed info before loading the entire form
 		$GLOBALS['post_type'] = 'post';
 		$tax = get_taxonomy( $taxonomy );
@@ -214,7 +214,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		return ob_get_clean();
 	}
 
-	function test_parent_dropdown_in_edit_tags() {
+	public function test_parent_dropdown_in_edit_tags() {
 		$this->pll_admin->default_term = new PLL_Admin_Default_Term( $this->pll_admin );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
@@ -246,7 +246,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
 	}
 
-	function test_language_dropdown_and_translations_in_edit_tags() {
+	public function test_language_dropdown_and_translations_in_edit_tags() {
 		$this->pll_admin->default_term = new PLL_Admin_Default_Term( $this->pll_admin );
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
@@ -276,7 +276,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '', $input->item( 0 )->getAttribute( 'value' ) ); // No translation in German
 	}
 
-	function get_parent_dropdown_in_new_term_form( $taxonomy ) {
+	protected function get_parent_dropdown_in_new_term_form( $taxonomy ) {
 		// NB: impossible to load edit-tags.php entirely as it would attempt to load a second instance of WP
 		// which is impossible due to constant definitions such as ABSPATH
 
@@ -300,7 +300,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		return ob_get_clean();
 	}
 
-	function test_parent_dropdown_in_new_tag() {
+	public function test_parent_dropdown_in_new_tag() {
 		$this->pll_admin->pref_lang = self::$model->get_language( 'en' );
 		$_GET['taxonomy'] = 'category';
 
@@ -338,7 +338,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $dropdown, '<option class="level-0" value="' . $fr . '" selected="selected">essai</option>' ) );
 	}
 
-	function test_language_dropdown_and_translations_in_new_tags() {
+	public function test_language_dropdown_and_translations_in_new_tags() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -390,7 +390,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '', $input->item( 0 )->getAttribute( 'value' ) ); // No translation in German
 	}
 
-	function test_post_categories_meta_box() {
+	public function test_post_categories_meta_box() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -413,7 +413,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $out, 'essai' ) );
 	}
 
-	function test_nav_menu_item_taxonomy_meta_box() {
+	public function test_nav_menu_item_taxonomy_meta_box() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -443,7 +443,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $out, 'essai' ) );
 	}
 
-	function test_get_terms_language_filter() {
+	public function test_get_terms_language_filter() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -466,7 +466,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $en, $fr ), $terms );
 	}
 
-	function test_create_terms_with_same_name() {
+	public function test_create_terms_with_same_name() {
 		$_REQUEST = $_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'en',

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -13,52 +13,52 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 		self::create_language( 'ar' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
-	function test_sanitize_title_for_current_language_without_character_conversion() {
+	public function test_sanitize_title_for_current_language_without_character_conversion() {
 		$this->pll_admin->curlang = self::$model->get_language( 'en' );
 		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fullmenge', sanitize_title( 'Füllmenge' ) );
 	}
 
-	function test_sanitize_title_for_language_from_form_without_character_conversion() {
+	public function test_sanitize_title_for_language_from_form_without_character_conversion() {
 			// Bug fixed in 2.4.1
 		$_POST['post_lang_choice'] = 'en';
 		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fullmenge', sanitize_title( 'Füllmenge' ) );
 	}
 
-	function test_sanitize_title_for_current_language_with_character_conversion() {
+	public function test_sanitize_title_for_current_language_with_character_conversion() {
 		$this->pll_admin->curlang = self::$model->get_language( 'de' );
 		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fuellmenge', sanitize_title( 'Füllmenge' ) );
 	}
 
-	function test_sanitize_title_for_language_from_form_with_character_conversion() {
+	public function test_sanitize_title_for_language_from_form_with_character_conversion() {
 		// Bug fixed in 2.4.1
 		$_POST['post_lang_choice'] = 'de';
 		$this->pll_admin->add_filters();
 		$this->assertEquals( 'fuellmenge', sanitize_title( 'Füllmenge' ) );
 	}
 
-	function test_sanitize_user_without_character_conversion() {
+	public function test_sanitize_user_without_character_conversion() {
 		$this->pll_admin->curlang = self::$model->get_language( 'en' );
 		$this->pll_admin->add_filters();
 		$this->assertEquals( 'angstrom', sanitize_user( 'ångström' ) );
 	}
 
-	function test_sanitize_user_with_character_conversion() {
+	public function test_sanitize_user_with_character_conversion() {
 		$this->pll_admin->curlang = self::$model->get_language( 'de' );
 		$this->pll_admin->add_filters();
 		$this->assertEquals( 'angstroem', sanitize_user( 'ångström' ) );
 	}
 
-	function test_personal_options_update() {
+	public function test_personal_options_update() {
 		$this->pll_admin->add_filters();
 		$_POST['description_de'] = 'Biography in German';
 		remove_action( 'personal_options_update', 'send_confirmation_on_profile_email' );
@@ -66,7 +66,7 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $_POST['description_de'], get_user_meta( 1, 'description_de', true ) );
 	}
 
-	function test_admin_body_class_ltr() {
+	public function test_admin_body_class_ltr() {
 		// Since WP 5.4, remove this filter which requires a WP_Screen that we don't provide and is not relevant for our test.
 		if ( class_exists( 'WP_Site_Health' ) ) {
 			remove_filter( 'admin_body_class', array( WP_Site_Health::get_instance(), 'admin_body_class' ) );
@@ -77,7 +77,7 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( ' pll-dir-ltr', apply_filters( 'admin_body_class', '' ) );
 	}
 
-	function test_admin_body_class_rtl() {
+	public function test_admin_body_class_rtl() {
 		// Since WP 5.4, remove this filter which requires a WP_Screen that we don't provide and is not relevant for our test.
 		if ( class_exists( 'WP_Site_Health' ) ) {
 			remove_filter( 'admin_body_class', array( WP_Site_Health::get_instance(), 'admin_body_class' ) );
@@ -89,7 +89,7 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 	}
 
 
-	function test_privacy_page_post_states() {
+	public function test_privacy_page_post_states() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -12,7 +12,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function update_language( $lang, $args ) {
+	protected function update_language( $lang, $args ) {
 		foreach ( array( 'name', 'slug', 'locale', 'term_group' ) as $key ) {
 			$defaults[ $key ] = $lang->$key;
 		}
@@ -23,7 +23,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		self::$model->update_language( $args );
 	}
 
-	function test_change_language_slug() {
+	public function test_change_language_slug() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -44,7 +44,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		// FIXME test widgets, menu locations and domains
 	}
 
-	function test_get_objects_with_no_lang() {
+	public function test_get_objects_with_no_lang() {
 		register_post_type( 'cpt' ); // add untranslated custom post type
 		register_taxonomy( 'tax', 'cpt' ); // add untranslated taxonomy
 
@@ -88,7 +88,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		_unregister_taxonomy( 'tax' );
 	}
 
-	function test_set_language_in_mass_for_posts() {
+	public function test_set_language_in_mass_for_posts() {
 		foreach ( $this->factory->post->create_many( 2, array() ) as $p ) {
 			self::$model->post->set_language( $p, 'en' );
 		}
@@ -106,7 +106,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_terms( 'post_translations' ) ); // no translation group for posts
 	}
 
-	function test_set_language_in_mass_for_terms() {
+	public function test_set_language_in_mass_for_terms() {
 		foreach ( $this->factory->tag->create_many( 2 ) as $t ) {
 			self::$model->term->set_language( $t, 'en' );
 		}

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -2,18 +2,18 @@
 
 class Admin_Notices_Test extends PLL_UnitTestCase {
 
-	static function wp_redirect() {
-		throw new Exception( 'Call to wp_redirect' );
-	}
-
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
-	function test_hide_notice() {
+	public static function wp_redirect() {
+		throw new Exception( 'Call to wp_redirect' );
+	}
+
+	public function test_hide_notice() {
 		// Allows to continue the execution after wp_redirect + exit.
 		add_filter( 'wp_redirect', array( __CLASS__, 'wp_redirect' ) );
 		if ( method_exists( $this, 'setExpectedException' ) ) {
@@ -37,7 +37,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'review' ), get_user_meta( 1, 'pll_dismissed_notices', true ) );
 	}
 
-	function test_no_review_notice_for_old_users() {
+	public function test_no_review_notice_for_old_users() {
 		wp_set_current_user( 1 );
 
 		$_GET['page'] = 'mlang';
@@ -53,7 +53,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $out, 'review' ) );
 	}
 
-	function test_review_notice() {
+	public function test_review_notice() {
 		wp_set_current_user( 1 );
 
 		$_GET['page'] = 'mlang';
@@ -74,7 +74,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		}
 	}
 
-	function test_hidden_review_notice() {
+	public function test_hidden_review_notice() {
 		wp_set_current_user( 1 );
 		update_user_meta( 1, 'pll_dismissed_notices', array( 'review' ) );
 
@@ -92,7 +92,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $out, 'review' ) );
 	}
 
-	function test_no_review_notice_for_non_admin() {
+	public function test_no_review_notice_for_non_admin() {
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
 
@@ -110,7 +110,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $out );
 	}
 
-	function test_pllwc_notice() {
+	public function test_pllwc_notice() {
 		wp_set_current_user( 1 );
 
 		$_GET['page'] = 'mlang';
@@ -129,7 +129,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $out, 'pllwc' ) );
 	}
 
-	function test_lingotek_notice() {
+	public function test_lingotek_notice() {
 		wp_set_current_user( 1 );
 
 		$_GET['page'] = 'mlang';
@@ -154,7 +154,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		}
 	}
 
-	function test_legacy_user_meta() {
+	public function test_legacy_user_meta() {
 		wp_set_current_user( 1 );
 		update_user_meta( 1, 'pll_dismissed_notices', array( 'test_notice' ) );
 

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -50,7 +50,9 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertStringContainsString( 'You are currently editing the page that shows your latest posts.', ob_get_clean() );
 	}
 
-	// Bug introduced in 2.2.2 and fixed in 2.2.3
+	/**
+	 * Bug introduced in 2.2.2 and fixed in 2.2.3.
+	 */
 	public function test_editor_on_page() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $en, 'en' );

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -12,7 +12,7 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
@@ -22,13 +22,13 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		$this->pll_admin->static_pages = new PLL_Admin_Static_Pages( $this->pll_admin );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		add_post_type_support( 'page', 'editor' );
 	}
 
-	function test_deactivate_editor_for_page_for_posts() {
+	public function test_deactivate_editor_for_page_for_posts() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -51,7 +51,7 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug introduced in 2.2.2 and fixed in 2.2.3
-	function test_editor_on_page() {
+	public function test_editor_on_page() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -76,7 +76,7 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertStringNotContainsString( 'You are currently editing the page that shows your latest posts.', ob_get_clean() );
 	}
 
-	function test_use_block_editor_for_post() {
+	public function test_use_block_editor_for_post() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -13,7 +13,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function test_admin_bar_menu() {
+	public function test_admin_bar_menu() {
 		global $wp_admin_bar;
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
 
@@ -38,7 +38,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '/wp-admin/edit.php?lang=fr', $fr->href );
 	}
 
-	function _test_scripts( $scripts ) {
+	protected function _test_scripts( $scripts ) {
 		$links_model = self::$model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
 		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
@@ -72,7 +72,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		in_array( 'css', $scripts ) ? $this->assertNotFalse( $test ) : $this->assertFalse( $test );
 	}
 
-	function test_scripts_in_post_list_table() {
+	public function test_scripts_in_post_list_table() {
 		$GLOBALS['hook_suffix'] = 'edit.php';
 		set_current_screen();
 
@@ -80,7 +80,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_untranslated_cpt_list_table() {
+	public function test_scripts_in_untranslated_cpt_list_table() {
 		$GLOBALS['hook_suffix'] = 'edit.php';
 		$_REQUEST['post_type'] = 'cpt';
 		register_post_type( 'cpt' );
@@ -90,7 +90,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_edit_post() {
+	public function test_scripts_in_edit_post() {
 		$GLOBALS['hook_suffix'] = 'post.php';
 		set_current_screen();
 
@@ -98,7 +98,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_edit_untranslated_cpt() {
+	public function test_scripts_in_edit_untranslated_cpt() {
 		$GLOBALS['hook_suffix'] = 'post.php';
 		$_REQUEST['post_type'] = 'cpt';
 		register_post_type( 'cpt' );
@@ -109,7 +109,7 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 
-	function test_scripts_in_media_list_table() {
+	public function test_scripts_in_media_list_table() {
 		$GLOBALS['hook_suffix'] = 'upload.php';
 		set_current_screen();
 
@@ -117,7 +117,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_terms_list_table() {
+	public function test_scripts_in_terms_list_table() {
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen();
 
@@ -125,7 +125,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_untranslated_custom_tax_list_table() {
+	public function test_scripts_in_untranslated_custom_tax_list_table() {
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		$_REQUEST['taxonomy'] = 'tax';
 		register_taxonomy( 'tax', 'post' );
@@ -135,7 +135,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_edit_term() {
+	public function test_scripts_in_edit_term() {
 		$GLOBALS['hook_suffix'] = 'term.php';
 		set_current_screen();
 
@@ -143,7 +143,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->_test_scripts( $scripts );
 	}
 
-	function test_scripts_in_edit_unstranslated_custom_tax() {
+	public function test_scripts_in_edit_unstranslated_custom_tax() {
 		$GLOBALS['hook_suffix'] = 'term.php';
 		$_REQUEST['taxonomy'] = 'tax';
 		register_taxonomy( 'tax', 'post' );
@@ -154,7 +154,7 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 
-	function test_scripts_in_user_profile() {
+	public function test_scripts_in_user_profile() {
 		$GLOBALS['hook_suffix'] = 'profile.php';
 		set_current_screen();
 

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -1,7 +1,7 @@
 <?php
 
 class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -15,7 +15,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
@@ -27,7 +27,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
 	}
 
-	function test_post_translations() {
+	public function test_post_translations() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -87,7 +87,7 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertEquals( $en, (string) $xml->response[1]->row->supplemental->post_id );
 	}
 
-	function test_term_translations() {
+	public function test_term_translations() {
 		$en = $this->factory->category->create();
 		self::$model->term->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -1,7 +1,7 @@
 <?php
 
 class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -16,7 +16,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
@@ -30,7 +30,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 	}
 
-	function test_post_lang_choice() {
+	public function test_post_lang_choice() {
 		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin ); // We need this for categories and tags
 
 		// categories
@@ -84,7 +84,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertNotFalse( strpos( $flag = $xml->response[3]->flag->response_data, 'Français' ) );
 	}
 
-	function test_page_lang_choice() {
+	public function test_page_lang_choice() {
 		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // we need this for the pages dropdown
 
 		// possible parents
@@ -137,7 +137,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertNotFalse( strpos( $flag = $xml->response[2]->flag->response_data, 'Français' ) );
 	}
 
-	function test_posts_not_translated() {
+	public function test_posts_not_translated() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test english' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -192,7 +192,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertEqualSets( array( $searched, $en ), wp_list_pluck( $response, 'id' ) );
 	}
 
-	function test_save_post_from_quick_edit() {
+	public function test_save_post_from_quick_edit() {
 		$post_id = $en = $this->factory->post->create();
 		self::$model->post->set_language( $post_id, 'en' );
 

--- a/tests/phpunit/tests/test-ajax-on-front.php
+++ b/tests/phpunit/tests/test-ajax-on-front.php
@@ -17,23 +17,23 @@ class Ajax_On_Front_Test extends PLL_Ajax_UnitTestCase {
 		copy( dirname( __FILE__ ) . '/../data/fr_FR.mo', WP_LANG_DIR . '/fr_FR.mo' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		unload_textdomain( 'default' );
 	}
 
-	function _ajax_test_locale() {
+	public function _ajax_test_locale() {
 		load_default_textdomain();
 		wp_die( wp_json_encode( __( 'Dashboard' ) ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 	}
 
-	function test_locale_for_logged_in_user() {
+	public function test_locale_for_logged_in_user() {
 		wp_set_current_user( 1 );
 		update_user_meta( 1, 'locale', 'en_US' );
 

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -12,7 +12,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		self::$model->options['post_types'] = array(
@@ -33,14 +33,14 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		new PLL_CRUD_Terms( $frontend );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		_unregister_post_type( 'trcpt' );
 		_unregister_taxonomy( 'trtax' );
 	}
 
-	function test_category() {
+	public function test_category() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -61,7 +61,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'category__in' => array( $en ) ) ) );
 	}
 
-	function test_tag() {
+	public function test_tag() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -89,7 +89,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag_slug__in' => array( 'test' ) ) ) );
 	}
 
-	function test_custom_tax() {
+	public function test_custom_tax() {
 		$term_fr = $fr = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -187,7 +187,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $post_en, $post_fr ), wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
-	function test_post() {
+	public function test_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -204,7 +204,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $fr ) ), get_posts( array( 'post__in' => array( $en ) ) ) );
 	}
 
-	function test_page() {
+	public function test_page() {
 		$parent_en = $en = $this->factory->post->create( array( 'post_title' => 'test_parent', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -233,7 +233,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
 	}
 
-	function test_get_terms() {
+	public function test_get_terms() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -15,7 +15,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -42,7 +42,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	}
 
 	// overrides WP_UnitTestCase::go_to
-	function go_to( $url ) {
+	public function go_to( $url ) {
 		// copy paste of WP_UnitTestCase::go_to
 		$_GET = $_POST = array();
 		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
@@ -85,7 +85,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$GLOBALS['wp']->main( $parts['query'] );
 	}
 
-	function test_home_latest_posts() {
+	public function test_home_latest_posts() {
 		$fr = $this->factory->post->create();
 		self::$model->post->set_language( $fr, 'fr' );
 
@@ -93,7 +93,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 	}
 
-	function test_home_latest_posts_with_hide_default() {
+	public function test_home_latest_posts_with_hide_default() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -101,7 +101,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	function test_single_post() {
+	public function test_single_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -115,7 +115,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	function test_page() {
+	public function test_page() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -129,7 +129,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	function test_category_default_lang() {
+	public function test_category_default_lang() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -137,7 +137,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	function test_category_non_default_lang() {
+	public function test_category_non_default_lang() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -145,7 +145,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 	}
 
-	function test_post_tag_default_lang() {
+	public function test_post_tag_default_lang() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -153,7 +153,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	function test_post_tag_non_default_lang() {
+	public function test_post_tag_non_default_lang() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -161,7 +161,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', $this->frontend->curlang->slug );
 	}
 
-	function test_archive() {
+	public function test_archive() {
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -175,7 +175,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	function test_archive_with_default_permalinks() {
+	public function test_archive_with_default_permalinks() {
 		$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -41,7 +41,11 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->frontend = new PLL_Frontend( $links_model );
 	}
 
-	// overrides WP_UnitTestCase::go_to
+	/**
+	 * Overrides WP_UnitTestCase::go_to().
+	 *
+	 * @param string $url The URL for the request.
+	 */
 	public function go_to( $url ) {
 		// copy paste of WP_UnitTestCase::go_to
 		$_GET = $_POST = array();

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -15,7 +15,7 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -48,14 +48,14 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$this->frontend = new PLL_Frontend( $links_model );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		$_SERVER = $this->server;
 	}
 
 	// overrides WP_UnitTestCase::go_to
-	function go_to( $url ) {
+	public function go_to( $url ) {
 		// copy paste of WP_UnitTestCase::go_to
 		$_GET = $_POST = array();
 		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
@@ -99,7 +99,7 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$GLOBALS['wp']->main( $parts['query'] );
 	}
 
-	function test_home_latest_posts() {
+	public function test_home_latest_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -119,7 +119,7 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$this->assertEquals( trailingslashit( $this->hosts['fr'] ), $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_single_post() {
+	public function test_single_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -54,7 +54,11 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$_SERVER = $this->server;
 	}
 
-	// overrides WP_UnitTestCase::go_to
+	/**
+	 * Overrides WP_UnitTestCase::go_to().
+	 *
+	 * @param string $url The URL for the request.
+	 */
 	public function go_to( $url ) {
 		// copy paste of WP_UnitTestCase::go_to
 		$_GET = $_POST = array();

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -15,13 +15,13 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		self::$model->post->register_taxonomy();
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		self::delete_all_languages();
 
 		parent::tear_down();
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// FIXME: Tests fail when trying to use a new instance of PLL_Admin_Model
@@ -29,7 +29,7 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		$this->frontend = new PLL_Frontend( $links_model );
 	}
 
-	function accepted_languages_provider() {
+	public function accepted_languages_provider() {
 		return array(
 			array( 'fr,fr-fr;q=0.8,en-us;q=0.5,en;q=0.3', 'en' ),
 			array( 'en-us;q=0.5,de-de', 'de' ),
@@ -43,10 +43,11 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 
 	/**
 	 * @dataProvider accepted_languages_provider
+	 *
 	 * @param string      $accept_languages_header Accept-Language HTTP header like those issued by web browsers.
 	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
 	 */
-	function test_browser_preferred_language( $accept_languages_header, $expected_preference ) {
+	public function test_browser_preferred_language( $accept_languages_header, $expected_preference ) {
 		self::create_language( 'en_US' );
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'fr_FR' );
@@ -65,7 +66,7 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $expected_preference, $choose_lang->get_preferred_browser_language() );
 	}
 
-	function accepted_languages_with_same_slug_provider() {
+	public function accepted_languages_with_same_slug_provider() {
 		return array(
 			array( 'en-gb;q=0.8,en-us;q=0.5,en;q=0.3', 'en' ),
 			array( 'en-us;q=0.8,en-gb;q=0.5,en;q=0.3', 'us' ),
@@ -78,10 +79,11 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 	 * @see https://wordpress.org/support/topic/browser-detection
 	 *
 	 * @dataProvider accepted_languages_with_same_slug_provider
+	 *
 	 * @param string      $accept_languages_header Accept-Language HTTP header like those issued by web browsers.
 	 * @param string|bool $expected_preference Expected results of our preferred browser language detection.
 	 */
-	function test_browser_preferred_language_with_same_slug( $accept_languages_header, $expected_preference ) {
+	public function test_browser_preferred_language_with_same_slug( $accept_languages_header, $expected_preference ) {
 		self::create_language( 'en_GB', array( 'term_group' => 2 ) );
 		self::create_language( 'en_US', array( 'slug' => 'us', 'term_group' => 1 ) );
 
@@ -98,5 +100,4 @@ class Choose_Lang_Test extends PLL_UnitTestCase {
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept_languages_header;
 		$this->assertEquals( $expected_preference, $choose_lang->get_preferred_browser_language() );
 	}
-
 }

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -15,7 +15,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// set a user to pass current_user_can tests
@@ -28,7 +28,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		unset( $this->pll_admin->filter_lang );
 
 		parent::tear_down();
@@ -37,12 +37,12 @@ class Columns_Test extends PLL_UnitTestCase {
 	/**
 	 * This must be the first test due to the static variable in get_culumn_headers().
 	 */
-	function test_no_screen_options_in_term_screen() {
+	public function test_no_screen_options_in_term_screen() {
 		set_current_screen( 'term.php' );
 		$this->assertEmpty( get_column_headers( get_current_screen() ) );
 	}
 
-	function test_post_with_no_language() {
+	public function test_post_with_no_language() {
 		$post_id = $this->factory->post->create();
 
 		ob_start();
@@ -51,7 +51,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	function test_post_language() {
+	public function test_post_language() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -70,7 +70,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $column, 'href' ) );
 	}
 
-	function test_untranslated_post() {
+	public function test_untranslated_post() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -88,7 +88,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	// special case for media
-	function test_untranslated_media() {
+	public function test_untranslated_media() {
 		$en = $this->factory->attachment->create_object( 'image.jpg' );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -105,7 +105,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	function test_translated_post() {
+	public function test_translated_post() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -126,7 +126,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	function test_term_with_no_language() {
+	public function test_term_with_no_language() {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
@@ -138,7 +138,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $column_fr );
 	}
 
-	function test_term_language() {
+	public function test_term_language() {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
@@ -156,7 +156,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $column, 'href' ) );
 	}
 
-	function test_untranslated_term() {
+	public function test_untranslated_term() {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
@@ -174,7 +174,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	function test_translated_term() {
+	public function test_translated_term() {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
@@ -197,7 +197,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	function test_add_post_column() {
+	public function test_add_post_column() {
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
@@ -211,7 +211,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'comments', $columns[ $en + 2 ] );
 	}
 
-	function test_add_post_column_with_filter() {
+	public function test_add_post_column_with_filter() {
 		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
@@ -219,7 +219,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertFalse( array_search( 'language_fr', $hidden ) );
 	}
 
-	function test_add_term_column() {
+	public function test_add_term_column() {
 		set_current_screen( 'edit-tags.php' );
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
@@ -234,7 +234,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'posts', $columns[ $en + 2 ] );
 	}
 
-	function test_add_term_column_with_filter() {
+	public function test_add_term_column_with_filter() {
 		set_current_screen( 'edit-tags.php' );
 		$this->pll_admin->filter_lang = self::$model->get_language( 'fr' );
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
@@ -243,7 +243,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertFalse( array_search( 'language_en', $hidden ) );
 	}
 
-	function test_post_inline_edit() {
+	public function test_post_inline_edit() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -87,7 +87,9 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	// special case for media
+	/**
+	 * Special case for media.
+	 */
 	public function test_untranslated_media() {
 		$en = $this->factory->attachment->create_object( 'image.jpg' );
 		self::$model->post->set_language( $en, 'en' );

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -1,7 +1,7 @@
 <?php
 
 class Columns_Test extends PLL_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -2,7 +2,7 @@
 
 class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
-	function test_add_and_delete_language() {
+	public function test_add_and_delete_language() {
 		// first language
 		$args = array(
 			'name'       => 'English',
@@ -68,7 +68,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.3
-	function test_unique_language_code_if_same_as_locale() {
+	public function test_unique_language_code_if_same_as_locale() {
 		// First language
 		$args = array(
 			'name'       => 'العربية',
@@ -89,7 +89,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		self::$model->delete_language( $lang->term_id );
 	}
 
-	function test_invalid_languages() {
+	public function test_invalid_languages() {
 		global $wp_settings_errors;
 
 		$args = array(
@@ -126,7 +126,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	/**
 	 * Issue #910
 	 */
-	function test_language_properties_in_transient() {
+	public function test_language_properties_in_transient() {
 		$args = array(
 			'name'       => 'English',
 			'slug'       => 'en',

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -67,7 +67,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array(), self::$model->get_languages_list() );
 	}
 
-	// Bug fixed in 2.3
+	/**
+	 * Bug fixed in 2.3.
+	 */
 	public function test_unique_language_code_if_same_as_locale() {
 		// First language
 		$args = array(

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -17,7 +17,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		self::create_language( 'es_ES' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
@@ -31,7 +31,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->pll_admin->default_term->add_hooks();
 	}
 
-	function get_edit_term_form( $tag_ID, $taxonomy ) {
+	protected function get_edit_term_form( $tag_ID, $taxonomy ) {
 		// Prepare all needed info before loading the entire form
 		$GLOBALS['post_type'] = 'post';
 		$tax                  = get_taxonomy( $taxonomy );
@@ -50,7 +50,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		return ob_get_clean();
 	}
 
-	function test_default_category_in_edit_tags() {
+	public function test_default_category_in_edit_tags() {
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
 		$default = self::$model->term->get( get_option( 'default_category' ), 'de' );
@@ -71,7 +71,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'disabled', $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_term_language_with_default_category() {
+	public function test_term_language_with_default_category() {
 
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy']  = 'category';
@@ -83,7 +83,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $column, 'default_cat' ) );
 	}
 
-	function test_add_and_delete_language() {
+	public function test_add_and_delete_language() {
 
 		$args = array(
 			'name'       => 'العربية',
@@ -101,7 +101,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $default_cat_lang->slug );
 	}
 
-	function test_new_default_category() {
+	public function test_new_default_category() {
 
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'new-default' ) );
 		update_option( 'default_category', $term_id );
@@ -112,7 +112,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 	}
 
 	// bug introduced by WP 4.3 and fixed in v1.8.2
-	function test_default_category_in_list_table() {
+	public function test_default_category_in_list_table() {
 
 		$id = $this->factory->term->create( array( 'taxonomy' => 'category' ) ); // a non default category
 		$default = get_option( 'default_category' );
@@ -140,7 +140,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $list, 'edit-tags.php?action=delete&amp;taxonomy=category&amp;tag_ID=' . $id . '&amp;' ) );
 	}
 
-	function test_get_option_default_category() {
+	public function test_get_option_default_category() {
 		$option = get_option( 'default_category' );
 		$option_lang = self::$model->term->get_language( $option );
 
@@ -154,7 +154,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'es', $option_lang->slug );
 	}
 
-	function test_update_term_when_updating_default_language() {
+	public function test_update_term_when_updating_default_language() {
 		$option = get_option( 'default_category' );
 		$option_lang = self::$model->term->get_language( $option );
 		$es_option = self::$model->term->get_translation( $option, 'es' );

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -2,7 +2,7 @@
 
 
 class Default_Term_Test extends PLL_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -111,7 +111,9 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( 'en', 'fr', 'de', 'es' ), array_keys( $translations ) );
 	}
 
-	// bug introduced by WP 4.3 and fixed in v1.8.2
+	/**
+	 * Bug introduced by WP 4.3 and fixed in v1.8.2.
+	 */
 	public function test_default_category_in_list_table() {
 
 		$id = $this->factory->term->create( array( 'taxonomy' => 'category' ) ); // a non default category

--- a/tests/phpunit/tests/test-filters-links.php
+++ b/tests/phpunit/tests/test-filters-links.php
@@ -13,7 +13,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -47,7 +47,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->frontend->filters_links->cache->method( 'get' )->willReturn( false );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		_unregister_post_type( 'cpt' );
@@ -56,7 +56,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		_unregister_taxonomy( 'trtax' );
 	}
 
-	function test_get_permalink_for_posts() {
+	public function test_get_permalink_for_posts() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( home_url( '/test/' ), get_permalink( $post_id ) );
@@ -66,7 +66,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/essai/' ), get_permalink( $post_id ) );
 	}
 
-	function test_get_permalink_for_pages() {
+	public function test_get_permalink_for_pages() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'page-test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( home_url( '/page-test/' ), get_permalink( $post_id ) );
@@ -76,7 +76,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/page-essai/' ), get_permalink( $post_id ) );
 	}
 
-	function test_get_permalink_for_cpt() {
+	public function test_get_permalink_for_cpt() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'trcpt' ) );
 		self::$model->post->set_language( $post_id, 'en' );
 		$this->assertEquals( home_url( '/trcpt/test/' ), get_permalink( $post_id ) );
@@ -86,12 +86,12 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/trcpt/essai/' ), get_permalink( $post_id ) );
 	}
 
-	function test_get_permalink_for_untranslated_cpt() {
+	public function test_get_permalink_for_untranslated_cpt() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'cpt' ) );
 		$this->assertEquals( home_url( '/cpt/test/' ), get_permalink( $post_id ) );
 	}
 
-	function test_attached_attachment() {
+	public function test_attached_attachment() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $post_id, 'en' );
 
@@ -125,7 +125,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/essai/image-fr/' ), get_permalink( $attachment_id ) );
 	}
 
-	function test_unattached_attachment() {
+	public function test_unattached_attachment() {
 		$attachment_id = $this->factory->attachment->create_object(
 			'image.jpg',
 			0,
@@ -153,7 +153,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/image-fr/' ), get_permalink( $attachment_id ) );
 	}
 
-	function test_translated_term_link() {
+	public function test_translated_term_link() {
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'cats' ) );
 		self::$model->term->set_language( $term_id, 'en' );
 		$this->assertEquals( home_url( '/category/cats/' ), get_term_link( $term_id, 'category' ) );
@@ -163,19 +163,19 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/category/chats/' ), get_term_link( $term_id, 'category' ) );
 	}
 
-	function test_untranslated_term_link() {
+	public function test_untranslated_term_link() {
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'cats' ) );
 		$this->assertEquals( home_url( '/tax/cats/' ), get_term_link( $term_id, 'tax' ) );
 	}
 
-	function test_language_term_link() {
+	public function test_language_term_link() {
 		$term_id = self::$model->get_language( 'en' )->term_id;
 		$this->assertEquals( home_url( '/' ), get_term_link( $term_id, 'language' ) );
 		$term_id = self::$model->get_language( 'fr' )->term_id;
 		$this->assertEquals( home_url( '/fr/' ), get_term_link( $term_id, 'language' ) );
 	}
 
-	function test_post_format_link() {
+	public function test_post_format_link() {
 		$this->factory->term->create( array( 'taxonomy' => 'post_format', 'name' => 'post-format-aside' ) ); // shouldn't WP do that ?
 
 		$this->frontend->curlang = self::$model->get_language( 'en' );
@@ -185,7 +185,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/type/aside/' ), get_post_format_link( 'aside' ) );
 	}
 
-	function test_archive_link() {
+	public function test_archive_link() {
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 		$this->assertEquals( home_url( '/trcpt/' ), get_post_type_archive_link( 'trcpt' ) );
 		$this->assertEquals( home_url( '/feed/' ), get_feed_link() );
@@ -205,7 +205,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/fr/2015/10/05/' ), get_day_link( 2015, 10, 5 ) );
 	}
 
-	function test_get_custom_logo() {
+	public function test_get_custom_logo() {
 		// Setup logo
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
 		$contents = file_get_contents( $filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -217,7 +217,9 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $archives, 'February 2012' ) );
 	}
 
-	// Bug fixed in v1.9
+	/**
+	 * Bug fixed in v1.9.
+	 */
 	public function test_adjacent_post_and_archives_for_untranslated_post_type() {
 		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
 
@@ -396,7 +398,9 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', $language->slug );
 	}
 
-	// Bug fixed in 2.3.5
+	/**
+	 * Bug fixed in 2.3.5.
+	 */
 	public function test_get_terms_inside_query() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
 		self::$model->term->set_language( $en, 'en' );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -19,7 +19,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
@@ -27,7 +27,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		new PLL_Frontend_Filters_Links( $this->frontend );
 	}
 
-	function test_get_pages() {
+	public function test_get_pages() {
 		foreach ( $this->factory->post->create_many( 3, array( 'post_type' => 'page' ) ) as $page ) {
 			self::$model->post->set_language( $page, 'en' );
 		}
@@ -73,7 +73,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertCount( 1, $pages );
 	}
 
-	function test_get_posts() {
+	public function test_get_posts() {
 		foreach ( $this->factory->post->create_many( 3, array() ) as $p ) {
 			self::$model->post->set_language( $p, 'en' );
 		}
@@ -118,7 +118,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'en' ), array_values( array_unique( $languages ) ) );
 	}
 
-	function test_sticky_posts() {
+	public function test_sticky_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 		stick_post( $en );
@@ -134,7 +134,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $fr, reset( $sticky ) ); // the sticky post
 	}
 
-	function test_get_comments() {
+	public function test_get_comments() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 		$en = $this->factory->comment->create( array( 'comment_post_ID' => $en, 'comment_approved' => '1' ) );
@@ -163,7 +163,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $en, $fr ), $comments );
 	}
 
-	function test_get_terms() {
+	public function test_get_terms() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -191,7 +191,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $en, $fr, $de ), $terms );
 	}
 
-	function test_adjacent_post_and_archives() {
+	public function test_adjacent_post_and_archives() {
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$m = 2 * $i - 1;
 			$en[ $i ] = $this->factory->post->create( array( 'post_date' => "2012-0$m-01 12:00:00" ) );
@@ -218,7 +218,7 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in v1.9
-	function test_adjacent_post_and_archives_for_untranslated_post_type() {
+	public function test_adjacent_post_and_archives_for_untranslated_post_type() {
 		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
 
 		for ( $m = 1; $m <= 3; $m++ ) {
@@ -240,7 +240,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		_unregister_post_type( 'cpt' );
 	}
 
-	function test_language_attributes_for_valid_locale() {
+	public function test_language_attributes_for_valid_locale() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		new PLL_Frontend_Filters( $this->frontend );
 
@@ -248,7 +248,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		language_attributes();
 	}
 
-	function test_language_attributes_for_invalid_locale() {
+	public function test_language_attributes_for_invalid_locale() {
 		$this->frontend->curlang = self::$model->get_language( 'de' );
 		new PLL_Frontend_Filters( $this->frontend );
 
@@ -256,7 +256,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		language_attributes();
 	}
 
-	function test_save_post() {
+	public function test_save_post() {
 		$this->frontend->posts = new PLL_CRUD_Posts( $this->frontend );
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 
@@ -268,7 +268,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->post->get_language( $post_id )->slug );
 	}
 
-	function test_save_page_with_parent() {
+	public function test_save_page_with_parent() {
 		$this->frontend->posts = new PLL_CRUD_Posts( $this->frontend );
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 
@@ -280,7 +280,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->post->get_language( $post_id )->slug );
 	}
 
-	function test_save_term() {
+	public function test_save_term() {
 		new PLL_CRUD_Terms( $this->frontend );
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 
@@ -292,7 +292,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
 	}
 
-	function test_save_category_with_parent() {
+	public function test_save_category_with_parent() {
 		new PLL_CRUD_Terms( $this->frontend );
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 
@@ -304,7 +304,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
 	}
 
-	function test_get_pages_language_filter() {
+	public function test_get_pages_language_filter() {
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -335,7 +335,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertCount( 2, get_pages( array( 'lang' => '' ) ) );
 	}
 
-	function test_site_title_in_password_change_email() {
+	public function test_site_title_in_password_change_email() {
 		// Important to use a language available in DIR_TESTDATA . '/languages/', otherwise switch_to_locale() doesn't switch.
 		$language = self::$model->get_language( 'es' );
 		$_mo = new PLL_MO();
@@ -361,7 +361,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		reset_phpmailer_instance();
 	}
 
-	function test_site_title_in_email_change_confirmation_email() {
+	public function test_site_title_in_email_change_confirmation_email() {
 		$language = self::$model->get_language( 'es' );
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );
@@ -388,7 +388,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		reset_phpmailer_instance();
 	}
 
-	function _action_pre_get_posts() {
+	public function _action_pre_get_posts() {
 		$terms = get_terms( 'post_tag', array( 'hide_empty' => false ) );
 		$language = self::$model->term->get_language( $terms[0]->term_id );
 
@@ -397,7 +397,7 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.3.5
-	function test_get_terms_inside_query() {
+	public function test_get_terms_inside_query() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
 		self::$model->term->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -34,8 +34,8 @@ class Flags_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" alt="Français" />', $lang->get_display_flag() );
 	}
 
-	/*
-	 * bug fixed in 1.8
+	/**
+	 * Bug fixed in 1.8
 	 */
 	public function test_default_flag_ssl() {
 		$_SERVER['HTTPS'] = 'on';

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -15,20 +15,20 @@ class Flags_Test extends PLL_UnitTestCase {
 		copy( dirname( __FILE__ ) . '/../data/fr_FR.png', WP_CONTENT_DIR . '/polylang/fr_FR.png' );
 	}
 
-	static function wpTearDownAfterClass() {
+	public static function wpTearDownAfterClass() {
 		parent::wpTearDownAfterClass();
 
 		unlink( WP_CONTENT_DIR . '/polylang/fr_FR.png' );
 		rmdir( WP_CONTENT_DIR . '/polylang' );
 	}
 
-	function test_default_flag() {
+	public function test_default_flag() {
 		$lang = self::$model->get_language( 'en' );
 		$this->assertEquals( plugins_url( '/flags/us.png', POLYLANG_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.
 		$this->assertEquals( 1, preg_match( '#<img src="data:image\/png;base64,(.+)" alt="English" width="16" height="11" style="(.+)" \/>#', $lang->get_display_flag() ) );
 	}
 
-	function test_custom_flag() {
+	public function test_custom_flag() {
 		$lang = self::$model->get_language( 'fr' );
 		$this->assertEquals( content_url( '/polylang/fr_FR.png' ), $lang->get_display_flag_url() );
 		$this->assertEquals( '<img src="/wp-content/polylang/fr_FR.png" alt="Français" />', $lang->get_display_flag() );
@@ -37,7 +37,7 @@ class Flags_Test extends PLL_UnitTestCase {
 	/*
 	 * bug fixed in 1.8
 	 */
-	function test_default_flag_ssl() {
+	public function test_default_flag_ssl() {
 		$_SERVER['HTTPS'] = 'on';
 
 		$lang = self::$model->get_language( 'en' );
@@ -46,7 +46,7 @@ class Flags_Test extends PLL_UnitTestCase {
 		unset( $_SERVER['HTTPS'] );
 	}
 
-	function test_custom_flag_ssl() {
+	public function test_custom_flag_ssl() {
 		$_SERVER['HTTPS'] = 'on';
 
 		$lang = self::$model->get_language( 'fr' );

--- a/tests/phpunit/tests/test-hreflang.php
+++ b/tests/phpunit/tests/test-hreflang.php
@@ -17,7 +17,7 @@ class Hreflang_Test extends PLL_UnitTestCase {
 		self::$model->options['hide_default'] = 0;
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
@@ -36,7 +36,7 @@ class Hreflang_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang'] = &$this->frontend;
 	}
 
-	function test_hreflang() {
+	public function test_hreflang() {
 		$uk = $this->factory->post->create();
 		self::$model->post->set_language( $uk, 'uk' );
 
@@ -73,7 +73,7 @@ class Hreflang_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $out, 'x-default' ) );
 	}
 
-	function test_paginated_post() {
+	public function test_paginated_post() {
 		$uk = $this->factory->post->create( array( 'post_content' => 'en1<!--nextpage-->en2' ) );
 		self::$model->post->set_language( $uk, 'uk' );
 
@@ -101,7 +101,7 @@ class Hreflang_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $out );
 	}
 
-	function test_paged_archive() {
+	public function test_paged_archive() {
 		update_option( 'posts_per_page', 2 ); // to avoid creating too much posts
 
 		$posts_us = $this->factory->post->create_many( 3 );

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -2,7 +2,7 @@
 
 class Install_Test extends PLL_UnitTestCase {
 
-	function test_activate() {
+	public function test_activate() {
 		delete_option( 'polylang' );
 		do_action( 'activate_' . POLYLANG_BASENAME );
 
@@ -20,7 +20,7 @@ class Install_Test extends PLL_UnitTestCase {
 	 * The constant PLL_REMOVE_ALL_DATA must not be defined.
 	 * This test must be executed before all uninstall tests.
 	 */
-	function test_uninstall_without_removing_data() {
+	public function test_uninstall_without_removing_data() {
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );
 		}
@@ -38,7 +38,7 @@ class Install_Test extends PLL_UnitTestCase {
 	/**
 	 * This test requires the definition of the constants WP_UNINSTALL_PLUGIN and PLL_REMOVE_ALL_DATA
 	 */
-	function test_uninstall_removing_data() {
+	public function test_uninstall_removing_data() {
 		global $wpdb;
 
 		do_action( 'activate_' . POLYLANG_BASENAME );

--- a/tests/phpunit/tests/test-license.php
+++ b/tests/phpunit/tests/test-license.php
@@ -2,7 +2,7 @@
 
 class License_Test extends PLL_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->license = new PLL_License( 'polylang-pro/polylang.php', 'Polylang Pro', POLYLANG_VERSION, 'WP SYNTEX' );
@@ -27,7 +27,7 @@ class License_Test extends PLL_UnitTestCase {
 		);
 	}
 
-	function test_valid() {
+	public function test_valid() {
 		$this->license->license_data = (object) array(
 			'success' => 1,
 			'expires' => gmdate( 'Y-m-d H:i:s', strtotime( '+60 days' ) ),
@@ -36,7 +36,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Your license key expires on' ) );
 	}
 
-	function test_expires_soon() {
+	public function test_expires_soon() {
 		$this->license->license_data = (object) array(
 			'success' => 1,
 			'expires' => gmdate( 'Y-m-d H:i:s', strtotime( '+14 days' ) ),
@@ -45,7 +45,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Your license key will expire soon' ) );
 	}
 
-	function test_lifetime() {
+	public function test_lifetime() {
 		$this->license->license_data = (object) array(
 			'success' => 1,
 			'expires' => 'lifetime',
@@ -54,7 +54,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'The license key never expires' ) );
 	}
 
-	function test_expired_after_last_check() {
+	public function test_expired_after_last_check() {
 		$this->license->license_data = (object) array(
 			'success' => 1,
 			'expires' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 days' ) ),
@@ -63,7 +63,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Your license key expired on' ) );
 	}
 
-	function test_expired() {
+	public function test_expired() {
 		$this->license->license_data = (object) array(
 			'success' => false,
 			'error' => 'expired',
@@ -73,7 +73,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Your license key expired on' ) );
 	}
 
-	function test_invalid_license() {
+	public function test_invalid_license() {
 		$this->license->license_data = (object) array(
 			'success' => false,
 			'error' => 'missing',
@@ -82,7 +82,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Invalid license' ) );
 	}
 
-	function test_disabled_license() {
+	public function test_disabled_license() {
 		$this->license->license_data = (object) array(
 			'success' => false,
 			'error' => 'disabled',
@@ -92,7 +92,7 @@ class License_Test extends PLL_UnitTestCase {
 	}
 
 
-	function test_license_exists_but_wrong_product() {
+	public function test_license_exists_but_wrong_product() {
 		$this->license->license_data = (object) array(
 			'success' => false,
 			'error' => 'item_name_mismatch',
@@ -101,7 +101,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'This is not a Polylang Pro license key' ) );
 	}
 
-	function test_limit_reached() {
+	public function test_limit_reached() {
 		$this->license->license_data = (object) array(
 			'success' => false,
 			'error' => 'no_activations_left',
@@ -110,7 +110,7 @@ class License_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $this->license->get_form_field(), 'Your license key has reached its activation limit' ) );
 	}
 
-	function test_activate_license() {
+	public function test_activate_license() {
 		update_option( 'polylang_licenses', '' ); // Put wrong option for testing strenghness.
 
 		$this->license->activate_license( '00001111222233334444555566667777' );

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -64,13 +64,17 @@ class Links_Default_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 	}
 
-	// bug fixed in 1.8
+	/**
+	 * Bug fixed in 1.8.
+	 */
 	public function test_home_url() {
 		$this->assertEquals( $this->host . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->host . '/?lang=fr', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
-	// bug fixed in v1.8
+	/**
+	 * Bug fixed in 1.8.
+	 */
 	public function test_language_code_in_post_url() {
 		self::$model->options['force_lang'] = 1;
 		$frontend = new PLL_Frontend( $this->links_model );

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -14,7 +14,7 @@ class Links_Default_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		self::$model->options['post_types'] = array(
@@ -27,51 +27,51 @@ class Links_Default_Test extends PLL_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	function test_add_language_to_link() {
+	public function test_add_language_to_link() {
 		$url = $this->host . '/?p=test';
 
 		$this->assertEquals( $this->host . '/?p=test', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_double_add_language_to_link() {
+	public function test_double_add_language_to_link() {
 		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->add_language_to_link( $this->host . '/?p=test&lang=fr', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_remove_language_from_link() {
+	public function test_remove_language_from_link() {
 		$this->assertEquals( $this->host . '/?p=test', $this->links_model->remove_language_from_link( $this->host . '/?p=test&lang=fr' ) );
 	}
 
-	function test_switch_language_in_link() {
+	public function test_switch_language_in_link() {
 		$this->assertEquals( $this->host . '/?p=test', $this->links_model->switch_language_in_link( $this->host . '/?p=test&lang=fr', self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->host . '/?p=test&lang=de', $this->links_model->switch_language_in_link( $this->host . '/?p=test&lang=fr', self::$model->get_language( 'de' ) ) );
 		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->switch_language_in_link( $this->host . '/?p=test', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_add_paged_to_link() {
+	public function test_add_paged_to_link() {
 		$this->assertEquals( $this->host . '/?p=test&paged=2', $this->links_model->add_paged_to_link( $this->host . '/?p=test', 2 ) );
 		$this->assertEquals( $this->host . '/?p=test&lang=fr&paged=2', $this->links_model->add_paged_to_link( $this->host . '/?p=test&lang=fr', 2 ) );
 	}
 
-	function test_remove_paged_from_link() {
+	public function test_remove_paged_from_link() {
 		$this->assertEquals( $this->host . '/?p=test', $this->links_model->remove_paged_from_link( $this->host . '/?p=test&paged=2' ) );
 		$this->assertEquals( $this->host . '/?p=test&lang=fr', $this->links_model->remove_paged_from_link( $this->host . '/?p=test&lang=fr&paged=2' ) );
 	}
 
-	function test_get_language_from_url() {
+	public function test_get_language_from_url() {
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->host, PHP_URL_HOST );
 		$_SERVER['REQUEST_URI'] = '/?p=test&lang=fr';
 		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 	}
 
 	// bug fixed in 1.8
-	function test_home_url() {
+	public function test_home_url() {
 		$this->assertEquals( $this->host . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->host . '/?lang=fr', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
 	// bug fixed in v1.8
-	function test_language_code_in_post_url() {
+	public function test_language_code_in_post_url() {
 		self::$model->options['force_lang'] = 1;
 		$frontend = new PLL_Frontend( $this->links_model );
 		new PLL_Filters_Links( $frontend );
@@ -104,7 +104,7 @@ class Links_Default_Test extends PLL_UnitTestCase {
 		$this->assertStringContainsString( 'lang=fr', get_permalink( $fr ) );
 	}
 
-	function test_language_from_post_content() {
+	public function test_language_from_post_content() {
 		self::$model->options['force_lang'] = 0;
 		$frontend = new PLL_Frontend( $this->links_model );
 		new PLL_Filters_Links( $frontend );

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -99,7 +99,9 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->_test_remove_paged_from_link();
 	}
 
-	// Bug fixed in 2.6
+	/**
+	 * Bug fixed in 2.6.
+	 */
 	public function test_link_filters_mixing_ssl() {
 		$this->root = 'https://example.org'; // $this->links_model->home uses http
 		$this->_test_add_language_to_link();
@@ -152,7 +154,9 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $this->host . '/language/fr/', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 	}
 
-	// Issue fixed in version 2.1.2
+	/**
+	 * Issue fixed in version 2.1.2.
+	 */
 	public function test_get_language_from_url_with_wrong_ssl() {
 		$server = $_SERVER;
 

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -15,7 +15,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -30,7 +30,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->links_model->init();
 	}
 
-	function _test_add_language_to_link() {
+	protected function _test_add_language_to_link() {
 		$url = $this->root . '/test/';
 
 		self::$model->options['rewrite'] = 1;
@@ -42,7 +42,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $this->root . '/language/fr/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
-	function _test_double_add_language_to_link() {
+	protected function _test_double_add_language_to_link() {
 		self::$model->options['rewrite'] = 1;
 		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->add_language_to_link( $this->root . '/fr/test/', self::$model->get_language( 'fr' ) ) );
 
@@ -50,7 +50,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $this->root . '/language/fr/test/', $this->links_model->add_language_to_link( $this->root . '/language/fr/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function _test_remove_language_from_link() {
+	protected function _test_remove_language_from_link() {
 		self::$model->options['rewrite'] = 1;
 		$this->assertEquals( $this->root . '/en/test/', $this->links_model->remove_language_from_link( $this->root . '/en/test/' ) );
 		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_language_from_link( $this->root . '/fr/test/' ) );
@@ -60,26 +60,26 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_language_from_link( $this->root . '/language/fr/test/' ) );
 	}
 
-	function _test_switch_language_in_link() {
+	protected function _test_switch_language_in_link() {
 		self::$model->options['rewrite'] = 1;
 		$this->assertEquals( $this->root . '/test/', $this->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->root . '/de/test/', $this->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$model->get_language( 'de' ) ) );
 		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->switch_language_in_link( $this->root . '/test/', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function _test_add_paged_to_link() {
+	protected function _test_add_paged_to_link() {
 		self::$model->options['rewrite'] = 1;
 		$this->assertEquals( $this->root . '/test/page/2/', $this->links_model->add_paged_to_link( $this->root . '/test/', 2 ) );
 		$this->assertEquals( $this->root . '/fr/test/page/2/', $this->links_model->add_paged_to_link( $this->root . '/fr/test/', 2 ) );
 	}
 
-	function _test_remove_paged_from_link() {
+	protected function _test_remove_paged_from_link() {
 		self::$model->options['rewrite'] = 1;
 		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_paged_from_link( $this->root . '/test/page/2/' ) );
 		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->remove_paged_from_link( $this->root . '/fr/test/page/2/' ) );
 	}
 
-	function test_link_filters_with_absolute_links() {
+	public function test_link_filters_with_absolute_links() {
 		$this->root = $this->host;
 		$this->_test_add_language_to_link();
 		$this->_test_double_add_language_to_link();
@@ -87,10 +87,9 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->_test_switch_language_in_link();
 		$this->_test_add_paged_to_link();
 		$this->_test_remove_paged_from_link();
-
 	}
 
-	function test_link_filters_with_relative_links() {
+	public function test_link_filters_with_relative_links() {
 		$this->root = '';
 		$this->_test_add_language_to_link();
 		$this->_test_double_add_language_to_link();
@@ -98,11 +97,10 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->_test_switch_language_in_link();
 		$this->_test_add_paged_to_link();
 		$this->_test_remove_paged_from_link();
-
 	}
 
 	// Bug fixed in 2.6
-	function test_link_filters_mixing_ssl() {
+	public function test_link_filters_mixing_ssl() {
 		$this->root = 'https://example.org'; // $this->links_model->home uses http
 		$this->_test_add_language_to_link();
 		$this->_test_double_add_language_to_link();
@@ -110,10 +108,9 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->_test_switch_language_in_link();
 		$this->_test_add_paged_to_link();
 		$this->_test_remove_paged_from_link();
-
 	}
 
-	function test_link_filters_with_home_in_subdirectory() {
+	public function test_link_filters_with_home_in_subdirectory() {
 		$this->root = 'http://example.org/polylang-pro';
 		$this->links_model->home = $this->root;
 		$this->_test_add_language_to_link();
@@ -124,7 +121,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->_test_remove_paged_from_link();
 	}
 
-	function test_get_language_from_url() {
+	public function test_get_language_from_url() {
 		$server = $_SERVER;
 
 		$this->assertEquals( 'fr', $this->links_model->get_language_from_url( home_url( '/fr' ) ) );
@@ -146,7 +143,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$_SERVER = $server;
 	}
 
-	function test_home_url() {
+	public function test_home_url() {
 		$this->assertEquals( $this->host . '/', $this->links_model->home_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->host . '/fr/', $this->links_model->home_url( self::$model->get_language( 'fr' ) ) );
 
@@ -156,7 +153,7 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 	}
 
 	// Issue fixed in version 2.1.2
-	function test_get_language_from_url_with_wrong_ssl() {
+	public function test_get_language_from_url_with_wrong_ssl() {
 		$server = $_SERVER;
 
 		$_SERVER['REQUEST_URI'] = '/fr/test/';

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -39,7 +39,9 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEquals( $this->hosts['fr'] . '/wp-login.php', wp_login_url() );
 	}
 
-	// Bug fixed in version 2.1.2
+	/**
+	 * Bug fixed in version 2.1.2.
+	 */
 	public function test_second_level_domain() {
 		self::$model->options['domains']['fr'] = 'http://example.org.fr';
 		$this->links_model = self::$model->get_links_model();
@@ -55,7 +57,9 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEquals( 'http://example.org/test/', $this->links_model->remove_language_from_link( $url, self::$model->get_language( 'fr' ) ) );
 	}
 
-	// Bug fixed in 2.3.5
+	/**
+	 * Bug fixed in 2.3.5.
+	 */
 	public function test_redirect_www() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$filters_links = new PLL_Frontend_Filters_Links( $frontend );

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -2,7 +2,7 @@
 
 class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -23,7 +23,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	function test_wrong_get_language_from_url() {
+	public function test_wrong_get_language_from_url() {
 		$_SERVER['HTTP_HOST'] = 'de.example.fr';
 		$this->assertEmpty( $this->links_model->get_language_from_url() );
 
@@ -31,7 +31,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEmpty( $this->links_model->get_language_from_url() );
 	}
 
-	function test_login_url() {
+	public function test_login_url() {
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->hosts['en'], PHP_URL_HOST );
 		$this->assertEquals( $this->hosts['en'] . '/wp-login.php', wp_login_url() );
 
@@ -40,7 +40,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 	}
 
 	// Bug fixed in version 2.1.2
-	function test_second_level_domain() {
+	public function test_second_level_domain() {
 		self::$model->options['domains']['fr'] = 'http://example.org.fr';
 		$this->links_model = self::$model->get_links_model();
 
@@ -56,7 +56,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 	}
 
 	// Bug fixed in 2.3.5
-	function test_redirect_www() {
+	public function test_redirect_www() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$filters_links = new PLL_Frontend_Filters_Links( $frontend );
 
@@ -72,7 +72,7 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEquals( 'http://www.example.fr/test/', $filters_links->check_canonical_url( 'http://' . $_SERVER['HTTP_HOST'] . '/test/', false ) );
 	}
 
-	function test_permalink_and_shortlink() {
+	public function test_permalink_and_shortlink() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$filters_links = new PLL_Frontend_Filters_Links( $frontend );
 

--- a/tests/phpunit/tests/test-links-subdomain.php
+++ b/tests/phpunit/tests/test-links-subdomain.php
@@ -2,7 +2,7 @@
 
 class Links_Subdomain_Test extends PLL_Domain_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -22,14 +22,14 @@ class Links_Subdomain_Test extends PLL_Domain_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	function test_get_language_from_url() {
+	public function test_get_language_from_url() {
 		$this->assertEquals( 'en', $this->links_model->get_language_from_url( 'http://example.org' ) );
 		$this->assertEquals( 'en', $this->links_model->get_language_from_url( 'http://example.org/test/' ) );
 		$this->assertEquals( 'fr', $this->links_model->get_language_from_url( 'http://fr.example.org/test/' ) );
 		$this->assertEquals( 'fr', $this->links_model->get_language_from_url( 'http://fr.example.org' ) );
 	}
 
-	function test_get_language_from_url_with_empty_param() {
+	public function test_get_language_from_url_with_empty_param() {
 		$_SERVER['HTTP_HOST'] = 'fr.example.org';
 		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
 
@@ -40,7 +40,7 @@ class Links_Subdomain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEquals( 'en', $this->links_model->get_language_from_url() );
 	}
 
-	function test_wrong_get_language_from_url() {
+	public function test_wrong_get_language_from_url() {
 		$this->assertEmpty( $this->links_model->get_language_from_url( 'http://es.example.org' ) );
 		$this->assertEmpty( $this->links_model->get_language_from_url( 'http://fr.org' ) );
 

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -12,7 +12,7 @@ class Media_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$options = array_merge( PLL_Install::get_default_options(), array( 'media_support' => 1 ) );
@@ -25,7 +25,7 @@ class Media_Test extends PLL_UnitTestCase {
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );  // don't create intermediate sizes to save time
 	}
 
-	function test_upload() {
+	public function test_upload() {
 		$this->pll_admin->pref_lang = self::$model->get_language( 'fr' );
 
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
@@ -36,7 +36,7 @@ class Media_Test extends PLL_UnitTestCase {
 		wp_delete_attachment( $fr );
 	}
 
-	function test_media_translation_and_delete_attachment() {
+	public function test_media_translation_and_delete_attachment() {
 		$this->pll_admin->pref_lang = self::$model->get_language( 'en' );
 
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
@@ -59,7 +59,7 @@ class Media_Test extends PLL_UnitTestCase {
 		$this->assertFileDoesNotExist( $filename );
 	}
 
-	function test_attachment_fields_to_edit() {
+	public function test_attachment_fields_to_edit() {
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
 		$fr = $this->factory->attachment->create_upload_object( $filename );
 		self::$model->post->set_language( $fr, 'fr' );
@@ -83,7 +83,7 @@ class Media_Test extends PLL_UnitTestCase {
 	/**
 	 * @since 3.1 Since the language and translations are updated through a previous AJAX call, we'd rather not perform an unnecessary update now.
 	 */
-	function test_attachment_fields_to_save() {
+	public function test_attachment_fields_to_save() {
 		$filename = dirname( __FILE__ ) . '/../data/image.jpg';
 		$en = $this->factory->attachment->create_upload_object( $filename );
 		self::$model->post->set_language( $en, 'en' );
@@ -112,7 +112,7 @@ class Media_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 0, $set_language_spy->getInvocationCount() );
 	}
 
-	function test_create_media_translation_with_slashes() {
+	public function test_create_media_translation_with_slashes() {
 		$slash_2 = '\\\\';
 		$en = $this->factory->attachment->create(
 			array(

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -14,7 +14,7 @@ class Model_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	function test_languages_list() {
+	public function test_languages_list() {
 		self::$model->post->register_taxonomy(); // needed otherwise posts are not counted
 
 		$this->assertEquals( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
@@ -27,7 +27,7 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
 	}
 
-	function test_term_exists() {
+	public function test_term_exists() {
 		$parent = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$model->term->set_language( $parent, 'en' );
 		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $parent ) );
@@ -44,13 +44,13 @@ class Model_Test extends PLL_UnitTestCase {
 	/**
 	 * Bug fixed in 2.7
 	 */
-	function test_term_exists_with_special_character() {
+	public function test_term_exists_with_special_character() {
 		$term = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'Cook & eat' ) );
 		self::$model->term->set_language( $term, 'en' );
 		$this->assertEquals( $term, self::$model->term_exists( 'Cook & eat', 'category', 0, 'en' ) );
 	}
 
-	function test_count_posts() {
+	public function test_count_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -84,7 +84,7 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 2, self::$model->count_posts( $language, array( 'post_type' => array( 'post', 'page' ) ) ) );
 	}
 
-	function test_translated_post_types() {
+	public function test_translated_post_types() {
 		// deactivate the cache
 		self::$model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
 		self::$model->cache->method( 'get' )->willReturn( false );
@@ -102,7 +102,7 @@ class Model_Test extends PLL_UnitTestCase {
 		self::$model->cache = new PLL_Cache();
 	}
 
-	function test_translated_taxonomies() {
+	public function test_translated_taxonomies() {
 		$this->assertTrue( self::$model->is_translated_taxonomy( 'category' ) );
 		$this->assertTrue( self::$model->is_translated_taxonomy( 'post_tag' ) );
 		$this->assertFalse( self::$model->is_translated_taxonomy( 'post_format' ) );
@@ -110,7 +110,7 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertFalse( self::$model->is_translated_taxonomy( 'language' ) );
 	}
 
-	function test_filtered_taxonomies() {
+	public function test_filtered_taxonomies() {
 		$this->assertTrue( self::$model->is_filtered_taxonomy( 'post_format' ) );
 		$this->assertFalse( self::$model->is_filtered_taxonomy( 'category' ) );
 		$this->assertFalse( self::$model->is_filtered_taxonomy( 'post_tag' ) );
@@ -118,7 +118,7 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertFalse( self::$model->is_filtered_taxonomy( 'language' ) );
 	}
 
-	function test_is_translated_post_type() {
+	public function test_is_translated_post_type() {
 		self::$model->options['post_types'] = array(
 			'trcpt' => 'trcpt',
 		);
@@ -143,7 +143,7 @@ class Model_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['polylang'] );
 	}
 
-	function test_is_translated_taxonomy() {
+	public function test_is_translated_taxonomy() {
 		self::$model->options['taxonomies'] = array(
 			'trtax' => 'trtax',
 		);
@@ -167,7 +167,7 @@ class Model_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['polylang'] );
 	}
 
-	function test_is_filtered_taxonomy() {
+	public function test_is_filtered_taxonomy() {
 		$this->assertTrue( self::$model->is_filtered_taxonomy( array( 'post_format' ) ) );
 		$this->assertFalse( self::$model->is_filtered_taxonomy( array( 'category' ) ) );
 		$this->assertTrue( self::$model->is_filtered_taxonomy( array( 'post_format', 'category' ) ) );

--- a/tests/phpunit/tests/test-multisite.php
+++ b/tests/phpunit/tests/test-multisite.php
@@ -3,7 +3,7 @@
 if ( is_multisite() ) :
 
 	class Multisite_Test extends PLL_UnitTestCase {
-		function test_new_site() {
+		public function test_new_site() {
 			$site_id = $this->factory->blog->create();
 			$options = get_option( 'polylang' );
 			$this->assertNotFalse( $options );

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -13,7 +13,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$registered_nav_menus = get_registered_nav_menus();
@@ -25,7 +25,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	function test_nav_menu_locations() {
+	public function test_nav_menu_locations() {
 		// get the primary location of the current theme
 		$locations = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
@@ -118,7 +118,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertStringContainsString( 'No language', wp_nav_menu( $args ) );
 	}
 
-	function test_delete_nav_menu() {
+	public function test_delete_nav_menu() {
 		$theme = get_option( 'stylesheet' );
 
 		// get the primary location of the current theme
@@ -156,7 +156,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'fr' => $menu_fr ), $options['nav_menus'][ $theme ][ $primary_location ] );
 	}
 
-	function test_auto_add_pages_to_menu() {
+	public function test_auto_add_pages_to_menu() {
 		// create 2 menus
 		$menu_en = wp_create_nav_menu( 'menu_en' );
 		$menu_fr = wp_create_nav_menu( 'menu_fr' );
@@ -192,7 +192,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $post_id, reset( $menu_items )->object_id ); // our page menu item in menu_fr
 	}
 
-	function test_combine_location() {
+	public function test_combine_location() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 
@@ -201,7 +201,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'primary___fr', $nav_menu->combine_location( 'primary___fr', self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_explode_location() {
+	public function test_explode_location() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 
@@ -209,7 +209,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'location' => 'primary', 'lang' => 'fr' ), $nav_menu->explode_location( 'primary___fr' ) );
 	}
 
-	function setup_nav_menus( $options ) {
+	protected function setup_nav_menus( $options ) {
 		// create posts
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -255,7 +255,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		return $primary_location;
 	}
 
-	function test_nav_menu_language_switcher() {
+	public function test_nav_menu_language_switcher() {
 		$options = array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1 ); // default values
 		$primary_location = $this->setup_nav_menus( $options );
 
@@ -275,7 +275,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['polylang'] );
 	}
 
-	function test_nav_menu_language_switcher_as_dropdown() {
+	public function test_nav_menu_language_switcher_as_dropdown() {
 		$options = array( 'hide_if_no_translation' => 0, 'hide_current' => 1, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1, 'dropdown' => 1 );
 		$primary_location = $this->setup_nav_menus( $options );
 
@@ -303,7 +303,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['polylang'] );
 	}
 
-	function test_menu_items_with_multiple_language_switchers() {
+	public function test_menu_items_with_multiple_language_switchers() {
 		// The switchers dropdown options.
 		$switchers_options = array(
 			array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1, 'dropdown' => 1 ),
@@ -352,7 +352,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['polylang'] );
 	}
 
-	function test_update_nav_menu_item() {
+	public function test_update_nav_menu_item() {
 		wp_set_current_user( 1 );
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
@@ -382,7 +382,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, get_post_meta( $item_id, '_pll_menu_item', true ) );
 	}
 
-	function test_language_switcher_metabox() {
+	public function test_language_switcher_metabox() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->admin_init(); // Setup filters
@@ -398,7 +398,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $xpath->query( '//input[@value="#pll_switcher"]' )->length );
 	}
 
-	function test_set_theme_mod_from_edit_menus_tab() {
+	public function test_set_theme_mod_from_edit_menus_tab() {
 		wp_set_current_user( 1 );
 
 		// Get the primary location of the current theme
@@ -431,7 +431,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 2, $options['nav_menu_locations'][ $primary_location ] );
 	}
 
-	function test_set_theme_mod_from_manage_locations_tab() {
+	public function test_set_theme_mod_from_manage_locations_tab() {
 		wp_set_current_user( 1 );
 
 		// Get the primary location of the current theme
@@ -461,7 +461,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 4, $options['nav_menu_locations'][ $primary_location ] );
 	}
 
-	function test_admin_nav_menus_scripts() {
+	public function test_admin_nav_menus_scripts() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
 		$pll_admin->nav_menus = new PLL_Admin_Nav_Menu( $pll_admin );

--- a/tests/phpunit/tests/test-no-languages.php
+++ b/tests/phpunit/tests/test-no-languages.php
@@ -2,7 +2,9 @@
 
 class No_Languages_Test extends PLL_UnitTestCase {
 
-	// bug fixed in 1.8.2
+	/**
+	 * Bug fixed in 1.8.2.
+	 */
 	public function test_api_on_admin() {
 		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
 

--- a/tests/phpunit/tests/test-no-languages.php
+++ b/tests/phpunit/tests/test-no-languages.php
@@ -3,7 +3,7 @@
 class No_Languages_Test extends PLL_UnitTestCase {
 
 	// bug fixed in 1.8.2
-	function test_api_on_admin() {
+	public function test_api_on_admin() {
 		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
 
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -2,7 +2,7 @@
 
 class OLT_Manager_Test extends PLL_UnitTestCase {
 
-	function test_polylang_first() {
+	public function test_polylang_first() {
 		$plugins = array(
 			'jetpack/jetpack.php',
 			POLYLANG_BASENAME,

--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -3,7 +3,7 @@
 class Parent_Page_Test extends PLL_UnitTestCase {
 	static $editor;
 
-	static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
@@ -12,7 +12,7 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests.

--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -1,7 +1,7 @@
 <?php
 
 class Parent_Page_Test extends PLL_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );

--- a/tests/phpunit/tests/test-polylang.php
+++ b/tests/phpunit/tests/test-polylang.php
@@ -2,14 +2,14 @@
 
 class Polylang_Test extends PLL_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// The call to go_to triggers the parse_request action and rest_api_loaded ends with a die().
 		remove_action( 'parse_request', 'rest_api_loaded' );
 	}
 
-	function test_rest_request_plain_permalinks() {
+	public function test_rest_request_plain_permalinks() {
 		// A real rest_route parameter is detected as a REST request.
 		$this->go_to(
 			add_query_arg(
@@ -54,7 +54,7 @@ class Polylang_Test extends PLL_UnitTestCase {
 		$this->assertFalse( Polylang::is_rest_request() );
 	}
 
-	function test_rest_request_pretty_permalinks() {
+	public function test_rest_request_pretty_permalinks() {
 		// A call with a REST URL.
 		$this->go_to(
 			home_url( '/wp-json/wp/v2/posts/1' )

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -13,7 +13,7 @@ class Query_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -55,7 +55,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->frontend->filters_links->cache->method( 'get' )->willReturn( false );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		_unregister_post_type( 'cpt' );
@@ -64,7 +64,7 @@ class Query_Test extends PLL_UnitTestCase {
 		_unregister_taxonomy( 'trtax' );
 	}
 
-	function test_home_latest_posts() {
+	public function test_home_latest_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -83,7 +83,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_single_post() {
+	public function test_single_post() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -99,7 +99,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_single_post_private_translation() {
+	public function test_single_post_private_translation() {
 		// the 'get_user_metadata' filter in frontend-filters breaks this user_description gets '' instead of an array ?
 		$author_en = $this->factory->user->create( array( 'role' => 'author' ) );
 
@@ -127,7 +127,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->delete_user( $author_en );
 	}
 
-	function test_page() {
+	public function test_page() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -143,7 +143,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_category() {
+	public function test_category() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -169,7 +169,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/category/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_post_tag() {
+	public function test_post_tag() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -193,7 +193,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/tag/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_post_format() {
+	public function test_post_format() {
 		$post_id = $this->factory->post->create();
 		set_post_format( $post_id, 'aside' );
 		self::$model->post->set_language( $post_id, 'fr' );
@@ -213,7 +213,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/type/aside/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_translated_custom_tax() {
+	public function test_translated_custom_tax() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'trtax', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -243,7 +243,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/trtax/test/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_untranslated_custom_tax() {
+	public function test_untranslated_custom_tax() {
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
 		$post_id = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
 		wp_set_post_terms( $post_id, 'test', 'tax' );
@@ -256,7 +256,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 	}
 
-	function test_translated_post_type_archive() {
+	public function test_translated_post_type_archive() {
 		$fr = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
 		self::$model->post->set_language( $fr, 'fr' );
 
@@ -275,7 +275,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/trcpt/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_untranslated_post_type_archive() {
+	public function test_untranslated_post_type_archive() {
 		$post_id = $this->factory->post->create( array( 'post_type' => 'cpt' ) );
 
 		$this->go_to( home_url( '/cpt/' ) );
@@ -289,7 +289,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
 	}
 
-	function test_archives() {
+	public function test_archives() {
 		$fr = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
 		self::$model->post->set_language( $fr, 'fr' );
 
@@ -349,7 +349,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/2007/09/04/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_search() {
+	public function test_search() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -367,7 +367,7 @@ class Query_Test extends PLL_UnitTestCase {
 	/**
 	 * After https://core.trac.wordpress.org/ticket/11330 an empty search doesn't return the homepage anymore.
 	 */
-	function test_empty_search() {
+	public function test_empty_search() {
 		$this->go_to( home_url( '/fr/?s=' ) );
 		$this->assertQueryTrue( 'is_search' );
 	}
@@ -375,12 +375,12 @@ class Query_Test extends PLL_UnitTestCase {
 	/**
 	 * Issue #937.
 	 */
-	function test_invalid_search() {
+	public function test_invalid_search() {
 		$this->go_to( home_url( '/fr/random/?s=' ) );
 		$this->assertQueryTrue( 'is_404' );
 	}
 
-	function test_search_in_category() {
+	public function test_search_in_category() {
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -406,7 +406,7 @@ class Query_Test extends PLL_UnitTestCase {
 
 	// bug fixed in v1.7.11: error 404 for attachments
 	// bug fixed in v1.9.1: language switcher does not link to media translation for anonymous user
-	function test_attachment() {
+	public function test_attachment() {
 		$post_en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $post_en, 'en' );
 
@@ -429,7 +429,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.1: language switcher does not link to media translation for unattached media
-	function test_unattached_attachment() {
+	public function test_unattached_attachment() {
 		$en = $this->factory->post->create( array( 'post_title' => 'img_en', 'post_type' => 'attachment' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -446,7 +446,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// bug fixed in v1.8: is_tax set on main feeds
-	function test_main_feed() {
+	public function test_main_feed() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -463,7 +463,7 @@ class Query_Test extends PLL_UnitTestCase {
 
 	// bug in 1.8 on secondary query, fixed in 1.8.1
 	// see https://wordpress.org/support/topic/issue-with-get_posts-in-version-18
-	function test_untranslated_custom_tax_with_translated_cpt() {
+	public function test_untranslated_custom_tax_with_translated_cpt() {
 		register_taxonomy( 'tax', 'trcpt' );
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
 
@@ -487,7 +487,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// "Issue" fixed in 2.0.10: Drafts should not appear in language switcher
-	function test_draft() {
+	public function test_draft() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_status' => 'draft' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -501,7 +501,7 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	function test_cat() {
+	public function test_cat() {
 		// Categories
 		$cat_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $cat_en, 'en' );
@@ -538,7 +538,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug introduced in 2.2 and fixed in 2.2.4
-	function test_any() {
+	public function test_any() {
 		// Posts
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
@@ -559,7 +559,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.3.3
-	function test_tax_query_with_relation_or() {
+	public function test_tax_query_with_relation_or() {
 		register_taxonomy_for_object_type( 'tax', 'trcpt' ); // *untranslated* custom tax
 
 		// Taxonomy
@@ -593,7 +593,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// Tests cases with 'lang' and no post type in query.
-	function test_language_and_no_post_type_in_query() {
+	public function test_language_and_no_post_type_in_query() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
 		self::$model->post->set_language( $post_id, 'fr' );
 
@@ -647,7 +647,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	// Issue fixed in 2.6.6
-	function test_category_with_post_type_added_late_in_query() {
+	public function test_category_with_post_type_added_late_in_query() {
 		register_taxonomy_for_object_type( 'category', array( 'post', 'trcpt' ) );
 
 		$cpt_id = $this->factory->post->create( array( 'post_type' => 'trcpt' ) );
@@ -675,7 +675,7 @@ class Query_Test extends PLL_UnitTestCase {
 	 * Bug introduced by WP 5.5 and fixed in Polylang 2.8.
 	 * The sticky posts should appear only once.
 	 */
-	function test_sticky_posts() {
+	public function test_sticky_posts() {
 		$fr = $this->factory->post->create();
 		self::$model->post->set_language( $fr, 'fr' );
 		stick_post( $fr );

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -404,8 +404,10 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/category/test/?s=test' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 	}
 
-	// bug fixed in v1.7.11: error 404 for attachments
-	// bug fixed in v1.9.1: language switcher does not link to media translation for anonymous user
+	/**
+	 * Bug fixed in v1.7.11: error 404 for attachments.
+	 * Bug fixed in v1.9.1: language switcher does not link to media translation for anonymous user.
+	 */
 	public function test_attachment() {
 		$post_en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $post_en, 'en' );
@@ -428,7 +430,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/test/img_en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
 	}
 
-	// Bug fixed in 2.1: language switcher does not link to media translation for unattached media
+	/**
+	 * Bug fixed in 2.1: language switcher does not link to media translation for unattached media.
+	 */
 	public function test_unattached_attachment() {
 		$en = $this->factory->post->create( array( 'post_title' => 'img_en', 'post_type' => 'attachment' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -445,7 +449,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/img_en/' ), $this->frontend->links->get_translation_url( self::$model->get_language( 'en' ) ) ); // bug fixed in v1.9.1
 	}
 
-	// bug fixed in v1.8: is_tax set on main feeds
+	/**
+	 * Bug fixed in v1.8: is_tax set on main feeds.
+	 */
 	public function test_main_feed() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
@@ -461,8 +467,11 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertQueryTrue( 'is_feed' );
 	}
 
-	// bug in 1.8 on secondary query, fixed in 1.8.1
-	// see https://wordpress.org/support/topic/issue-with-get_posts-in-version-18
+	/**
+	 * Bug in 1.8 on secondary query, fixed in 1.8.1.
+	 *
+	 * @see https://wordpress.org/support/topic/issue-with-get_posts-in-version-18
+	 */
 	public function test_untranslated_custom_tax_with_translated_cpt() {
 		register_taxonomy( 'tax', 'trcpt' );
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
@@ -486,7 +495,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
 	}
 
-	// "Issue" fixed in 2.0.10: Drafts should not appear in language switcher
+	/**
+	 * "Issue" fixed in 2.0.10: Drafts should not appear in language switcher.
+	 */
 	public function test_draft() {
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_status' => 'draft' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -537,7 +548,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $query->posts );
 	}
 
-	// Bug introduced in 2.2 and fixed in 2.2.4
+	/**
+	 * Bug introduced in 2.2 and fixed in 2.2.4.
+	 */
 	public function test_any() {
 		// Posts
 		$en = $this->factory->post->create();
@@ -558,7 +571,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
 	}
 
-	// Bug fixed in 2.3.3
+	/**
+	 * Bug fixed in 2.3.3
+	 */
 	public function test_tax_query_with_relation_or() {
 		register_taxonomy_for_object_type( 'tax', 'trcpt' ); // *untranslated* custom tax
 
@@ -592,7 +607,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $query->posts );
 	}
 
-	// Tests cases with 'lang' and no post type in query.
+	/**
+	 * Tests cases with 'lang' and no post type in query.
+	 */
 	public function test_language_and_no_post_type_in_query() {
 		$post_id = $this->factory->post->create( array( 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
 		self::$model->post->set_language( $post_id, 'fr' );
@@ -646,7 +663,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_id ) ), $query->posts );
 	}
 
-	// Issue fixed in 2.6.6
+	/**
+	 * Issue fixed in 2.6.6.
+	 */
 	public function test_category_with_post_type_added_late_in_query() {
 		register_taxonomy_for_object_type( 'category', array( 'post', 'trcpt' ) );
 

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -13,7 +13,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		global $wp_rewrite;
@@ -38,7 +38,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$this->frontend->init();
 	}
 
-	function test_admin_bar_search_form() {
+	public function test_admin_bar_search_form() {
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
@@ -51,7 +51,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$this->assertStringContainsString( home_url( '/fr/' ), $node->title );
 	}
 
-	function test_get_search_form() {
+	public function test_get_search_form() {
 		global $wp_rewrite;
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
@@ -69,7 +69,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 	/**
 	 * Issue #829
 	 */
-	function test_get_search_form_with_wrong_inital_url() {
+	public function test_get_search_form_with_wrong_inital_url() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$form = '<form role="search" method="get" class="search-form" action="http://example.org/fr/accueil/">
 				<label>
@@ -85,7 +85,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 	/**
 	 * PR #780
 	 */
-	function test_search_form_is_not_emptied() {
+	public function test_search_form_is_not_emptied() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$form = '<form action="http://example.org" method="get"><input type="submit" value="Search" /></form>';
 		$form = apply_filters( 'get_search_form', $form );
@@ -95,7 +95,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 	/**
 	 * PR #780
 	 */
-	function test_search_form_with_simple_quotes_in_html() {
+	public function test_search_form_with_simple_quotes_in_html() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$form = "<form action='http://example.org' method='get'><input type='submit' value='Search' /></form>";
 		$form = apply_filters( 'get_search_form', $form );
@@ -105,7 +105,7 @@ class Search_Form_Test extends PLL_UnitTestCase {
 	/**
 	 * PR #780
 	 */
-	function test_search_form_with_no_quotes_in_html() {
+	public function test_search_form_with_no_quotes_in_html() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$form = '<form action=http://example.org method=get><input type=submit value=Search /></form>';
 		$form = apply_filters( 'get_search_form', $form );

--- a/tests/phpunit/tests/test-settings-browser.php
+++ b/tests/phpunit/tests/test-settings-browser.php
@@ -2,20 +2,20 @@
 
 class Settings_Browser_Test extends PLL_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
 		$this->pll_env = new PLL_Settings( $links_model );
 	}
 
-	function test_active_true() {
+	public function test_active_true() {
 		self::$model->options['browser'] = 1;
 		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertTrue( $module->is_active() );
 	}
 
-	function test_active_false() {
+	public function test_active_false() {
 		self::$model->options['browser'] = 0;
 		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertFalse( $module->is_active() );

--- a/tests/phpunit/tests/test-settings-cpt.php
+++ b/tests/phpunit/tests/test-settings-cpt.php
@@ -2,7 +2,7 @@
 
 class Settings_CPT_Test extends PLL_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// De-activate cache for translated post types and taxonomies
@@ -16,26 +16,26 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->pll_env = new PLL_Settings( $links_model );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		_unregister_post_type( 'cpt' );
 		_unregister_taxonomy( 'tax' );
 	}
 
-	function filter_translated_post_type_in_settings( $post_types, $is_settings ) {
+	public function filter_translated_post_type_in_settings( $post_types, $is_settings ) {
 		$post_types[] = 'cpt';
 		return $post_types;
 	}
 
-	function filter_untranslated_post_type_in_settings( $post_types, $is_settings ) {
+	public function filter_untranslated_post_type_in_settings( $post_types, $is_settings ) {
 		if ( $is_settings ) {
 			$post_types[] = 'cpt';
 		}
 		return $post_types;
 	}
 
-	function filter_translated_post_type_not_in_settings( $post_types, $is_settings ) {
+	public function filter_translated_post_type_not_in_settings( $post_types, $is_settings ) {
 		if ( $is_settings ) {
 			$k = array_search( 'cpt', $post_types );
 			unset( $post_types[ $k ] );
@@ -45,19 +45,19 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		return $post_types;
 	}
 
-	function filter_translated_taxonomy_in_settings( $taxonomies, $is_settings ) {
+	public function filter_translated_taxonomy_in_settings( $taxonomies, $is_settings ) {
 		$taxonomies[] = 'tax';
 		return $taxonomies;
 	}
 
-	function filter_untranslated_taxonomy_in_settings( $taxonomies, $is_settings ) {
+	public function filter_untranslated_taxonomy_in_settings( $taxonomies, $is_settings ) {
 		if ( $is_settings ) {
 			$taxonomies[] = 'tax';
 		}
 		return $taxonomies;
 	}
 
-	function filter_translated_taxonomy_not_in_settings( $taxonomies, $is_settings ) {
+	public function filter_translated_taxonomy_not_in_settings( $taxonomies, $is_settings ) {
 		if ( $is_settings ) {
 			$k = array_search( 'tax', $taxonomies );
 			unset( $taxonomies[ $k ] );
@@ -67,12 +67,12 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		return $taxonomies;
 	}
 
-	function test_no_cpt_no_tax() {
+	public function test_no_cpt_no_tax() {
 		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_untranslated_public_post_type() {
+	public function test_untranslated_public_post_type() {
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 
@@ -85,7 +85,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_translated_public_post_type() {
+	public function test_translated_public_post_type() {
 		self::$model->options['post_types'] = array( 'cpt' );
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -99,7 +99,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_programmatically_translated_public_post_type() {
+	public function test_programmatically_translated_public_post_type() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -113,27 +113,27 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'disabled', $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_untranslated_private_post_type() {
+	public function test_untranslated_private_post_type() {
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_translated_private_post_type() {
+	public function test_translated_private_post_type() {
 		self::$model->options['post_types'] = array( 'cpt' );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_programmatically_translated_private_post_type() {
+	public function test_programmatically_translated_private_post_type() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_not_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_untranslated_private_post_type_in_settings() {
+	public function test_untranslated_private_post_type_in_settings() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_untranslated_post_type_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -147,7 +147,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_translated_private_post_type_in_settings() {
+	public function test_translated_private_post_type_in_settings() {
 		self::$model->options['post_types'] = array( 'cpt' );
 		add_filter( 'pll_get_post_types', array( $this, 'filter_untranslated_post_type_in_settings' ), 10, 2 );
 		register_post_type( 'cpt', array( 'public' => false, 'label' => 'CPT' ) );
@@ -162,7 +162,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_untranslated_public_taxonomy() {
+	public function test_untranslated_public_taxonomy() {
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 
@@ -175,7 +175,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_translated_public_taxonomy() {
+	public function test_translated_public_taxonomy() {
 		self::$model->options['taxonomies'] = array( 'tax' );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -189,7 +189,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_programmatically_translated_public_taxonomy() {
+	public function test_programmatically_translated_public_taxonomy() {
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -203,13 +203,13 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'disabled', $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_untranslated_private_taxonomy() {
+	public function test_untranslated_private_taxonomy() {
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_translated_private_taxonomy() {
+	public function test_translated_private_taxonomy() {
 		self::$model->options['taxonomies'] = array( 'tax' );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -217,14 +217,14 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_programmatically_translated_private_taxonomy() {
+	public function test_programmatically_translated_private_taxonomy() {
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_not_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 		$this->assertEmpty( $module->get_form() );
 	}
 
-	function test_untranslated_private_taxonomy_in_settings() {
+	public function test_untranslated_private_taxonomy_in_settings() {
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_untranslated_taxonomy_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
@@ -238,7 +238,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $input->item( 0 )->getAttribute( 'disabled' ) );
 	}
 
-	function test_translated_private_taxonomy_in_settings() {
+	public function test_translated_private_taxonomy_in_settings() {
 		self::$model->options['taxonomies'] = array( 'tax' );
 		add_filter( 'pll_get_taxonomies', array( $this, 'filter_untranslated_taxonomy_in_settings' ), 10, 2 );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => false ) );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -12,7 +12,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// Avoid http call
@@ -20,7 +20,7 @@ class Settings_Test extends PLL_UnitTestCase {
 	}
 
 	// bug introduced and fixed in 1.9alpha
-	function test_edit_language() {
+	public function test_edit_language() {
 		$lang = self::$model->get_language( 'fr' );
 
 		// setup globals
@@ -61,7 +61,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'selected', $option->item( 0 )->getAttribute( 'selected' ) );
 	}
 
-	function test_notice_for_objects_with_no_lang() {
+	public function test_notice_for_objects_with_no_lang() {
 		$_GET['page'] = 'mlang';
 		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		set_current_screen();
@@ -100,7 +100,7 @@ class Settings_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug introduced in 2.1-dev
-	function test_display_settings_errors() {
+	public function test_display_settings_errors() {
 		add_settings_error( 'test', 'test', 'ERROR' );
 		$links_model = self::$model->get_links_model();
 		$pll_env = new PLL_Settings( $links_model );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -19,7 +19,9 @@ class Settings_Test extends PLL_UnitTestCase {
 		add_filter( 'pre_transient_available_translations', '__return_empty_array' );
 	}
 
-	// bug introduced and fixed in 1.9alpha
+	/**
+	 * Bug introduced and fixed in 1.9alpha.
+	 */
 	public function test_edit_language() {
 		$lang = self::$model->get_language( 'fr' );
 
@@ -99,7 +101,9 @@ class Settings_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $out );
 	}
 
-	// Bug introduced in 2.1-dev
+	/**
+	 * Bug introduced in 2.1-dev.
+	 */
 	public function test_display_settings_errors() {
 		add_settings_error( 'test', 'test', 'ERROR' );
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -16,7 +16,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function init( $sitemap_class = 'PLL_Sitemaps' ) {
+	protected function init( $sitemap_class = 'PLL_Sitemaps' ) {
 		global $wp_rewrite, $wp_sitemaps;
 
 		// Initialize sitemaps.
@@ -53,14 +53,14 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->pll_env->filters_links->cache->method( 'get' )->willReturn( false );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		_unregister_post_type( 'cpt' );
 		_unregister_taxonomy( 'tax' );
 	}
 
-	function test_sitemap_providers() {
+	public function test_sitemap_providers() {
 		$this->init();
 
 		$providers = wp_get_sitemap_providers();
@@ -70,7 +70,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	// The page sitemaps always include the homepages.
-	function test_sitemaps_page() {
+	public function test_sitemaps_page() {
 		$this->init();
 
 		$providers = wp_get_sitemap_providers();
@@ -82,7 +82,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
 
-	function test_sitemaps_posts() {
+	public function test_sitemaps_posts() {
 		$this->init();
 
 		$en = self::factory()->post->create( array( 'post_author' => 1 ) );
@@ -114,7 +114,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
 	}
 
-	function test_sitemaps_untranslated_cpt_and_tax() {
+	public function test_sitemaps_untranslated_cpt_and_tax() {
 		$this->init();
 
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
@@ -136,7 +136,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
 	}
 
-	function test_home_urls() {
+	public function test_home_urls() {
 		self::$model->options['hide_default'] = 1;
 		$this->init();
 
@@ -161,7 +161,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['wp_actions']['template_redirect'] );
 	}
 
-	function test_url_list_posts() {
+	public function test_url_list_posts() {
 		self::$model->options['hide_default'] = 1;
 		$this->init();
 		$this->pll_env->terms = new PLL_CRUD_Terms( $this->pll_env );
@@ -218,7 +218,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
 	}
 
-	function test_subdomains() {
+	public function test_subdomains() {
 		self::$model->options['force_lang'] = 2;
 		$this->init( 'PLL_Sitemaps_Domain' );
 
@@ -233,7 +233,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
 
-	function test_subdomains_home_url() {
+	public function test_subdomains_home_url() {
 		self::$model->options['force_lang'] = 2;
 		$this->init( 'PLL_Sitemaps_Domain' );
 
@@ -255,7 +255,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['wp_actions']['template_redirect'] );
 	}
 
-	function test_domains() {
+	public function test_domains() {
 		self::$model->options['force_lang'] = 3;
 		self::$model->options['domains'] = array(
 			'en' => 'http://example.org',

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -69,7 +69,9 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		}
 	}
 
-	// The page sitemaps always include the homepages.
+	/**
+	 * The page sitemaps always include the homepages.
+	 */
 	public function test_sitemaps_page() {
 		$this->init();
 

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -12,7 +12,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function test_term_slugs() {
+	public function test_term_slugs() {
 		$links_model = self::$model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
 		new PLL_Admin_Filters_Term( $pll_admin ); // activate our filters

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -61,7 +61,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		self::$model->options['hide_default'] = 0;
@@ -95,7 +95,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->frontend->static_pages->pll_language_defined();
 	}
 
-	static function wpTearDownAfterClass() {
+	public static function wpTearDownAfterClass() {
 		wp_delete_post( self::$home_en );
 		wp_delete_post( self::$home_fr );
 		wp_delete_post( self::$home_de );
@@ -106,7 +106,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		remove_filter( 'pll_languages_list', array( 'PLL_Static_Pages', 'pll_languages_list' ), 2, 2 ); // Avoid breaking next tests
 	}
 
-	function test_front_page_with_default_options() {
+	public function test_front_page_with_default_options() {
 		global $wp_rewrite;
 
 		self::$model->clean_languages_cache();
@@ -128,7 +128,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/' ), false ) );
 	}
 
-	function test_front_page_with_query() {
+	public function test_front_page_with_query() {
 		global $wp_rewrite;
 
 		self::$model->clean_languages_cache();
@@ -147,7 +147,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/accueil/?query=1' ), false ) );
 	}
 
-	function test_paged_front_page() {
+	public function test_paged_front_page() {
 		global $wp_rewrite;
 
 		self::$model->clean_languages_cache();
@@ -176,7 +176,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/en/home/page/2/' ), false ) );
 	}
 
-	function test_front_page_with_hide_default() {
+	public function test_front_page_with_hide_default() {
 		global $wp_rewrite;
 
 		self::$model->options['hide_default'] = 1;
@@ -210,7 +210,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// special case for default permalinks
-	function test_front_page_with_hide_default_plain_permalinks() {
+	public function test_front_page_with_hide_default_plain_permalinks() {
 		global $wp_rewrite;
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( '' );
@@ -242,7 +242,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/' ), false ) );
 	}
 
-	function test_paged_front_page_plain_permalinks() {
+	public function test_paged_front_page_plain_permalinks() {
 		global $wp_rewrite;
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( '' );
@@ -272,7 +272,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '?page=2' ), false ) );
 	}
 
-	function test_front_page_with_redirect_lang() {
+	public function test_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
 		self::$model->options['redirect_lang'] = 1;
@@ -295,7 +295,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/' ), false ) );
 	}
 
-	function test_page_for_posts() {
+	public function test_page_for_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -317,7 +317,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
 	}
 
-	function test_paged_page_for_posts() {
+	public function test_paged_page_for_posts() {
 		update_option( 'posts_per_page', 2 ); // to avoid creating too much posts
 
 		$en = $this->factory->post->create_many( 3 );
@@ -346,7 +346,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// bug fixed in 1.8beta3 : non translated posts page always link to the static front page even when they should not
-	function test_untranslated_page_for_posts() {
+	public function test_untranslated_page_for_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -360,7 +360,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// bug fixed in 1.8.1
-	function test_paged_front_page_with_hide_default() {
+	public function test_paged_front_page_with_hide_default() {
 		global $wp_rewrite;
 
 		self::$model->options['hide_default'] = 1;
@@ -382,7 +382,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// for good measure test that too
-	function test_front_page_with_redirect_lang_and_hide_default() {
+	public function test_front_page_with_redirect_lang_and_hide_default() {
 		global $wp_rewrite;
 
 		self::$model->options['redirect_lang'] = 1;
@@ -403,7 +403,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/fr/page/2/' ), false ) );
 	}
 
-	function test_post_states() {
+	public function test_post_states() {
 		ob_start();
 		_post_states( get_post( self::$home_en ) );
 		$this->assertNotFalse( strpos( ob_get_clean(), "<span class='post-state'>Front Page</span>" ) );
@@ -438,13 +438,13 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.0
-	function test_get_post_type_archive_link_for_posts() {
+	public function test_get_post_type_archive_link_for_posts() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$this->assertEquals( 'http://example.org/fr/articles/', get_post_type_archive_link( 'post' ) );
 	}
 
 	// Bug introduced and fixed in 2.3
-	function test_archives_with_front_page_with_redirect_lang() {
+	public function test_archives_with_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
 		$en = $this->factory->post->create( array( 'post_title' => 'test', 'post_date' => '2007-09-04 00:00:00', 'post_author' => 1 ) );
@@ -471,7 +471,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug introduced and fixed in 2.3
-	function test_post_type_archives_with_front_page_with_redirect_lang() {
+	public function test_post_type_archives_with_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
 		$wp_rewrite->init();
@@ -498,19 +498,19 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	}
 
 	// Add custom query var
-	function extra_query_vars( $query_vars ) {
+	public function extra_query_vars( $query_vars ) {
 		$query_vars[] = 'action';
 		return $query_vars;
 	}
 
 	// Add custom root rewrite rule
-	function extra_root_rewrite_rules( $rules ) {
+	public function extra_root_rewrite_rules( $rules ) {
 		$rules['^testing/?$'] = 'index.php?action=testing';
 		return $rules;
 	}
 
 	// Bug introduced in 2.3 and fixed in 2.3.1
-	function test_extra_query_var_with_front_page_with_query_with_redirect_lang() {
+	public function test_extra_query_var_with_front_page_with_query_with_redirect_lang() {
 		global $wp_rewrite;
 
 		add_filter( 'query_vars', array( $this, 'extra_query_vars' ) );
@@ -530,7 +530,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertFalse( is_front_page() );
 	}
 
-	function test_front_page_with_orderby_with_redirect_lang() {
+	public function test_front_page_with_orderby_with_redirect_lang() {
 		global $wp_rewrite;
 
 		self::$model->options['redirect_lang'] = 1;

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -209,7 +209,9 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( home_url( '/' ), redirect_canonical( home_url( '/en/home/' ), false ) );
 	}
 
-	// special case for default permalinks
+	/**
+	 * Special case for default permalinks.
+	 */
 	public function test_front_page_with_hide_default_plain_permalinks() {
 		global $wp_rewrite;
 		$wp_rewrite->init();
@@ -345,7 +347,9 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertCount( 1, $GLOBALS['wp_query']->posts );
 	}
 
-	// bug fixed in 1.8beta3 : non translated posts page always link to the static front page even when they should not
+	/**
+	 * Bug fixed in 1.8beta3 : non translated posts page always link to the static front page even when they should not
+	 */
 	public function test_untranslated_page_for_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
@@ -359,7 +363,9 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'de' ) ) );
 	}
 
-	// bug fixed in 1.8.1
+	/**
+	 * Bug fixed in 1.8.1.
+	 */
 	public function test_paged_front_page_with_hide_default() {
 		global $wp_rewrite;
 
@@ -381,7 +387,9 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( redirect_canonical( home_url( '/page/2/' ), false ) );
 	}
 
-	// for good measure test that too
+	/**
+	 * For good measure test that too.
+	 */
 	public function test_front_page_with_redirect_lang_and_hide_default() {
 		global $wp_rewrite;
 
@@ -437,13 +445,17 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $out, "<span class='post-state'>Posts Page</span>" ) );
 	}
 
-	// Bug fixed in 2.0
+	/**
+	 * Bug fixed in 2.0.
+	 */
 	public function test_get_post_type_archive_link_for_posts() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		$this->assertEquals( 'http://example.org/fr/articles/', get_post_type_archive_link( 'post' ) );
 	}
 
-	// Bug introduced and fixed in 2.3
+	/**
+	 * Bug introduced and fixed in 2.3.
+	 */
 	public function test_archives_with_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
@@ -470,7 +482,9 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $GLOBALS['wp_query']->posts );
 	}
 
-	// Bug introduced and fixed in 2.3
+	/**
+	 * Bug introduced and fixed in 2.3.
+	 */
 	public function test_post_type_archives_with_front_page_with_redirect_lang() {
 		global $wp_rewrite;
 
@@ -497,19 +511,29 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		_unregister_post_type( 'trcpt' );
 	}
 
-	// Add custom query var
+	/**
+	 * Add custom query var.
+	 *
+	 * @param string[] $query_vars Query vars.
+	 */
 	public function extra_query_vars( $query_vars ) {
 		$query_vars[] = 'action';
 		return $query_vars;
 	}
 
-	// Add custom root rewrite rule
+	/**
+	 * Add custom root rewrite rule.
+	 *
+	 * @param string[] $rules Extra rewrite rules.
+	 */
 	public function extra_root_rewrite_rules( $rules ) {
 		$rules['^testing/?$'] = 'index.php?action=testing';
 		return $rules;
 	}
 
-	// Bug introduced in 2.3 and fixed in 2.3.1
+	/**
+	 * Bug introduced in 2.3 and fixed in 2.3.1.
+	 */
 	public function test_extra_query_var_with_front_page_with_query_with_redirect_lang() {
 		global $wp_rewrite;
 

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -20,7 +20,9 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	// copied from WP widgets tests
+	/**
+	 * Copied from WP widgets tests.
+	 */
 	public function clean_up_global_scope() {
 		global $_wp_sidebars_widgets, $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
@@ -64,7 +66,9 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertCount( 4, array_intersect( array( 'blogname', 'blogdescription', 'date_format', 'time_format' ), $names ) );
 	}
 
-	// FIXME: order of nest two tests matters due to static protected strings in PLL_Admin_Strings
+	/**
+	 * /!\ The order of nest two tests matters due to static protected strings in PLL_Admin_Strings.
+	 */
 	public function test_widget_title_filtered_by_language() {
 		global $wp_registered_widgets;
 
@@ -126,8 +130,10 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertContains( 'My Title', $strings );
 	}
 
-	// Bug fixed in 2.1
-	// Test #63
+	/**
+	 * Bug fixed in 2.1.
+	 * Issue #63.
+	 */
 	public function test_html_string() {
 		update_option( 'use_balanceTags', 1 ); // To break malformed html in versions < 2.1
 		$language = self::$model->get_language( 'fr' );
@@ -148,8 +154,10 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '<p>malformed fr<p>', pll__( '<p>malformed<p>' ) );
 	}
 
-	// Bug introduced in 2.1 and fixed in 2.1.1
-	// Test #94
+	/**
+	 * Bug introduced in 2.1 and fixed in 2.1.1.
+	 * Issue #94.
+	 */
 	public function test_slashed_string() {
 		$language = self::$model->get_language( 'fr' );
 		$_mo = new PLL_MO();

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -14,14 +14,14 @@ class Strings_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->links_model = self::$model->get_links_model();
 	}
 
 	// copied from WP widgets tests
-	function clean_up_global_scope() {
+	public function clean_up_global_scope() {
 		global $_wp_sidebars_widgets, $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
 		$_wp_sidebars_widgets = array();
@@ -34,7 +34,7 @@ class Strings_Test extends PLL_UnitTestCase {
 		parent::clean_up_global_scope();
 	}
 
-	function add_widget_search() {
+	protected function add_widget_search() {
 		update_option(
 			'widget_search',
 			array(
@@ -52,11 +52,11 @@ class Strings_Test extends PLL_UnitTestCase {
 		);
 	}
 
-	function _return_fr_FR() {
+	public function _return_fr_FR() {
 		return array( 'fr_FR' );
 	}
 
-	function test_base_strings() {
+	public function test_base_strings() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$pll_admin->init();
 		$strings = PLL_Admin_Strings::get_strings();
@@ -65,7 +65,7 @@ class Strings_Test extends PLL_UnitTestCase {
 	}
 
 	// FIXME: order of nest two tests matters due to static protected strings in PLL_Admin_Strings
-	function test_widget_title_filtered_by_language() {
+	public function test_widget_title_filtered_by_language() {
 		global $wp_registered_widgets;
 
 		$this->add_widget_search();
@@ -95,7 +95,7 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertNotContains( 'My Title', $strings );
 	}
 
-	function test_widget_title_in_all_languages() {
+	public function test_widget_title_in_all_languages() {
 		global $wp_registered_widgets;
 
 		$this->add_widget_search();
@@ -128,7 +128,7 @@ class Strings_Test extends PLL_UnitTestCase {
 
 	// Bug fixed in 2.1
 	// Test #63
-	function test_html_string() {
+	public function test_html_string() {
 		update_option( 'use_balanceTags', 1 ); // To break malformed html in versions < 2.1
 		$language = self::$model->get_language( 'fr' );
 		$_mo = new PLL_MO();
@@ -150,7 +150,7 @@ class Strings_Test extends PLL_UnitTestCase {
 
 	// Bug introduced in 2.1 and fixed in 2.1.1
 	// Test #94
-	function test_slashed_string() {
+	public function test_slashed_string() {
 		$language = self::$model->get_language( 'fr' );
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( '\slashed', '\slashed fr' ) );
@@ -171,7 +171,7 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '\\\slashed fr', pll__( '\\\slashed' ) );
 	}
 
-	function test_switch_to_locale() {
+	public function test_switch_to_locale() {
 		// Strings translations
 		$mo = new PLL_MO();
 		$mo->add_entry( $mo->make_entry( 'test', 'test en' ) );

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -18,7 +18,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		self::$model->post->register_taxonomy(); // Needed for post counting
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
@@ -32,7 +32,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->switcher = new PLL_Switcher();
 	}
 
-	function test_the_languages_raw() {
+	public function test_the_languages_raw() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -94,7 +94,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 	/**
 	 *  Very basic tests for the switcher as list
 	 */
-	function test_list() {
+	public function test_list() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -157,7 +157,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 	/**
 	 * Very basic tests for the switcher as dropdown
 	 */
-	function test_dropdown() {
+	public function test_dropdown() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -187,7 +187,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $xpath->query( '//script' )->length );
 	}
 
-	function test_with_hide_if_no_translation_option_in_admin_context() {
+	public function test_with_hide_if_no_translation_option_in_admin_context() {
 		$links_model = self::$model->get_links_model();
 		$this->admin = new PLL_Admin( $links_model );
 		$this->admin->init();

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -17,7 +17,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$author = $factory->user->create( array( 'role' => 'author' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
@@ -26,7 +26,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
-	function test_copy_taxonomies() {
+	public function test_copy_taxonomies() {
 		$tag_en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'slug' => 'tag_en' ) );
 		self::$model->term->set_language( $tag_en, 'en' );
 
@@ -89,7 +89,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertFalse( get_post_format( $from ) );
 	}
 
-	function test_copy_custom_fields() {
+	public function test_copy_custom_fields() {
 		$from = $this->factory->post->create();
 		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, 'key', 'value' );
@@ -114,7 +114,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_post_meta( $from, 'key', true ) );
 	}
 
-	function test_sync_multiple_custom_fields() {
+	public function test_sync_multiple_custom_fields() {
 		self::$model->options['sync'] = array( 'post_meta' );
 		$sync = new PLL_Admin_Sync( $this->pll_admin );
 
@@ -155,7 +155,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( 'value1', 'value4' ), get_post_meta( $to, 'key' ) );
 	}
 
-	function test_create_post_translation() {
+	public function test_create_post_translation() {
 		// categories
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		self::$model->term->set_language( $en, 'en' );
@@ -198,7 +198,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_sticky( $to ) );
 	}
 
-	function test_create_page_translation() {
+	public function test_create_page_translation() {
 		// parent pages
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -236,7 +236,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'full-width.php', get_page_template_slug( $to ) );
 	}
 
-	function test_save_post_with_sync() {
+	public function test_save_post_with_sync() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Attachment for thumbnail
@@ -291,11 +291,11 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_sticky( $to ) );
 	}
 
-	function filter_theme_page_templates() {
+	public function filter_theme_page_templates() {
 		return array( 'templates/test.php' => 'Test Template Page' );
 	}
 
-	function test_save_page_with_sync() {
+	public function test_save_page_with_sync() {
 		$GLOBALS['post_type'] = 'page';
 		add_filter( 'theme_page_templates', array( $this, 'filter_theme_page_templates' ) ); // Allow to test templates with themes without templates
 
@@ -339,7 +339,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'templates/test.php', get_page_template_slug( $to ) );
 	}
 
-	function test_save_term_with_sync_in_post() {
+	public function test_save_term_with_sync_in_post() {
 		self::$model->options['sync'] = array( 'taxonomies' );
 
 		$from = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
@@ -375,7 +375,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_object_in_term( $fr, 'category', $to ) );
 	}
 
-	function test_save_term_with_parent_sync() {
+	public function test_save_term_with_parent_sync() {
 		// Parents
 		$en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		self::$model->term->set_language( $en, 'en' );
@@ -413,7 +413,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	 * Test the child sync if we edit (delete) the translated term parent
 	 * Bug fixed in 2.6.4
 	 */
-	function test_child_sync_if_delete_translated_term_parent() {
+	public function test_child_sync_if_delete_translated_term_parent() {
 		// Children.
 		$child_en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		self::$model->term->set_language( $child_en, 'en' );
@@ -443,7 +443,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( get_term( $child_en )->parent, 0 );
 	}
 
-	function test_create_post_translation_with_sync_post_date() {
+	public function test_create_post_translation_with_sync_post_date() {
 		// source post
 		$from = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		self::$model->post->set_language( $from, 'en' );
@@ -467,7 +467,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug introduced in 2.0.8 and fixed in 2.1
-	function test_quick_edit_with_sync_page_parent() {
+	public function test_quick_edit_with_sync_page_parent() {
 		$_REQUEST['post_type'] = 'page';
 
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
@@ -500,7 +500,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
 	}
 
-	function test_create_post_translation_with_sync_date() {
+	public function test_create_post_translation_with_sync_date() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// source post
@@ -528,11 +528,11 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '2007-09-04 00:00:00', get_post( $to )->post_date );
 	}
 
-	function _add_term_meta_to_copy() {
+	public function _add_term_meta_to_copy() {
 		return array( 'key' );
 	}
 
-	function test_copy_term_metas() {
+	public function test_copy_term_metas() {
 		$from = $this->factory->term->create();
 		self::$model->term->set_language( $from, 'en' );
 		add_term_meta( $from, 'key', 'value' );
@@ -557,7 +557,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_term_meta( $from, 'key', true ) );
 	}
 
-	function test_sync_multiple_term_metas() {
+	public function test_sync_multiple_term_metas() {
 		$sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$from = $this->factory->term->create();
@@ -585,7 +585,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( 'value1', 'value4' ), get_term_meta( $to, 'key' ) );
 	}
 
-	function test_sync_post_with_metas_to_remove() {
+	public function test_sync_post_with_metas_to_remove() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Posts
@@ -620,7 +620,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( 'value1' ), get_post_meta( $from, 'key2' ) );
 	}
 
-	function test_source_post_was_sticky_before_sync_was_active() {
+	public function test_source_post_was_sticky_before_sync_was_active() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Posts
@@ -649,7 +649,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertTrue( is_sticky( $to ) );
 	}
 
-	function test_target_post_was_sticky_before_sync_was_active() {
+	public function test_target_post_was_sticky_before_sync_was_active() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Posts
@@ -673,7 +673,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.3.2
-	function test_delete_term() {
+	public function test_delete_term() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
 		// Categories
@@ -702,7 +702,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.3.11
-	function test_category_hierarchy() {
+	public function test_category_hierarchy() {
 		// Categories
 		$child_en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		self::$model->term->set_language( $en, 'en' );
@@ -735,7 +735,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	// Bug fixed in 2.5.2
-	function test_sync_category_parent_modification() {
+	public function test_sync_category_parent_modification() {
 		// Parent 1
 		$p1en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		self::$model->term->set_language( $en, 'en' );
@@ -775,7 +775,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $p2en, $term->parent );
 	}
 
-	function test_if_cannot_synchronize() {
+	public function test_if_cannot_synchronize() {
 		add_filter( 'pll_pre_current_user_can_synchronize_post', '__return_null' ); // Enable capability check
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
@@ -839,7 +839,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'aside', get_post_format( $from ) );
 	}
 
-	function test_slashes() {
+	public function test_slashes() {
 		self::$model->options['sync'] = array( 'post_meta' );
 		$sync = new PLL_Admin_Sync( $this->pll_admin );
 

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -466,7 +466,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( get_post( $from )->post_date_gmt, get_post( $to )->post_date_gmt );
 	}
 
-	// Bug introduced in 2.0.8 and fixed in 2.1
+	/**
+	 * Bug introduced in 2.0.8 and fixed in 2.1.
+	 */
 	public function test_quick_edit_with_sync_page_parent() {
 		$_REQUEST['post_type'] = 'page';
 
@@ -672,7 +674,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertfalse( is_sticky( $to ) );
 	}
 
-	// Bug fixed in 2.3.2
+	/**
+	 * Bug fixed in 2.3.2.
+	 */
 	public function test_delete_term() {
 		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
 
@@ -701,7 +705,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( $en ), wp_get_post_categories( $post_en ) );
 	}
 
-	// Bug fixed in 2.3.11
+	/**
+	 * Bug fixed in 2.3.11.
+	 */
 	public function test_category_hierarchy() {
 		// Categories
 		$child_en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
@@ -734,7 +740,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $parent_en, $term->parent );
 	}
 
-	// Bug fixed in 2.5.2
+	/**
+	 * Bug fixed in 2.5.2.
+	 */
 	public function test_sync_category_parent_modification() {
 		// Parent 1
 		$p1en = $en = $this->factory->term->create( array( 'taxonomy' => 'category' ) );

--- a/tests/phpunit/tests/test-terms-list.php
+++ b/tests/phpunit/tests/test-terms-list.php
@@ -1,7 +1,7 @@
 <?php
 
 class Terms_List_Test extends PLL_UnitTestCase {
-	static $editor;
+	protected static $editor;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory

--- a/tests/phpunit/tests/test-terms-list.php
+++ b/tests/phpunit/tests/test-terms-list.php
@@ -15,7 +15,7 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
@@ -26,7 +26,7 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
 	}
 
-	function test_term_list_with_admin_language_filter() {
+	public function test_term_list_with_admin_language_filter() {
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -6,7 +6,7 @@
  */
 class Translate_Option_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
@@ -15,7 +15,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$links_model = self::$model->get_links_model();
@@ -23,7 +23,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang'] = &$this->pll_admin;
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		unset( $GLOBALS['polylang'] );
@@ -44,7 +44,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		new PLL_Translate_Option( 'my_option' );
 	}
 
-	function test_update_option_simple() {
+	public function test_update_option_simple() {
 		$this->prepare_option_simple();
 
 		$languages = array( 'en', 'fr' );
@@ -66,7 +66,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'val_fr', get_option( 'my_option' ) );
 	}
 
-	function test_update_option_simple_with_no_translation() {
+	public function test_update_option_simple_with_no_translation() {
 		$this->prepare_option_simple();
 		$this->add_string_translations( 'en', array( 'val' => 'val' ) );
 
@@ -80,7 +80,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'new_val', get_option( 'my_option' ) );
 	}
 
-	function test_update_option_simple_when_filtered() {
+	public function test_update_option_simple_when_filtered() {
 		$this->prepare_option_simple();
 		$this->add_string_translations( 'en', array( 'val' => 'val_en' ) );
 
@@ -180,13 +180,13 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		}
 	}
 
-	function test_update_option_multiple() {
+	public function test_update_option_multiple() {
 		$this->prepare_option_multiple( 'ARRAY' );
 		$this->register_option_multiple();
 		$this->_test_update_option_multiple();
 	}
 
-	function test_update_option_multiple_with_wildcard() {
+	public function test_update_option_multiple_with_wildcard() {
 		$this->prepare_option_multiple( 'ARRAY' );
 		$this->register_option_multiple_with_wildcard();
 		$this->_test_update_option_multiple();
@@ -206,13 +206,13 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		}
 	}
 
-	function test_update_object_option_multiple() {
+	public function test_update_object_option_multiple() {
 		$this->prepare_option_multiple( 'OBJECT' );
 		$this->register_option_multiple();
 		$this->_test_update_object_option_multiple();
 	}
 
-	function test_update_object_option_multiple_with_wildcard() {
+	public function test_update_object_option_multiple_with_wildcard() {
 		$this->prepare_option_multiple( 'OBJECT' );
 		$this->register_option_multiple_with_wildcard();
 		$this->_test_update_object_option_multiple();
@@ -237,19 +237,19 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'new_val11', $options['options_group_1']['sub_option_name_11'] );
 	}
 
-	function test_update_option_multiple_with_no_translation() {
+	public function test_update_option_multiple_with_no_translation() {
 		$this->prepare_option_multiple( 'ARRAY' );
 		$this->register_option_multiple();
 		$this->_test_update_option_multiple_with_no_translation();
 	}
 
-	function test_update_option_multiple_with_no_translation_with_wildcard() {
+	public function test_update_option_multiple_with_no_translation_with_wildcard() {
 		$this->prepare_option_multiple( 'ARRAY' );
 		$this->register_option_multiple_with_wildcard();
 		$this->_test_update_option_multiple_with_no_translation();
 	}
 
-	function _test_update_object_option_multiple_with_no_translation() {
+	protected function _test_update_object_option_multiple_with_no_translation() {
 		$this->do_no_translate_strings();
 
 		$this->update_option_with_new_val( 'OBJECT' );
@@ -260,13 +260,13 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'new_val11', $options->options_group_1->sub_option_name_11 );
 	}
 
-	function test_update_object_option_multiple_with_no_translation() {
+	public function test_update_object_option_multiple_with_no_translation() {
 		$this->prepare_option_multiple( 'OBJECT' );
 		$this->register_option_multiple();
 		$this->_test_update_object_option_multiple_with_no_translation();
 	}
 
-	function test_update_object_option_multiple_with_no_translation_with_wildcard() {
+	public function test_update_object_option_multiple_with_no_translation_with_wildcard() {
 		$this->prepare_option_multiple( 'OBJECT' );
 		$this->register_option_multiple_with_wildcard();
 		$this->_test_update_object_option_multiple_with_no_translation();
@@ -298,25 +298,25 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertArrayNotHasKey( 'val11_en', $mo->entries );
 	}
 
-	function test_update_option_multiple_when_filtered() {
+	public function test_update_option_multiple_when_filtered() {
 		$this->prepare_option_multiple( 'ARRAY' );
 		$this->register_option_multiple();
 		$this->_test_update_option_with_translated_val( 'ARRAY' );
 	}
 
-	function test_update_option_multiple_when_filtered_with_wildcard() {
+	public function test_update_option_multiple_when_filtered_with_wildcard() {
 		$this->prepare_option_multiple( 'ARRAY' );
 		$this->register_option_multiple_with_wildcard();
 		$this->_test_update_option_with_translated_val( 'ARRAY' );
 	}
 
-	function test_update_object_option_multiple_when_filtered() {
+	public function test_update_object_option_multiple_when_filtered() {
 		$this->prepare_option_multiple( 'OBJECT' );
 		$this->register_option_multiple();
 		$this->_test_update_option_with_translated_val( 'OBJECT' );
 	}
 
-	function test_update_object_option_multiple_when_filtered_with_wildcard() {
+	public function test_update_object_option_multiple_when_filtered_with_wildcard() {
 		$this->prepare_option_multiple( 'OBJECT' );
 		$this->register_option_multiple_with_wildcard();
 		$this->_test_update_option_with_translated_val( 'OBJECT' );

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -2,14 +2,14 @@
 
 class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
-	static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		update_option( 'show_on_front', 'page' );

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -143,12 +143,11 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 
 	/**
 	 * @dataProvider update_language_provider
+	 *
 	 * @param string[] $original_group An array of language locales to be included in the original translations group.
 	 * @param string   $to A language locale to update the post to.
 	 * @param string[] $expected_new_group An array of language locales to be included in the new translations group.
 	 * @param string[] $expected_former_group Optional. Represents the former translations group of the post if changing language should have set the post in a separate group.
-	 *
-	 * @throws Exception
 	 */
 	public function test_update_language( $original_group, $to, $expected_new_group, $expected_former_group = array() ) {
 		wp_set_current_user( 1 ); // Needs edit_post capability.

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -13,14 +13,14 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 	}
 
-	function test_post_language() {
+	public function test_post_language() {
 		$post_id = $this->factory->post->create();
 		self::$model->post->set_language( $post_id, 'fr' );
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $post_id )->slug );
 	}
 
-	function test_post_translation() {
+	public function test_post_translation() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -39,7 +39,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		$this->assertEquals( self::$model->post->get_translation( $de, 'fr' ), $fr );
 	}
 
-	function test_delete_post_translation() {
+	public function test_delete_post_translation() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
 
@@ -62,7 +62,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		$this->assertFalse( self::$model->post->get_translation( $de, 'fr' ) ); // fails
 	}
 
-	function test_current_user_can_synchronize() {
+	public function test_current_user_can_synchronize() {
 		add_filter( 'pll_pre_current_user_can_synchronize_post', '__return_null' ); // Enable capability check
 
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
@@ -104,7 +104,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		$this->assertFalse( self::$model->post->current_user_can_synchronize( $de ) );
 	}
 
-	function test_current_user_can_read() {
+	public function test_current_user_can_read() {
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
 
 		wp_set_current_user( 0 );

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -13,7 +13,7 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 	}
 
-	function test_term_language() {
+	public function test_term_language() {
 		$term_id = $this->factory->term->create();
 		self::$model->term->set_language( $term_id, 'fr' );
 
@@ -21,7 +21,7 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 		$this->assertCount( 2, get_terms( 'term_translations' ) ); // 1 translation group per term + 1 for default categories
 	}
 
-	function test_term_translation() {
+	public function test_term_translation() {
 		$en = $this->factory->term->create();
 		self::$model->term->set_language( $en, 'en' );
 
@@ -40,7 +40,7 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 		$this->assertEquals( self::$model->term->get_translation( $de, 'fr' ), $fr );
 	}
 
-	function test_delete_term_translation() {
+	public function test_delete_term_translation() {
 		$en = $this->factory->term->create();
 		self::$model->term->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-widgets-calendar.php
+++ b/tests/phpunit/tests/test-widgets-calendar.php
@@ -12,7 +12,7 @@ class Widget_Calendar_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
@@ -25,7 +25,7 @@ class Widget_Calendar_Test extends PLL_UnitTestCase {
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	function test_get_calendar() {
+	public function test_get_calendar() {
 		$en = $this->factory->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		self::$model->post->set_language( $en, 'en' );
 

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -12,7 +12,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->links_model = self::$model->get_links_model();
@@ -31,7 +31,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 	/**
 	 * Copied from WP widgets tests
 	 */
-	function clean_up_global_scope() {
+	public function clean_up_global_scope() {
 		global $_wp_sidebars_widgets, $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
 
 		$_wp_sidebars_widgets = array();
@@ -44,7 +44,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		parent::clean_up_global_scope();
 	}
 
-	function test_form() {
+	public function test_form() {
 		global $wp_registered_widgets;
 
 		set_current_screen( 'widgets' );
@@ -60,7 +60,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $form, 'widget-search-2-pll_lang' ) );
 	}
 
-	function update_lang_choice( $widget, $lang ) {
+	protected function update_lang_choice( $widget, $lang ) {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		new PLL_Admin_Filters_Widgets_Options( $pll_admin );
 
@@ -76,7 +76,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$widget->update_callback();
 	}
 
-	function test_display_with_filter() {
+	public function test_display_with_filter() {
 		global $wp_registered_widgets;
 
 		wp_widgets_init();
@@ -98,7 +98,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 	}
 
-	function test_display_with_no_filter() {
+	public function test_display_with_no_filter() {
 		global $wp_registered_widgets;
 
 		wp_widgets_init();
@@ -121,7 +121,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 	}
 
 
-	function test_widget_media_image() {
+	public function test_widget_media_image() {
 		self::$model->options['media_support'] = 1;
 		$pll_admin = new PLL_Admin( $this->links_model );
 
@@ -185,7 +185,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['polylang'] );
 	}
 
-	function test_wp_get_sidebars_widgets() {
+	public function test_wp_get_sidebars_widgets() {
 		global $wp_registered_widgets;
 
 		update_option(
@@ -215,7 +215,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$this->assertFalse( in_array( 'search-2', $sidebars['sidebar-1'] ) );
 	}
 
-	function test_widgets_language_filter_is_not_displayed_for_page_builders() {
+	public function test_widgets_language_filter_is_not_displayed_for_page_builders() {
 		set_current_screen( 'post' );
 		$options = PLL_Install::get_default_options();
 		$model = new PLL_Admin_Model( $options );

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -17,20 +17,20 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	static function wpTearDownAfterClass() {
+	public static function wpTearDownAfterClass() {
 		parent::wpTearDownAfterClass();
 
 		unlink( WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
 		rmdir( WP_CONTENT_DIR . '/polylang' );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->links_model = self::$model->get_links_model();
 	}
 
-	function prepare_options( $method = 'ARRAY' ) {
+	protected function prepare_options( $method = 'ARRAY' ) {
 		// mirror options defined in the sample wpml-config.xml
 		$my_plugins_options = array(
 			'option_name_1'   => 'val1',
@@ -77,7 +77,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		update_option( 'generic_option_2', 'generic_val_2' );
 	}
 
-	function translate_options( $slug ) {
+	protected function translate_options( $slug ) {
 		$language = self::$model->get_language( $slug );
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
@@ -103,7 +103,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$mo->export_to_db( $language );
 	}
 
-	function test_cf() {
+	public function test_cf() {
 		wp_set_current_user( 1 ); // To pass current_user_can_synchronize() test
 
 		$pll_admin = new PLL_Admin( $this->links_model );
@@ -152,7 +152,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 2007, get_post_meta( $from, 'date-added', true ) );
 	}
 
-	function test_custom_term_field() {
+	public function test_custom_term_field() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
@@ -199,7 +199,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'D', get_term_meta( $from, 'term_meta_D', true ) );
 	}
 
-	function test_cpt() {
+	public function test_cpt() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
@@ -221,7 +221,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		_unregister_post_type( 'dvd' );
 	}
 
-	function test_tax() {
+	public function test_tax() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
@@ -245,7 +245,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		_unregister_taxonomy( 'publisher' );
 	}
 
-	function test_translate_strings() {
+	public function test_translate_strings() {
 		$this->prepare_options( 'ARRAY' ); // Before reading the wpml-config.xml file.
 		$this->translate_options( 'fr' );
 
@@ -275,7 +275,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'generic_val_2_fr', get_option( 'generic_option_2' ) );
 	}
 
-	function test_translate_strings_object() {
+	public function test_translate_strings_object() {
 		$this->prepare_options( 'OBJECT' ); // Before reading the wpml-config.xml file.
 		$this->translate_options( 'fr' );
 
@@ -303,7 +303,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 
-	function _test_register_string() {
+	protected function _test_register_string() {
 		$GLOBALS['polylang'] = new PLL_Admin( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
@@ -327,12 +327,12 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertContains( 'generic_val_2', $strings );
 	}
 
-	function test_register_string() {
+	public function test_register_string() {
 		$this->prepare_options( 'ARRAY' );
 		$this->_test_register_string();
 	}
 
-	function test_register_string_object() {
+	public function test_register_string_object() {
 		$this->prepare_options( 'OBJECT' );
 		$this->_test_register_string();
 	}

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -16,7 +16,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->links_model = self::$model->get_links_model();
@@ -24,7 +24,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		PLL_WPML_Compat::instance()->api = new PLL_WPML_API(); // Loads the WPML API
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		// Cleaning the previous registered strings translations that were added
@@ -40,7 +40,7 @@ class WPML_Test extends PLL_UnitTestCase {
 	 *
 	 * @see https://wordpress.org/support/topic/after-update-apeared-warnings
 	 */
-	function test_acf() {
+	public function test_acf() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -52,7 +52,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		_unregister_post_type( 'acf' );
 	}
 
-	function test_wpml_active_languages() {
+	public function test_wpml_active_languages() {
 		self::$model->post->register_taxonomy(); // Needed otherwise posts are not counted
 
 		$en = $this->factory->post->create( array( 'post_type' => 'page' ) );
@@ -99,7 +99,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEqualSetsWithIndex( array( 'fr', 'en', 'de' ), array_keys( $languages ) );
 	}
 
-	function test_wpml_current_language() {
+	public function test_wpml_current_language() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -110,7 +110,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', apply_filters( 'wpml_current_language', null ) );
 	}
 
-	function test_wpml_default_language() {
+	public function test_wpml_default_language() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -120,7 +120,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'fr', wpml_get_default_language() ); // Legacy
 	}
 
-	function test_wpml_add_language_form_field() {
+	public function test_wpml_add_language_form_field() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -131,7 +131,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '<input type="hidden" name="lang" value="fr" />', ob_get_clean() );
 	}
 
-	function test_wpml_post_language_details() {
+	public function test_wpml_post_language_details() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -155,7 +155,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertFalse( $lang['different_language'] );
 	}
 
-	function test_wpml_language_code() {
+	public function test_wpml_language_code() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -170,7 +170,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', apply_filters( 'wpml_element_language_code', null, array( 'element_id' => $id, 'element_type' => 'category' ) ) );
 	}
 
-	function test_wpml_home_url() {
+	public function test_wpml_home_url() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 		$frontend->links = new PLL_Frontend_Links( $frontend );
@@ -180,7 +180,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'http://example.org/?lang=fr', icl_get_home_url() ); // Legacy
 	}
 
-	function test_wpml_element_link() {
+	public function test_wpml_element_link() {
 		global $wp_rewrite;
 
 		// Switch to pretty permalinks
@@ -253,7 +253,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '<a href="http://example.org/fr/test-fr/">test fr</a>', ob_get_clean() );
 	}
 
-	function test_wpml_object_id() {
+	public function test_wpml_object_id() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -278,7 +278,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $cat, apply_filters( 'wpml_object_id', $cat, 'category', true ) );
 	}
 
-	function test_wpml_object_id_nav_menu() {
+	public function test_wpml_object_id_nav_menu() {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		$GLOBALS['polylang'] = $pll_admin;
 
@@ -318,7 +318,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $menu_fr, apply_filters( 'wpml_object_id', $menu_fr, 'nav_menu' ) );
 	}
 
-	function test_wpml_element_has_translations() {
+	public function test_wpml_element_has_translations() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;
 
@@ -353,7 +353,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertFalse( apply_filters( 'wpml_element_has_translations', null, $id, 'category' ) );
 	}
 
-	function test_strings_translations() {
+	public function test_strings_translations() {
 		add_action( 'pll_get_strings', array( PLL_WPML_Compat::instance(), 'get_strings' ) ); // Add filter as it is removed at the end of fisrt test (singleton!)
 
 		// Register
@@ -390,7 +390,7 @@ class WPML_Test extends PLL_UnitTestCase {
 	/**
 	 * Bug fixed in version 2.2
 	 */
-	function test_wpml_permalink() {
+	public function test_wpml_permalink() {
 		global $wp_rewrite;
 
 		// Switch to pretty permalinks

--- a/tests/phpunit/tests/themes/test-twenty-fourteen.php
+++ b/tests/phpunit/tests/themes/test-twenty-fourteen.php
@@ -22,7 +22,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			switch_theme( 'twentyfourteen' );
 		}
 
-		function set_up() {
+		public function set_up() {
 			parent::set_up();
 
 			require_once get_template_directory() . '/functions.php';
@@ -36,19 +36,19 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			$this->frontend->featured_content->init();
 		}
 
-		static function wpTearDownAfterClass() {
+		public static function wpTearDownAfterClass() {
 			parent::wpTearDownAfterClass();
 
 			switch_theme( self::$stylesheet );
 		}
 
-		function tear_down() {
+		public function tear_down() {
 			parent::tear_down();
 
 			unset( $GLOBALS['polylang'] );
 		}
 
-		function test_ephemera_widget() {
+		public function test_ephemera_widget() {
 			global $content_width; // The widget accesses this global, no matter what it contains.
 			$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 
@@ -77,7 +77,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			unset( $content_width );
 		}
 
-		function setup_featured_tags() {
+		protected function setup_featured_tags() {
 			self::$tag_en = $en = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'featured' ) );
 			self::$model->term->set_language( $en, 'en' );
 
@@ -94,7 +94,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			update_option( 'featured-content', $options );
 		}
 
-		function test_option_featured_content() {
+		public function test_option_featured_content() {
 			$this->setup_featured_tags();
 
 			$this->frontend->curlang = self::$model->get_language( 'en' );
@@ -106,7 +106,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			$this->assertEquals( self::$tag_fr, $settings['tag-id'] );
 		}
 
-		function test_featured_content_ids() {
+		public function test_featured_content_ids() {
 			$this->setup_featured_tags();
 
 			$en = $this->factory->post->create( array( 'tags_input' => array( 'featured' ) ) );

--- a/tests/phpunit/tests/themes/test-twenty-seventeen.php
+++ b/tests/phpunit/tests/themes/test-twenty-seventeen.php
@@ -20,23 +20,23 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyseventee
 			switch_theme( 'twentyseventeen' );
 		}
 
-		function set_up() {
+		public function set_up() {
 			parent::set_up();
 
 			require_once get_template_directory() . '/functions.php';
 		}
 
-		static function wpTearDownAfterClass() {
+		public static function wpTearDownAfterClass() {
 			parent::wpTearDownAfterClass();
 
 			switch_theme( self::$stylesheet );
 		}
 
-		function get_template_part( $slug, $name ) {
+		public function get_template_part( $slug, $name ) {
 			include get_template_directory() . "/{$slug}-{$name}.php";
 		}
 
-		function test_front_page_panels() {
+		public function test_front_page_panels() {
 			// Allow to locate the template part of Twenty Seventeen as the original mechanism uses constants
 			add_action( 'get_template_part_template-parts/page/content', array( $this, 'get_template_part' ), 10, 2 );
 

--- a/tests/phpunit/tests/themes/test-twenty-seventeen.php
+++ b/tests/phpunit/tests/themes/test-twenty-seventeen.php
@@ -3,7 +3,7 @@
 if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyseventeen/style.css' ) ) {
 
 	class Twenty_Seventeen_Test extends PLL_UnitTestCase {
-		static $stylesheet;
+		protected static $stylesheet;
 
 		/**
 		 * @param WP_UnitTest_Factory $factory


### PR DESCRIPTION
- Add visibility to all test methods.
- Fix wrong style of method comments when there is one.
- Remove @throws comments as they don't seem to be relevant.