### PR TITLE
Allow dealerdirect/phpcodesniffer-composer-installer as of Composer 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       env: "WP_VERSION=5.9 WP_MULTISITE=0"
 
     - name: "WP 5.9 - PHP 7.4"
+      dist: "bionic"
       php: "7.4"
       env: "WP_VERSION=5.9 WP_MULTISITE=0"
 

--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,10 @@
 		"lint": "Runs both PHPCS and PHPStan.",
 		"build": "Builds the project.",
 		"dist": "Make the zip file to distibute the project release."
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
## Issue
Since Composer 2.2, it ask permission the first time a dependency want to run code. See: https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

## Changes
Update `composer.json` to allow `dealerdirect/phpcodesniffer-composer-installer`.
Also modify the distribution in Travis for php 7.4 to avoid `php: error while loading shared libraries: libargon2.so.1: cannot open shared object file: No such file or directory`