### PR TITLE
Override WordPress styles

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -373,6 +373,12 @@
 	background: #fff;
 }
 
+/* Override WordPress styles */
+.languages_page_mlang_strings .metabox-holder > #normal-sortables .postbox .submit {
+	float: none;
+	padding: 0;
+}
+
 @media screen and ( max-width: 782px ) {
 	/* settings */
 	#wpbody-content .pll-settings .pll-configure > td {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1356

#https://github.com/polylang/polylang/pull/1008 and https://github.com/polylang/polylang-pro/pull/1315 PRs introduced a regression  in Polylang Pro 3.2. described in the [issue](https://github.com/polylang/polylang-pro/issues/1356) with a misalignment of submit buttons.

See explanations in issue [#1356 comment](https://github.com/polylang/polylang-pro/issues/1356#issuecomment-1122478249)

# Changes
Add a more precise CSS selector to override WordPress styles and change `float` and `padding` properties

# Expected behaviour
Same as before in Polylang 3.1.4 with submit buttons correctly aligned on the left.