### PR TITLE
keep query string in redirect url from the requested one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         - "composer update"
       script:
         - "vendor/bin/phpcs -s --extensions=php,js ./"
-        - "vendor/bin/phpstan analyze --memory-limit=2G"
+        - "vendor/bin/phpstan analyze --memory-limit=512M"
 
     - name: "WP 5.6 - PHP 7.2"
       php: "7.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         - "composer update"
       script:
         - "vendor/bin/phpcs -s --extensions=php,js ./"
-        - "vendor/bin/phpstan analyze --memory-limit=512M"
+        - "vendor/bin/phpstan analyze --memory-limit=1024M"
 
     - name: "WP 5.6 - PHP 7.2"
       php: "7.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         - "composer update"
       script:
         - "vendor/bin/phpcs -s --extensions=php,js ./"
-        - "vendor/bin/phpstan analyze --memory-limit=1024M"
+        - "vendor/bin/phpstan analyze --memory-limit=2G"
 
     - name: "WP 5.6 - PHP 7.2"
       php: "7.2"

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -403,7 +403,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 					}
-					$redirect_url = $this->maybe_keep_query_string_in_redirect_url( $requested_url, $redirect_url);
+					$redirect_url = $this->maybe_keep_query_string_in_redirect_url( $requested_url, $redirect_url );
 					$language = $this->get_queried_term_language();
 				} else {
 					// We need to switch the language when there is no language provided in a pretty permalink.

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -403,10 +403,18 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 					}
-					// Keep query string from the requested URL if any.
-					$parsed_requested_url = wp_parse_url( $requested_url );
-					if ( $parsed_requested_url && isset( $parsed_requested_url['query'] ) && ! empty( $parsed_requested_url['query'] ) ) {
-						$redirect_url = $redirect_url . '?' . $parsed_requested_url['query'];
+					// Keeps query string from the requested URL if any.
+					$query_string = wp_parse_url( $requested_url, PHP_URL_QUERY );
+
+					if ( is_string( $query_string ) && ! empty( $query_string ) ) {
+						// Removes query string parameters which can be used for rewriting.
+						parse_str( $query_string, $parameters );
+						foreach ( $parameters as $parameter_name => $value ) {
+							if ( in_array( $parameter_name, array( 'cat', 'tag', 'category_name', 'feed', 'paged' ), true ) ) {
+								unset( $parameters[ $parameter_name ] );
+							}
+						}
+						$redirect_url = $redirect_url . ( empty( $parameters ) ? '' : '?' . http_build_query( $parameters ) );
 					}
 					$language = $this->get_queried_term_language();
 				} else {

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -403,6 +403,11 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 					}
+					// Keep query string from the requested URL if any.
+					$parsed_requested_url = wp_parse_url( $requested_url );
+					if ( $parsed_requested_url && isset( $parsed_requested_url['query'] ) && ! empty( $parsed_requested_url['query'] ) ) {
+						$redirect_url = $redirect_url . '?' . $parsed_requested_url['query'];
+					}
 					$language = $this->get_queried_term_language();
 				} else {
 					// We need to switch the language when there is no language provided in a pretty permalink.

--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -403,19 +403,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 					} else {
 						$redirect_url = $this->maybe_add_page_to_redirect_url( get_term_link( $term_id ) );
 					}
