### PR TITLE
Fix parent page for parent unstranslatable post type

### DIFF
--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -197,10 +197,12 @@ class PLL_CRUD_Posts {
 	 */
 	public function wp_insert_post_parent( $post_parent, $post_id ) {
 		$lang = $this->model->post->get_language( $post_id );
+		$parent_post_type = $post_parent > 0 ? get_post_type( $post_parent ) : null;
 		// Dont break the hierarchy in case the post has no language
-		if ( ! empty( $lang ) ) {
+		if ( ! empty( $lang ) && ! empty( $parent_post_type ) && $this->model->is_translated_post_type( $parent_post_type ) ) {
 			$post_parent = $this->model->post->get_translation( $post_parent, $lang );
 		}
+
 		return $post_parent;
 	}
 

--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -81,4 +81,18 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 		$this->assertEquals( get_post( $child_page_id )->post_parent, 0 );
 
 	}
+
+	public function test_should_not_modify_parent_when_its_post_type_is_untranslatable() {
+		register_post_type( 'unstranslatable_cpt' );
+
+		$parent_id = $this->factory->post->create( array( 'post_title' => 'untranslated parent cpt', 'post_type' => 'unstranslatable_cpt' ) );
+
+		$child_page_id = $this->factory->post->create( array( 'post_title' => 'post with a untranslated parent', 'post_type' => 'page' ) );
+		self::$model->post->set_language( $child_page_id, 'en' );
+
+		wp_update_post( array( 'ID' => $child_page_id, 'post_parent' => $parent_id ) );
+
+		$child_page = get_post( $child_page_id );
+		$this->assertEquals( get_post( $child_page_id )->post_parent, $parent_id, "The unstranlated parent post id should be {$parent_id}" );
+	}
 }


### PR DESCRIPTION
Fixes [HS#18717](https://secure.helpscout.net/conversation/1818755470/18717/)

In fact since https://github.com/polylang/polylang/pull/911 was merged we introduced an issue in the customer code.

Indeed before, with Polylang 2.9.x, the post parent translation assignment was done only in a bulk action context.
Since Polylang 3.1.x, to fix https://github.com/polylang/polylang-pro/issues/971 this assignment is done in all contexts.

However it's because we assume that the parent post type is the same as the child post type and thus translatable.

In the customer case, the parent post type is different than the child post type and also untranslatable.
This is what causes the issue.

## Changes
- add a condition to check if the parent post type is translatable before assigning the parent translation to the post.
- add a PHPUnit test to cover this case

## Expected behavior
- The customer validated the patch we provided and corresponding on this PR.