### PR TITLE
Avoid to redirect if the queried object is defined not to use WordPress rewriting feature

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -390,16 +390,16 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
 		 */
 		$obj = get_queried_object();
-		if ( ! empty( $obj  ) ) {
+		if ( ! empty( $obj ) ) {
 			if ( $obj instanceof WP_Post ) {
 				$post_type = get_post_type_object( $obj->post_type );
-				if ( ! empty( $post_type ) && false === $post_type->rewrite  ) {
+				if ( ! empty( $post_type ) && false === $post_type->rewrite ) {
 					return;
 				}
 			}
 			if ( $obj instanceof WP_Term ) {
 				$taxonomy = get_taxonomy( $obj->taxonomy );
-				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite  ) {
+				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite ) {
 					return;
 				}
 			}

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -382,6 +382,27 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			return;
 		}
 
+		/*
+		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
+		 */
+		$obj = get_queried_object();
+		if ( ! empty( $obj ) ) {
+			if ( $obj instanceof WP_Post ) {
+				if ( 'post' !== $obj->post_type && 'page' !== $obj->post_type ) {
+					$post_type = get_post_type_object( $obj->post_type );
+					if ( ! empty( $post_type ) && false === $post_type->rewrite ) {
+						return;
+					}
+				}
+			}
+			if ( $obj instanceof WP_Term ) {
+				$taxonomy = get_taxonomy( $obj->taxonomy );
+				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite ) {
+					return;
+				}
+			}
+		}
+
 		if ( empty( $requested_url ) ) {
 			$requested_url = pll_get_requested_url();
 		}
@@ -471,25 +492,6 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		 * @param PLL_Language $language The language detected.
 		 */
 		$redirect_url = apply_filters( 'pll_check_canonical_url', $redirect_url, $language );
