### PR TITLE
Remove customize admin bar and submenu when using a block theme

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -503,6 +503,10 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	/**
 	 * Remove the customize submenu when using a block theme.
 	 *
+	 * WordPress removes the Customizer menu if a block theme is activated and no other plugins interact with it.
+	 * As Polylang interacts with the Customizer, we have to delete this menu ourselves in the case of a block theme,
+	 * unless another plugin than Polylang interacts with the Customizer.
+	 *
 	 * @since 3.2
 	 *
 	 * @return void

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -508,9 +508,14 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	public function remove_customize_submenu() {
 		global $submenu;
 
+		// Exit if a block theme isn't activated.
+		if ( ! wp_is_block_theme() ) {
+			return;
+		}
+
 		if ( ! empty( $submenu['themes.php'] ) ) {
 			foreach ( $submenu['themes.php'] as $submenu_item ) {
-				if ( 'customize' === $submenu_item[1] && wp_is_block_theme() ) {
+				if ( 'customize' === $submenu_item[1] ) {
 					remove_submenu_page( 'themes.php', $submenu_item[2] );
 				}
 			}

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -506,12 +506,12 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * @since 3.2
 	 */
 	public function remove_customize_submenu() {
-		global $submenu;
-
 		// Exit if a block theme isn't activated.
 		if ( ! wp_is_block_theme() ) {
 			return;
 		}
+
+		global $submenu;
 
 		if ( ! empty( $submenu['themes.php'] ) ) {
 			foreach ( $submenu['themes.php'] as $submenu_item ) {

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -514,11 +514,14 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		}
 
 		global $wp_filter;
-		if ( isset( $wp_filter['customize_register'] ) ) {
-			$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
-			if ( $customize_register_hooks > 1 ) {
-				return;
-			}
+		if ( empty( $wp_filter['customize_register'] ) ) {
+			return;
+		}
+
+		$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
+
+		if ( $customize_register_hooks > 1 ) {
+			return;
 		}
 
 		global $submenu;

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -504,6 +504,8 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * Remove the customize submenu when using a block theme.
 	 *
 	 * @since 3.2
+	 *
+	 * @return void
 	 */
 	public function remove_customize_submenu() {
 		// Exit if a block theme isn't activated.

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -511,6 +511,14 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			return;
 		}
 
+		global $wp_filter;
+		if ( isset( $wp_filter['customize_register'] ) ) {
+			$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
+			if ( $customize_register_hooks > 1 ) {
+				return;
+			}
+		}
+
 		global $submenu;
 
 		if ( ! empty( $submenu['themes.php'] ) ) {

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -507,7 +507,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 */
 	public function remove_customize_submenu() {
 		// Exit if a block theme isn't activated.
-		if ( ! wp_is_block_theme() ) {
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
 			return;
 		}
 

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -68,6 +68,8 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		// Adds the link to the languages panel in the WordPress admin menu
 		add_action( 'admin_menu', array( $this, 'add_menus' ) );
 
+		add_action( 'admin_menu', array( $this, 'remove_customize_submenu' ) );
+
 		// Setup js scripts and css styles
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'admin_print_footer_scripts' ), 0 ); // High priority in case an ajax request is sent by an immediately invoked function
@@ -495,6 +497,23 @@ abstract class PLL_Admin_Base extends PLL_Base {
 					'meta'   => 'all' === $lang->slug ? array() : array( 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ),
 				)
 			);
+		}
+	}
+
+	/**
+	 * Remove the customize submenu when using a block theme.
+	 *
+	 * @since 3.2
+	 */
+	public function remove_customize_submenu() {
+		global $submenu;
+
+		if ( ! empty( $submenu['themes.php'] ) ) {
+			foreach ( $submenu['themes.php'] as $submenu_item ) {
+				if ( 'customize' === $submenu_item[1] && wp_is_block_theme() ) {
+					remove_submenu_page( 'themes.php', $submenu_item[2] );
+				}
+			}
 		}
 	}
 }

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -518,8 +518,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			return;
 		}
 
