### PR TITLE
PHP 8.1: Fix deprecated notice fired in set_url_scheme()

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -193,7 +193,6 @@ class Polylang {
 		 */
 		$class = apply_filters( 'pll_model', PLL_SETTINGS || self::is_wizard() ? 'PLL_Admin_Model' : 'PLL_Model' );
 		$model = new $class( $options );
-		$links_model = $model->get_links_model();
 
 		if ( ! $model->get_languages_list() ) {
 			/**
@@ -227,7 +226,8 @@ class Polylang {
 		$class = apply_filters( 'pll_context', $class );
 
 		if ( ! empty( $class ) ) {
-			$polylang = new $class( $links_model );
+			$links_model = $model->get_links_model();
+			$polylang    = new $class( $links_model );
 
 			/**
 			 * Fires after the $polylang object is created and before the API is loaded

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -165,12 +165,9 @@ abstract class PLL_Links_Model {
 	 * @return void
 	 */
 	protected function set_home_url( $language ) {
-		// We should always have a default language here, except, temporarily, in PHPUnit tests. The test here protects against PHP notices.
-		if ( isset( $this->options['default_lang'] ) ) {
-			$search_url = $this->home_url( $language );
-			$home_url = empty( $language->page_on_front ) || $this->options['redirect_lang'] ? $search_url : $this->front_page_url( $language );
-			$language->set_home_url( $search_url, $home_url );
-		}
+		$search_url = $this->home_url( $language );
+		$home_url = empty( $language->page_on_front ) || $this->options['redirect_lang'] ? $search_url : $this->front_page_url( $language );
+		$language->set_home_url( $search_url, $home_url );
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -23,7 +23,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.
 		add_filter( 'wp_doing_ajax', '__return_false' );
 
-		$this->options = PLL_Install::get_default_options();
+		$this->options = get_option( 'polylang' );
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -66,15 +66,11 @@ trait PLL_UnitTestCase_Trait {
 
 		$args = array_merge( $values, $args );
 
-		$links_model     = self::$model->get_links_model();
-		$pll_admin = new PLL_Admin( $links_model );
-		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
-
 		$errors = self::$model->add_language( $args );
 		if ( is_wp_error( $errors ) ) {
 			throw new InvalidArgumentException( $errors->get_error_message() );
 		}
-		$admin_default_term->handle_default_term_on_create_language( $args );
+
 		self::$model->clean_languages_cache();
 	}
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -11,6 +11,11 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		self::$model->post->register_taxonomy();
 
+		$links_model     = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
+		$admin_default_term->add_hooks();
+
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE_formal' );

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -8,6 +8,11 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
+		$links_model     = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
+		$admin_default_term->add_hooks();
+
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -23,6 +23,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		require_once POLYLANG_DIR . '/include/api.php';
 
 		self::generate_shared_fixtures( $factory );
+		self::$model->clean_languages_cache();
 	}
 
 	/**

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -11,6 +11,12 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		parent::wpSetUpBeforeClass( $factory );
 
 		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$links_model     = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
+		$admin_default_term->add_hooks();
+
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE_formal' );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -8,6 +8,11 @@ class Settings_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
+		$links_model     = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
+		$admin_default_term->add_hooks();
+
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 	}

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -59,10 +59,13 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $fr, 'fr' );
 
 		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+		self::$model->clean_languages_cache();
 	}
 
 	public function set_up() {
 		parent::set_up();
+
 
 		self::$model->options['hide_default'] = 0;
 		self::$model->options['redirect_lang'] = 0;

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -10,6 +10,11 @@ class Sync_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
+		$links_model     = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
+		$admin_default_term->add_hooks();
+
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -8,6 +8,11 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
+		$links_model     = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );
+		$admin_default_term->add_hooks();
+
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE_formal' );


### PR DESCRIPTION
**The goal of this PR is to fix the deprecated notice with PHP 8.1:**
```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/travis/build/polylang/polylang/tmp/wordpress/wp-includes/link-template.php on line 3786
```
This notice is fired in `set_url_scheme()` called from `PLL_Language::set_url_scheme()`.
As far as I know, this notice should never occur in production but only in phpunit tests. This is due to ghost filters `PLL_Links_Model::pll_after_languages_cache()` acting on incomplete `PLL_Language` objects (without the home or flag urls).

Indeed apart from the links model used in a test, we could have other links model instantiated in the class `Polylang` when the plugin is loaded initially before all tests, and also each time a language is created with the `create_language()` helper method.

**Changes introduced by this PR:**
- In PHPUnit tests, stop instantiating a `PLL_Links_Model` object in `create_language()` helper method. This means that the default category in the corresponding language is not created anymore. This creation is thus made only in the test classes needing it.
- In PHPUnit tests, we need to clear the languages cache when actions done in `wpSetUpBeforeClass()` call `PLL_Model::get_languages_list()` in a way or another. This is to avoid to use a truncated languages list (without the home or flag urls) in the following tests.
- In `PLL_Canonical_UnitTestCase::set_up()`, get options from the database (instead of using the default options) to ensure that we get the default language inside.
- In the class `Polylang`. The links model object was always instantiated. It is now instantiated only when the main Polylang obejct is instantiated. This avoids to have a ghost `PLL_Links_Model` object and its active filters when the plugin is initially loaded from the tests bootstrap.
- In `PLL_Links_Models::set_home_url()`, I remove a test which was added specifically to hide notices occuring in PHPUnit tests (a way to hide things under the rug), as this is now fixed by this PR.