### PR TITLE
Fix PHP notice triggered by Yoast SEO when adding a new language

### DIFF
--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -163,7 +163,9 @@ class PLL_Filters_Links {
 		// In case someone calls get_term_link for the 'language' taxonomy.
 		if ( 'language' === $tax ) {
 			$lang = $this->model->get_language( $term->term_id );
-			return $this->links_model->home_url( $lang );
+			if ( $lang ) {
+				return $this->links_model->home_url( $lang );
+			}
 		}
 
 		return $link;

--- a/include/model.php
+++ b/include/model.php
@@ -58,6 +58,7 @@ class PLL_Model {
 		add_action( 'update_option_permalink_structure', array( $this, 'clean_languages_cache' ) );
 		add_action( 'update_option_siteurl', array( $this, 'clean_languages_cache' ) );
 		add_action( 'update_option_home', array( $this, 'clean_languages_cache' ) );
+		add_action( 'create_language', array( $this, 'clean_languages_cache' ) );
 
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ) );
 
@@ -92,7 +93,8 @@ class PLL_Model {
 
 				if ( ! empty( $languages ) && ! empty( $term_languages ) ) {
 					foreach ( $languages as $k => $v ) {
-						$languages[ $k ] = new PLL_Language( $v, $term_languages[ 'pll_' . $v->slug ] );
+						$term_language   = isset( $term_languages[ 'pll_' . $v->slug ] ) ? $term_languages[ 'pll_' . $v->slug ] : null;
+						$languages[ $k ] = new PLL_Language( $v, $term_language );
 					}
 
 					// We will need the languages list to allow its access in the filter below.

--- a/include/model.php
+++ b/include/model.php
@@ -58,7 +58,6 @@ class PLL_Model {
 		add_action( 'update_option_permalink_structure', array( $this, 'clean_languages_cache' ) );
 		add_action( 'update_option_siteurl', array( $this, 'clean_languages_cache' ) );
 		add_action( 'update_option_home', array( $this, 'clean_languages_cache' ) );
-		add_action( 'create_language', array( $this, 'clean_languages_cache' ) );
 
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ) );
 
@@ -93,8 +92,11 @@ class PLL_Model {
 
 				if ( ! empty( $languages ) && ! empty( $term_languages ) ) {
 					foreach ( $languages as $k => $v ) {
-						$term_language   = isset( $term_languages[ 'pll_' . $v->slug ] ) ? $term_languages[ 'pll_' . $v->slug ] : null;
-						$languages[ $k ] = new PLL_Language( $v, $term_language );
+						if ( ! isset( $term_languages[ 'pll_' . $v->slug ] ) ) {
+							unset( $languages[ $k ] );
+							continue;
+						}
+						$languages[ $k ] = new PLL_Language( $v, $term_languages[ 'pll_' . $v->slug ] );
 					}
 
 					// We will need the languages list to allow its access in the filter below.


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1153

Check `$lang` before filtering the links.

Do not add an incomplete language to the languages list.