### PR TITLE
Prevent random languages oreder with WP 6.0

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,6 +33,11 @@ parameters:
 			count: 1
 			path: admin/admin-base.php
 
+		-
+			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, array\\{mixed, 'filter_language…'\\} given\\.$#"
+			count: 1
+			path: include/model.php
+
 		# Ignored because of https://github.com/polylang/polylang/commit/fedd9b62354ae4179e39e1fd822cfee1a12643d5
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -67,9 +67,9 @@ trait PLL_UnitTestCase_Trait {
 		$languages = include POLYLANG_DIR . '/settings/languages.php';
 		$values    = $languages[ $locale ];
 
-		$values['slug'] = $values['code'];
-		$values['rtl'] = (int) ( 'rtl' === $values['dir'] );
-		$values['term_group'] = count( self::$model->get_languages_list() );
+		$values['slug']       = $values['code'];
+		$values['rtl']        = (int) ( 'rtl' === $values['dir'] );
+		$values['term_group'] = 0;
 
 		$args = array_merge( $values, $args );
 

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -17,14 +17,34 @@ class Model_Test extends PLL_UnitTestCase {
 	public function test_languages_list() {
 		self::$model->post->register_taxonomy(); // needed otherwise posts are not counted
 
-		$this->assertSameSets( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
-		$this->assertSameSets( array( 'English', 'Français' ), self::$model->get_languages_list( array( 'fields' => 'name' ) ) );
-		$this->assertSameSets( array(), self::$model->get_languages_list( array( 'hide_empty' => true ) ) );
+		$this->assertSame( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertSame( array( 'English', 'Français' ), self::$model->get_languages_list( array( 'fields' => 'name' ) ) );
+		$this->assertSame( array(), self::$model->get_languages_list( array( 'hide_empty' => true ) ) );
 
 		$post_id = $this->factory->post->create();
 		self::$model->post->set_language( $post_id, 'en' );
 
-		$this->assertSameSets( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
+		$this->assertSame( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
+	}
+
+	public function test_languages_list_order() {
+		$languages = array(
+			'it_IT' => array(
+				'term_group' => 17,
+			),
+			'es_ES' => array(
+				'term_group' => 6,
+			),
+		);
+
+		foreach ( $languages as $locale => $data ) {
+			self::create_language( $locale, $data );
+		}
+
+		$languages = self::$model->get_languages_list( array( 'fields' => 'slug' ) );
+		$expected  = array( 'en', 'fr', 'es', 'it' );
+
+		$this->assertSame( $expected, $languages, 'Expected the languages to be ordered by term_group and term_id.' );
 	}
 
 	public function test_term_exists() {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1345.

With WP 6.0, the order of the languages seems inconsistent for languages having the same `term_group`.

This was fixed temporarilly in tests by https://github.com/polylang/polylang/pull/1020.

The first idea was to set the `term_group` each time a language is created, and add an upgrade routine to set the `term_group` on existing languages.

A simpler approach is to use the filter `'get_terms_orderby'` to set `orderby` to `term_group, term_id` instead of simply `term_group`.