### PR TITLE
Load strings translations accordingly to user locale when the password is retrieved 

### DIFF
--- a/include/base.php
+++ b/include/base.php
@@ -62,7 +62,7 @@ abstract class PLL_Base {
 		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
 		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
 		add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
-		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WordPress switch the locale in retrieve_password().
+		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 10, 0 ); // Password reset email.
 		// Switch_to_blog
 		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );
 	}

--- a/include/base.php
+++ b/include/base.php
@@ -62,6 +62,7 @@ abstract class PLL_Base {
 		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
 		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
 		add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
+		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 1, 0 );
 
 		// Switch_to_blog
 		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );

--- a/include/base.php
+++ b/include/base.php
@@ -62,8 +62,7 @@ abstract class PLL_Base {
 		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
 		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
 		add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
-		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
-
+		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WordPress switch the locale in retrieve_password().
 		// Switch_to_blog
 		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );
 	}

--- a/include/base.php
+++ b/include/base.php
@@ -62,7 +62,7 @@ abstract class PLL_Base {
 		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
 		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
 		add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
-		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 1, 0 );
+		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
 
 		// Switch_to_blog
 		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );

--- a/tests/phpunit/tests/test-email-strings.php
+++ b/tests/phpunit/tests/test-email-strings.php
@@ -1,0 +1,97 @@
+<?php
+
+class Email_Strings_Test extends PLL_UnitTestCase {
+
+	/**
+	 * @var PLL_Links_Model
+	 */
+	protected $links_model;
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		// Let's create languages available in DIR_TESTDATA . '/languages/' so locale switches is done correctly in tests.
+		self::create_language( 'en_US' );
+		self::create_language( 'es_ES' );
+
+		require_once POLYLANG_DIR . '/include/api.php';
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->links_model = self::$model->get_links_model();
+	}
+
+
+	public function test_retrieve_password_default_language() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
+		}
+
+		// Create string translations.
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'My Site' ) );
+		$_mo->export_to_db( self::$model->get_language( 'en' ) );
+
+		reset_phpmailer_instance();
+		self::factory()->user->create(
+			array(
+				'user_login' => 'janeDoe',
+				'user_email' => 'jane.doe@example.com',
+				'locale'     => 'en_US',
+			)
+		);
+
+		$_POST['user_login'] = 'janeDoe'; // Backward compatibility with WordPress < 5.7
+
+		// Set PLL environment.
+		$admin = new PLL_Admin( $this->links_model );
+		$admin->init();
+
+		// Let's send the mail.
+		$mailer = tests_retrieve_phpmailer_instance();
+		$result = retrieve_password();
+		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'My Site' ), 'Blogname string has not been translated in mail subject.' );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'My Site' ), 'Blogname string has not been translated in mail body.' );
+		reset_phpmailer_instance();
+	}
+
+	public function test_retrieve_password_secondary_language() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
+		}
+
+		// Create string translations.
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi Sitio' ) );
+		$_mo->export_to_db( self::$model->get_language( 'es' ) );
+
+		reset_phpmailer_instance();
+		self::factory()->user->create(
+			array(
+				'user_login' => 'Picasso',
+				'user_email' => 'picasso@example.com',
+				'locale'     => 'es_ES',
+			)
+		);
+
+		$_POST['user_login'] = 'Picasso'; // Backward compatibility with WordPress < 5.7
+
+		// Set PLL environment.
+		$admin = new PLL_Admin( $this->links_model );
+		$admin->init();
+
+		// Let's send the mail.
+		$mailer = tests_retrieve_phpmailer_instance();
+		$result = retrieve_password();
+		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi Sitio' ), 'Blogname string has not been translated in mail subject.' );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi Sitio' ), 'Blogname string has not been translated in mail body.' );
+		reset_phpmailer_instance();
+	}
+}