-					// Keeps query string from the requested URL if any.
-					$query_string = wp_parse_url( $requested_url, PHP_URL_QUERY );
-
-					if ( is_string( $query_string ) && ! empty( $query_string ) ) {
-						// Removes query string parameters which can be used for rewriting.
-						parse_str( $query_string, $parameters );
-						foreach ( $parameters as $parameter_name => $value ) {
-							if ( in_array( $parameter_name, array( 'cat', 'tag', 'category_name', 'feed', 'paged' ), true ) ) {
-								unset( $parameters[ $parameter_name ] );
-							}
-						}
-						$redirect_url = $redirect_url . ( empty( $parameters ) ? '' : '?' . http_build_query( $parameters ) );
-					}
+					$redirect_url = $this->maybe_keep_query_string_in_redirect_url( $requested_url, $redirect_url);
 					$language = $this->get_queried_term_language();
 				} else {
 					// We need to switch the language when there is no language provided in a pretty permalink.
@@ -511,6 +499,33 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 		if ( ! empty( $this->wp_query()->query['paged'] ) && $page = get_query_var( 'paged' ) ) {
 			$redirect_url = $this->links_model->add_paged_to_link( $redirect_url, $page );
 		}
+		return $redirect_url;
+	}
+
+	/**
+	 * Returns the link by keeping the query string if necessary.
+	 *
+	 * @since 3.2
+	 *
+	 * @param string $requested_url The original requested URL.
+	 * @param string $redirect_url  The url to redirect to.
+	 * @return string The modified url to redirect to.
+	 */
+	protected function maybe_keep_query_string_in_redirect_url( $requested_url, $redirect_url ) {
+		// Keeps query string from the requested URL if any.
+		$query_string = wp_parse_url( $requested_url, PHP_URL_QUERY );
+
+		if ( is_string( $query_string ) && ! empty( $query_string ) ) {
+			// Removes query string parameters which can be used for rewriting.
+			parse_str( $query_string, $parameters );
+			foreach ( $parameters as $parameter_name => $value ) {
+				if ( in_array( $parameter_name, array( 'cat', 'tag', 'category_name', 'feed', 'paged' ), true ) ) {
+					unset( $parameters[ $parameter_name ] );
+				}
+			}
+			$redirect_url = $redirect_url . ( empty( $parameters ) ? '' : '?' . http_build_query( $parameters ) );
+		}
+
 		return $redirect_url;
 	}
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -132,6 +132,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?p=' . self::$post_en, '/en/post-format-test-audio/' );
 	}
 
