### PR TITLE
Avoid redirection in secondary language for terms request in permalinks

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -395,7 +395,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		elseif ( is_category() || is_tag() || is_tax() ) {
 			if ( $this->model->is_translated_taxonomy( $this->get_queried_taxonomy( $this->wp_query()->tax_query ) ) ) {
-				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) ) ) {
+				if ( $this->links_model->using_permalinks && ( ! empty( $this->wp_query()->query['cat'] ) || ! empty( $this->wp_query()->query['tag'] ) || ! empty( $this->wp_query()->query['category_name'] ) ) ) {
 					// When we receive a plain permalink with a cat or tag query var, we need to redirect to the pretty permalink.
 					$term_id = $this->get_queried_term_id( $this->wp_query()->tax_query );
 					if ( is_feed() ) {
@@ -518,6 +518,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		}
 		$field = $queried_terms[ $taxonomy ]['field'];
 		$term  = reset( $queried_terms[ $taxonomy ]['terms'] );
+		$lang  = isset( $queried_terms['language']['terms'] ) ? reset( $queried_terms['language']['terms'] ) : '';
 
 		// We can get a term_id when requesting a plain permalink, eg /?cat=1.
 		if ( 'term_id' === $field ) {
@@ -526,13 +527,21 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		// We get a slug when requesting a pretty permalink with the wrong language.
 		$args = array(
-			'lang' => '',
+			'lang' => $lang,
 			'taxonomy' => $taxonomy,
 			$field => $term,
 			'hide_empty' => false,
 			'fields' => 'ids',
 		);
 		$terms = get_terms( $args );
+
+		if ( empty( $terms ) ) {
+			// The queried language does not correspond to the queried term.
+			// So let's get only the querried term.
+			$args['lang'] = '';
+			$terms = get_terms( $args );
+		}
+
 		return reset( $terms );
 	}
 

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -535,9 +535,18 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		);
 		$terms = get_terms( $args );
 
-		$tr_term = $this->model->term->get_translation( reset( $terms ), $lang );
+		$filtered_terms_by_lang = array_filter(
+			$terms,
+			function( $term ) use( $lang ) {
+				$term_lang = $this->model->term->get_language( $term );
 
-		if ( $tr_term ) {
+				return $term_lang->slug === $lang;
+			}
+		);
+
+		$tr_term = reset( $filtered_terms_by_lang );
+
+		if ( ! empty( $tr_term ) ) {
 			// The queried term exists in the desired language.
 			return $tr_term;
 		}

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -540,7 +540,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			function ( $term ) use ( $lang ) {
 				$term_lang = $this->model->term->get_language( $term );
 
-				return $term_lang->slug === $lang;
+				return ! empty( $term_lang ) && $term_lang->slug === $lang;
 			}
 		);
 

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -537,7 +537,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 
 		$filtered_terms_by_lang = array_filter(
 			$terms,
-			function( $term ) use( $lang ) {
+			function ( $term ) use ( $lang ) {
 				$term_lang = $this->model->term->get_language( $term );
 
 				return $term_lang->slug === $lang;

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -525,9 +525,9 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			return $term;
 		}
 
-		// We get a slug when requesting a pretty permalink with the wrong language.
+		// We get a slug when requesting a pretty permalink. Let's query all corresponding terms.
 		$args = array(
-			'lang' => $lang,
+			'lang' => '',
 			'taxonomy' => $taxonomy,
 			$field => $term,
 			'hide_empty' => false,
@@ -535,13 +535,14 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		);
 		$terms = get_terms( $args );
 
-		if ( empty( $terms ) ) {
-			// The queried language does not correspond to the queried term.
-			// So let's get only the querried term.
-			$args['lang'] = '';
-			$terms = get_terms( $args );
+		$tr_term = $this->model->term->get_translation( reset( $terms ), $lang );
+
+		if ( $tr_term ) {
+			// The queried term exists in the desired language.
+			return $tr_term;
 		}
 
+		// The queried term doesn't exist in the desired language, let's return the first one retrieved.
 		return reset( $terms );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1336

## Problem
- A redirection is made when a request is made on a term in a secondary language toward the default one.
- `PLL_Frontend_Filters_Links::get_queried_term_id()` seems to always return the term in default language when called in `check_canonical_url()`. See: https://github.com/polylang/polylang/blob/2abf0174d98ca97a668cc0e17e55be95ccc47a6e/frontend/frontend-filters-links.php#L400
- Later when retrieving the term link, it returns the wrong redirect link. See: https://github.com/polylang/polylang/blob/2abf0174d98ca97a668cc0e17e55be95ccc47a6e/frontend/frontend-filters-links.php#L404

## Changes
- In `PLL_Frontend_Filters_Links::get_queried_term_id()`, get the terms with the `lang` parameter set.
- If no term is returned, then the queried language might be the wrong one.
- In this case, get the terms with no language set and return it.