### PR TITLE
Fix language selector for product quick edit

### DIFF
--- a/js/src/post.js
+++ b/js/src/post.js
@@ -25,7 +25,7 @@ jQuery(
 		const handleQuickEditInsertion = ( mutationsList ) => {
 			for ( const mutation of mutationsList ) {
 				const form = mutation.addedNodes[0];
-				if ( 0 < mutation.addedNodes.length && ( form.classList.contains( 'inline-edit-post' ) || form.classList.contains( 'inline-edit-product' ) ) ) {
+				if ( 0 < mutation.addedNodes.length && form.classList.contains( 'inline-editor' ) ) {
 					// WordPress has inserted the quick edit form.
 					const post_id = Number( form.id.substring( 5 ) );
 

--- a/js/src/post.js
+++ b/js/src/post.js
@@ -25,9 +25,10 @@ jQuery(
 		const handleQuickEditInsertion = ( mutationsList ) => {
 			for ( const mutation of mutationsList ) {
 				const form = mutation.addedNodes[0];
-				if ( 0 < mutation.addedNodes.length && form.classList.contains( 'inline-edit-post' ) ) {
+				if ( 0 < mutation.addedNodes.length && ( form.classList.contains( 'inline-edit-post' ) || form.classList.contains( 'inline-edit-product' ) ) ) {
 					// WordPress has inserted the quick edit form.
 					const post_id = Number( form.id.substring( 5 ) );
+					console.log(post_id);
 
 					if ( post_id > 0 ) {
 						// Get the language dropdown.

--- a/js/src/post.js
+++ b/js/src/post.js
@@ -28,7 +28,6 @@ jQuery(
 				if ( 0 < mutation.addedNodes.length && ( form.classList.contains( 'inline-edit-post' ) || form.classList.contains( 'inline-edit-product' ) ) ) {
 					// WordPress has inserted the quick edit form.
 					const post_id = Number( form.id.substring( 5 ) );
-					console.log(post_id);
 
 					if ( post_id > 0 ) {
 						// Get the language dropdown.


### PR DESCRIPTION
## Issue
In our Polylang plugin for WooCommerce, a regression occurred because of this [commit](https://github.com/polylang/polylang/commit/c010007ade943893f1d022859cf6135a61d9f707) .
We check only for post quick edit table on this line: https://github.com/polylang/polylang/blob/c010007ade943893f1d022859cf6135a61d9f707/js/src/post.js#L28

See: 
![Capture d’écran 2022-05-13 à 17 52 54](https://user-images.githubusercontent.com/69580439/168321289-7b215ca8-c182-463f-b2e2-715584b46052.png)


## Changes
- ~Also test `inline-edit-product` class in the quick edit table.~
- Tests the inserted node contains the class `inline-editor` which seems to exists for all kind of post types in the quick edit form.

This PR is a quick fix, there should be another way to handle this allowing us to handle all post types. Maybe based on the `location.href` ?