### PR TITLE
Update PHPStan Baseline since esc_sql() parsing has now dynamic return type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -511,11 +511,6 @@ parameters:
 			path: frontend/frontend-auto-translate.php
 
 		-
-			message: "#^Parameter \\#2 \\$pieces of function implode expects array, string given\\.$#"
-			count: 1
-			path: frontend/frontend-auto-translate.php
-
-		-
 			message: "#^@param PLL_Language \\$language does not accept actual type of parameter\\: PLL_Language\\|null\\.$#"
 			count: 1
 			path: frontend/frontend-filters-links.php
@@ -1337,11 +1332,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, array\\{mixed, 'get_terms_args'\\} given\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
-			message: "#^Parameter \\#2 \\$pieces of function implode expects array, string given\\.$#"
 			count: 1
 			path: include/model.php
 


### PR DESCRIPTION
szepeviktor/phpstan-wordpress is now updated with this [PR](https://github.com/szepeviktor/phpstan-wordpress/pull/96) which allow a better dynamic return type for `esc_sql()`. Formerly it leads to several errors on implode function which accepts only array. Now PHPStan understand we give it an `array` and not `string|array` type.
