### PR TITLE
PHP 8.1: Fix deprecated notices

### DIFF
--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -50,7 +50,7 @@ class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
 
 		$requested_url   = pll_get_requested_url();
 		$requested_host  = str_replace( 'www.', '', wp_parse_url( $requested_url, PHP_URL_HOST ) ); // Remove www. for the comparison
-		$requested_path  = rtrim( str_replace( $this->index, '', wp_parse_url( $requested_url, PHP_URL_PATH ) ), '/' ); // Some PHP setups turn requests for / into /index.php in REQUEST_URI
+		$requested_path  = rtrim( str_replace( $this->index, '', (string) wp_parse_url( $requested_url, PHP_URL_PATH ) ), '/' ); // Some PHP setups turn requests for / into /index.php in REQUEST_URI
 		$requested_query = wp_parse_url( $requested_url, PHP_URL_QUERY );
 
 		// Home is requested

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -95,10 +95,10 @@ class Polylang {
 	 */
 	public static function is_rest_request() {
 		// Handle pretty permalinks.
-		$home_path       = trim( wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+		$home_path       = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
 		$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
 
-		$req_uri = trim( wp_parse_url( pll_get_requested_url(), PHP_URL_PATH ), '/' );
+		$req_uri = trim( (string) wp_parse_url( pll_get_requested_url(), PHP_URL_PATH ), '/' );
 		$req_uri = preg_replace( $home_path_regex, '', $req_uri );
 		$req_uri = trim( $req_uri, '/' );
 		$req_uri = str_replace( 'index.php', '', $req_uri );
@@ -106,7 +106,7 @@ class Polylang {
 
 		// And also test rest_route query string parameter is not empty for plain permalinks.
 		$query_string = array();
-		wp_parse_str( wp_parse_url( pll_get_requested_url(), PHP_URL_QUERY ), $query_string );
+		wp_parse_str( (string) wp_parse_url( pll_get_requested_url(), PHP_URL_QUERY ), $query_string );
 		$rest_route = isset( $query_string['rest_route'] ) ? trim( $query_string['rest_route'], '/' ) : false;
 
 		return 0 === strpos( $req_uri, rest_get_url_prefix() . '/' ) || ! empty( $rest_route );

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -123,10 +123,10 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 			$url = pll_get_requested_url();
 		}
 
-		$path = wp_parse_url( $url, PHP_URL_PATH );
+		$path = (string) wp_parse_url( $url, PHP_URL_PATH );
 		$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : $this->home . '/' . $this->root;
 
-		$pattern = wp_parse_url( $root . ( $this->options['rewrite'] ? '' : 'language/' ), PHP_URL_PATH );
+		$pattern = (string) wp_parse_url( $root . ( $this->options['rewrite'] ? '' : 'language/' ), PHP_URL_PATH );
 		$pattern = preg_quote( $pattern, '#' );
 		$pattern = '#^' . $pattern . '(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')(/|$)#';
 		return preg_match( $pattern, trailingslashit( $path ), $matches ) ? $matches[1] : ''; // $matches[1] is the slug of the requested language

--- a/include/model.php
+++ b/include/model.php
@@ -508,6 +508,8 @@ class PLL_Model {
 		$counts = wp_cache_get( $cache_key, 'counts' );
 
 		if ( false === $counts ) {
+			$counts = array();
+
 			$select = "SELECT pll_tr.term_taxonomy_id, COUNT( * ) AS num_posts FROM {$wpdb->posts}";
 			$join = $this->post->join_clause();
 			$where = sprintf( " WHERE post_status = '%s'", esc_sql( $q['post_status'] ) );

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -101,7 +101,7 @@ class PLL_WPSEO {
 	 */
 	public function wpseo_home_url( $url, $path ) {
 		if ( empty( $path ) ) {
-			$path = ltrim( wp_parse_url( pll_get_requested_url(), PHP_URL_PATH ), '/' );
+			$path = ltrim( (string) wp_parse_url( pll_get_requested_url(), PHP_URL_PATH ), '/' );
 		}
 
 		if ( preg_match( '#sitemap(_index)?\.xml|([^\/]+?)-?sitemap([0-9]+)?\.xml|([a-z]+)?-?sitemap\.xsl#', $path ) ) {

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -21,6 +21,8 @@ trait PLL_UnitTestCase_Trait {
 		$options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
 		$options['media_support'] = 1; // Force option to pre 3.1 value otherwise phpunit tests break on Travis.
 		self::$model = new PLL_Admin_Model( $options );
+
+		remove_action( 'current_screen', '_load_remote_block_patterns' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-accept-languages-collection.php
+++ b/tests/phpunit/tests/test-accept-languages-collection.php
@@ -23,6 +23,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 	protected function get_known_language( $locale ) {
 		$language = self::$known_languages[ $locale ];
 		$language['slug'] = $language['code'];
+		$language['w3c']  = isset( $language['w3c'] ) ? $language['w3c'] : str_replace( '_', '-', $language['locale'] );
 		return new PLL_Language( $language );
 	}
 

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -23,7 +23,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options = PLL_Install::get_default_options();
+		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Admin_Model( $options );
 		$links_model = new PLL_Links_Default( $model );
 		$this->pll_admin = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -229,7 +229,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$lang = $this->pll_admin->pref_lang = self::$model->get_language( 'en' );
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 		$post_ID = $this->factory->post->create();
-		wp_set_object_terms( $post_ID, null, 'language' ); // Intentionally remove the language
+		wp_set_object_terms( $post_ID, array(), 'language' ); // Intentionally remove the language
 
 		ob_start();
 		$this->pll_admin->classic_editor->post_language();
@@ -247,7 +247,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 		$post_ID = $this->factory->post->create();
-		wp_set_object_terms( $post_ID, null, 'language' ); // Intentionally remove the language
+		wp_set_object_terms( $post_ID, array(), 'language' ); // Intentionally remove the language
 
 		$en = $this->factory->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -15,7 +15,7 @@ class Media_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options = array_merge( PLL_Install::get_default_options(), array( 'media_support' => 1 ) );
+		$options = array_merge( PLL_Install::get_default_options(), array( 'media_support' => 1, 'default_lang' => 'en' ) );
 		$model = new PLL_Admin_Model( $options );
 		$links_model = new PLL_Links_Default( $model );
 		$this->pll_admin = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -30,6 +30,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$_GET['pll_action'] = $_REQUEST['pll_action'] = 'edit'; // languages_page() tests $_REQUEST
 		$_GET['lang'] = $lang->term_id;
 		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
+		$GLOBALS['plugin_page'] = 'mlang';
 		get_admin_page_title();
 		set_current_screen();
 

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -196,7 +196,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 	 * @covers PLL_Translated_Object::save_translations()
 	 */
 	public function test_dont_save_translations_with_incorrect_language() {
-		$options = PLL_Install::get_default_options();
+		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Model( $options );
 		$model->post = new PLL_Translated_Post( $model );
 

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -64,7 +64,7 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 	}
 
 	public function test_dont_save_translations_with_incorrect_language() {
-		$options = PLL_Install::get_default_options();
+		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Model( $options );
 		$model->term = new PLL_Translated_Term( $model );
 

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -217,7 +217,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 	public function test_widgets_language_filter_is_not_displayed_for_page_builders() {
 		set_current_screen( 'post' );
-		$options = PLL_Install::get_default_options();
+		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Admin_Model( $options );
 		$links_model = new PLL_Links_Default( $model );
 		$polylang = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/themes/test-twenty-fourteen.php
+++ b/tests/phpunit/tests/themes/test-twenty-fourteen.php
@@ -52,11 +52,11 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress/wp-content/themes/twentyfourteen
 			global $content_width; // The widget accesses this global, no matter what it contains.
 			$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 
-			$en = $this->factory->post->create( array( 'post_content' => 'Test' ) );
+			$en = $this->factory->post->create( array( 'post_content' => 'Test', 'post_author' => 1 ) );
 			set_post_format( $en, 'aside' );
 			self::$model->post->set_language( $en, 'en' );
 
-			$fr = $this->factory->post->create( array( 'post_content' => 'Essai' ) );
+			$fr = $this->factory->post->create( array( 'post_content' => 'Essai', 'post_author' => 1 ) );
 			set_post_format( $fr, 'aside' );
 			self::$model->post->set_language( $fr, 'fr' );
 


### PR DESCRIPTION
**Fixes in Polylang code:**
- `wp_parse_url()` may return null. Ensure that we cast the return value to a string when used in a function expecting a string.
- `wp_cache_get()` may return false. The conversion to an array must nok be explicit.

**Fixes in PHPUnit tests:**
- Ensure that `Accept_Languages_Collection_Test::get_known_language()` always returns a language with the `w3c` property.
- Avoid loading remote block patterns which is useless and currently fires a bunch of notices.
- Specify an author for posts in the Ephemera widget test to avoid `get_the_author()` to return null which in the end causes a notice in `ent2ncr()`. 
- Specify `$plugin_page` in Settings test to avoid a notice in `get_plugin_page_hookname()`.
- Make sure to define `$options['default_lang']` in tests as, [when not defined, the home and search urls are not set in `PLL_Language` objects](https://github.com/polylang/polylang/blob/3.1.3/include/links-model.php#L169), causing a notice in `set_url_scheme()`. 
- To remove relationships, pass an empty array to `wp_set_object_terms()` instead of null.

**Fired by WP independantly from Polylang:**
- ```PHP Deprecated:  rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /app/polylang/tmp/wordpress/wp-includes/formatting.php on line 2760```
This is due to `load_script_textdomain()` having always an empty path for WP scripts. See proposed patch: https://core.trac.wordpress.org/attachment/ticket/53635/53635-09-script-translations.patch

**Not fixed in this PR:**
- ```PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /app/polylang/tmp/wordpress/wp-includes/link-template.php on line 3786```. I propose to fix this in a separate PR.