--- a/tests/phpunit/tests/test-email-strings.php
+++ b/tests/phpunit/tests/test-email-strings.php
@@ -28,6 +28,11 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 
 
 	public function test_retrieve_password_default_language() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '5.7', '>' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress version 5.7 or higher.' );
+		}
+
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
 		}
@@ -46,15 +51,13 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 			)
 		);
 
-		$_POST['user_login'] = 'janeDoe'; // Backward compatibility with WordPress < 5.7
-
 		// Set PLL environment.
 		$admin = new PLL_Admin( $this->links_model );
 		$admin->init();
 
 		// Let's send the mail.
 		$mailer = tests_retrieve_phpmailer_instance();
-		$result = retrieve_password();
+		$result = retrieve_password( 'janeDoe' );
 		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'My Site' ), 'Blogname string has not been translated in mail subject.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'My Site' ), 'Blogname string has not been translated in mail body.' );
@@ -62,6 +65,11 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_retrieve_password_secondary_language() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '5.7', '>' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress version 5.7 or higher.' );
+		}
+
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
 		}
@@ -80,15 +88,13 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 			)
 		);
 
-		$_POST['user_login'] = 'Picasso'; // Backward compatibility with WordPress < 5.7
-
 		// Set PLL environment.
 		$admin = new PLL_Admin( $this->links_model );
 		$admin->init();
 
 		// Let's send the mail.
 		$mailer = tests_retrieve_phpmailer_instance();
-		$result = retrieve_password();
+		$result = retrieve_password( 'Picasso' );
 		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi Sitio' ), 'Blogname string has not been translated in mail subject.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi Sitio' ), 'Blogname string has not been translated in mail body.' );

--- a/tests/phpunit/tests/test-email-strings.php
+++ b/tests/phpunit/tests/test-email-strings.php
@@ -29,7 +29,7 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 
 	public function test_retrieve_password_default_language() {
 		global $wp_version;
-		if ( version_compare( $wp_version, '5.7', '>' ) ) {
+		if ( version_compare( $wp_version, '5.7', '<' ) ) {
 			$this->markTestSkipped( 'This test requires WordPress version 5.7 or higher.' );
 		}
 
@@ -66,7 +66,7 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 
 	public function test_retrieve_password_secondary_language() {
 		global $wp_version;
-		if ( version_compare( $wp_version, '5.7', '>' ) ) {
+		if ( version_compare( $wp_version, '5.7', '<' ) ) {
 			$this->markTestSkipped( 'This test requires WordPress version 5.7 or higher.' );
 		}
 
@@ -98,6 +98,62 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi Sitio' ), 'Blogname string has not been translated in mail subject.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi Sitio' ), 'Blogname string has not been translated in mail body.' );
+		reset_phpmailer_instance();
+	}
+
+	public function test_site_title_in_password_change_email() {
+		// Important to use a language available in DIR_TESTDATA . '/languages/', otherwise switch_to_locale() doesn't switch.
+		$language = self::$model->get_language( 'es' );
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );
+		$_mo->export_to_db( $language );
+
+		reset_phpmailer_instance();
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, 'locale', 'es_ES' );
+
+		// Set PLL environment.
+		$admin = new PLL_Admin( $this->links_model );
+		$admin->init();
+		$frontend_filters = new PLL_Admin_Filters( $admin );
+
+		$userdata = array(
+			'ID'        => $user_id,
+			'user_pass' => 'new password',
+		);
+		wp_update_user( $userdata );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi sitio' ) );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi sitio' ) );
+		reset_phpmailer_instance();
+	}
+
+	public function test_site_title_in_email_change_confirmation_email() {
+		$language = self::$model->get_language( 'es' );
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );
+		$_mo->export_to_db( $language );
+
+		reset_phpmailer_instance();
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, 'locale', 'es_ES' );
+		wp_set_current_user( $user_id );
+		set_current_screen( 'profile.php' );
+
+		// Set PLL environment.
+		$admin = new PLL_Admin( $this->links_model );
+		$admin->init();
+
+		$_POST = array(
+			'user_id' => $user_id,
+			'email'   => 'my_new_email@example.org',
+		);
+		do_action( 'personal_options_update', $user_id );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi sitio' ) );
+		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi sitio' ) );
 		reset_phpmailer_instance();
 	}
 }

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -337,59 +337,6 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertCount( 2, get_pages( array( 'lang' => '' ) ) );
 	}
 
