### PR TITLE
Fix PHPStan errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -64,3 +64,9 @@ parameters:
 			message: "#^Parameter \\#2 \\$input1 of function array_map expects array, string given\\.$#"
 			count: 1
 			path: settings/table-string.php
+
+		# Ignored due to a wrong doc of wp_tag_cloud()
+		-
+			message: "#^Parameter \\#1 \\$args of function wp_tag_cloud expects (.+) given\\.$#"
+			count: 1
+			path: admin/admin-filters-term.php

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -251,9 +251,10 @@ class PLL_Settings_Module {
 			// Don't use flush_rewrite_rules as we don't have the right links model and permastruct
 			delete_option( 'rewrite_rules' );
 
+
 			ob_start();
 
-			if ( ! get_settings_errors() ) {
+			if ( empty( get_settings_errors() ) ) {
 				// Send update message
 				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'updated' );
 				settings_errors();

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -364,7 +364,8 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public static function redirect( $args = array() ) {
-		if ( $errors = get_settings_errors() ) {
+		$errors = get_settings_errors();
+		if ( ! empty( $errors ) ) {
 			set_transient( 'settings_errors', $errors, 30 );
 			$args['settings-updated'] = 1;
 		}


### PR DESCRIPTION
With WordPress stubs 5.9 arrays are documented in a way that PHPStan can understand :). 
See https://github.com/php-stubs/wordpress-stubs/pull/21 to know more. 

For example, the `wp_tag_cloud()` function is documented in stubs like this:
```php
   /**
     * Displays a tag cloud.
     *
     * Outputs a list of tags in what is called a 'tag cloud', where the size of each tag
     * is determined by how many times that particular tag has been assigned to posts.
     *
     * @since 2.3.0
     * @since 2.8.0 Added the `taxonomy` argument.
     * @since 4.8.0 Added the `show_count` argument.
     *
     * @param array|string $args {
     *     Optional. Array or string of arguments for displaying a tag cloud. See wp_generate_tag_cloud()
     *     and get_terms() for the full lists of arguments that can be passed in `$args`.
     *
     *     @type int    $number    The number of tags to display. Accepts any positive integer
     *                             or zero to return all. Default 45.
     *     @type string $link      Whether to display term editing links or term permalinks.
     *                             Accepts 'edit' and 'view'. Default 'view'.
     *     @type string $post_type The post type. Used to highlight the proper post type menu
     *                             on the linked edit page. Defaults to the first post type
     *                             associated with the taxonomy.
     *     @type bool   $echo      Whether or not to echo the return value. Default true.
     * }
     * @return void|string|string[] Void if 'echo' argument is true, or on failure. Otherwise, tag cloud
     *                              as a string or an array, depending on 'format' argument.
     * @phpstan-param array{
     *   number?: int,
     *   link?: string,
     *   post_type?: string,
     *   echo?: bool,
     * } $args
     */
    function wp_tag_cloud($args = '')
```
This causes reporting 2 errors due to the return value of `get_settings_errors()`. This is fixed by this PR.
A 3rd error reported in the usage of `wp_tag_cloud()` is ignored as it looks to me that the WordPres documentation is incomplete.
