### PR TITLE
Block editor not available for the page for posts

### DIFF
--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -46,7 +46,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * Don't use the block editor for the translations of the pages for posts with WP < 5.8.
 	 *
 	 * @since 2.5
-	 * @since 3.2 Don't disable the block editor for the page for posts in WP >= 5.8.
+	 * @since 3.3 Don't disable the block editor for the page for posts in WP >= 5.8.
 	 *
 	 * @param bool    $use_block_editor Whether the post can be edited or not.
 	 * @param WP_Post $post             The post being checked.
@@ -197,7 +197,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 * Tells if we should disable the block editor.
 	 * The block editor was disabled for the page for posts in WP 5.0, then enabled again in WP 5.8.
 	 *
-	 * @since 3.2
+	 * @since 3.3
 	 *
 	 * @param WP_Post $post Current post.
 	 * @return bool

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -27,7 +27,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		$this->links = &$polylang->links;
 
 		// Removes the editor and the template select dropdown for pages for posts
-		add_filter( 'use_block_editor_for_post', array( $this, 'use_block_editor_for_post' ), 10, 2 ); // Since WP 5.0
+		add_filter( 'use_block_editor_for_post', array( $this, 'use_block_editor_for_post' ), 10, 2 ); // Since WP 5.0, backward compatibility with WP < 5.8.
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
 
 		// Add post state for translations of the front page and posts page

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -93,7 +93,7 @@ class PLL_Static_Pages {
 	/**
 	 * Init the hooks that filter the "page on front" and "page for posts" options.
 	 *
-	 * @since 3.3
+	 * @since 3.2
 	 *
 	 * @return void
 	 */
@@ -145,7 +145,7 @@ class PLL_Static_Pages {
 	 * Translates the page on front option.
 	 *
 	 * @since 1.8
-	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
+	 * @since 3.2 Was previously defined in PLL_Frontend_Static_Pages.
 	 *
 	 * @param  int $page_id ID of the page on front.
 	 * @return int

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -93,7 +93,7 @@ class PLL_Static_Pages {
 	/**
 	 * Init the hooks that filter the "page on front" and "page for posts" options.
 	 *
-	 * @since 3.2
+	 * @since 3.3
 	 *
 	 * @return void
 	 */
@@ -145,7 +145,7 @@ class PLL_Static_Pages {
 	 * Translates the page on front option.
 	 *
 	 * @since 1.8
-	 * @since 3.2 Was previously defined in PLL_Frontend_Static_Pages.
+	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
 	 *
 	 * @param  int $page_id ID of the page on front.
 	 * @return int

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -83,15 +83,9 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 
 		ob_start();
 		do_action( 'edit_form_after_title', get_post( $fr ) );
-		$after_title = ob_get_clean();
 
-		if ( $this->is_wp_58() ) {
-			$this->assertTrue( post_type_supports( 'page', 'editor' ) );
-			$this->assertStringNotContainsString( 'You are currently editing the page that shows your latest posts.', $after_title );
-		} else {
-			$this->assertFalse( post_type_supports( 'page', 'editor' ) );
-			$this->assertStringContainsString( 'You are currently editing the page that shows your latest posts.', $after_title );
-		}
+		$this->assertTrue( post_type_supports( 'page', 'editor' ) );
+		$this->assertStringNotContainsString( 'You are currently editing the page that shows your latest posts.', ob_get_clean() );
 	}
 
 	public function test_use_block_editor_for_post() {
@@ -115,7 +109,7 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
 
-		$this->assertSame( $this->is_wp_58(), use_block_editor_for_post( $en ) );
+		$this->assertSame( $this->is_wp_58(), use_block_editor_for_post( $fr ) );
 
 		$page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $page_id, 'fr' );

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -45,11 +45,18 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
 
 		do_action( 'add_meta_boxes', 'page', get_post( $fr ) );
-		$this->assertFalse( post_type_supports( 'page', 'editor' ) );
 
 		ob_start();
 		do_action( 'edit_form_after_title', get_post( $fr ) );
-		$this->assertStringContainsString( 'You are currently editing the page that shows your latest posts.', ob_get_clean() );
+		$after_title = ob_get_clean();
+
+		if ( $this->is_wp_58() ) {
+			$this->assertTrue( post_type_supports( 'page', 'editor' ) );
+			$this->assertStringNotContainsString( 'You are currently editing the page that shows your latest posts.', $after_title );
+		} else {
+			$this->assertFalse( post_type_supports( 'page', 'editor' ) );
+			$this->assertStringContainsString( 'You are currently editing the page that shows your latest posts.', $after_title );
+		}
 	}
 
 	/**
@@ -73,11 +80,18 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 
 		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		do_action( 'add_meta_boxes', 'page', get_post( $fr ) );
-		$this->assertTrue( post_type_supports( 'page', 'editor' ) );
 
 		ob_start();
 		do_action( 'edit_form_after_title', get_post( $fr ) );
-		$this->assertStringNotContainsString( 'You are currently editing the page that shows your latest posts.', ob_get_clean() );
+		$after_title = ob_get_clean();
+
+		if ( $this->is_wp_58() ) {
+			$this->assertTrue( post_type_supports( 'page', 'editor' ) );
+			$this->assertStringNotContainsString( 'You are currently editing the page that shows your latest posts.', $after_title );
+		} else {
+			$this->assertFalse( post_type_supports( 'page', 'editor' ) );
+			$this->assertStringContainsString( 'You are currently editing the page that shows your latest posts.', $after_title );
+		}
 	}
 
 	public function test_use_block_editor_for_post() {
@@ -96,12 +110,12 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		$this->pll_admin->curlang = self::$model->get_language( 'en' );
 		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
 
-		$this->assertFalse( use_block_editor_for_post( $en ) );
+		$this->assertSame( $this->is_wp_58(), use_block_editor_for_post( $en ) );
 
 		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		do_action( 'pll_language_defined', $this->pll_admin->curlang->slug, $this->pll_admin->curlang );
 
-		$this->assertFalse( use_block_editor_for_post( $fr ) );
+		$this->assertSame( $this->is_wp_58(), use_block_editor_for_post( $en ) );
 
 		$page_id = $this->factory->post->create( array( 'post_type' => 'page', 'post_content' => '' ) );
 		self::$model->post->set_language( $page_id, 'fr' );
@@ -110,5 +124,9 @@ class Admin_Static_Pages_Test extends PLL_UnitTestCase {
 		$post_id = $this->factory->post->create( array( 'post_content' => '' ) );
 		self::$model->post->set_language( $post_id, 'fr' );
 		$this->assertTrue( use_block_editor_for_post( $post_id ) );
+	}
+
+	private function is_wp_58() {
+		return version_compare( $GLOBALS['wp_version'], '5.8' ) >= 0;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1307.

WP 5.0: the block editor is disabled for the page for posts. Polylang mimics this behavior for the pages for posts in secondary languages.

WP 5.8: the block editor is enabled again. This PR is about reproducing this mechanic, by disabling the block editor for the translations of the page for posts, but only for WP <5.8.

Also, by using `use_block_editor_for_post()` in `PLL_Admin_Static_Pages->add_meta_boxes()`, we make sure to not disable it if a third party plugin, like Classic Editor, re-enables it.

## How to test manually

1. On WP >= 5.8, visit the edition screen of the page for posts (default language): the block editor should be available.
2. Do the same for the translations of this page and get the same behavior.
3. For other pages, the block editor should be available.
4. Install and activate the plugin Classic Editor.
5. Go to CE's settings page and enable the possibility to switch from one editor to the other.
6. Go back to the edition screen of the page for posts (default language):
  - If you are in block editor mode:
    1. The block editor should still be available.
    2. Switch to the classic editor: Options menu (the 3 vertical dots at the upper right of the screen), "Switch to classic editor.
    3. The classic editor should be disabled.
  - If you are in classic editor mode:
    1. The classic editor should be disabled.
    2. Switch to the block editor: link in a meta-box.
    3. The block editor should be available.
7. Do the same for the translations of this page and get the same behavior.
8. For other pages, the block editor should be available.
9. If you want to try out with WP < 5.8, you can repeat the same steps: this time the block editor should not be available.