### PR TITLE
Fix create default term for first language

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -88,6 +88,9 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 		$this->notices = new PLL_Admin_Notices( $this );
 
+		$this->default_term = new PLL_Admin_Default_Term( $this );
+		$this->default_term->add_hooks();
+
 		if ( ! $this->model->get_languages_list() ) {
 			return;
 		}
@@ -95,8 +98,6 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		$this->links = new PLL_Admin_Links( $this ); // FIXME needed here ?
 		$this->static_pages = new PLL_Admin_Static_Pages( $this ); // FIXME needed here ?
 		$this->filters_links = new PLL_Filters_Links( $this ); // FIXME needed here ?
-		$this->default_term = new PLL_Admin_Default_Term( $this );
-		$this->default_term->add_hooks();
 
 		// Filter admin language for users
 		// We must not call user info before WordPress defines user roles in wp-settings.php


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1228

The default WordPress category wasn't duplicate into the other languages when adding first languages, because the `get_languages_list()` method returned before initializing the different hooks of the `PLL_Admin_Default_Term` class.