### PR TITLE
Add hooks when defining the language in admin

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -371,8 +371,8 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		 *
 		 * @since 3.2
 		 *
-		 * @param PLL_Language   $curlang  Instance of the current language.
-		 * @param PLL_Admin_Base $polylang Instance of the main Polylang's object.
+		 * @param PLL_Language|false|null $curlang  Instance of the current language.
+		 * @param PLL_Admin_Base          $polylang Instance of the main Polylang's object.
 		 */
 		$this->curlang = apply_filters( 'pll_admin_current_language', $this->curlang, $this );
 

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -376,7 +376,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		}
 
 		/**
-		 * Fires after the language is defined by PLL in the admin context.
+		 * Fires after the language is (maybe) defined by PLL in the admin context.
 		 *
 		 * @since 1234
 		 *

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -342,7 +342,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		/**
 		 * Fires before the language is defined by PLL in the admin context.
 		 *
-		 * @since 1234
+		 * @since 3.2
 		 *
 		 * @param PLL_Admin_Base $polylang Instance of the main PLL's object.
 		 */
@@ -378,7 +378,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		/**
 		 * Fires after the language is (maybe) defined by PLL in the admin context.
 		 *
-		 * @since 1234
+		 * @since 3.2
 		 *
 		 * @param PLL_Admin_Base $polylang Instance of the main PLL's object.
 		 */

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -339,15 +339,6 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	public function set_current_language() {
 		$this->curlang = $this->filter_lang;
 
-		/**
-		 * Fires before the language is defined by PLL in the admin context.
-		 *
-		 * @since 3.2
-		 *
-		 * @param PLL_Admin_Base $polylang Instance of the main PLL's object.
-		 */
-		do_action( 'pll_before_admin_language_defined', $this );
-
 		// Edit Post
 		if ( isset( $_REQUEST['pll_post_id'] ) && $lang = $this->model->post->get_language( (int) $_REQUEST['pll_post_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = $lang;

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -339,6 +339,15 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	public function set_current_language() {
 		$this->curlang = $this->filter_lang;
 
+		/**
+		 * Fires before the language is defined by PLL in the admin context.
+		 *
+		 * @since 1234
+		 *
+		 * @param PLL_Admin_Base $polylang Instance of the main PLL's object.
+		 */
+		do_action( 'pll_before_admin_language_defined', $this );
+
 		// Edit Post
 		if ( isset( $_REQUEST['pll_post_id'] ) && $lang = $this->model->post->get_language( (int) $_REQUEST['pll_post_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = $lang;
@@ -366,8 +375,17 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			$this->curlang = $this->model->get_language( sanitize_key( $_REQUEST['lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
+		/**
+		 * Fires after the language is defined by PLL in the admin context.
+		 *
+		 * @since 1234
+		 *
+		 * @param PLL_Admin_Base $polylang Instance of the main PLL's object.
+		 */
+		do_action( 'pll_after_admin_language_defined', $this );
+
 		// Inform that the admin language has been set.
-		if ( $this->curlang ) {
+		if ( ! empty( $this->curlang ) ) {
 			/** This action is documented in frontend/choose-lang.php */
 			do_action( 'pll_language_defined', $this->curlang->slug, $this->curlang );
 		} else {

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -367,16 +367,17 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		}
 
 		/**
-		 * Fires after the language is (maybe) defined by PLL in the admin context.
+		 * Filters the current language used by Polylang in the admin context.
 		 *
 		 * @since 3.2
 		 *
-		 * @param PLL_Admin_Base $polylang Instance of the main PLL's object.
+		 * @param PLL_Language   $curlang  Instance of the current language.
+		 * @param PLL_Admin_Base $polylang Instance of the main Polylang's object.
 		 */
-		do_action( 'pll_after_admin_language_defined', $this );
+		$this->curlang = apply_filters( 'pll_admin_current_language', $this->curlang, $this );
 
 		// Inform that the admin language has been set.
-		if ( ! empty( $this->curlang ) ) {
+		if ( $this->curlang instanceof PLL_Language ) {
 			/** This action is documented in frontend/choose-lang.php */
 			do_action( 'pll_language_defined', $this->curlang->slug, $this->curlang );
 		} else {


### PR DESCRIPTION
Similarly to #947, fire a filter after the current language is defined, this time in the admin context. This allows to define the current language in "sub-contexts", like in the site editor.