### PR TITLE
Fix array comparison in testcase-domain

### DIFF
--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -74,7 +74,7 @@ class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 
 	public function test_allowed_redirect_hosts() {
 		$hosts = str_replace( 'http://', '', array_values( $this->hosts ) );
-		$this->assertEquals( $hosts, $this->links_model->allowed_redirect_hosts( array() ) );
+		$this->assertSameSets( $hosts, $this->links_model->allowed_redirect_hosts( array() ) );
 		$this->assertEquals( $this->hosts['fr'], wp_validate_redirect( $this->hosts['fr'] ) );
 	}
 


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/1308.

Using `assertEquals()` to compare arrays seems to fail randomly with PHP 8.0 + WP 6.0.
This fixes this issue by using `assertSameSets()`.