### PR TITLE
Only sync metas of sync tax

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -443,7 +443,17 @@ class PLL_WPSEO {
 		$keys[] = '_yoast_wpseo_meta-robots-nofollow';
 		$keys[] = '_yoast_wpseo_meta-robots-adv';
 
-		$taxonomies = PLL()->sync->taxonomies->get_taxonomies_to_copy( $sync, $from, $to );
+
+		$taxonomies = get_taxonomies(
+			array(
+				'hierarchical' => true,
+				'public'       => true,
+			)
+		);
+
+		$sync_taxonomies = PLL()->sync->taxonomies->get_taxonomies_to_copy( $sync, $from, $to );
+
+		$taxonomies = array_intersect( $taxonomies, $sync_taxonomies );
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$keys[] = '_yoast_wpseo_primary_' . $taxonomy;

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -474,11 +474,9 @@ class PLL_WPSEO {
 	 */
 	public function translate_post_meta( $value, $key, $lang ) {
 		if ( false !== strpos( $key, '_yoast_wpseo_primary_' ) ) {
-			$term_id = pll_get_term( $value, $lang );
-			if ( $term_id ) {
-				return $term_id;
+			if ( PLL()->model->is_translated_taxonomy( $key ) ) {
+				return pll_get_term( $value, $lang );
 			}
-			return $value;
 		}
 		return $value;
 	}

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -472,11 +472,15 @@ class PLL_WPSEO {
 	 * @return int
 	 */
 	public function translate_post_meta( $value, $key, $lang ) {
-		if ( false !== strpos( $key, '_yoast_wpseo_primary_' ) ) {
-			if ( PLL()->model->is_translated_taxonomy( $key ) ) {
-				return pll_get_term( $value, $lang );
-			}
+		if ( ! strpos( $key, '_yoast_wpseo_primary_' ) ) {
+			return $value;
 		}
-		return $value;
+
+		$taxonomy = str_replace( '_yoast_wpseo_primary_', '', $key );
+		if ( ! PLL()->model->is_translated_taxonomy( $taxonomy ) ) {
+			return $value;
+		}
+
+		return pll_get_term( $value, $lang );
 	}
 }

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -443,7 +443,6 @@ class PLL_WPSEO {
 		$keys[] = '_yoast_wpseo_meta-robots-nofollow';
 		$keys[] = '_yoast_wpseo_meta-robots-adv';
 
-
 		$taxonomies = get_taxonomies(
 			array(
 				'hierarchical' => true,

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -472,7 +472,7 @@ class PLL_WPSEO {
 	 * @return int
 	 */
 	public function translate_post_meta( $value, $key, $lang ) {
-		if ( ! strpos( $key, '_yoast_wpseo_primary_' ) ) {
+		if ( 0 !== strpos( $key, '_yoast_wpseo_primary_' ) ) {
 			return $value;
 		}
 

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -44,6 +44,7 @@ class PLL_Sync_Tax {
 	 *
 	 * @since 1.7
 	 * @since 2.1 The `$from`, `$to`, `$lang` parameters were added.
+	 * @since 3.2 Changed visibility from protected to public.
 	 *
 	 * @param bool   $sync True if it is synchronization, false if it is a copy.
 	 * @param int    $from Id of the post from which we copy informations, optional, defaults to null.

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -51,7 +51,7 @@ class PLL_Sync_Tax {
 	 * @param string $lang Language slug, optional, defaults to null.
 	 * @return string[] List of taxonomy names.
 	 */
-	protected function get_taxonomies_to_copy( $sync, $from = null, $to = null, $lang = null ) {
+	public function get_taxonomies_to_copy( $sync, $from = null, $to = null, $lang = null ) {
 		$taxonomies = ! $sync || in_array( 'taxonomies', $this->options['sync'] ) ? $this->model->get_translated_taxonomies() : array();
 		if ( ! $sync || in_array( 'post_format', $this->options['sync'] ) ) {
 			$taxonomies[] = 'post_format';


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1143

Metas were synchronized for unsynchronized taxonomies.
**Now**, metas are only synchronized for synchronized taxonomies.

`$from` and `$to` were added for consistency and safety.
`pll_get_term()` is now checked.