### PR TITLE
Translate the "posts page" in get_post_type_archive_link()

### DIFF
--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -52,12 +52,8 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * @return bool
 	 */
 	public function use_block_editor_for_post( $use_block_editor, $post ) {
-		if ( 'page' === $post->post_type ) {
-			add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
-
-			if ( ( get_option( 'page_for_posts' ) == $post->ID ) && empty( $post->post_content ) ) {
-				return false;
-			}
+		if ( 'page' === $post->post_type && empty( $post->post_content ) && (int) get_option( 'page_for_posts' ) === $post->ID ) {
+			return false;
 		}
 
 		return $use_block_editor;
@@ -74,13 +70,9 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * @return void
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
-		if ( 'page' === $post_type ) {
-			add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
-
-			if ( ( get_option( 'page_for_posts' ) == $post->ID ) && empty( $post->post_content ) ) {
-				add_action( 'edit_form_after_title', '_wp_posts_page_notice' );
-				remove_post_type_support( $post_type, 'editor' );
-			}
+		if ( 'page' === $post_type && empty( $post->post_content ) && (int) get_option( 'page_for_posts' ) === $post->ID ) {
+			add_action( 'edit_form_after_title', '_wp_posts_page_notice' );
+			remove_post_type_support( $post_type, 'editor' );
 		}
 	}
 

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -34,7 +34,6 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 		$this->links_model = &$polylang->links_model;
 		$this->links = &$polylang->links;
 
-		add_action( 'pll_language_defined', array( $this, 'pll_language_defined' ) );
 		add_action( 'pll_home_requested', array( $this, 'pll_home_requested' ) );
 
 		// Manages the redirection of the homepage
@@ -55,12 +54,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 * @return void
 	 */
 	public function pll_language_defined() {
-		// Translates our page on front and page for posts properties
-		$this->init();
-
-		// Translates page for posts and page on front
-		add_filter( 'option_page_on_front', array( $this, 'translate_page_on_front' ) );
-		add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
+		parent::pll_language_defined();
 
 		// Support theme customizer
 		if ( isset( $_POST['wp_customize'], $_POST['customized'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
@@ -78,19 +72,6 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 */
 	public function pll_home_requested() {
 		set_query_var( 'page_id', $this->curlang->page_on_front );
-	}
-
-	/**
-	 * Translates page on front
-	 *
-	 * @since 1.8
-	 *
-	 * @param int $v page on front page id
-	 * @return int
-	 */
-	public function translate_page_on_front( $v ) {
-		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache
-		return isset( $this->curlang->page_on_front ) && ( $this->curlang->page_on_front ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_on_front : $v;
 	}
 
 	/**

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -185,16 +185,16 @@ class PLL_Filters_Links {
 
 	/**
 	 * Modifies the post type archive links to add the language parameter
-	 * only if the post type is translated
+	 * only if the post type is translated.
 	 *
 	 * The filter was originally only on frontend but is needed on admin too for
-	 * compatibility with the archive link of the ACF link field since ACF 5.4.0
+	 * compatibility with the archive link of the ACF link field since ACF 5.4.0.
 	 *
 	 * @since 1.7.6
 	 *
-	 * @param string $link
-	 * @param string $post_type
-	 * @return string modified link
+	 * @param string $link      The post type archive permalink.
+	 * @param string $post_type Post type name.
+	 * @return string
 	 */
 	public function post_type_archive_link( $link, $post_type ) {
 		return $this->model->is_translated_post_type( $post_type ) && 'post' !== $post_type ? $this->links_model->switch_language_in_link( $link, $this->curlang ) : $link;

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -93,7 +93,7 @@ class PLL_Static_Pages {
 	/**
 	 * Init the hooks that filter the "page on front" and "page for posts" options.
 	 *
-	 * @since 3.3
+	 * @since 3.2
 	 *
 	 * @return void
 	 */
@@ -148,7 +148,7 @@ class PLL_Static_Pages {
 	 * Translates page on front.
 	 *
 	 * @since 1.8
-	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
+	 * @since 3.2 Was previously defined in PLL_Frontend_Static_Pages.
 	 *
 	 * @param int $v page on front page id.
 	 * @return int

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -56,6 +56,8 @@ class PLL_Static_Pages {
 
 		$this->init();
 
+		add_action( 'pll_language_defined', array( $this, 'pll_language_defined' ) );
+
 		// Modifies the page link in case the front page is not in the default language
 		add_filter( 'page_link', array( $this, 'page_link' ), 20, 2 );
 
@@ -86,6 +88,22 @@ class PLL_Static_Pages {
 			$this->page_on_front = 0;
 			$this->page_for_posts = 0;
 		}
+	}
+
+	/**
+	 * Init the hooks that filter the "page on front" and "page for posts" options.
+	 *
+	 * @since 3.3
+	 *
+	 * @return void
+	 */
+	public function pll_language_defined() {
+		// Translates our page on front and page for posts properties
+		$this->init();
+
+		// Translates page for posts and page on front
+		add_filter( 'option_page_on_front', array( $this, 'translate_page_on_front' ) );
+		add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
 	}
 
 	/**
@@ -124,6 +142,20 @@ class PLL_Static_Pages {
 		}
 
 		return $languages;
+	}
+
+	/**
+	 * Translates page on front.
+	 *
+	 * @since 1.8
+	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
+	 *
+	 * @param int $v page on front page id.
+	 * @return int
+	 */
+	public function translate_page_on_front( $v ) {
+		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache
+		return isset( $this->curlang->page_on_front ) && ( $this->curlang->page_on_front ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_on_front : $v;
 	}
 
 	/**

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -145,30 +145,30 @@ class PLL_Static_Pages {
 	}
 
 	/**
-	 * Translates page on front.
+	 * Translates the page on front option.
 	 *
 	 * @since 1.8
 	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
 	 *
-	 * @param int $v page on front page id.
+	 * @param  int $page_id ID of the page on front.
 	 * @return int
 	 */
-	public function translate_page_on_front( $v ) {
-		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache
-		return isset( $this->curlang->page_on_front ) && ( $this->curlang->page_on_front ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_on_front : $v;
+	public function translate_page_on_front( $page_id ) {
+		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+		return ! empty( $this->curlang->page_on_front ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_on_front : $page_id;
 	}
 
 	/**
-	 * Translates page for posts
+	 * Translates the page for posts option.
 	 *
 	 * @since 1.8
 	 *
-	 * @param int $v page for posts page id
+	 * @param  int $page_id ID of the page for posts.
 	 * @return int
 	 */
-	public function translate_page_for_posts( $v ) {
-		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache
-		return isset( $this->curlang->page_for_posts ) && ( $this->curlang->page_for_posts ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_for_posts : $v;
+	public function translate_page_for_posts( $page_id ) {
+		// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+		return ! empty( $this->curlang->page_for_posts ) && ! doing_action( 'switch_blog' ) ? $this->curlang->page_for_posts : $page_id;
 	}
 
 	/**

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -93,7 +93,7 @@ class PLL_Static_Pages {
 	/**
 	 * Init the hooks that filter the "page on front" and "page for posts" options.
 	 *
-	 * @since 3.2
+	 * @since 3.3
 	 *
 	 * @return void
 	 */
@@ -148,7 +148,7 @@ class PLL_Static_Pages {
 	 * Translates page on front.
 	 *
 	 * @since 1.8
-	 * @since 3.2 Was previously defined in PLL_Frontend_Static_Pages.
+	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
 	 *
 	 * @param int $v page on front page id.
 	 * @return int

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -98,10 +98,7 @@ class PLL_Static_Pages {
 	 * @return void
 	 */
 	public function pll_language_defined() {
-		// Translates our page on front and page for posts properties
-		$this->init();
-
-		// Translates page for posts and page on front
+		// Translates page for posts and page on front.
 		add_filter( 'option_page_on_front', array( $this, 'translate_page_on_front' ) );
 		add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
 	}

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -42,6 +42,8 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		self::$model->clean_languages_cache();
 
 		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
+		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
+
 		do_action( 'add_meta_boxes', 'page', get_post( $fr ) );
 		$this->assertFalse( post_type_supports( 'page', 'editor' ) );
 
@@ -92,9 +94,13 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		self::$model->clean_languages_cache();
 
 		$this->pll_admin->curlang = self::$model->get_language( 'en' );
+		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
+
 		$this->assertFalse( use_block_editor_for_post( $en ) );
 
 		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
+		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
+
 		$this->assertFalse( use_block_editor_for_post( $fr ) );
 
 		$page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -450,7 +450,10 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	 */
 	public function test_get_post_type_archive_link_for_posts() {
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
-		$this->assertEquals( 'http://example.org/fr/articles/', get_post_type_archive_link( 'post' ) );
+		$this->assertSame( 'http://example.org/fr/articles/', get_post_type_archive_link( 'post' ) );
+
+		$this->frontend->curlang = self::$model->get_language( 'en' );
+		$this->assertSame( 'http://example.org/en/posts/', get_post_type_archive_link( 'post' ) );
 	}
 
 	/**


### PR DESCRIPTION
This fixes https://github.com/polylang/polylang-pro/issues/1178.

Since WP 4.5.0, the function `get_post_type_archive_link()` supports posts. This case is already handled by Polylang by filtering the "page for posts" option, but this was done only on frontend. This PR now also filters this option on the admin side.  
While at it, this option also does the same thing for the "page on front" option, to keep a consistent behavior.