### PR TITLE
Fix dropdown selector

### DIFF
--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -35,7 +35,7 @@ class PLL_Walker_Dropdown extends Walker {
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
-			! empty( $element->locale ) ? sprintf( ' lang="%s"', esc_attr( str_replace( '_', '-', $element->locale ) ) ) : '',
+			! empty( $element->locale ) ? sprintf( ' lang="%s"', esc_attr( $element->locale ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
 			esc_html( $element->name )
 		);

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -35,7 +35,7 @@ class PLL_Walker_Dropdown extends Walker {
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
-			method_exists( $element, 'get_locale' ) ? sprintf( ' lang="%s"', esc_attr( $element->get_locale( 'display' ) ) ) : '',
+			! empty( $element->locale ) ? sprintf( ' lang="%s"', esc_attr( str_replace( '_', '-', $element->locale ) ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
 			esc_html( $element->name )
 		);

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -187,7 +187,8 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $xpath->query( '//script' )->length );
 		$lang_attributes = $xpath->query( '//select/option/@lang' );
 		$this->assertEquals( self::$model->get_language( 'en' )->get_locale( 'display' ), $lang_attributes->item( 0 )->value );
-		$this->assertEquals( self::$model->get_language( 'fr' )->get_locale( 'display' ), $lang_attributes->item( 1 )->value );	}
+		$this->assertEquals( self::$model->get_language( 'fr' )->get_locale( 'display' ), $lang_attributes->item( 1 )->value );
+	}
 
 	public function test_with_hide_if_no_translation_option_in_admin_context() {
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -185,7 +185,9 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'selected', $option->item( 0 )->getAttribute( 'selected' ) );
 		$this->assertNotEmpty( $xpath->query( '//select/option[.="Français"]' )->length );
 		$this->assertNotEmpty( $xpath->query( '//script' )->length );
-	}
+		$languages_attribute = $xpath->query( '//select/option/@lang' );
+		$this->assertEquals( self::$model->get_language( 'en' )->get_locale( 'display' ), $languages_attribute->item( 0 )->value );
+		$this->assertEquals( self::$model->get_language( 'fr' )->get_locale( 'display' ), $languages_attribute->item( 1 )->value );	}
 
 	public function test_with_hide_if_no_translation_option_in_admin_context() {
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -186,8 +186,8 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $xpath->query( '//select/option[.="Français"]' )->length );
 		$this->assertNotEmpty( $xpath->query( '//script' )->length );
 		$lang_attributes = $xpath->query( '//select/option/@lang' );
-		$this->assertEquals( self::$model->get_language( 'en' )->get_locale( 'display' ), $lang_attributes->item( 0 )->value );
-		$this->assertEquals( self::$model->get_language( 'fr' )->get_locale( 'display' ), $lang_attributes->item( 1 )->value );
+		$this->assertEquals( 'en-US', $lang_attributes->item( 0 )->value );
+		$this->assertEquals( 'fr-FR', $lang_attributes->item( 1 )->value );
 	}
 
 	public function test_with_hide_if_no_translation_option_in_admin_context() {

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -185,9 +185,9 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'selected', $option->item( 0 )->getAttribute( 'selected' ) );
 		$this->assertNotEmpty( $xpath->query( '//select/option[.="Français"]' )->length );
 		$this->assertNotEmpty( $xpath->query( '//script' )->length );
-		$languages_attribute = $xpath->query( '//select/option/@lang' );
-		$this->assertEquals( self::$model->get_language( 'en' )->get_locale( 'display' ), $languages_attribute->item( 0 )->value );
-		$this->assertEquals( self::$model->get_language( 'fr' )->get_locale( 'display' ), $languages_attribute->item( 1 )->value );	}
+		$lang_attributes = $xpath->query( '//select/option/@lang' );
+		$this->assertEquals( self::$model->get_language( 'en' )->get_locale( 'display' ), $lang_attributes->item( 0 )->value );
+		$this->assertEquals( self::$model->get_language( 'fr' )->get_locale( 'display' ), $lang_attributes->item( 1 )->value );	}
 
 	public function test_with_hide_if_no_translation_option_in_admin_context() {
 		$links_model = self::$model->get_links_model();


### PR DESCRIPTION
Fix https://github.com/polylang/polylang/issues/1027

The `element` object didn't have a `get_locale` method, so an empty string was returned.

Now we get the locale directly from the `element` object, and transform it to **w3c** format.