+	public function test_should_not_remove_query_string_parameter_from_post_plain_permalink_url() {
+		$this->assertCanonical( '?foo=bar&p=' . self::$post_en, '/en/post-format-test-audio/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_post_rewritten_url() {
+		$this->assertCanonical( '/en/post-format-test-audio/?foo=bar&p=' . self::$post_en, '/en/post-format-test-audio/?foo=bar' );
+	}
+
 	public function test_post_feed_with_incorrect_language() {
 		$this->assertCanonical( '/fr/post-format-test-audio/feed/', '/en/post-format-test-audio/feed/' );
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -233,11 +233,19 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public function test_should_not_remove_query_string_parameter_from_category_plain_permalink_url() {
-		$this->assertCanonical( '?sort=asc&cat=' . self::$term_en, '/en/category/parent/?sort=asc' );
+		$this->assertCanonical( '?foo=bar&cat=' . self::$term_en, '/en/category/parent/?foo=bar' );
 	}
 
 	public function test_should_not_remove_query_string_parameter_from_category_rewritten_url() {
-		$this->assertCanonical( '/en/category/parent/?sort=asc', '/en/category/parent/?sort=asc' );
+		$this->assertCanonical( '/en/category/parent/?foo=bar', '/en/category/parent/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_tag_plain_permalink_url() {
+		$this->assertCanonical( '?foo=bar&tag=test-tag', '/en/tag/test-tag/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_tag_rewritten_url() {
+		$this->assertCanonical( '/en/tag/test-tag/?foo=bar', '/en/tag/test-tag/?foo=bar' );
 	}
 
 	public function test_paged_category_from_plain_permalink() {

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -113,8 +113,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 			'custom_tax',
 			null,
 			array(
-				'public'    => true,
-				'rewrite'   => true,
+				'public'  => true,
+				'rewrite' => true,
 			)
 		);
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -166,6 +166,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?page_id=' . self::$page_id, '/en/parent-page/' );
 	}
 
+	public function test_should_not_remove_query_string_parameter_from_page_plain_permalink_url() {
+		$this->assertCanonical( '?foo=bar&page_id=' . self::$page_id, '/en/parent-page/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_page_rewritten_url() {
+		$this->assertCanonical( '/en/parent-page/?foo=bar&page_id=' . self::$page_id, '/en/parent-page/?foo=bar' );
+	}
+
 	public function test_page_feed_with_incorrect_language() {
 		$this->assertCanonical( '/fr/parent-page/feed/', '/en/parent-page/feed/' );
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -39,6 +39,20 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		add_action(
 			'registered_taxonomy',
 			function( $taxonomy ) {
+
+				if ( ! taxonomy_exists( 'custom_tax' ) ) {
+					register_taxonomy(
+						'custom_tax',
+						'post',
+						array(
+							'public'  => true,
+							'rewrite' => true,
+						)
+					);
+					$custom_term_en = self::factory()->term->create( array( 'taxonomy' => 'custom_tax', 'name' => 'custom-term' ) );
+					self::$model->term->set_language( $custom_term_en, 'en' );
+
+				}
 				if ( 'post_format' === $taxonomy && ! post_type_exists( 'pllcanonical' ) ) { // Last taxonomy registered in {@see https://github.com/WordPress/wordpress-develop/blob/36ef9cbca96fca46e7daf1ee687bb6a20788385c/src/wp-includes/taxonomy.php#L158-L174 create_initial_taxonomies()}
 					register_post_type(
 						'pllcanonical',
@@ -108,18 +122,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				),
 			)
 		);
-
-		register_taxonomy(
-			'custom_tax',
-			null,
-			array(
-				'public'  => true,
-				'rewrite' => true,
-			)
-		);
-
-		$custom_term_en = $this->factory()->term->create( array( 'taxonomy' => 'custom_tax', 'name' => 'custom-term' ) );
-		self::$model->term->set_language( $custom_term_en, 'en' );
 
 		add_filter(
 			'pll_get_taxonomies',

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -232,6 +232,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?cat=' . self::$term_en, '/en/category/parent/' );
 	}
 
+	public function test_should_not_remove_query_string_parameter_from_category_plain_permalink_url() {
+		$this->assertCanonical( '?sort=asc&cat=' . self::$term_en, '/en/category/parent/?sort=asc' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_category_rewritten_url() {
+		$this->assertCanonical( '/en/category/parent/?sort=asc', '/en/category/parent/?sort=asc' );
+	}
+
 	public function test_paged_category_from_plain_permalink() {
 		update_option( 'posts_per_page', 1 );
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -243,6 +243,15 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' );
 	}
 
+	public function test_should_not_remove_query_string_parameter_from_custom_post_type_plain_permalink_url() {
+		// WordPress redirect_canonical() doesn't rewrite plain permalink for custom post types.
+		$this->assertCanonical( '?foo=bar&pllcanonical=custom-post', '/en/?foo=bar&pllcanonical=custom-post' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_custom_post_type_rewritten_url() {
+		$this->assertCanonical( '/en/pllcanonical/custom-post/?foo=bar', '/en/pllcanonical/custom-post/?foo=bar' );
+	}
+
 	public function test_category_with_name_and_language() {
 		$this->assertCanonical(
 			'/en/category/parent/',

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -131,15 +131,15 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 	}
 
-/**
- * Creates a new custom taxonomy term for each test where it's required.
- *
- * @return void
- */
-protected function create_custom_term() {
-	$custom_term_en = self::factory()->term->create( array( 'taxonomy' => 'custom_tax', 'name' => 'custom-term' ) );
-	self::$model->term->set_language( $custom_term_en, 'en' );
-}
+	/**
+	 * Creates a new custom taxonomy term for each test where it's required.
+	 *
+	 * @return void
+	 */
+	protected function create_custom_term() {
+		$custom_term_en = self::factory()->term->create( array( 'taxonomy' => 'custom_tax', 'name' => 'custom-term' ) );
+		self::$model->term->set_language( $custom_term_en, 'en' );
+	}
 
 	public function test_post_with_name_and_language() {
 		$this->assertCanonical(


### PR DESCRIPTION
Fixes #1048 

Regression probably introduced #1017 and especially the condition on `category_name` https://github.com/polylang/polylang/blob/3.2.2/frontend/frontend-filters-links.php#L398

`get_term_link()` or `get_term_feed_link()`  functions generate the new URL from scratch without taking care of an existing query string in the URL.

## Changes
- Add a condition to check if a query string exist in the requested URL and add it to the redirect URL generated by the two functions mentioned above.
- Take care to remove query string parameters which can be used for rewriting.

## Expected behaviour
No redirection when the URL is correct and just has a query string in addition.
Same behaviour as before in Polylang 3.1.4