-	public function test_site_title_in_password_change_email() {
-		// Important to use a language available in DIR_TESTDATA . '/languages/', otherwise switch_to_locale() doesn't switch.
-		$language = self::$model->get_language( 'es' );
-		$_mo = new PLL_MO();
-		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );
-		$_mo->export_to_db( $language );
-
-		reset_phpmailer_instance();
-		$user_id = self::factory()->user->create();
-		update_user_meta( $user_id, 'locale', 'es_ES' );
-
-		$this->frontend = new PLL_Admin( $this->frontend->links_model );
-		$this->frontend->filters = new PLL_Admin_Filters( $this->frontend );
-
-		$userdata = array(
-			'ID'        => $user_id,
-			'user_pass' => 'new password',
-		);
-		wp_update_user( $userdata );
-
-		$mailer = tests_retrieve_phpmailer_instance();
-		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi sitio' ) );
-		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi sitio' ) );
-		reset_phpmailer_instance();
-	}
-
-	public function test_site_title_in_email_change_confirmation_email() {
-		$language = self::$model->get_language( 'es' );
-		$_mo = new PLL_MO();
-		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi sitio' ) );
-		$_mo->export_to_db( $language );
-
-		reset_phpmailer_instance();
-		$user_id = self::factory()->user->create();
-		update_user_meta( $user_id, 'locale', 'es_ES' );
-		wp_set_current_user( $user_id );
-		set_current_screen( 'profile.php' );
-
-		$pll_env = new PLL_Admin( $this->frontend->links_model );
-		$pll_env->init();
-
-		$_POST = array(
-			'user_id' => $user_id,
-			'email'   => 'my_new_email@example.org',
-		);
-		do_action( 'personal_options_update', $user_id );
-
-		$mailer = tests_retrieve_phpmailer_instance();
-		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi sitio' ) );
-		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi sitio' ) );
-		reset_phpmailer_instance();
-	}
-
 	public function _action_pre_get_posts() {
 		$terms = get_terms( 'post_tag', array( 'hide_empty' => false ) );
 		$language = self::$model->term->get_language( $terms[0]->term_id );

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -218,7 +218,7 @@ class Strings_Test extends PLL_UnitTestCase {
 		$_mo->export_to_db( self::$model->get_language( 'en' ) );
 
 		reset_phpmailer_instance();
-		$user_id = self::factory()->user->create(
+		self::factory()->user->create(
 			array(
 				'user_login' => 'janeDoe',
 				'user_email' => 'jane.doe@example.com',
@@ -226,13 +226,15 @@ class Strings_Test extends PLL_UnitTestCase {
 			)
 		);
 
+		$_POST['user_login'] = 'janeDoe'; // Backward compatibility with WordPress < 5.7
+
 		// Set Polylang environment.
 		$admin = new PLL_Admin( $this->links_model );
 		$admin->init();
 
 		// Let's send the mail.
 		$mailer = tests_retrieve_phpmailer_instance();
-		$result = retrieve_password( 'janeDoe' );
+		$result = retrieve_password();
 		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'My Site' ), 'Blogname string has not been translated in mail subject.' );
 		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'My Site' ), 'Blogname string has not been translated in mail body.' );
@@ -253,6 +255,8 @@ class Strings_Test extends PLL_UnitTestCase {
 				'locale'     => 'es_ES',
 			)
 		);