-
-		/*
-		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
-		 */
-		$obj = get_queried_object();
-		if ( ! empty( $obj ) ) {
-			if ( $obj instanceof WP_Post ) {
-				$post_type = get_post_type_object( $obj->post_type );
-				if ( ! empty( $post_type ) && false === $post_type->rewrite ) {
-					return $redirect_url;
-				}
-			}
-			if ( $obj instanceof WP_Term ) {
-				$taxonomy = get_taxonomy( $obj->taxonomy );
-				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite ) {
-					return $redirect_url;
-				}
-			}
-		}
 
 		// The language is not correctly set so let's redirect to the correct url for this object
 		if ( $do_redirect ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -390,7 +390,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
 		 */
 		$obj = get_queried_object();
-		if ( ! empty( $obj ) ) {
+		if ( ! empty( $obj ) && $do_redirect ) {
 			if ( $obj instanceof WP_Post ) {
 				$post_type = get_post_type_object( $obj->post_type );
 				if ( ! empty( $post_type ) && false === $post_type->rewrite ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -386,6 +386,25 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			$requested_url = pll_get_requested_url();
 		}
 
+		/*
+		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
+		 */
+		$obj = get_queried_object();
+		if ( ! empty( $obj  ) ) {
+			if ( $obj instanceof WP_Post ) {
+				$post_type = get_post_type_object( $obj->post_type );
+				if ( ! empty( $post_type ) && false === $post_type->rewrite  ) {
+					return;
+				}
+			}
+			if ( $obj instanceof WP_Term ) {
+				$taxonomy = get_taxonomy( $obj->taxonomy );
+				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite  ) {
+					return;
+				}
+			}
+		}
+
 		if ( is_single() || is_page() ) {
 			$post = get_post();
 			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -386,25 +386,6 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			$requested_url = pll_get_requested_url();
 		}
 
-		/*
-		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
-		 */
-		$obj = get_queried_object();
-		if ( ! empty( $obj ) && $do_redirect ) {
-			if ( $obj instanceof WP_Post ) {
-				$post_type = get_post_type_object( $obj->post_type );
-				if ( ! empty( $post_type ) && false === $post_type->rewrite ) {
-					return;
-				}
-			}
-			if ( $obj instanceof WP_Term ) {
-				$taxonomy = get_taxonomy( $obj->taxonomy );
-				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite ) {
-					return;
-				}
-			}
-		}
-
 		if ( is_single() || is_page() ) {
 			$post = get_post();
 			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
@@ -490,6 +471,25 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		 * @param PLL_Language $language The language detected.
 		 */
 		$redirect_url = apply_filters( 'pll_check_canonical_url', $redirect_url, $language );
+
+		/*
+		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
+		 */
+		$obj = get_queried_object();
+		if ( ! empty( $obj ) ) {
+			if ( $obj instanceof WP_Post ) {
+				$post_type = get_post_type_object( $obj->post_type );
+				if ( ! empty( $post_type ) && false === $post_type->rewrite ) {
+					return $redirect_url;
+				}
+			}
+			if ( $obj instanceof WP_Term ) {
+				$taxonomy = get_taxonomy( $obj->taxonomy );
+				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite ) {
+					return $redirect_url;
+				}
+			}
+		}
 
 		// The language is not correctly set so let's redirect to the correct url for this object
 		if ( $do_redirect ) {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -361,7 +361,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 *
 	 * @param string $requested_url Optional, defaults to requested url.
 	 * @param bool   $do_redirect   Optional, whether to perform the redirect or not.
-	 * @return string|void Returns if redirect is not performed.
+	 * @return string|bool|void Returns if redirect is not performed.
 	 */
 	public function check_canonical_url( $requested_url = '', $do_redirect = true ) {
 		// Don't redirect in same cases as WP.

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -382,27 +382,6 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 			return;
 		}
 
-		/*
-		 * If the queried object is defined not to use rewriting feature, we shouldn't redirect.
-		 */
-		$obj = get_queried_object();
-		if ( ! empty( $obj ) ) {
-			if ( $obj instanceof WP_Post ) {
-				if ( 'post' !== $obj->post_type && 'page' !== $obj->post_type ) {
-					$post_type = get_post_type_object( $obj->post_type );
-					if ( ! empty( $post_type ) && false === $post_type->rewrite ) {
-						return;
-					}
-				}
-			}
-			if ( $obj instanceof WP_Term ) {
-				$taxonomy = get_taxonomy( $obj->taxonomy );
-				if ( ! empty( $taxonomy ) && false === $taxonomy->rewrite ) {
-					return;
-				}
-			}
-		}
-
 		if ( empty( $requested_url ) ) {
 			$requested_url = pll_get_requested_url();
 		}

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -68,7 +68,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
 			$base = $this->options['rewrite'] ? '' : 'language/';
-			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug . '/';
+			$slug = user_trailingslashit( $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug );
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
 			if ( false === strpos( $url, $new = $root . $slug ) ) {
@@ -102,8 +102,12 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
 			$pattern = preg_quote( $root, '#' );
-			$pattern = '#' . $pattern . ( $this->options['rewrite'] ? '' : 'language/' ) . '(' . implode( '|', $languages ) . ')(/|$)#';
-			$url = preg_replace( $pattern, $root, $url );
+			$pattern = '#(?<root>' . $pattern . ")" . ( $this->options['rewrite'] ? '' : 'language/' ) . '(?:' . implode( '|', $languages ) . ')((?<query>\?)|/|$)#';
+			// $1 backreference corresponds on root part of URL.
+			// $2 backreference corresponds on the query string separator or slash or end of URL.
+			// $3 backreference corresponds on the query string separator only; returns nothing if there is something between the language code and the separator.
+			// Language part in the URL isn't captured.
+			$url = preg_replace( $pattern, '$1$3', $url );
 		}
 		return $url;
 	}

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -68,7 +68,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
 			$base = $this->options['rewrite'] ? '' : 'language/';
-			$slug = user_trailingslashit( $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug );
+			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : user_trailingslashit( $base . $lang->slug );
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
 			if ( false === strpos( $url, $new = $root . $slug ) ) {

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -102,7 +102,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
 			$pattern = preg_quote( $root, '#' );
-			$pattern = '#(?<root>' . $pattern . ")" . ( $this->options['rewrite'] ? '' : 'language/' ) . '(?:' . implode( '|', $languages ) . ')((?<query>\?)|/|$)#';
+			$pattern = '#(?<root>' . $pattern . ')' . ( $this->options['rewrite'] ? '' : 'language/' ) . '(?:' . implode( '|', $languages ) . ')((?<query>\?)|/|$)#';
 			// $1 backreference corresponds on root part of URL.
 			// $2 backreference corresponds on the query string separator or slash or end of URL.
 			// $3 backreference corresponds on the query string separator only; returns nothing if there is something between the language code and the separator.

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -68,12 +68,15 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
 			$base = $this->options['rewrite'] ? '' : 'language/';
-			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : trailingslashit( $base . $lang->slug );
+			$slug = '';
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
-			$parsed_url = wp_parse_url( $url );
-			if ( is_array( $parsed_url ) && array_key_exists( 'path', $parsed_url ) && empty( trim( $parsed_url['path'], '/' ) ) && ! empty( $slug ) ) {
-				$slug = user_trailingslashit( $slug );
+			if ( $this->options['default_lang'] !== $lang->slug || ! $this->options['hide_default'] ) {
+				$slug = trailingslashit( $base . $lang->slug );
+				$parsed_url = wp_parse_url( $url );
+				if ( is_array( $parsed_url ) && array_key_exists( 'path', $parsed_url ) && empty( trim( $parsed_url['path'], '/' ) ) && ! empty( $slug ) ) {
+					$slug = user_trailingslashit( $slug );
+				}
 			}
 
 			if ( false === strpos( $url, $new = $root . $slug ) ) {

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -72,7 +72,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
 			$parsed_url = wp_parse_url( $url );
-			if ( is_array( $parsed_url) && array_key_exists( 'path', $parsed_url ) && empty( trim( $parsed_url['path'], '/' ) ) && ! empty( $slug ) ) {
+			if ( is_array( $parsed_url ) && array_key_exists( 'path', $parsed_url ) && empty( trim( $parsed_url['path'], '/' ) ) && ! empty( $slug ) ) {
 				$slug = user_trailingslashit( $slug );
 			}
 

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -68,8 +68,13 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
 			$base = $this->options['rewrite'] ? '' : 'language/';
-			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : user_trailingslashit( $base . $lang->slug );
+			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : trailingslashit( $base . $lang->slug );
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
+
+			$parsed_url = wp_parse_url( $url );
+			if ( is_array( $parsed_url) && array_key_exists( 'path', $parsed_url ) && empty( trim( $parsed_url['path'], '/' ) ) && ! empty( $slug ) ) {
+				$slug = user_trailingslashit( $slug );
+			}
 
 			if ( false === strpos( $url, $new = $root . $slug ) ) {
 				$pattern = preg_quote( $root, '#' );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1151,11 +1151,6 @@ parameters:
 			path: include/links-directory.php
 
 		-
-			message: "#^Parameter \\#2 \\$replace of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: include/links-directory.php
-
-		-
 			message: "#^Method PLL_Links_Domain\\:\\:add_language_to_link\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: include/links-domain.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -561,11 +561,6 @@ parameters:
 			path: frontend/frontend-filters-links.php
 
 		-
-			message: "#^Method PLL_Frontend_Filters_Links\\:\\:check_canonical_url\\(\\) should return string\\|void but returns string\\|false\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
 			message: "#^Method PLL_Frontend_Filters_Links\\:\\:get_queried_taxonomy\\(\\) should return string but returns int\\|string\\|null\\.$#"
 			count: 1
 			path: frontend/frontend-filters-links.php

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -36,7 +36,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
-		$wp_rewrite->set_permalink_structure( $this->structure );
+		$wp_rewrite->set_permalink_structure( $structure );
 
 		// $wp_rewrite->flush_rules() is called in self::assertCanonical()
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -132,6 +132,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->set_permalink_structure( '/%category%/%postname%' );
 		$this->assertCanonical( '/en?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
 	}
+
 	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_with_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%/' );
 		$this->assertCanonical( '/en/?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -59,13 +59,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 		$unrewriting_cpt_id = $factory->post->create( array( 'post_type' => 'pll-unrewriting-cpt', 'post_title' => 'custom-post' ) );
 		self::$model->post->set_language( $unrewriting_cpt_id, 'en' );
-		add_filter(
-			'pll_get_post_types',
-			function( $post_types ) {
-				$post_types[] = 'pll-unrewriting-cpt';
-				return $post_types;
-			}
-		);
 
 		self::$custom_post_id = $factory->post->create(
 			array(
@@ -126,24 +119,32 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				),
 			)
 		);
+		add_filter(
+			'pll_get_post_types',
+			function( $post_types ) {
+				$post_types[] = 'pll-unrewriting-cpt';
+				return $post_types;
+			}
+		);
 	}
 
 	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_without_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%' );
-		$this->assertCanonical( '/en/?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
+		$this->assertCanonical( '/en?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
 	}
 	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_with_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%/' );
-		$this->assertCanonical( '/en?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
+		$this->assertCanonical( '/en/?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
 	}
 
 	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_without_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%' );
-		$this->assertCanonical( '/fr/?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
+		$this->assertCanonical( '/fr?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
 	}
+
 	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_with_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%/' );
-		$this->assertCanonical( '/fr?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
+		$this->assertCanonical( '/fr/?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
 	}
 
 	public function test_post_with_name_and_language() {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -50,7 +50,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				}
 			}
 		);
-		$test = register_post_type(
+		register_post_type(
 			'pll-unrewriting-cpt',
 			array(
 				'public'  => true,

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -59,7 +59,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 		$unrewriting_cpt_id = $factory->post->create( array( 'post_type' => 'pll-unrewriting-cpt', 'post_title' => 'custom-post' ) );
 		self::$model->post->set_language( $unrewriting_cpt_id, 'en' );
-		add_filter( 'pll_get_post_types',
+		add_filter(
+			'pll_get_post_types',
 			function( $post_types ) {
 				$post_types[] = 'pll-unrewriting-cpt';
 				return $post_types;
@@ -127,20 +128,20 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 	}
 
-	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_without_trailing_slash(){
+	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_without_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%' );
 		$this->assertCanonical( '/en/?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
 	}
-	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_with_trailing_slash(){
+	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_with_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%/' );
 		$this->assertCanonical( '/en?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
 	}
 
-	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_without_trailing_slash(){
+	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_without_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%' );
 		$this->assertCanonical( '/fr/?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
 	}
-	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_with_trailing_slash(){
+	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_with_trailing_slash() {
 		$this->set_permalink_structure( '/%category%/%postname%/' );
 		$this->assertCanonical( '/fr?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -50,6 +50,22 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				}
 			}
 		);
+		$test = register_post_type(
+			'pll-unrewriting-cpt',
+			array(
+				'public'  => true,
+				'rewrite' => false,
+			)
+		);
+		$unrewriting_cpt_id = $factory->post->create( array( 'post_type' => 'pll-unrewriting-cpt', 'post_title' => 'custom-post' ) );
+		self::$model->post->set_language( $unrewriting_cpt_id, 'en' );
+		add_filter( 'pll_get_post_types',
+			function( $post_types ) {
+				$post_types[] = 'pll-unrewriting-cpt';
+				return $post_types;
+			}
+		);
+
 		self::$custom_post_id = $factory->post->create(
 			array(
 				'import_id'  => 416,
@@ -89,6 +105,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		_unregister_post_type( 'pllcanonical' );
+		_unregister_post_type( 'pll-unrewriting-cpt' );
 
 		parent::wpTearDownAfterClass();
 	}
@@ -108,6 +125,24 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				),
 			)
 		);
+	}
+
+	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_without_trailing_slash(){
+		$this->set_permalink_structure( '/%category%/%postname%' );
+		$this->assertCanonical( '/en/?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
+	}
+	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_with_trailing_slash(){
+		$this->set_permalink_structure( '/%category%/%postname%/' );
+		$this->assertCanonical( '/en?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
+	}
+
+	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_without_trailing_slash(){
+		$this->set_permalink_structure( '/%category%/%postname%' );
+		$this->assertCanonical( '/fr/?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
+	}
+	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_with_trailing_slash(){
+		$this->set_permalink_structure( '/%category%/%postname%/' );
+		$this->assertCanonical( '/fr?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
 	}
 
 	public function test_post_with_name_and_language() {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1340

As explained in [the issue](https://github.com/polylang/polylang-pro/issues/1340) the infinite redirection loop occurs when:
- Polylang is set in directory
- WordPress permalink setting is set as pretty permalink and defined without trailing slash and with `/%category%/` placeholder
- A custom post type is defined not to use rewriting feature.

_Could be in conflicts with #1049_

## Changes

As the WP `redirect_canonical()` function remove the trailing slash in the URL, this one become something like that http://mysite.com/fr?elementor_library=my-template.

So this PR propose to correct the regular expression in `PLL_Links_Directory::remove_language_from_link()` to remove correctly the language from the URL in this case and then avoid to add twice the language by calling  `PLL_Links_Directory::add_language_to_link()`.

But this fix isn't sufficient because `PLL_Links_Directory::add_language_to_link()` always added a slash behind the language code. https://github.com/polylang/polylang/blob/3.2.2/include/links-directory.php#L71
So we loop again with the starting URL http://mysite.com/fr/?elementor_library=my-template and fall in a infinite loop too.

The PR also propose to use `user_trailingslashit()`, as WP does in `redirect_canonical()` https://github.com/WordPress/WordPress/blob/5.9.3/wp-includes/canonical.php#L665,  to remove the slash behind the language code when it is added to the URL and required and thus avoid this infinite loop.

## Expected behaviour
We don't have anymore the infinite redirection as in the customer case
