### PR TITLE
Change ajax-response id not to target default ajax-response HTML tag which is used by WordPress

### DIFF
--- a/js/src/admin.js
+++ b/js/src/admin.js
@@ -292,7 +292,9 @@ jQuery(
 					ajaxurl,
 					data,
 					function( response ) {
-						var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+						// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
+						// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+						var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 						$.each(
 							res.responses,
 							function() {

--- a/js/src/admin.js
+++ b/js/src/admin.js
@@ -292,8 +292,7 @@ jQuery(
 					ajaxurl,
 					data,
 					function( response ) {
-						// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
-						// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+						// Target a non existing WP HTML id to avoid a conflict with WP ajax requests.
 						var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 						$.each(
 							res.responses,

--- a/js/src/block-editor.js
+++ b/js/src/block-editor.js
@@ -107,8 +107,7 @@ jQuery(
 							ajaxurl,
 							data,
 							function( response ) {
-								// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
-								// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+								// Target a non existing WP HTML id to avoid a conflict with WP ajax requests.
 								var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 								$.each(
 									res.responses,

--- a/js/src/block-editor.js
+++ b/js/src/block-editor.js
@@ -107,7 +107,9 @@ jQuery(
 							ajaxurl,
 							data,
 							function( response ) {
-								var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+								// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
+								// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+								var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 								$.each(
 									res.responses,
 									function() {

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -136,8 +136,7 @@ jQuery(
 							ajaxurl,
 							data,
 							function( response ) {
-								// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
-								// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+								// Target a non existing WP HTML id to avoid a conflict with WP ajax requests.
 								var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 								$.each(
 									res.responses,

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -136,7 +136,7 @@ jQuery(
 							ajaxurl,
 							data,
 							function( response ) {
-								var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+								var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 								$.each(
 									res.responses,
 									function() {

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -136,6 +136,8 @@ jQuery(
 							ajaxurl,
 							data,
 							function( response ) {
+								// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
+								// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
 								var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 								$.each(
 									res.responses,

--- a/js/src/term.js
+++ b/js/src/term.js
@@ -187,7 +187,9 @@ jQuery(
 					ajaxurl,
 					data,
 					function( response ) {
-						var res = wpAjax.parseAjaxResponse( response, 'ajax-response' );
+						// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
+						// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+						var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 						$.each(
 							res.responses,
 							function() {

--- a/js/src/term.js
+++ b/js/src/term.js
@@ -91,7 +91,9 @@ jQuery(
 					switch ( data['action'] ) {
 						// when adding a term, the new term_id is in the ajax response
 						case 'add-tag':
-							res = wpAjax.parseAjaxResponse( xhr.responseXML, 'ajax-response' );
+							// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
+							// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+							res = wpAjax.parseAjaxResponse( xhr.responseXML, 'pll-ajax-response' );
 							$.each(
 								res.responses,
 								function() {

--- a/js/src/term.js
+++ b/js/src/term.js
@@ -67,8 +67,7 @@ jQuery(
 						data,
 						function( response ) {
 							if ( response ) {
-								// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
-								// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+								// Target a non existing WP HTML id to avoid a conflict with WP ajax requests.
 								var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 								$.each(
 									res.responses,
@@ -91,8 +90,7 @@ jQuery(
 					switch ( data['action'] ) {
 						// when adding a term, the new term_id is in the ajax response
 						case 'add-tag':
-							// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
-							// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+							// Target a non existing WP HTML id to avoid a conflict with WP ajax requests.
 							res = wpAjax.parseAjaxResponse( xhr.responseXML, 'pll-ajax-response' );
 							$.each(
 								res.responses,
@@ -189,8 +187,7 @@ jQuery(
 					ajaxurl,
 					data,
 					function( response ) {
-						// Since WP changeset #52710 parseAjaxReponse() return content to notice the user in a HTML tag with ajax-response id.
-						// Not to disturb this behaviour by executing another ajax request in the ajaxSuccess event, we need to target another unexisting id.
+						// Target a non existing WP HTML id to avoid a conflict with WP ajax requests.
 						var res = wpAjax.parseAjaxResponse( response, 'pll-ajax-response' );
 						$.each(
 							res.responses,


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1202

Continuation of https://github.com/polylang/polylang/pull/936

This PR propose to target an unexisting pll-ajax-response id not to overwrite the default WordPress message notice.