### PR TITLE
remove the last slash on $root that causes the pattern replace fails …

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -71,6 +71,10 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug . '/';
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
+			if (preg_match( '/\/\/$/', $root)) {
+				  $root = substr( $root, 0, -1 );
+			}
+
 			if ( false === strpos( $url, $new = $root . $slug ) ) {
 				$pattern = preg_quote( $root, '#' );
 				$pattern = '#' . $pattern . '#';


### PR DESCRIPTION
Our setup:

- Multi language site
- WP ultimo to manage plans and custom domains
- Polylang to translate web pages

When $root ends with two slashes the replacement the path with language does not work and the links does not include the language path. 

This line can return a $root with two ending slashes if home ends by / and $this->root is empty.

$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );

I know it can be improved but a modification has been required to make our setup work

