### PR TITLE
Disable language dropdown for default categories in quick edit form

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -301,7 +301,7 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		if ( $column == $this->get_first_language_column() ) {
-			$out = sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );
+			$out .= sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );
 		}
 
 		// Link to edit term ( or a translation )

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -273,4 +273,27 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $options->item( 1 )->getAttribute( 'value' ) );
 		$this->assertEquals( 'fr', $options->item( 2 )->getAttribute( 'value' ) );
 	}
+
+	public function test_custom_term_column_for_default_category() {
+		$GLOBALS['taxonomy']     = 'category';
+		$GLOBALS['post_type']    = 'post';
+		$out                     = '';
+		$column                  = 'language_en';
+		$default_cat_id          = get_option( 'default_category' );
+		self::$model->term->set_language( $default_cat_id, 'en' );
+		$admin_default_term = new PLL_Admin_Default_Term( $this->pll_admin );
+		$admin_default_term->add_hooks();
+		$column = apply_filters( 'manage_category_custom_column', $out, $column, $default_cat_id );
+
+		$this->assertNotEmpty( $column, 'The generated language column should not be empty.' );
+
+		$doc = new DomDocument();
+		$doc->loadHTML( $column, LIBXML_NOERROR );
+		$xpath = new DOMXpath( $doc );
+
+		$def_cat = $xpath->query( "//div[@id=\"default_cat_{$default_cat_id}\"]" );
+		$this->assertSame( 1, $def_cat->length, 'Only one element with the default category ID should be rendered.' );
+		$def_cat_class_attr = $def_cat->item( 0 )->getAttribute( 'class' );
+		$this->assertSame( 'hidden', $def_cat_class_attr, 'The element of the default category should be hidden.' );
+	}
 }

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -275,25 +275,4 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $options->item( 1 )->getAttribute( 'value' ) );
 		$this->assertEquals( 'fr', $options->item( 2 )->getAttribute( 'value' ) );
 	}
-
-	public function test_custom_term_column_for_default_category() {
-		$GLOBALS['taxonomy']     = 'category';
-		$GLOBALS['post_type']    = 'post';
-		$out                     = '';
-		$column                  = 'language_en';
-		$default_cat_id          = get_option( 'default_category' );
-		self::$model->term->set_language( $default_cat_id, 'en' );
-		$column = apply_filters( 'manage_category_custom_column', $out, $column, $default_cat_id );
-
-		$this->assertNotEmpty( $column, 'The generated language column should not be empty.' );
-
-		$doc = new DomDocument();
-		$doc->loadHTML( $column );
-		$xpath = new DOMXpath( $doc );
-
-		$def_cat = $xpath->query( "//div[@id=\"default_cat_{$default_cat_id}\"]" );
-		$this->assertSame( 1, $def_cat->length, 'Only one element with the default category ID should be rendered.' );
-		$def_cat_class_attr = $def_cat->item( 0 )->getAttribute( 'class' );
-		$this->assertSame( 'hidden', $def_cat_class_attr, 'The element of the default category should be hidden.' );
-	}
 }

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -288,7 +288,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $column, 'The generated language column should not be empty.' );
 
 		$doc = new DomDocument();
-		$doc->loadHTML( $column, LIBXML_NOERROR );
+		$doc->loadHTML( $column );
 		$xpath = new DOMXpath( $doc );
 
 		$def_cat = $xpath->query( "//div[@id=\"default_cat_{$default_cat_id}\"]" );

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -21,10 +21,12 @@ class Columns_Test extends PLL_UnitTestCase {
 		// set a user to pass current_user_can tests
 		wp_set_current_user( self::$editor );
 
-		$links_model = self::$model->get_links_model();
+		$links_model     = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 
-		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
+		$this->pll_admin->links        = new PLL_Admin_Links( $this->pll_admin );
+		$this->pll_admin->default_term = new PLL_Admin_Default_Term( $this->pll_admin );
+		$this->pll_admin->default_term->add_hooks();
 		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
 	}
 
@@ -281,8 +283,6 @@ class Columns_Test extends PLL_UnitTestCase {
 		$column                  = 'language_en';
 		$default_cat_id          = get_option( 'default_category' );
 		self::$model->term->set_language( $default_cat_id, 'en' );
-		$admin_default_term = new PLL_Admin_Default_Term( $this->pll_admin );
-		$admin_default_term->add_hooks();
 		$column = apply_filters( 'manage_category_custom_column', $out, $column, $default_cat_id );
 
 		$this->assertNotEmpty( $column, 'The generated language column should not be empty.' );

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -31,10 +31,10 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$links_model     = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 
-		$this->pll_admin->filters_term    = new PLL_Admin_Filters_Term( $this->pll_admin );
-		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
+		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
 		$this->pll_admin->default_term = new PLL_Admin_Default_Term( $this->pll_admin );
 		$this->pll_admin->default_term->add_hooks();
+		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
 	}
 
 	protected function get_edit_term_form( $tag_ID, $taxonomy ) {
@@ -176,5 +176,26 @@ class Default_Term_Test extends PLL_UnitTestCase {
 
 		$this->assertEquals( 'es', $option_lang->slug );
 		$this->assertEquals( $option, $es_option );
+	}
+
+	public function test_custom_term_column_for_default_category() {
+		$GLOBALS['taxonomy']     = 'category';
+		$GLOBALS['post_type']    = 'post';
+		$out                     = '';
+		$column                  = 'language_en';
+		$default_cat_id          = get_option( 'default_category' );
+		self::$model->term->set_language( $default_cat_id, 'en' );
+		$column = apply_filters( 'manage_category_custom_column', $out, $column, $default_cat_id );
+
+		$this->assertNotEmpty( $column, 'The generated language column should not be empty.' );
+
+		$doc = new DomDocument();
+		$doc->loadHTML( $column );
+		$xpath = new DOMXpath( $doc );
+
+		$def_cat = $xpath->query( "//div[@id=\"default_cat_{$default_cat_id}\"]" );
+		$this->assertSame( 1, $def_cat->length, 'Only one element with the default category ID should be rendered.' );
+		$def_cat_class_attr = $def_cat->item( 0 )->getAttribute( 'class' );
+		$this->assertSame( 'hidden', $def_cat_class_attr, 'The element of the default category should be hidden.' );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1333

## Changes 
-  Both `PLL_Admin_Filters_Columns::term_column()` and `PLL_Admin_Default_Term::term_column()` are filtering `manage_category_custom_column`. But in `PLL_Admin_Filters_Columns` we do not use the passed `$out` variable and thus overriding  what's done in `PLL_Admin_Filters_Columns`. So we avoid that now by concatenating the strings. 
- Add a test for the `default_cat_{$term_id}` identifier.

## Test instructions
- Visit the quick edit in terms.
- Language dropdown should be disable for default terms.  