### PR TITLE
PHP 8.1 : Don't load remote featured patterns for tests

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -23,6 +23,7 @@ trait PLL_UnitTestCase_Trait {
 		self::$model = new PLL_Admin_Model( $options );
 
 		remove_action( 'current_screen', '_load_remote_block_patterns' );
+		remove_action( 'current_screen', '_load_remote_featured_patterns' );
 	}
 
 	/**


### PR DESCRIPTION
WordPress just added a new function hooked to `current_screen` to load remote patterns: https://core.trac.wordpress.org/ticket/54623
- PHPUnit tests should not fire remote requests.
- With PHP 8.1, this fires a bunch of notices in the Requests library

Hopefully at some point, WordPress will stop loading these remote patterns during: https://core.trac.wordpress.org/ticket/54724
Waiting for this, I propose to do it ourselves.