### PR TITLE
Update switcher.php

### DIFF
--- a/include/switcher.php
+++ b/include/switcher.php
@@ -122,7 +122,9 @@ class PLL_Switcher {
 		$out   = array();
 		
 		// Prevent fatal errors in missing model definition
-		if (!isset($this->links) || !isset($this->links->model) || !isset($this->links->model->get_languages_list)) return $out;
+		if ( ! isset( $this->links ) || ! isset( $this->links->model ) || ! isset( $this->links->model->get_languages_list ) ) {
+			return $out;
+		}
 
 		foreach ( $this->links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			$id = (int) $language->term_id;

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -120,6 +120,9 @@ class PLL_Switcher {
 	protected function get_elements( $args ) {
 		$first = true;
 		$out   = array();
+		
+		// Prevent fatal errors in missing model definition
+		if (!isset($this->links) || !isset($this->links->model) || !isset($this->links->model->get_languages_list)) return $out;
 
 		foreach ( $this->links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
 			$id = (int) $language->term_id;


### PR DESCRIPTION
Prevent fatal errors in missing model definition due multisite site clone procedures.