### PR TITLE
Introduced function pll_filter_input()

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -107,3 +107,24 @@ function pll_use_block_editor_plugin() {
 	 */
 	return class_exists( 'PLL_Block_Editor_Plugin' ) && apply_filters( 'pll_use_block_editor_plugin', ! defined( 'PLL_USE_BLOCK_EDITOR_PLUGIN' ) || PLL_USE_BLOCK_EDITOR_PLUGIN );
 }
+
+/**
+ * Wrapper of `filter_input()` to make things testable.
+ * For internal use only.
+ *
+ * @since 3.2
+ * @link  https://www.php.net/manual/en/function.filter-input.php
+ * @private
+ *
+ * @param  int       $type     One of `INPUT_GET`, `INPUT_POST`, `INPUT_COOKIE`, `INPUT_SERVER`, or `INPUT_ENV`.
+ * @param  string    $var_name Name of a variable to get.
+ * @param  int       $filter   The ID of the filter to apply. If omitted, FILTER_DEFAULT will be used, which is
+ *                             equivalent to FILTER_UNSAFE_RAW. This will result in no filtering taking place by
+ *                             default.
+ * @param  array|int $options  Associative array of options or bitwise disjunction of flags. If filter accepts
+ *                             options, flags can be provided in "flags" field of array.
+ * @return mixed
+ */
+function pll_filter_input( $type, $var_name, $filter = FILTER_DEFAULT, $options = 0 ) {
+	return filter_input( $type, $var_name, $filter, $options );
+}


### PR DESCRIPTION
This function is needed in future developments.
`pll_filter_input()` is basically a wrapper for the native php function `filter_input()`: wrapping it make it stubable for phpunit tests.

Note: the PR [PLLPro#1167](https://github.com/polylang/polylang-pro/pull/1167) introduces a new (undeclared) class property `$polylang->full_site_editing`, maybe this PR should also declare it.