### PR TITLE
Fix arrays comparisons in model's tests

### DIFF
--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -17,14 +17,14 @@ class Model_Test extends PLL_UnitTestCase {
 	public function test_languages_list() {
 		self::$model->post->register_taxonomy(); // needed otherwise posts are not counted
 
-		$this->assertEquals( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
-		$this->assertEquals( array( 'English', 'Français' ), self::$model->get_languages_list( array( 'fields' => 'name' ) ) );
-		$this->assertEquals( array(), self::$model->get_languages_list( array( 'hide_empty' => true ) ) );
+		$this->assertSameSets( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertSameSets( array( 'English', 'Français' ), self::$model->get_languages_list( array( 'fields' => 'name' ) ) );
+		$this->assertSameSets( array(), self::$model->get_languages_list( array( 'hide_empty' => true ) ) );
 
 		$post_id = $this->factory->post->create();
 		self::$model->post->set_language( $post_id, 'en' );
 
-		$this->assertEquals( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
+		$this->assertSameSets( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
 	}
 
 	public function test_term_exists() {


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/1308.

Using `assertEquals()` to compare arrays [seems to fail with php 8.0 + WP 6.0](https://app.travis-ci.com/github/polylang/polylang/jobs/566142065). This fixes this issue by using `assertSameSets()`.