### PR TITLE
Improve performance of the get_pages() filter

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -398,37 +398,6 @@ abstract class PLL_Translated_Object {
 	}
 
 	/**
-	 * Returns ids of objects in a language similarly to get_objects_in_term() for a taxonomy.
-	 * It is faster than get_objects_in_term() as it avoids a JOIN.
-	 *
-	 * @since 1.4
-	 *
-	 * @param PLL_Language $lang PLL_Language object.
-	 * @return int[] Object ids.
-	 */
-	public function get_objects_in_language( $lang ) {
-		global $wpdb;
-		$tt_id = $this->tax_tt;
-
-		$last_changed = wp_cache_get_last_changed( 'terms' );
-		$cache_key    = "polylang:get_objects_in_language:{$lang->$tt_id}:{$last_changed}";
-		$cache        = wp_cache_get( $cache_key, 'terms' );
-
-		if ( false === $cache ) {
-			$object_ids = $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $lang->$tt_id ) );
-			wp_cache_set( $cache_key, $object_ids, 'terms' );
-		} else {
-			$object_ids = (array) $cache;
-		}
-
-		if ( ! $object_ids ) {
-			return array();
-		}
-
-		return $object_ids;
-	}
-
-	/**
 	 * Check if a user can synchronize translations.
 	 *
 	 * @since 2.6


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1225

When filtering `get_pages()`, there are 2 cases to handle depending if a given number of pages is requested or not.

In the first case, we need to exclude all pages not in the requested language. The page ids to exclude are obtained with a call to `get_posts()`. This PR doesn't change this.

In the second case, we need to filter found pages by the requested language. This was done by intersecting the page ids with the object ids in the requested language. Although our method `get_objects_in_language()` shoudl be slightly better thant the native `get_objects_in_term()`, it can be quite slow when there are tens of thousands of posts (whathever their post types as the function doesn't take the post type as param). This is harmful when there are tens of thousands of posts or custom posts and only a few pages. Requesting ids of posts in a language and in the requested post type should improve the situation.

Two methods were envisaged:
- Keeping a direct sql query as today and add the post type to the query. As the function would take the post type as param, this would require to move it to the child class `PLL_Translated_Post` instead of `PLL_Translated_Object`. The fact that we need to JOIN the DB query to the posts table makes this solution less interesting than before.
- The selected choice: Use `get_posts()` as we already do for the list of ids to exclude. This is consistent and in fact allows to reuse the code. Hopefully the overhead added by `WP_Query` compared to a direct SQL would not harm the performance too much.

NB1: I remove the `get_objects_in_language()` method as it shouldn't be used anywhere else.
NB2: This PR also fixes a bug (never reported as far as I know) that I noticed in the params of `get_posts()`. The post status is added in case the original `get_pages()` call is made for pages in a status different than `publish`.