+
+		$_POST['user_login'] = 'Picasso'; // Backward compatibility with WordPress < 5.7
 
 		// Set Polylang environment.
 		$admin = new PLL_Admin( $this->links_model );

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -10,7 +10,6 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
-		self::create_language( 'es_ES' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
@@ -209,73 +208,5 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'test en', pll__( 'test' ) );
 
 		$GLOBALS['wp_locale_switcher'] = $old_locale_switcher; // Reset the original global var
-	}
-
-	public function test_retrieve_password_default_language() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
-		}
-
-		// Create string translations.
-		$_mo = new PLL_MO();
-		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'My Site' ) );
-		$_mo->export_to_db( self::$model->get_language( 'en' ) );
-
-		reset_phpmailer_instance();
-		self::factory()->user->create(
-			array(
-				'user_login' => 'janeDoe',
-				'user_email' => 'jane.doe@example.com',
-				'locale'     => 'en_US',
-			)
-		);
-
-		$_POST['user_login'] = 'janeDoe'; // Backward compatibility with WordPress < 5.7
-
-		// Set Polylang environment.
-		$admin = new PLL_Admin( $this->links_model );
-		$admin->init();
-
-		// Let's send the mail.
-		$mailer = tests_retrieve_phpmailer_instance();
-		$result = retrieve_password();
-		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
-		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'My Site' ), 'Blogname string has not been translated in mail subject.' );
-		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'My Site' ), 'Blogname string has not been translated in mail body.' );
-		reset_phpmailer_instance();
-	}
-
-	public function test_retrieve_password_secondary_language() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
-		}
-
-		// Create string translations.
-		$_mo = new PLL_MO();
-		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi Sitio' ) );
-		$_mo->export_to_db( self::$model->get_language( 'es' ) );
-
-		reset_phpmailer_instance();
-		$user_id = self::factory()->user->create(
-			array(
-				'user_login' => 'Picasso',
-				'user_email' => 'picasso@example.com',
-				'locale'     => 'es_ES',
-			)
-		);
-
-		$_POST['user_login'] = 'Picasso'; // Backward compatibility with WordPress < 5.7
-
-		// Set Polylang environment.
-		$admin = new PLL_Admin( $this->links_model );
-		$admin->init();
-
-		// Let's send the mail.
-		$mailer = tests_retrieve_phpmailer_instance();
-		$result = retrieve_password( 'Picasso' );
-		$this->assertTrue( $result, 'No mail has been sent to retrieve password.' );
-		$this->assertNotFalse( strpos( $mailer->get_sent()->subject, 'Mi Sitio' ), 'Blogname string has not been translated in mail subject.' );
-		$this->assertNotFalse( strpos( $mailer->get_sent()->body, 'Mi Sitio' ), 'Blogname string has not been translated in mail body.' );
-		reset_phpmailer_instance();
 	}
 }

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -212,6 +212,10 @@ class Strings_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_retrieve_password_default_language() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
+		}
+
 		// Create string translations.
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'My Site' ) );
@@ -242,6 +246,10 @@ class Strings_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_retrieve_password_secondary_language() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'The blog name string is not translatable in retrieve password email for multisite.' );
+		}
+
 		// Create string translations.
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( get_bloginfo( 'name' ), 'Mi Sitio' ) );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1346

## Issue
When the user locale is set on site default, the strings translations wasn't loaded during `retrieve_password()` call. Which means that the `blogname` was not translated neither in the mail subject nor in the body.

## Changes
- Hooks `PLL_Base::load_strings_translations` to `lostpassword_post` action. This way, strings are loaded even if there is no locale switching later in `retrieve_password()`. (e.g. if the user has site default language set)
- Add test for `blogname` translation in retrieve password mail for default language and for secondary language.

*Note:  `retrieve_password()` switch the locale before getting the `blogname` option, which allow us to translate this string correctly only for secondary language (when a true locale switch occurs). By loading the strings translations when  `lostpassword_post` action is done, we are sure to load at least the site default language anyway.*