-		$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
-
+		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
 		if ( $customize_register_hooks > 1 ) {
 			return;
 		}

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -508,18 +508,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * @return void
 	 */
 	public function remove_customize_submenu() {
-		// Exit if a block theme isn't activated.
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
-			return;
-		}
-
-		global $wp_filter;
-		if ( empty( $wp_filter['customize_register'] ) ) {
-			return;
-		}
-
-		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
-		if ( $customize_register_hooks > 1 ) {
+		if ( ! $this->should_customize_menu_be_removed() ) {
 			return;
 		}
 

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -242,7 +242,7 @@ class PLL_Frontend extends PLL_Base {
 	 * @since 3.2
 	 */
 	public function remove_customize_admin_bar() {
-		if ( wp_is_block_theme() ) {
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			global $wp_admin_bar;
 
 			$wp_admin_bar->remove_menu( 'customize' );

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -240,6 +240,8 @@ class PLL_Frontend extends PLL_Base {
 	 * Remove the customize admin bar on front-end when using a block theme.
 	 *
 	 * @since 3.2
+	 *
+	 * @return void
 	 */
 	public function remove_customize_admin_bar() {
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -253,7 +253,7 @@ class PLL_Frontend extends PLL_Base {
 			return;
 		}
 
-		$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
+		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
 		if ( $customize_register_hooks > 1 ) {
 			return;
 		}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -249,11 +249,13 @@ class PLL_Frontend extends PLL_Base {
 		}
 
 		global $wp_filter;
-		if ( isset( $wp_filter['customize_register'] ) ) {
-			$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
-			if ( $customize_register_hooks > 1 ) {
-				return;
-			}
+		if ( empty( $wp_filter['customize_register'] ) ) {
+			return;
+		}
+
+		$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
+		if ( $customize_register_hooks > 1 ) {
+			return;
 		}
 
 		global $wp_admin_bar;

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -239,6 +239,10 @@ class PLL_Frontend extends PLL_Base {
 	/**
 	 * Remove the customize admin bar on front-end when using a block theme.
 	 *
+	 * WordPress removes the Customizer menu if a block theme is activated and no other plugins interact with it.
+	 * As Polylang interacts with the Customizer, we have to delete this menu ourselves in the case of a block theme,
+	 * unless another plugin than Polylang interacts with the Customizer.
+	 *
 	 * @since 3.2
 	 *
 	 * @return void

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -86,7 +86,7 @@ class PLL_Frontend extends PLL_Base {
 			add_action( 'template_redirect', array( $this, 'auto_translate' ), 7 );
 		}
 
-		add_action( 'wp_before_admin_bar_render', array( $this, 'remove_customize_admin_bar' ) );
+		add_action( 'admin_bar_menu', array( $this, 'remove_customize_admin_bar' ), 41 ); // After WP_Admin_Bar::add_menus
 	}
 
 	/**
@@ -245,6 +245,7 @@ class PLL_Frontend extends PLL_Base {
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			global $wp_admin_bar;
 
+			remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' ); // To avoid the script launch.
 			$wp_admin_bar->remove_menu( 'customize' );
 		}
 	}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -243,6 +243,14 @@ class PLL_Frontend extends PLL_Base {
 	 */
 	public function remove_customize_admin_bar() {
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+
+			if ( isset( $wp_filter['customize_register'] ) ) {
+				$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
+				if ( $customize_register_hooks > 1 ) {
+					return;
+				}
+			}
+
 			global $wp_admin_bar;
 
 			remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' ); // To avoid the script launch.

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -244,6 +244,7 @@ class PLL_Frontend extends PLL_Base {
 	public function remove_customize_admin_bar() {
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 
+			global $wp_filter;
 			if ( isset( $wp_filter['customize_register'] ) ) {
 				$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
 				if ( $customize_register_hooks > 1 ) {

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -244,17 +244,7 @@ class PLL_Frontend extends PLL_Base {
 	 * @return void
 	 */
 	public function remove_customize_admin_bar() {
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
-			return;
-		}
-
-		global $wp_filter;
-		if ( empty( $wp_filter['customize_register'] ) ) {
-			return;
-		}
-
-		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
-		if ( $customize_register_hooks > 1 ) {
+		if ( ! $this->should_customize_menu_be_removed() ) {
 			return;
 		}
 

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -85,6 +85,8 @@ class PLL_Frontend extends PLL_Base {
 		if ( ! defined( 'PLL_AUTO_TRANSLATE' ) || PLL_AUTO_TRANSLATE ) {
 			add_action( 'template_redirect', array( $this, 'auto_translate' ), 7 );
 		}
+
+		add_action( 'wp_before_admin_bar_render', array( $this, 'remove_customize_admin_bar' ) );
 	}
 
 	/**
@@ -231,6 +233,19 @@ class PLL_Frontend extends PLL_Base {
 			}
 
 			$this->load_strings_translations();
+		}
+	}
+
+	/**
+	 * Remove the customize admin bar on front-end when using a block theme.
+	 *
+	 * @since 3.2
+	 */
+	public function remove_customize_admin_bar() {
+		global $wp_admin_bar;
+
+		if ( wp_is_block_theme() ) {
+			$wp_admin_bar->remove_menu( 'customize' );
 		}
 	}
 }

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -242,9 +242,9 @@ class PLL_Frontend extends PLL_Base {
 	 * @since 3.2
 	 */
 	public function remove_customize_admin_bar() {
-		global $wp_admin_bar;
-
 		if ( wp_is_block_theme() ) {
+			global $wp_admin_bar;
+
 			$wp_admin_bar->remove_menu( 'customize' );
 		}
 	}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -244,20 +244,21 @@ class PLL_Frontend extends PLL_Base {
 	 * @return void
 	 */
 	public function remove_customize_admin_bar() {
-		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
-
-			global $wp_filter;
-			if ( isset( $wp_filter['customize_register'] ) ) {
-				$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
-				if ( $customize_register_hooks > 1 ) {
-					return;
-				}
-			}
-
-			global $wp_admin_bar;
-
-			remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' ); // To avoid the script launch.
-			$wp_admin_bar->remove_menu( 'customize' );
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
+			return;
 		}
+
+		global $wp_filter;
+		if ( isset( $wp_filter['customize_register'] ) ) {
+			$customize_register_hooks = count( $wp_filter['customize_register']->callbacks );
+			if ( $customize_register_hooks > 1 ) {
+				return;
+			}
+		}
+
+		global $wp_admin_bar;
+
+		remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' ); // To avoid the script launch.
+		$wp_admin_bar->remove_menu( 'customize' );
 	}
 }

--- a/include/base.php
+++ b/include/base.php
@@ -167,4 +167,30 @@ abstract class PLL_Base {
 		 */
 		return $new_blog_id !== $prev_blog_id && in_array( POLYLANG_BASENAME, $plugins ) && get_option( 'polylang' );
 	}
+
+	/**
+	 * Check if the customize menu should be removed or not.
+	 *
+	 * @since 3.2
+	 *
+	 * @return bool True if it should be removed, false otherwise.
+	 */
+	public function should_customize_menu_be_removed() {
+		// Exit if a block theme isn't activated.
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
+			return false;
+		}
+
+		global $wp_filter;
+		if ( empty( $wp_filter['customize_register'] ) ) {
+			return false;
+		}
+
+		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
+		if ( $customize_register_hooks > 1 ) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -109,6 +109,7 @@ trait PLL_UnitTestCase_Trait {
 
 	protected function require_wp_menus( $trigger_hooks = true ) {
 		global $submenu, $wp_filter;
+		global $_wp_submenu_nopriv;
 
 		if ( isset( static::$submenu ) ) {
 			$submenu = static::$submenu;

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -12,6 +12,13 @@ trait PLL_UnitTestCase_Trait {
 	public static $model;
 
 	/**
+	 * The admin submenu.
+	 *
+	 * @var array $submenu
+	 */
+	protected static $submenu;
+
+	/**
 	 * Initialization before all tests run.
 	 *
 	 * @param WP_UnitTest_Factory $factory WP_UnitTest_Factory object.
@@ -98,5 +105,36 @@ trait PLL_UnitTestCase_Trait {
 				self::$model->delete_language( $lang->term_id );
 			}
 		}
+	}
+
+	protected function require_wp_menus( $trigger_hooks = true ) {
+		global $submenu, $wp_filter;
+
+		if ( isset( static::$submenu ) ) {
+			$submenu = static::$submenu;
+
+			if ( $trigger_hooks ) {
+				do_action( 'admin_menu', '' );
+			}
+
+			return static::$submenu;
+		}
+
+		$hooks = isset( $wp_filter['admin_menu'] ) ? $wp_filter['admin_menu'] : null;
+		unset( $wp_filter['admin_menu'] );
+
+		require_once ABSPATH . 'wp-admin/menu.php';
+
+		static::$submenu = $submenu;
+
+		if ( isset( $hooks ) ) {
+			$wp_filter['admin_menu'] = $hooks;
+		}
+
+		if ( $trigger_hooks ) {
+			do_action( 'admin_menu', '' );
+		}
+
+		return static::$submenu;
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -199,7 +199,7 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		self::require_wp_menus();
 
-		$this->assertFalse( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
+		$this->assertNotContains( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ) );
 	}
 
 	public function test_remove_customize_submenu_with_non_block_base_theme() {
@@ -214,6 +214,6 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		self::require_wp_menus();
 
-		$this->assertTrue( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
+		$this->assertContains( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ) );
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -194,8 +194,8 @@ class Admin_Test extends PLL_UnitTestCase {
 
 
 		$links_model = self::$model->get_links_model();
-		$this->pll_admin = new PLL_Admin( $links_model );
-		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
+		$pll_admin = new PLL_Admin( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
 
 		self::require_wp_menus();
 
@@ -209,8 +209,8 @@ class Admin_Test extends PLL_UnitTestCase {
 		unset( $_wp_theme_features['widgets'] );
 
 		$links_model = self::$model->get_links_model();
-		$this->pll_admin = new PLL_Admin( $links_model );
-		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
+		$pll_admin = new PLL_Admin( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
 
 		self::require_wp_menus();
 

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -28,6 +28,8 @@ class Admin_Test extends PLL_UnitTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
+		remove_action( 'customize_register', array( $this, 'whatever' ) );
+
 		switch_theme( self::$stylesheet );
 	}
 

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -192,6 +192,8 @@ class Admin_Test extends PLL_UnitTestCase {
 		global $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
 
+		global $_wp_submenu_nopriv;
+
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -198,10 +198,29 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->pll_admin = new PLL_Admin( $links_model );
 		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
 
-		require_once ABSPATH . 'wp-admin/menu.php';
+		self::require_wp_menus();
 
 		do_action( 'admin_menu', '' );
 
 		$this->assertFalse( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
+	}
+
+	public function test_remove_customize_submenu_with_non_block_base_theme() {
+		global $submenu;
+
+		global $_wp_theme_features;
+		unset( $_wp_theme_features['widgets'] );
+
+		global $_wp_submenu_nopriv;
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
+
+		self::require_wp_menus();
+
+		do_action( 'admin_menu', '' );
+
+		$this->assertTrue( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -2,6 +2,8 @@
 require POLYLANG_DIR . '/include/api.php';
 
 class Admin_Test extends PLL_UnitTestCase {
+	protected static $editor;
+	protected static $stylesheet;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory
@@ -11,6 +13,22 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
+
+		self::$editor = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		switch_theme( self::$stylesheet );
 	}
 
 	public function test_admin_bar_menu() {
@@ -160,5 +178,28 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		$scripts = array( 'pll_ajax_backend', 'user', 'css' );
 		$this->_test_scripts( $scripts );
+	}
+
+	public function test_remove_customize_submenu_with_block_base_theme() {
+		$block_base_theme = wp_get_theme( 'twentytwentytwo' );
+		if ( ! $block_base_theme->exists() ) {
+			self::markTestSkipped( 'This test requires twenty twenty two' );
+		}
+
+		global $submenu;
+		switch_theme( 'twentytwentytwo' );
+
+		global $_wp_theme_features;
+		unset( $_wp_theme_features['widgets'] );
+
+		$links_model = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
+
+		require_once ABSPATH . 'wp-admin/menu.php';
+
+		do_action( 'admin_menu', '' );
+
+		$this->assertFalse( in_array( 'customize', array_merge( ...array_values($submenu['themes.php'] ) ), true ) );
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -192,7 +192,6 @@ class Admin_Test extends PLL_UnitTestCase {
 		global $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
 
-		global $_wp_submenu_nopriv;
 
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
@@ -210,8 +209,6 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		global $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
-
-		global $_wp_submenu_nopriv;
 
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -200,6 +200,6 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		do_action( 'admin_menu', '' );
 
-		$this->assertFalse( in_array( 'customize', array_merge( ...array_values($submenu['themes.php'] ) ), true ) );
+		$this->assertFalse( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -199,8 +199,6 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		self::require_wp_menus();
 
-		do_action( 'admin_menu', '' );
-
 		$this->assertFalse( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
 	}
 
@@ -215,8 +213,6 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
 
 		self::require_wp_menus();
-
-		do_action( 'admin_menu', '' );
 
 		$this->assertTrue( in_array( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ), true ) );
 	}

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -216,4 +216,27 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		$this->assertContains( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ) );
 	}
+
+	public function test_do_not_remove_customize_submenu_with_block_base_theme_if_a_plugin_use_it() {
+		$block_base_theme = wp_get_theme( 'twentytwentytwo' );
+		if ( ! $block_base_theme->exists() ) {
+			self::markTestSkipped( 'This test requires twenty twenty two' );
+		}
+
+		global $submenu;
+		switch_theme( 'twentytwentytwo' );
+
+		global $_wp_theme_features;
+		unset( $_wp_theme_features['widgets'] );
+
+		$links_model = self::$model->get_links_model();
+		$pll_admin = new PLL_Admin( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
+
+		add_action( 'customize_register', array( $this, 'whatever' ) );
+
+		self::require_wp_menus();
+
+		$this->assertContains( 'customize', array_merge( ...array_values( $submenu['themes.php'] ) ) );
+	}
 }

--- a/tests/phpunit/tests/test-frontend.php
+++ b/tests/phpunit/tests/test-frontend.php
@@ -1,0 +1,64 @@
+<?php
+
+
+class Frontend_Test extends PLL_UnitTestCase {
+	protected static $editor;
+	protected static $stylesheet;
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::$editor = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		switch_theme( self::$stylesheet );
+	}
+
+	public function test_remove_customize_admin_bar_with_block_base_theme() {
+		global $wp_admin_bar;
+		switch_theme( 'twentytwentytwo' );
+		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
+
+		$links_model = self::$model->get_links_model();
+		$frontend = new PLL_Frontend( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
+
+		_wp_admin_bar_init();
+		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+		do_action( 'wp_before_admin_bar_render' );
+
+		$this->assertEquals( null, $wp_admin_bar->get_node('customize') );
+	}
+
+	public function test_remove_customize_admin_bar_with_non_block_base_theme() {
+		global $wp_admin_bar;
+		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
+
+		$links_model = self::$model->get_links_model();
+		$frontend = new PLL_Frontend( $links_model );
+		$this->nav_menu = new PLL_Nav_Menu( $frontend ); // For auto added pages to menu.
+
+		_wp_admin_bar_init();
+		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+
+		remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' ); // To avoid the script launch in test.
+
+		do_action( 'wp_before_admin_bar_render' );
+
+		$this->assertInstanceOf( stdClass::class, $wp_admin_bar->get_node('customize') );
+	}
+}

--- a/tests/phpunit/tests/test-frontend.php
+++ b/tests/phpunit/tests/test-frontend.php
@@ -47,7 +47,7 @@ class Frontend_Test extends PLL_UnitTestCase {
 		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
 		do_action( 'wp_before_admin_bar_render' );
 
-		$this->assertEquals( null, $wp_admin_bar->get_node('customize') );
+		$this->assertEquals( null, $wp_admin_bar->get_node( 'customize' ) );
 	}
 
 	public function test_remove_customize_admin_bar_with_non_block_base_theme() {
@@ -65,6 +65,6 @@ class Frontend_Test extends PLL_UnitTestCase {
 
 		do_action( 'wp_before_admin_bar_render' );
 
-		$this->assertInstanceOf( stdClass::class, $wp_admin_bar->get_node('customize') );
+		$this->assertInstanceOf( stdClass::class, $wp_admin_bar->get_node( 'customize' ) );
 	}
 }

--- a/tests/phpunit/tests/test-frontend.php
+++ b/tests/phpunit/tests/test-frontend.php
@@ -30,6 +30,12 @@ class Frontend_Test extends PLL_UnitTestCase {
 
 	public function test_remove_customize_admin_bar_with_block_base_theme() {
 		global $wp_admin_bar;
+
+		$block_base_theme = wp_get_theme( 'twentytwentytwo' );
+		if ( ! $block_base_theme->exists() ) {
+			self::markTestSkipped( 'This test requires twenty twenty two' );
+		}
+
 		switch_theme( 'twentytwentytwo' );
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1174

The customize menu isn't display anymore on the **admin bar** and on the **submenu** when Polylang is activated (when using a block theme).

EDIT : But it is still displayed if another activated plugin is hooked on `customize_register`