### PR TITLE
Prevent core, plugins and themes updates directly from the test case.

### DIFF
--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -5,4 +5,12 @@
  */
 class PLL_Ajax_UnitTestCase extends WP_Ajax_UnitTestCase {
 	use PLL_UnitTestCase_Trait;
+
+	public function set_up() {
+		parent::set_up();
+
+		remove_action( 'admin_init', '_maybe_update_core' );
+		remove_action( 'admin_init', '_maybe_update_plugins' );
+		remove_action( 'admin_init', '_maybe_update_themes' );
+	}
 }

--- a/tests/phpunit/tests/test-ajax-columns.php
+++ b/tests/phpunit/tests/test-ajax-columns.php
@@ -17,7 +17,6 @@ class Ajax_Columns_Test extends PLL_Ajax_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -18,7 +18,6 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
 
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -17,7 +17,6 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-		remove_all_actions( 'admin_init' ); // To save (a lot of) time as WP will attempt to update core and plugins.
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests.
 

--- a/tests/phpunit/tests/test-ajax-on-front.php
+++ b/tests/phpunit/tests/test-ajax-on-front.php
@@ -17,11 +17,6 @@ class Ajax_On_Front_Test extends PLL_Ajax_UnitTestCase {
 		copy( dirname( __FILE__ ) . '/../data/fr_FR.mo', WP_LANG_DIR . '/fr_FR.mo' );
 	}
 
-	public function set_up() {
-		parent::set_up();
-		remove_all_actions( 'admin_init' ); // to save ( a lot of ) time as WP will attempt to update core and plugins
-	}
-
 	public function tear_down() {
 		parent::tear_down();
 


### PR DESCRIPTION
WordPress attempts to fire updates in ajax requests. This must be prevented in PHPunit tests. 
The WordPress ajax test case is supposed to [remove the corresponding actions](https://github.com/WordPress/wordpress-develop/blob/5.8.3/tests/phpunit/includes/testcase-ajax.php#L121-L123), but this is inefficient. 
Thus, we used to remove the actions in the `set_up()` of tests but this is easy to forget (and we did in a Polylang Pro test). 
Let's move the removal to the ajax test case. Let's also remove only the update actions instead of all `admin_init` actions. 