### PR TITLE
Introduce new class PLL_Db_Tools

### DIFF
--- a/include/db-tools.php
+++ b/include/db-tools.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit; // @phpstan-ignore-line
+
+/**
+ * Small set of tools to work with the database.
+ *
+ * @since 3.2
+ */
+class PLL_Db_Tools {
+
+	/**
+	 * Changes an array of values into a comma separated list, ready to be used in a `IN ()` clause.
+	 * Only string and integers and supported for now.
+	 *
+	 * @since 3.2
+	 *
+	 * @param  array<int|string> $values An array of values.
+	 * @return string                    A comma separated list of values.
+	 */
+	public static function prepare_values_list( $values ) {
+		$values = array_map( array( __CLASS__, 'prepare_value' ), (array) $values );
+
+		return implode( ',', $values );
+	}
+
+	/**
+	 * Wraps a value in escaped double quotes or casts as an integer.
+	 * Only string and integers and supported for now.
+	 *
+	 * @since  3.2
+	 * @global wpdb $wpdb
+	 *
+	 * @param  int|string $value A value.
+	 * @return int|string
+	 */
+	public static function prepare_value( $value ) {
+		if ( ! is_numeric( $value ) ) {
+			return $GLOBALS['wpdb']->prepare( '%s', $value );
+		}
+
+		return (int) $value;
+	}
+}

--- a/tests/phpunit/tests/test-db-tools.php
+++ b/tests/phpunit/tests/test-db-tools.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Tests for methods of the class `PLL_Db_Tool`.
+ */
+class PLL_Db_Tools_Test extends PLL_UnitTestCase {
+
+	/**
+	 * @see PLL_Db_Tools::prepare_values_list()
+	 *
+	 * @return void
+	 */
+	public function test_prepare_values_list_should_escape_and_join_values() {
+		$values   = array( '', "l'omelette au \"fromage\"", 123, '456' );
+		$expected = "'','l\'omelette au \\\"fromage\\\"',123,456";
+
+		$result = PLL_Db_Tools::prepare_values_list( $values );
+
+		$this->assertSame( $expected, $result, 'PLL_Db_Tools::prepare_values_list() should escape and join the given value' );
+	}
+
+	/**
+	 * @dataProvider dataProviderQuote
+	 * @see PLL_Db_Tools::prepare_value()
+	 *
+	 * @param  string $value    The value to test.
+	 * @param  string $expected The expected value.
+	 * @return void
+	 */
+	public function test_prepare_value_should_quote_non_numerical_values( $value, $expected ) {
+		$result = PLL_Db_Tools::prepare_value( $value );
+		$this->assertSame( $expected, $result, "'PLL_Db_Tools::prepare_value() should add quotes to '$value'" );
+	}
+
+	/**
+	 * @dataProvider dataProviderNotQuote
+	 * @see PLL_Db_Tools::prepare_value()
+	 *
+	 * @param  string $value    The value to test.
+	 * @param  string $expected The expected value.
+	 * @return void
+	 */
+	public function test_prepare_value_should_not_quote_numerical_values( $value, $expected ) {
+		$result       = PLL_Db_Tools::prepare_value( $value );
+		$value_string = is_string( $value ) ? "'$value'" : $value;
+		$this->assertSame( $expected, $result, "PLL_Db_Tools::prepare_value() should not add quotes to {$value_string}" );
+	}
+
+	public function dataProviderQuote() {
+		return array(
+			'empty string'              => array(
+				'value'    => '',
+				'expected' => "''",
+			),
+			'string with simple quotes' => array(
+				'value'    => "l'omelette",
+				'expected' => "'l\'omelette'",
+			),
+			'string with double quotes' => array(
+				'value'    => 'au "fromage"',
+				'expected' => "'au \\\"fromage\\\"'",
+			),
+		);
+	}
+
+	public function dataProviderNotQuote() {
+		return array(
+			'integer'        => array(
+				'value'    => 123,
+				'expected' => 123,
+			),
+			'numeric string' => array(
+				'value'    => '456',
+				'expected' => 456,
+			),
+		);
+	}
+}


### PR DESCRIPTION
This class regroups a small set of tools to work with the database.

2 methods:
- `prepare_value()` will wrap strings in quotes, or cast numeric values into integers.
- `prepare_values_list()` will change an array of values into a comma separated list of values, ready to be used in a `IN ()` clause. Ex: `'foo','bar','baz',4,7`.

Those 2 methods work only for strings and integers: we never work with float values for example, so I limited to those 2 types (for now) to keep the methods simple.