### PR TITLE
Yoast SEO: Test the existence of current language before using it

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -288,17 +288,17 @@ class PLL_WPSEO {
 	}
 
 	/**
-	 * Get alternate language codes for Opengraph
+	 * Get alternate language codes for Opengraph.
 	 *
 	 * @since 2.7.3
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	protected function get_ogp_alternate_languages() {
 		$alternates = array();
 
 		foreach ( PLL()->model->get_languages_list() as $language ) {
-			if ( PLL()->curlang->slug !== $language->slug && PLL()->links->get_translation_url( $language ) && isset( $language->facebook ) ) {
+			if ( isset( PLL()->curlang ) && PLL()->curlang->slug !== $language->slug && PLL()->links->get_translation_url( $language ) && isset( $language->facebook ) ) {
 				$alternates[] = $language->facebook;
 			}
 		}


### PR DESCRIPTION
Fixes #954 

Unfortunately, the details provided in #954 did not allow @Chrystll to reproduce the issue. Althougth the settings indicate that the language is set from the content (the current language definition is thus delayed to the `wp` action), the tests demonstrate that the current language is already set when the filter `wpseo_frontend_presenters` is applied by Yoast SEO.

I would have prefer to understand, but anyway the warning itself is easy to fix. 

EDIT: Failing tests are not related to this PR (but to a change in Jetpack 10.5).