### PR TITLE
Add a term group when creating languages in tests.

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -69,7 +69,7 @@ trait PLL_UnitTestCase_Trait {
 
 		$values['slug'] = $values['code'];
 		$values['rtl'] = (int) ( 'rtl' === $values['dir'] );
-		$values['term_group'] = 0; // Default term_group.
+		$values['term_group'] = count( self::$model->get_languages_list() );
 
 		$args = array_merge( $values, $args );
 


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/1308.

Since WP 6.0, when retrieving the languages (in the tests), this languages's list is randomly not retrieved in the expected order.

By setting an ascending `term_group` in the language creation method, it will always be retrieved in the expected order. 