### PR TITLE
Improve documentation and types in PLL_Model

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -404,7 +404,9 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			update_user_meta( $user_id, 'pll_filter_content', ( $lang = $this->model->get_language( sanitize_key( $_GET['lang'] ) ) ) ? $lang->slug : '' ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
-		$this->filter_lang = $this->model->get_language( get_user_meta( get_current_user_id(), 'pll_filter_content', true ) );
+		$lang = get_user_meta( get_current_user_id(), 'pll_filter_content', true );
+
+		$this->filter_lang = is_string( $lang ) && ! empty( $lang ) ? $this->model->get_language( $lang ) : $this->filter_lang;
 
 		// Set preferred language for use when saving posts and terms: must not be empty
 		$this->pref_lang = empty( $this->filter_lang ) ? $this->model->get_language( $this->options['default_lang'] ) : $this->filter_lang;

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"php": ">=5.6"
 	},
 	"require-dev": {
-		"wpsyntex/polylang-phpstan": "^1.0",
+		"wpsyntex/polylang-phpstan": "dev-new-model-languages-list-dynamic-return",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"wp-coding-standards/wpcs": "*",
 		"automattic/vipwpcs": "*",

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -157,11 +157,11 @@ abstract class PLL_Choose_Lang {
 	 * Returns the preferred language
 	 * either from the cookie if it's a returning visit
 	 * or according to browser preference
-	 * or the default language
+	 * or the default language.
 	 *
 	 * @since 0.1
 	 *
-	 * @return object browser preferred language or default language
+	 * @return object Browser preferred language or default language.
 	 */
 	public function get_preferred_language() {
 		$language = false;
@@ -189,8 +189,19 @@ abstract class PLL_Choose_Lang {
 		 */
 		$slug = apply_filters( 'pll_preferred_language', $language, $cookie );
 
-		// Return default if there is no preferences in the browser or preferences does not match our languages or it is requested not to use the browser preference
-		return ( $lang = $this->model->get_language( $slug ) ) ? $lang : $this->model->get_language( $this->options['default_lang'] );
+		if ( ! empty( $slug ) && is_string( $slug ) ) {
+			$lang = $this->model->get_language( $slug );
+
+			if ( ! empty( $lang ) ) {
+				return $lang;
+			}
+		}
+
+		/**
+		 * Return default if there is no preferences in the browser or preferences does not match our languages or it is
+		 * requested not to use the browser preference.
+		 */
+		return $this->model->get_language( $this->options['default_lang'] );
 	}
 
 	/**
@@ -299,7 +310,7 @@ abstract class PLL_Choose_Lang {
 			$this->set_curlang_in_query( $query );
 		} elseif ( ( count( $query->query ) == 1 || ( is_paged() && count( $query->query ) == 2 ) ) && $lang = get_query_var( 'lang' ) ) {
 			// Set is_home on translated home page when it displays posts. It must be true on page 2, 3... too.
-			$lang = $this->model->get_language( $lang );
+			$lang = is_string( $lang ) && ! empty( $lang ) ? $this->model->get_language( $lang ) : false;
 			$this->set_language( $lang ); // Set the language now otherwise it will be too late to filter sticky posts!
 			$query->is_home = true;
 			$query->is_tax = false;

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -121,7 +121,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @return string modified WHERE clause
 	 */
 	public function getarchives_where( $sql, $r ) {
-		return ! empty( $r['post_type'] ) && $this->model->is_translated_post_type( $r['post_type'] ) ? $sql . $this->model->post->where_clause( $this->curlang ) : $sql;
+		return ! empty( $r['post_type'] ) && ! empty( $this->curlang ) && $this->model->is_translated_post_type( $r['post_type'] ) ? $sql . $this->model->post->where_clause( $this->curlang ) : $sql;
 	}
 
 	/**

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -171,7 +171,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 		}
 
 		// Redirect the language page to the homepage when using a static front page
-		elseif ( ( $this->options['redirect_lang'] || $this->options['hide_default'] ) && $this->is_front_page( $query ) && $lang = $this->model->get_language( get_query_var( 'lang' ) ) ) {
+		elseif ( ( $this->options['redirect_lang'] || $this->options['hide_default'] ) && $this->is_front_page( $query ) && is_string( get_query_var( 'lang' ) ) && $lang = $this->model->get_language( get_query_var( 'lang' ) ) ) {
 			$query->is_archive = $query->is_tax = false;
 			if ( ! empty( $lang->page_on_front ) ) {
 				$query->set( 'page_id', $lang->page_on_front );

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -83,7 +83,11 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	public function get_hosts() {
 		$hosts = array();
 		foreach ( $this->model->get_languages_list() as $lang ) {
-			$hosts[ $lang->slug ] = wp_parse_url( $this->home_url( $lang ), PHP_URL_HOST );
+			$host = wp_parse_url( $this->home_url( $lang ), PHP_URL_HOST );
+
+			if ( is_string( $host ) ) {
+				$hosts[ $lang->slug ] = $host;
+			}
 		}
 		return $hosts;
 	}

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -180,7 +180,7 @@ class PLL_Static_Pages {
 	 */
 	public function oembed_request_post_id( $post_id, $url ) {
 		foreach ( $this->model->get_languages_list() as $lang ) {
-			if ( trailingslashit( $url ) === trailingslashit( $lang->home_url ) ) {
+			if ( is_string( $lang->home_url ) && is_int( $lang->page_on_front ) && trailingslashit( $url ) === trailingslashit( $lang->home_url ) ) {
 				$post_id = $lang->page_on_front;
 			}
 		}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -410,7 +410,7 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @since 1.2
 	 *
-	 * @param PLL_Language|string|string[] $lang PLL_Language object or a comma separated list of language slug or an array of language slugs.
+	 * @param array<PLL_Language|string>|PLL_Language|string $lang PLL_Language object or a comma separated list of language slug or an array of language slugs.
 	 * @return string Where clause.
 	 */
 	public function where_clause( $lang ) {
@@ -490,8 +490,11 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @param  mixed $id A supposedly numeric ID.
 	 * @return int       A positive integer. `0` for non numeric values and negative integers.
+	 *
+	 * @phpstan-return int<0,max>
 	 */
 	public function sanitize_int_id( $id ) {
+		/** @var int<0,max> */
 		return is_numeric( $id ) && $id >= 1 ? (int) $id : 0;
 	}
 
@@ -503,6 +506,8 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @param  mixed $ids An associative array of translations with language code as key and translation ID as value.
 	 * @return array<int> An associative array of translations with language code as key and translation ID as value.
+	 *
+	 * @phpstan-return array<int<1,max>>
 	 */
 	public function sanitize_int_ids_list( $ids ) {
 		if ( empty( $ids ) || ! is_array( $ids ) ) {

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -343,6 +343,8 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @param int $limit Max number of posts to show per post type.
 	 * @return int[][] Array containing an array of post ids.
+	 *
+	 * @phpstan-param int<0,max> $limit
 	 */
 	public function get_post_ids_without_lang( $limit = 5 ) {
 		$posts = array();
@@ -367,6 +369,8 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @param int $limit Max number of terms to show per post type.
 	 * @return int[][] Array containing an array of term ids.
+	 *
+	 * @phpstan-param int<0,max> $limit
 	 */
 	public function get_term_ids_without_lang( $limit = 5 ) {
 		$terms = array();

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -196,8 +196,10 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		}
 
 		// If no language is present in $name, we may attempt to get the current sitemap url (e.g. in redirect_canonical() ).
-		if ( get_query_var( 'lang' ) ) {
-			$lang = $this->model->get_language( get_query_var( 'lang' ) );
+		$query_var = get_query_var( 'lang' );
+
+		if ( ! empty( $query_var ) && is_string( $query_var ) ) {
+			$lang = $this->model->get_language( $query_var );
 			$url = $this->provider->get_sitemap_url( $name, $page );
 			return $this->links_model->add_language_to_link( $url, $lang );
 		}

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -267,13 +267,15 @@ class PLL_WPML_API {
 	 * @return string
 	 */
 	public function wpml_permalink( $url, $lang = '' ) {
-		$lang = PLL()->model->get_language( $lang );
+		if ( ! empty( $lang ) ) {
+			$lang = PLL()->model->get_language( $lang );
+		}
 
 		if ( empty( $lang ) && ! empty( PLL()->curlang ) ) {
 			$lang = PLL()->curlang;
 		}
 
-		return empty( $lang ) ? $url : PLL()->links_model->switch_language_in_link( $url, $lang );
+		return $lang instanceof PLL_Language ? PLL()->links_model->switch_language_in_link( $url, $lang ) : $url;
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,7 +46,7 @@ parameters:
 			path: admin/admin-base.php
 
 		-
-			message: "#^Property PLL_Admin_Base\\:\\:\\$filter_lang \\(PLL_Language\\|null\\) does not accept PLL_Language\\|false\\.$#"
+			message: "#^Property PLL_Admin_Base\\:\\:\\$filter_lang \\(PLL_Language\\|null\\) does not accept PLL_Language\\|false\\|null\\.$#"
 			count: 1
 			path: admin/admin-base.php
 
@@ -466,6 +466,11 @@ parameters:
 			path: frontend/choose-lang.php
 
 		-
+			message: "#^Method PLL_Choose_Lang\\:\\:get_preferred_language\\(\\) should return object but returns PLL_Language\\|false\\.$#"
+			count: 1
+			path: frontend/choose-lang.php
+
+		-
 			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
 			count: 2
 			path: frontend/choose-lang.php
@@ -626,11 +631,6 @@ parameters:
 			path: frontend/frontend-filters-links.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, int\\|string given\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
 			message: "#^Property WP_Query\\:\\:\\$tax_query \\(WP_Tax_Query\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: frontend/frontend-filters-links.php
@@ -687,11 +687,6 @@ parameters:
 
 		-
 			message: "#^Method PLL_Frontend_Filters\\:\\:option_sticky_posts\\(\\) should return array\\<int\\> but returns mixed\\.$#"
-			count: 1
-			path: frontend/frontend-filters.php
-
-		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_Translated_Object\\:\\:where_clause\\(\\) expects array\\<string\\>\\|PLL_Language\\|string, PLL_Language\\|null given\\.$#"
 			count: 1
 			path: frontend/frontend-filters.php
 
@@ -847,6 +842,11 @@ parameters:
 
 		-
 			message: "#^Function pll_current_language\\(\\) should return PLL_Language\\|string\\|false but returns PLL_Language\\|false\\|null\\.$#"
+			count: 1
+			path: include/api.php
+
+		-
+			message: "#^Function pll_languages_list\\(\\) should return array\\<string\\> but returns array\\<int, PLL_Language\\>\\.$#"
 			count: 1
 			path: include/api.php
 
@@ -1201,11 +1201,6 @@ parameters:
 			path: include/links-permalinks.php
 
 		-
-			message: "#^Method PLL_Links_Subdomain\\:\\:get_hosts\\(\\) should return array\\<string\\> but returns array\\<int\\|string, mixed\\>\\.$#"
-			count: 1
-			path: include/links-subdomain.php
-
-		-
 			message: "#^Method PLL_Links_Subdomain\\:\\:remove_language_from_link\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: include/links-subdomain.php
@@ -1241,17 +1236,7 @@ parameters:
 			path: include/model.php
 
 		-
-			message: "#^Cannot access offset int on mixed\\.$#"
-			count: 2
-			path: include/model.php
-
-		-
 			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
-			message: "#^Method PLL_Model\\:\\:count_posts\\(\\) should return int but returns mixed\\.$#"
 			count: 1
 			path: include/model.php
 
@@ -1261,17 +1246,7 @@ parameters:
 			path: include/model.php
 
 		-
-			message: "#^Method PLL_Model\\:\\:get_languages_list\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
 			message: "#^Method PLL_Model\\:\\:get_links_model\\(\\) should return PLL_Links_Model but returns object\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
-			message: "#^Method PLL_Model\\:\\:get_objects_with_no_lang\\(\\) should return array but returns array\\|false\\.$#"
 			count: 1
 			path: include/model.php
 
@@ -1287,11 +1262,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$arr1 of function array_intersect expects array, mixed given\\.$#"
-			count: 2
-			path: include/model.php
-
-		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_Translated_Object\\:\\:where_clause\\(\\) expects array\\<string\\>\\|PLL_Language\\|string, PLL_Language\\|false given\\.$#"
 			count: 2
 			path: include/model.php
 
@@ -1532,6 +1502,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$str of function explode expects string, mixed given\\.$#"
 			count: 1
 			path: modules/lingotek/lingotek.php
+
+		-
+			message: "#^Argument of an invalid type PLL_Language supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: modules/site-health/admin-site-health.php
 
 		-
 			message: "#^Cannot call method get_must_translate_message\\(\\) on PLL_Admin_Static_Pages\\|null\\.$#"

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -53,9 +53,9 @@ class Model_Test extends PLL_UnitTestCase {
 		$child = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $parent ) );
 		self::$model->term->set_language( $child, 'en' );
 
-		$this->assertEquals( $parent, self::$model->term_exists( 'parent', 'category', 0, 'en' ) );
-		$this->assertEquals( $child, self::$model->term_exists( 'child', 'category', 0, 'en' ) );
-		$this->assertEquals( $child, self::$model->term_exists( 'child', 'category', $parent, 'en' ) );
+		$this->assertSame( $parent, self::$model->term_exists( 'parent', 'category', 0, 'en' ) );
+		$this->assertSame( $child, self::$model->term_exists( 'child', 'category', 0, 'en' ) );
+		$this->assertSame( $child, self::$model->term_exists( 'child', 'category', $parent, 'en' ) );
 		$this->assertEmpty( self::$model->term_exists( 'parent', 'category', 0, 'fr' ) );
 		$this->assertEmpty( self::$model->term_exists( 'child', 'category', 0, 'fr' ) );
 		$this->assertEmpty( self::$model->term_exists( 'child', 'category', $parent, 'fr' ) );
@@ -67,7 +67,7 @@ class Model_Test extends PLL_UnitTestCase {
 	public function test_term_exists_with_special_character() {
 		$term = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'Cook & eat' ) );
 		self::$model->term->set_language( $term, 'en' );
-		$this->assertEquals( $term, self::$model->term_exists( 'Cook & eat', 'category', 0, 'en' ) );
+		$this->assertSame( $term, self::$model->term_exists( 'Cook & eat', 'category', 0, 'en' ) );
 	}
 
 	public function test_count_posts() {
@@ -89,19 +89,19 @@ class Model_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $fr, 'fr' );
 
 		$language = self::$model->get_language( 'fr' );
-		$this->assertEquals( 2, self::$model->count_posts( $language ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'post_format' => 'post-format-aside' ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'year' => 2007 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9, 'day' => 4 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'm' => 2007 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'm' => 200709 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'm' => 20070904 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'author' => 1 ) ) );
-		$this->assertEquals( 1, self::$model->count_posts( $language, array( 'author_name' => 'admin' ) ) );
+		$this->assertSame( 2, self::$model->count_posts( $language ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'post_format' => 'post-format-aside' ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'year' => 2007 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'year' => 2007, 'monthnum' => 9, 'day' => 4 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'm' => 2007 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'm' => 200709 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'm' => 20070904 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'author' => 1 ) ) );
+		$this->assertSame( 1, self::$model->count_posts( $language, array( 'author_name' => 'admin' ) ) );
 
 		// Bug fixed in version 2.2.6
-		$this->assertEquals( 2, self::$model->count_posts( $language, array( 'post_type' => array( 'post', 'page' ) ) ) );
+		$this->assertSame( 2, self::$model->count_posts( $language, array( 'post_type' => array( 'post', 'page' ) ) ) );
 	}
 
 	public function test_translated_post_types() {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1314.

This improves documentation in `PLL_Model` and fixes issues reported by PHPStan about types.

Most of the work has been done around `PLL_Model->get_languages_list()`, by creating [a new PHPStan extension](https://github.com/polylang/polylang-phpstan/pull/3).

About `@phpstan-*` tags:
I added several `@phpstan-param` and `@phpstan-return` tags to specify types more precisely. This could have been done directly in the classic `@param` and `@return` tags but I prefered to keep these ones simpler and easier to read.
Example, post IDs are positive integers, the integer's range is specified:
```
@return int[] A list of post IDs.

@phpstan-return array<int<1,max>>
```

Several other fixes have been made in other files, following the changes in `PLL_Model`.

`PLL_Model`'s tests are now using `assertSame()` instead of `assertEquals()`.

Note: rollback `composer.json` once the PHPStan extension is merged into master.