### PR TITLE
Fix type error in array_keys()

### DIFF
--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -45,20 +45,22 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 	 * @return string[] List of meta keys.
 	 */
 	protected function get_metas_to_copy( $from, $to, $lang, $sync = false ) {
-		// Copy or synchronize post metas and allow plugins to do the same
-		$metas = get_post_custom( $from );
 		$keys = array();
 
-		// Get public meta keys ( including from translated post in case we just deleted a custom field )
+		// Get public meta keys ( including from translated post in case we just deleted a custom field ).
 		if ( ! $sync || in_array( 'post_meta', $this->options['sync'] ) ) {
-			foreach ( $keys = array_unique( array_merge( array_keys( $metas ), array_keys( get_post_custom( $to ) ) ) ) as $k => $meta_key ) {
+			$from_keys = (array) get_post_custom_keys( $from );
+			$to_keys   = (array) get_post_custom_keys( $to );
+
+			$keys = array_unique( array_merge( $from_keys, $to_keys ) );
+			foreach ( $keys as $k => $meta_key ) {
 				if ( is_protected_meta( $meta_key ) ) {
 					unset( $keys[ $k ] );
 				}
 			}
 		}
 
-		// Add page template and featured image
+		// Add page template and featured image.
 		foreach ( array( '_wp_page_template', '_thumbnail_id' ) as $meta ) {
 			if ( ! $sync || in_array( $meta, $this->options['sync'] ) ) {
 				$keys[] = $meta;


### PR DESCRIPTION
Fixes #986 

`get_post_custom()` may return other values than an array. This possibly causes a fatal error in PHP 8.1 if a post has no meta.

As we want only meta keys, this PR replaces calls to `get_post_custom()` by `get_post_custom_keys()`, taking care that this function may return void. 