### PR TITLE
Set accepted context in do_meta_boxes()

### DIFF
--- a/settings/view-tab-strings.php
+++ b/settings/view-tab-strings.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="metabox-holder">
 		<?php
 		wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
-		do_meta_boxes( 'languages_page_mlang_strings', 'bottom', array() );
+		do_meta_boxes( 'languages_page_mlang_strings', 'normal', array() );
 		?>
 	</div>
 


### PR DESCRIPTION
Some PHP Stan errors occurred regarding the use of `add_meta_box()` in Polylang Pro.
To prevent that, we have to conform ourself to the WordPress stubs which restrict the `$context` parameter to `"normal"|"side"|"advanced"` both for `do_meta_boxes()` and `add_meta_box()`.

I still opened an issue in php-stubs/wordpress-stubs (see: https://github.com/php-stubs/wordpress-stubs/issues/30).