### PR TITLE
Temporarily skip the Jetpack integration test

### DIFF
--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -28,7 +28,7 @@ if ( version_compare( $GLOBALS['wp_version'], '5.6', '>=' ) && file_exists( DIR_
 		}
 
 		public function test_opengraph() {
-			self:markTestSkipped( 'Temporarily skipped. See Issue Pro#1179' );
+			self::markTestSkipped( 'Temporarily skipped. See Issue Pro#1179' );
 
 			// create posts to get something  on home page
 			$en = $this->factory->post->create();

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -28,6 +28,8 @@ if ( version_compare( $GLOBALS['wp_version'], '5.6', '>=' ) && file_exists( DIR_
 		}
 
 		public function test_opengraph() {
+			self:markTestSkipped( 'Temporarily skipped. See Issue Pro#1179' );
+
 			// create posts to get something  on home page
 			$en = $this->factory->post->create();
 			self::$model->post->set_language( $en, 'en' );


### PR DESCRIPTION
Waiting for https://github.com/polylang/polylang-pro/issues/1179 to be fixed.
This could avoid us to miss another failing test.