### PR TITLE
Update szepeviktor / phpstan-wordpress

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -12,46 +12,46 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	/**
 	 * Current language (used to filter the content).
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 
 	/**
 	 * Language selected in the admin language filter.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $filter_lang;
 
 	/**
 	 * Preferred language to assign to new contents.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $pref_lang;
 
 	/**
-	 * @var PLL_Filters_Links
+	 * @var PLL_Filters_Links|null
 	 */
 	public $filters_links;
 
 	/**
-	 * @var PLL_Admin_Links
+	 * @var PLL_Admin_Links|null
 	 */
 	public $links;
 
 	/**
-	 * @var PLL_Admin_Notices
+	 * @var PLL_Admin_Notices|null
 	 */
 	public $notices;
 
 	/**
-	 * @var PLL_Admin_Static_Pages
+	 * @var PLL_Admin_Static_Pages|null
 	 */
 	public $static_pages;
 
 	/**
-	 * @var PLL_Admin_Default_Term
+	 * @var PLL_Admin_Default_Term|null
 	 */
 	public $default_term;
 

--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -17,7 +17,7 @@ class PLL_Admin_Block_Editor {
 	/**
 	 * Preferred language to assign to a new post.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	protected $pref_lang;
 

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -15,21 +15,21 @@ class PLL_Admin_Classic_Editor {
 	public $model;
 
 	/**
-	 * @var PLL_Admin_Links
+	 * @var PLL_Admin_Links|null
 	 */
 	public $links;
 
 	/**
 	 * Current language (used to filter the content).
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 
 	/**
 	 * Preferred language to assign to new contents.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $pref_lang;
 

--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -20,7 +20,7 @@ class PLL_Admin_Default_Term {
 	/**
 	 * Preferred language to assign to new contents.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	protected $pref_lang;
 

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -16,14 +16,14 @@ class PLL_Admin_Filters_Columns {
 	public $model;
 
 	/**
-	 * @var PLL_Admin_Links
+	 * @var PLL_Admin_Links|null
 	 */
 	public $links;
 
 	/**
 	 * Language selected in the admin language filter.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $filter_lang;
 

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -11,7 +11,7 @@
  */
 class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 	/**
-	 * @var PLL_CRUD_Posts
+	 * @var PLL_CRUD_Posts|null
 	 */
 	public $posts;
 

--- a/admin/admin-filters-post-base.php
+++ b/admin/admin-filters-post-base.php
@@ -15,16 +15,23 @@ abstract class PLL_Admin_Filters_Post_Base {
 	public $model;
 
 	/**
-	 * @var PLL_Links
+	 * @var PLL_Links|null
 	 */
 	public $links;
 
 	/**
 	 * Language selected in the admin language filter.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $filter_lang;
+
+	/**
+	 * Preferred language to assign to new contents.
+	 *
+	 * @var PLL_Language|null
+	 */
+	public $pref_lang;
 
 	/**
 	 * Constructor: setups filters and actions

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -12,7 +12,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 	/**
 	 * Current language (used to filter the content).
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -22,35 +22,35 @@ class PLL_Admin_Filters_Term {
 	public $model;
 
 	/**
-	 * @var PLL_Admin_Links
+	 * @var PLL_Admin_Links|null
 	 */
 	public $links;
 
 	/**
 	 * Language selected in the admin language filter.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $filter_lang;
 
 	/**
 	 * Preferred language to assign to the new terms.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $pref_lang;
 
 	/**
 	 * Stores the term name before creating a slug if needed.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $pre_term_name;
 
 	/**
 	 * Stores the current post_id when bulk editing posts.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	protected $post_id;
 
@@ -59,7 +59,7 @@ class PLL_Admin_Filters_Term {
 	 *
 	 * @since 2.8
 	 *
-	 * @var PLL_Admin_Default_Term
+	 * @var PLL_Admin_Default_Term|null
 	 */
 	protected $default_term;
 

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -10,7 +10,7 @@
  */
 class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	/**
-	 * @var PLL_Admin_Links
+	 * @var PLL_Admin_Links|null
 	 */
 	protected $links;
 

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -24,7 +24,7 @@ class PLL_Admin_Strings {
 	/**
 	 * The strings to register by default.
 	 *
-	 * @var string[]
+	 * @var string[]|null
 	 */
 	protected static $default_strings;
 

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -10,54 +10,54 @@
  */
 class PLL_Admin extends PLL_Admin_Base {
 	/**
-	 * @var PLL_Admin_Filters
+	 * @var PLL_Admin_Filters|null
 	 */
 	public $filters;
 
 	/**
-	 * @var PLL_Admin_Filters_Columns
+	 * @var PLL_Admin_Filters_Columns|null
 	 */
 	public $filters_columns;
 
 	/**
-	 * @var PLL_Admin_Filters_Post
+	 * @var PLL_Admin_Filters_Post|null
 	 */
 	public $filters_post;
 
 	/**
-	 * @var PLL_Admin_Filters_Term
+	 * @var PLL_Admin_Filters_Term|null
 	 */
 	public $filters_term;
 
 	/**
-	 * @var PLL_Admin_Filters_Media
+	 * @var PLL_Admin_Filters_Media|null
 	 */
 	public $filters_media;
 
 	/**
 	 * @since 2.9
 	 *
-	 * @var PLL_Filters_Sanitization
+	 * @var PLL_Filters_Sanitization|null
 	 */
 	public $filters_sanitization;
 
 	/**
-	 * @var PLL_Admin_Block_Editor
+	 * @var PLL_Admin_Block_Editor|null
 	 */
 	public $block_editor;
 
 	/**
-	 * @var PLL_Admin_Classic_Editor
+	 * @var PLL_Admin_Classic_Editor|null
 	 */
 	public $classic_editor;
 
 	/**
-	 * @var PLL_Admin_Nav_Menu
+	 * @var PLL_Admin_Nav_Menu|null
 	 */
 	public $nav_menu;
 
 	/**
-	 * @var PLL_Admin_Filters_Widgets_Options
+	 * @var PLL_Admin_Filters_Widgets_Options|null
 	 */
 	public $filters_widgets_options;
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"php": ">=5.6"
 	},
 	"require-dev": {
-		"wpsyntex/polylang-phpstan": "dev-level-up",
+		"wpsyntex/polylang-phpstan": "^1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"wp-coding-standards/wpcs": "*",
 		"automattic/vipwpcs": "*",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"php": ">=5.6"
 	},
 	"require-dev": {
-		"wpsyntex/polylang-phpstan": "dev-master",
+		"wpsyntex/polylang-phpstan": "dev-level-up",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"wp-coding-standards/wpcs": "*",
 		"automattic/vipwpcs": "*",

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -36,16 +36,6 @@ abstract class PLL_Choose_Lang {
 	public $curlang;
 
 	/**
-	 * @var PLL_Accept_Language|null
-	 */
-	private $lang_parse;
-
-	/**
-	 * @var PLL_Accept_Languages_Collection|null
-	 */
-	private $accept_langs;
-
-	/**
 	 * Constructor
 	 *
 	 * @since 1.2

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -31,15 +31,17 @@ abstract class PLL_Choose_Lang {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
+
 	/**
-	 * @var PLL_Accept_Language
+	 * @var PLL_Accept_Language|null
 	 */
 	private $lang_parse;
+
 	/**
-	 * @var PLL_Accept_Languages_Collection
+	 * @var PLL_Accept_Languages_Collection|null
 	 */
 	private $accept_langs;
 

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -18,7 +18,7 @@ class PLL_Frontend_Auto_Translate {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -11,7 +11,7 @@
 class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 	/**
-	 * @var PLL_Frontend_Links
+	 * @var PLL_Frontend_Links|null
 	 */
 	public $links;
 

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -324,13 +324,13 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		foreach ( $traces as $trace ) {
 			// Black list first
 			foreach ( $this->black_list as $v ) {
-				if ( ( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) ) || ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ) {
+				if ( ( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) ) || ( ! empty( $v['function'] ) && $trace['function'] === $v['function'] ) ) {
 					return $url;
 				}
 			}
 
 			foreach ( $this->white_list as $v ) {
-				if ( ( isset( $trace['function'], $v['function'] ) && $trace['function'] == $v['function'] ) ||
+				if ( ( ! empty( $v['function'] ) && $trace['function'] === $v['function'] ) ||
 					( isset( $trace['file'], $v['file'] ) && false !== strpos( $trace['file'], $v['file'] ) && in_array( $trace['function'], array( 'home_url', 'get_home_url', 'bloginfo', 'get_bloginfo' ) ) ) ) {
 					$ok = true;
 				}

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -19,7 +19,7 @@ class PLL_Frontend_Filters_Search {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -19,7 +19,7 @@ class PLL_Frontend_Filters_Widgets {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -12,7 +12,7 @@ class PLL_Frontend_Links extends PLL_Links {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 
@@ -166,6 +166,8 @@ class PLL_Frontend_Links extends PLL_Links {
 			}
 		}
 
+		$url = ! empty( $url ) && ! is_wp_error( $url ) ? $url : null;
+
 		/**
 		 * Filter the translation url of the current page before Polylang caches it
 		 *
@@ -174,7 +176,7 @@ class PLL_Frontend_Links extends PLL_Links {
 		 * @param null|string $url      The translation url, null if none was found
 		 * @param string      $language The language code of the translation
 		 */
-		$translation_url = apply_filters( 'pll_translation_url', ( isset( $url ) && ! is_wp_error( $url ) ? $url : null ), $language->slug );
+		$translation_url = apply_filters( 'pll_translation_url', $url, $language->slug );
 
 		// Don't cache before template_redirect to avoid a conflict with Barrel + WP Bakery Page Builder
 		if ( did_action( 'template_redirect' ) ) {

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -12,7 +12,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -17,7 +17,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	protected $links_model;
 
 	/**
-	 * @var PLL_Frontend_Links
+	 * @var PLL_Frontend_Links|null
 	 */
 	protected $links;
 

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -12,54 +12,54 @@ class PLL_Frontend extends PLL_Base {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 
 	/**
-	 * @var PLL_Frontend_Auto_Translate
+	 * @var PLL_Frontend_Auto_Translate|null
 	 */
 	public $auto_translate;
 
 	/**
 	 * The class selecting the current language.
 	 *
-	 * @var PLL_Choose_Lang
+	 * @var PLL_Choose_Lang|null
 	 */
 	public $choose_lang;
 
 	/**
-	 * @var PLL_Frontend_Filters
+	 * @var PLL_Frontend_Filters|null
 	 */
 	public $filters;
 
 	/**
-	 * @var PLL_Frontend_Filters_Links
+	 * @var PLL_Frontend_Filters_Links|null
 	 */
 	public $filters_links;
 
 	/**
-	 * @var PLL_Frontend_Filters_Search
+	 * @var PLL_Frontend_Filters_Search|null
 	 */
 	public $filters_search;
 
 	/**
-	 * @var PLL_Frontend_Links
+	 * @var PLL_Frontend_Links|null
 	 */
 	public $links;
 
 	/**
-	 * @var PLL_Frontend_Nav_Menu
+	 * @var PLL_Frontend_Nav_Menu|null
 	 */
 	public $nav_menu;
 
 	/**
-	 * @var PLL_Frontend_Static_Pages
+	 * @var PLL_Frontend_Static_Pages|null
 	 */
 	public $static_pages;
 
 	/**
-	 * @var PLL_Frontend_Filters_Widgets
+	 * @var PLL_Frontend_Filters_Widgets|null
 	 */
 	public $filters_widgets;
 

--- a/include/base.php
+++ b/include/base.php
@@ -31,14 +31,14 @@ abstract class PLL_Base {
 	/**
 	 * Registers hooks on insert / update post related actions and filters.
 	 *
-	 * @var PLL_CRUD_Posts
+	 * @var PLL_CRUD_Posts|null
 	 */
 	public $posts;
 
 	/**
 	 * Registers hooks on insert / update term related action and filters.
 	 *
-	 * @var PLL_CRUD_Terms
+	 * @var PLL_CRUD_Terms|null
 	 */
 	public $terms;
 

--- a/include/cache.php
+++ b/include/cache.php
@@ -22,7 +22,7 @@ class PLL_Cache {
 	 *
 	 * @var array
 	 */
-	protected $cache;
+	protected $cache = array();
 
 	/**
 	 * Constructor

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -123,10 +123,10 @@ class PLL_CRUD_Posts {
 	 *
 	 * @since 2.3
 	 *
-	 * @param int       $object_id Object ID.
-	 * @param WP_Term[] $terms     An array of object terms.
-	 * @param int[]     $tt_ids    An array of term taxonomy IDs.
-	 * @param string    $taxonomy  Taxonomy slug.
+	 * @param int            $object_id Object ID.
+	 * @param int[]|string[] $terms     An array of object term IDs or slugs.
+	 * @param int[]          $tt_ids    An array of term taxonomy IDs.
+	 * @param string         $taxonomy  Taxonomy slug.
 	 * @return void
 	 */
 	public function set_object_terms( $object_id, $terms, $tt_ids, $taxonomy ) {

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -18,14 +18,14 @@ class PLL_CRUD_Posts {
 	/**
 	 * Preferred language to assign to a new post.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	protected $pref_lang;
 
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	protected $curlang;
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -18,28 +18,28 @@ class PLL_CRUD_Terms {
 	/**
 	 * Current language (used to filter the content).
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 
 	/**
 	 * Language selected in the admin language filter.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $filter_lang;
 
 	/**
 	 * Preferred language to assign to new contents.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $pref_lang;
 
 	/**
 	 * Stores the 'lang' query var from WP_Query.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	private $tax_query_lang;
 

--- a/include/db-tools.php
+++ b/include/db-tools.php
@@ -3,7 +3,7 @@
  * @package Polylang
  */
 
-defined( 'ABSPATH' ) || exit; // @phpstan-ignore-line
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Small set of tools to work with the database.

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -29,14 +29,14 @@ class PLL_Filters_Links {
 	public $links_model;
 
 	/**
-	 * @var PLL_Links
+	 * @var PLL_Links|null
 	 */
 	public $links;
 
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/include/filters.php
+++ b/include/filters.php
@@ -31,7 +31,7 @@ class PLL_Filters {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	public $curlang;
 

--- a/include/language.php
+++ b/include/language.php
@@ -90,35 +90,35 @@ class PLL_Language {
 	/**
 	 * W3C locale.
 	 *
-	 * @var string.
+	 * @var string
 	 */
 	public $w3c;
 
 	/**
 	 * Facebook locale.
 	 *
-	 * @var string.
+	 * @var string|null
 	 */
 	public $facebook;
 
 	/**
 	 * Home url in this language.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $home_url;
 
 	/**
 	 * Home url to use in search forms.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $search_url;
 
 	/**
 	 * Host corresponding to this language.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $host;
 
@@ -132,14 +132,14 @@ class PLL_Language {
 	/**
 	 * Id of the page on front in this language ( set from pll_languages_list filter ).
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	public $page_on_front;
 
 	/**
 	 * Id of the page for posts in this language ( set from pll_languages_list filter ).
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	public $page_for_posts;
 
@@ -153,28 +153,28 @@ class PLL_Language {
 	/**
 	 * Url of the flag.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $flag_url;
 
 	/**
 	 * Html markup of the flag.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $flag;
 
 	/**
 	 * Url of the custom flag if it exists.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $custom_flag_url;
 
 	/**
 	 * Html markup of the custom flag if it exists.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $custom_flag;
 

--- a/include/license.php
+++ b/include/license.php
@@ -33,7 +33,7 @@ class PLL_License {
 	/**
 	 * License data, obtained from the API request.
 	 *
-	 * @var stdClass
+	 * @var stdClass|null
 	 */
 	public $license_data;
 

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -24,9 +24,9 @@ class PLL_Links_Default extends PLL_Links_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string       $url  The url to modify.
-	 * @param PLL_Language $lang The language object.
-	 * @return string Modified url.
+	 * @param string             $url  The url to modify.
+	 * @param PLL_Language|false $lang The language object.
+	 * @return string                  Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		return empty( $lang ) || ( $this->options['hide_default'] && $this->options['default_lang'] == $lang->slug ) ? $url : add_query_arg( 'lang', $lang->slug, $url );

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -61,9 +61,9 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string       $url  The url to modify.
-	 * @param PLL_Language $lang The language object.
-	 * @return string Modified url.
+	 * @param string             $url  The url to modify.
+	 * @param PLL_Language|false $lang The language object.
+	 * @return string                  Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {

--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -42,9 +42,9 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string       $url  The url to modify.
-	 * @param PLL_Language $lang The language object.
-	 * @return string Modified url.
+	 * @param string             $url  The url to modify.
+	 * @param PLL_Language|false $lang The language object.
+	 * @return string                  Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) && ! empty( $this->hosts[ $lang->slug ] ) ) {

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -60,9 +60,9 @@ abstract class PLL_Links_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string       $url  The url to modify.
-	 * @param PLL_Language $lang The language object.
-	 * @return string Modified url.
+	 * @param string             $url  The url to modify.
+	 * @param PLL_Language|false $lang The language object.
+	 * @return string                  Modified url.
 	 */
 	abstract public function add_language_to_link( $url, $lang );
 

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -37,9 +37,9 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string       $url  The url to modify.
-	 * @param PLL_Language $lang The language object.
-	 * @return string Modified url.
+	 * @param string             $url  The url to modify.
+	 * @param PLL_Language|false $lang The language object.
+	 * @return string                  Modified url.
 	 */
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) && false === strpos( $url, '://' . $lang->slug . '.' ) ) {

--- a/include/model.php
+++ b/include/model.php
@@ -217,9 +217,9 @@ class PLL_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string[]     $clauses The list of sql clauses in terms query.
-	 * @param PLL_Language $lang    PLL_Language object.
-	 * @return string[] Modified list of clauses.
+	 * @param string[]           $clauses The list of sql clauses in terms query.
+	 * @param PLL_Language|false $lang    PLL_Language object.
+	 * @return string[]                   Modified list of clauses.
 	 */
 	public function terms_clauses( $clauses, $lang ) {
 		if ( ! empty( $lang ) && false === strpos( $clauses['join'], 'pll_tr' ) ) {

--- a/include/model.php
+++ b/include/model.php
@@ -688,7 +688,7 @@ class PLL_Model {
 				SELECT object_id FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN (%s)
 			)
 			%s",
-			implode( "','", array_map( 'esc_sql', $taxonomies ) ),
+			implode( "','", esc_sql( $taxonomies ) ),
 			implode( ',', array_map( 'intval', $this->get_languages_list( array( 'fields' => 'tl_term_taxonomy_id' ) ) ) ),
 			$limit > 0 ? sprintf( 'LIMIT %d', intval( $limit ) ) : ''
 		);

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -16,7 +16,7 @@ class PLL_OLT_Manager {
 	/**
 	 * Singleton instance
 	 *
-	 * @var PLL_OLT_Manager
+	 * @var PLL_OLT_Manager|null
 	 */
 	protected static $instance;
 

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -23,7 +23,7 @@ class PLL_OLT_Manager {
 	/**
 	 * Stores the default site locale before it is modified.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $default_locale;
 

--- a/include/query.php
+++ b/include/query.php
@@ -92,7 +92,7 @@ class PLL_Query {
 	 * @return array queried taxonomies
 	 */
 	public function get_queried_taxonomies() {
-		return isset( $this->query->tax_query->queried_terms ) ? array_keys( wp_list_filter( $this->query->tax_query->queried_terms, array( 'operator' => 'NOT IN' ), 'NOT' ) ) : array();
+		return ! empty( $this->query->tax_query->queried_terms ) ? array_keys( wp_list_filter( $this->query->tax_query->queried_terms, array( 'operator' => 'NOT IN' ), 'NOT' ) ) : array();
 	}
 
 	/**
@@ -137,7 +137,7 @@ class PLL_Query {
 	 *
 	 * @since 2.2
 	 *
-	 * @param PLL_Language $lang Language.
+	 * @param PLL_Language|false $lang Language.
 	 * @return void
 	 */
 	public function filter_query( $lang ) {

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -12,14 +12,14 @@ class PLL_Static_Pages {
 	/**
 	 * Id of the page on front.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	public $page_on_front;
 
 	/**
 	 * Id of the page for posts.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	public $page_for_posts;
 
@@ -38,7 +38,7 @@ class PLL_Static_Pages {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	protected $curlang;
 

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -27,7 +27,7 @@ class PLL_Switcher {
 	);
 
 	/**
-	 * @var PLL_Links
+	 * @var PLL_Links|null
 	 */
 	protected $links;
 

--- a/install/t15s.php
+++ b/install/t15s.php
@@ -35,14 +35,14 @@ class PLL_T15S {
 	/**
 	 * Installed translations.
 	 *
-	 * @var array
+	 * @var array|null
 	 */
 	private static $installed_translations;
 
 	/**
 	 * Available languages.
 	 *
-	 * @var array
+	 * @var array|null
 	 */
 	private static $available_languages;
 

--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -14,7 +14,7 @@ class PLL_Integrations {
 	/**
 	 * Singleton instance.
 	 *
-	 * @var PLL_Integrations
+	 * @var PLL_Integrations|null
 	 */
 	protected static $instance;
 

--- a/integrations/wp-offload-media/as3cf.php
+++ b/integrations/wp-offload-media/as3cf.php
@@ -15,7 +15,7 @@ class PLL_AS3CF {
 	 *
 	 * @var bool[]
 	 */
-	private $is_media_translated;
+	private $is_media_translated = array();
 
 	/**
 	 * Initializes filters and actions.

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -25,7 +25,7 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @since 2.8
 	 *
-	 * @var PLL_Admin_Static_Pages
+	 * @var PLL_Admin_Static_Pages|null
 	 */
 	protected $static_pages;
 

--- a/modules/sync/sync-metas.php
+++ b/modules/sync/sync-metas.php
@@ -26,14 +26,14 @@ abstract class PLL_Sync_Metas {
 	 *
 	 * @var array
 	 */
-	protected $prev_value;
+	protected $prev_value = array();
 
 	/**
 	 * Stores the metas to synchronize before deleting them.
 	 *
 	 * @var array
 	 */
-	protected $to_copy;
+	protected $to_copy = array();
 
 	/**
 	 * Constructor

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -39,7 +39,7 @@ class PLL_Wizard {
 	/**
 	 * The current step.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $step;
 

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -15,7 +15,7 @@ class PLL_WPML_API {
 	/**
 	 * Stores the original language when the language is switched.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	private static $original_language = null;
 

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -14,7 +14,7 @@ class PLL_WPML_Compat {
 	/**
 	 * Singleton instance
 	 *
-	 * @var PLL_WPML_Compat
+	 * @var PLL_WPML_Compat|null
 	 */
 	protected static $instance;
 

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -21,14 +21,14 @@ class PLL_WPML_Config {
 	/**
 	 * The content of all read xml files.
 	 *
-	 * @var SimpleXMLElement[]
+	 * @var SimpleXMLElement[]|null
 	 */
 	protected $xmls;
 
 	/**
 	 * The list of xml files.
 	 *
-	 * @var string[]
+	 * @var string[]|null
 	 */
 	protected $files;
 

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -14,7 +14,7 @@ class PLL_WPML_Config {
 	/**
 	 * Singleton instance
 	 *
-	 * @var PLL_WPML_Config
+	 * @var PLL_WPML_Config|null
 	 */
 	protected static $instance;
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -62,3 +62,21 @@ parameters:
 			message: "#^Parameter \\#1 \\$args of function wp_tag_cloud expects (.+) given\\.$#"
 			count: 1
 			path: admin/admin-filters-term.php
+
+		# Ignored because WP_Query->tax_query can be falsy: it is set in WP_Query->parse_tax_query(), which is not called in the constructor.
+		- "#^Property WP_Query::\\$tax_query \\(WP_Tax_Query\\) in empty\\(\\) is not falsy\\.$#"
+
+		# Ignored because WP_Query->queried_object_id can be null.
+		- "#^Property WP_Query::\\$queried_object_id \\(int\\) in isset\\(\\) is not nullable\\.$#"
+
+		# Ignored because get_settings_errors() can be falsy (can return an empty array).
+		-
+			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: settings/settings-module.php
+
+		# Ignored because get_settings_errors() can be falsy (can return an empty array).
+		-
+			message: "#^Variable \\$errors in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: settings/settings.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,7 @@ parameters:
 		- install/
 		- modules/
 		- settings/
-	excludes_analyse:
+	excludePaths:
 		- **/load.php
 		- **/view*.php
 		- include/widget-calendar.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,7 +18,6 @@ parameters:
 	checkMissingIterableValueType: false
 	ignoreErrors:
 		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
-		- '#^Function vip_safe_wp_remote_get not found\.$#'
 		- '#^Parameter \#1 \$message of function wp_die expects string|WP_Error, int given\.$#'
 
 		# Temporarily ignored
@@ -39,23 +38,11 @@ parameters:
 			count: 1
 			path: include/api.php
 
-		# False positive?
-		-
-			message: "#^Function wpcom_vip_get_page_by_path\\(\\) never returns array so it can be removed from the return typehint\\.$#"
-			count: 1
-			path: include/functions.php
-
 		# Ignored because of https://wordpress.org/support/topic/detect-browser-language-sometimes-setting-null-language
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: frontend/choose-lang.php
-
-		# Ignored due to a wrong doc of wp_tag_cloud()
-		-
-			message: "#^Parameter \\#1 \\$args of function wp_tag_cloud expects (.+) given\\.$#"
-			count: 1
-			path: admin/admin-filters-term.php
 
 		# Ignored because WP_Query->tax_query can be falsy: it is set in WP_Query->parse_tax_query(), which is not called in the constructor.
 		- "#^Property WP_Query::\\$tax_query \\(WP_Tax_Query\\) in empty\\(\\) is not falsy\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -51,12 +51,6 @@ parameters:
 			count: 1
 			path: frontend/choose-lang.php
 
-		# Temporarily ignored
-		-
-			message: "#^Parameter \\#2 \\$input1 of function array_map expects array, string given\\.$#"
-			count: 1
-			path: settings/table-string.php
-
 		# Ignored due to a wrong doc of wp_tag_cloud()
 		-
 			message: "#^Parameter \\#1 \\$args of function wp_tag_cloud expects (.+) given\\.$#"

--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -24,7 +24,6 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
-		$this->options = &$polylang->options;
 		parent::__construct(
 			$polylang,
 			array(

--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -24,6 +24,9 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 	 * @param object $polylang polylang object
 	 */
 	public function __construct( &$polylang ) {
+		// Needed for `$this->is_available()`, which is used before calling the parent's constructor.
+		$this->options = &$polylang->options;
+
 		parent::__construct(
 			$polylang,
 			array(

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -46,7 +46,7 @@ class PLL_Settings_Module {
 	 * Stores the module name.
 	 * It must be unique.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $module;
 

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -19,7 +19,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	/**
 	 * The page id of the static front page.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	protected $page_on_front;
 

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -18,14 +18,14 @@ class PLL_Settings extends PLL_Admin_Base {
 	/**
 	 * Name of the active module.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $active_tab;
 
 	/**
 	 * Array of modules classes.
 	 *
-	 * @var PLL_Settings_Module[]
+	 * @var PLL_Settings_Module[]|null
 	 */
 	protected $modules;
 

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -382,7 +382,7 @@ class PLL_Table_String extends WP_List_Table {
 					continue;
 				}
 
-				$translations = array_map( 'trim', wp_unslash( $_POST['translation'][ $language->slug ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				$translations = array_map( 'trim', (array) wp_unslash( $_POST['translation'][ $language->slug ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 				$mo = new PLL_MO();
 				$mo->import_from_db( $language );

--- a/tests/phpunit/tests/test-settings-browser.php
+++ b/tests/phpunit/tests/test-settings-browser.php
@@ -10,13 +10,13 @@ class Settings_Browser_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_active_true() {
-		$this->pll_env->options['browser'] = 1;
+		self::$model->options['browser'] = 1;
 		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertTrue( $module->is_active() );
 	}
 
 	public function test_active_false() {
-		$this->pll_env->options['browser'] = 0;
+		self::$model->options['browser'] = 0;
 		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertFalse( $module->is_active() );
 	}

--- a/tests/phpunit/tests/test-settings-browser.php
+++ b/tests/phpunit/tests/test-settings-browser.php
@@ -10,13 +10,13 @@ class Settings_Browser_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_active_true() {
-		self::$model->options['browser'] = 1;
+		$this->pll_env->options['browser'] = 1;
 		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertTrue( $module->is_active() );
 	}
 
 	public function test_active_false() {
-		self::$model->options['browser'] = 0;
+		$this->pll_env->options['browser'] = 0;
 		$module = new PLL_Settings_Browser( $this->pll_env );
 		$this->assertFalse( $module->is_active() );
 	}


### PR DESCRIPTION
## Update to a newer version of PHPStan
We depend on szepeviktor/phpstan-wordpress to run our PHPStan tests, which bring latest version of PHPStan in v1.0.5. This leads to several errors reported in our code.

## List of errors to fix

 ------ ------------------------------------------------------------------------------- 
  Line   admin/admin-base.php                                                           
 ------ ------------------------------------------------------------------------------- 
   - [x] 362    Property PLL_Admin_Base::$curlang (PLL_Language) in empty() is not falsy.      
  - [x] 410    Property PLL_Admin_Base::$filter_lang (PLL_Language) in empty() is not falsy.  
  - [x] 462    Property PLL_Admin_Base::$filter_lang (PLL_Language) in empty() is not falsy.  
 ------ ------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------- 
  Line   admin/admin-default-term.php                                                            
 ------ ---------------------------------------------------------------------------------------- 
  - [x] 91     Property PLL_Admin_Default_Term::$pref_lang (PLL_Language) in isset() is not nullable.  
 ------ ---------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------ 
  Line   admin/admin-filters-columns.php                                                           
 ------ ------------------------------------------------------------------------------------------ 
  - [x] 116    Property PLL_Admin_Filters_Columns::$filter_lang (PLL_Language) in empty() is not falsy.  
 ------ ------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------- 
  Line   admin/admin-filters-post-base.php                                         
 ------ -------------------------------------------------------------------------- 
  - [x] 39     Access to an undefined property PLL_Admin_Filters_Post_Base::$pref_lang.  
 ------ -------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   admin/admin-filters-post.php                                                       
 ------ ----------------------------------------------------------------------------------- 
  - [x] 207    Property PLL_Admin_Filters_Post::$curlang (PLL_Language) in empty() is not falsy.  
 ------ ----------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------ 
  Line   admin/admin-filters-term.php                                                                          
 ------ ------------------------------------------------------------------------------------------------------ 
  - [x]      Ignored error pattern ^Parameter \number 1 \$args of function wp_tag_cloud expects (.+) given\.$ in path  
         /Users/hugodrelon/WPSyntex/polylang/admin/admin-filters-term.php was not matched in reported errors.  
 ------ ------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------ 
  Line   admin/admin-filters.php                                                 
 ------ ------------------------------------------------------------------------ 
  - [x] 101    Property PLL_Filters::$curlang (PLL_Language) in empty() is not falsy.  
 ------ ------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------- 
  Line   admin/admin.php                                                            
 ------ --------------------------------------------------------------------------- 
  - [x] 174    Property PLL_Admin_Base::$curlang (PLL_Language) in empty() is not falsy.  
 ------ --------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------- 
  Line   frontend/choose-lang-content.php                                            
 ------ ---------------------------------------------------------------------------- 
  - [x] 135    Property PLL_Choose_Lang::$curlang (PLL_Language) in empty() is not falsy.  
  - [x] 135    Result of && is always false.                                               
 ------ ---------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   frontend/choose-lang-url.php                                                   
 ------ ------------------------------------------------------------------------------- 
  - [x] 112    Property PLL_Choose_Lang::$curlang (PLL_Language) in isset() is not nullable.  
 ------ ------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   frontend/choose-lang.php                                                                                          
 ------ ------------------------------------------------------------------------------------------------------------------ 
  - [x]      Ignored error pattern ^Else branch is unreachable because ternary operator condition is always true\.$ in path  
         /Users/hugodrelon/WPSyntex/polylang/frontend/choose-lang.php was not matched in reported errors.                  
  - [x] 40     Property PLL_Choose_Lang::$lang_parse is unused.                                                                  
         💡 See: https://phpstan.org/developing-extensions/always-read-written-properties                                   
  - [x] 44     Property PLL_Choose_Lang::$accept_langs is unused.                                                                
         💡 See: https://phpstan.org/developing-extensions/always-read-written-properties                                   
  - [x] 91     Property PLL_Choose_Lang::$curlang (PLL_Language) in isset() is not nullable.                                     
  - [x] 97     Unreachable statement - code above always terminates.                                                             
  - [x] 125    Property PLL_Choose_Lang::$curlang (PLL_Language) in empty() is not falsy.                                        
 ------ ------------------------------------------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------- 
  Line   frontend/frontend-auto-translate.php                                   
 ------ ----------------------------------------------------------------------- 
  - [ ] 186    Parameter 2 $pieces of function implode expects array, string given.  
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------- 
  Line   frontend/frontend-filters-links.php                                                                              
 ------ ----------------------------------------------------------------------------------------------------------------- 
  - [x] 327    Offset 'function' on array{function: string, line?: int, file?: string, class?: class-string, type?: '->'|'::',  
         args?: array, object?: object} in isset() always exists and is not nullable.                                     
  - [x] 333    Offset 'function' on array{function: string, line?: int, file?: string, class?: class-string, type?: '->'|'::',  
         args?: array, object?: object} in isset() always exists and is not nullable.                                     
  - [x] 422    Property WP_Query::$tax_query (WP_Tax_Query) in empty() is not falsy.                                            
 ------ ----------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------ 
  Line   frontend/frontend-filters.php                                           
 ------ ------------------------------------------------------------------------ 
  - [x] 75     Property PLL_Filters::$curlang (PLL_Language) in empty() is not falsy.  
 ------ ------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------- 
  Line   frontend/frontend-links.php                                  
 ------ ------------------------------------------------------------- 
  - [x] 177    Variable $url in isset() always exists and is not nullable.  
 ------ ------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------- 
  Line   frontend/frontend-nav-menu.php                                                    
 ------ ---------------------------------------------------------------------------------- 
  - [x] 233    Property PLL_Frontend_Nav_Menu::$curlang (PLL_Language) in empty() is not falsy.  
  - [x] 271    Property PLL_Frontend_Nav_Menu::$curlang (PLL_Language) in empty() is not falsy.  
  - [x] 316    Property PLL_Frontend_Nav_Menu::$curlang (PLL_Language) in empty() is not falsy.  
 ------ ---------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   frontend/frontend-static-pages.php                                       
 ------ ------------------------------------------------------------------------- 
  - [x] 93     Property PLL_Language::$page_on_front (int) in isset() is not nullable.  
  - [x] 274    Property WP_Query::$queried_object_id (int) in isset() is not nullable.  
 ------ ------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   frontend/frontend.php                                                                         
 ------ ---------------------------------------------------------------------------------------------- 
  - [x] 168    Property PLL_Frontend::$curlang (PLL_Language) in empty() is not falsy.                       
  - [x] 231    Property PLL_Frontend::$static_pages (PLL_Frontend_Static_Pages) in isset() is not nullable.  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------- 
  Line   include/crud-posts.php                                                          
 ------ -------------------------------------------------------------------------------- 
  - [x] 70     Property PLL_CRUD_Posts::$pref_lang (PLL_Language) in isset() is not nullable.  
  - [x] 70     Result of && is always false.                                                   
  - [x] 70     Result of && is always false.                                                   
  - [x] 75     Property PLL_CRUD_Posts::$pref_lang (PLL_Language) in isset() is not nullable.  
  - [x] 141    Variable $strings in empty() always exists and is always falsy.                 
 ------ -------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------- 
  Line   include/crud-terms.php                                                          
 ------ -------------------------------------------------------------------------------- 
  - [x] 86     Property PLL_CRUD_Terms::$pref_lang (PLL_Language) in isset() is not nullable.  
  - [x] 86     Result of && is always false.                                                   
  - [x] 86     Result of && is always false.                                                   
  - [x] 92     Property PLL_CRUD_Terms::$pref_lang (PLL_Language) in isset() is not nullable.  
  - [x] 182    Property PLL_CRUD_Terms::$tax_query_lang (string) in isset() is not nullable.   
  - [x] 183    Property PLL_CRUD_Terms::$curlang (PLL_Language) in empty() is not falsy.       
 ------ -------------------------------------------------------------------------------- 

 ------ ------------------------------------------- 
  Line   include/db-tools.php                       
 ------ ------------------------------------------- 
  - [x] 6      No error to ignore is reported on line 6.  
 ------ ------------------------------------------- 

 ------ ------------------------------------------------------------------------ 
  Line   include/filters.php                                                     
 ------ ------------------------------------------------------------------------ 
  - [x] 129    Property PLL_Filters::$curlang (PLL_Language) in empty() is not falsy.  
  - [x] 133    Unreachable statement - code above always terminates.                   
  - [x] 281    Property PLL_Filters::$curlang (PLL_Language) in empty() is not falsy.  
  - [x] 297    Property PLL_Filters::$curlang (PLL_Language) in empty() is not falsy.  
  - [x] 340    Property PLL_Filters::$curlang (PLL_Language) in empty() is not falsy.  
 ------ ------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------- 
  Line   include/functions.php                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------- 
  - [x]      Ignored error pattern ^Function wpcom_vip_get_page_by_path\(\) never returns array so it can be removed from the  
         return typehint\.$ in path /Users/hugodrelon/WPSyntex/polylang/include/functions.php was not matched in reported  
         errors.                                                                                                            
 ------ ------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   include/license.php                                                      
 ------ ------------------------------------------------------------------------- 
  - [x] 245    Property PLL_License::$license_data (stdClass) in empty() is not falsy.  
  - [x] 260    Result of && is always true.                                             
  - [x] 260    Variable $license in empty() always exists and is not falsy.             
 ------ ------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------- 
  Line   include/links-default.php                                  
 ------ ----------------------------------------------------------- 
  - [x] 32     Variable $lang in empty() always exists and is not falsy.  
 ------ ----------------------------------------------------------- 

 ------ ----------------------------------------------------------- 
  Line   include/links-directory.php                                
 ------ ----------------------------------------------------------- 
  - [x] 69     Variable $lang in empty() always exists and is not falsy.  
 ------ ----------------------------------------------------------- 

 ------ ----------------------------------------------------------- 
  Line   include/links-domain.php                                   
 ------ ----------------------------------------------------------- 
  - [x] 50     Variable $lang in empty() always exists and is not falsy.  
 ------ ----------------------------------------------------------- 

 ------ ----------------------------------------------------------- 
  Line   include/links-subdomain.php                                
 ------ ----------------------------------------------------------- 
  - [x] 45     Variable $lang in empty() always exists and is not falsy.  
 ------ ----------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   include/model.php                                                                          
 ------ ------------------------------------------------------------------------------------------- 
  - [x] 225    Variable $lang in empty() always exists and is not falsy.                                  
  - [ ] 518    Parameter 2 $pieces of function implode expects array, string given.                      
  - [x] 691    Parameter 2 $array of function implode expects array<string>, array<array|string> given.  
 ------ ------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   include/olt-manager.php                                                                
 ------ --------------------------------------------------------------------------------------- 
  - [x] 80     Static property PLL_OLT_Manager::$instance (PLL_OLT_Manager) in empty() is not falsy.  
 ------ --------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------- 
  Line   include/query.php                                                          
 ------ --------------------------------------------------------------------------- 
  - [x] 95     Property WP_Tax_Query::$queried_terms (array) in isset() is not nullable.  
  - [x] 161    Variable $lang in empty() always exists and is not falsy.                  
 ------ --------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   include/static-pages.php                                                  
 ------ -------------------------------------------------------------------------- 
  - [x] 139    Property PLL_Language::$page_for_posts (int) in isset() is not nullable.  
 ------ -------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   modules/wpml/wpml-compat.php                                                           
 ------ --------------------------------------------------------------------------------------- 
  - [x] 58     Static property PLL_WPML_Compat::$instance (PLL_WPML_Compat) in empty() is not falsy.  
 ------ --------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   modules/wpml/wpml-config.php                                                           
 ------ --------------------------------------------------------------------------------------- 
  - [x] 54     Static property PLL_WPML_Config::$instance (PLL_WPML_Config) in empty() is not falsy.  
 ------ --------------------------------------------------------------------------------------- 

 ------ ------------------------------------- 
  Line   settings/settings-module.php         
 ------ ------------------------------------- 
  - [x] 257    Expression in empty() is not falsy.  
 ------ ------------------------------------- 

 ------ ------------------------------------------------------------- 
  Line   settings/settings.php                                        
 ------ ------------------------------------------------------------- 
  - [x] 368    Variable $errors in empty() always exists and is not falsy.  
 ------ ------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------- 
  Line   settings/table-string.php                                                                                     
 ------ -------------------------------------------------------------------------------------------------------------- 
  - [x]      Ignored error pattern ^Parameter \2 \$input1 of function array_map expects array, string given\.$ in path  
         /Users/hugodrelon/WPSyntex/polylang/settings/table-string.php was not matched in reported errors.             
  - [x] 385    Parameter 2 $array of function array_map expects array, string given.                                        
 ------ -------------------------------------------------------------------------------------------------------------- 

 -- ----------------------------------------------------------------------------------------------------------- 
     Error                                                                                                      
 -- ----------------------------------------------------------------------------------------------------------- 
  - [x]   Ignored error pattern ^Function vip_safe_wp_remote_get not found\.$ was not matched in reported errors.  
 -- ----------------------------------------------------------------------------------------------------------- 