### PR TITLE
Get back to 3.1.4 state in check_canonical_url()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -592,21 +592,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$redirect_url of method PLL_Frontend_Filters_Links\\:\\:maybe_add_page_to_redirect_url\\(\\) expects string, string\\|false given\\.$#"
-			count: 2
-			path: frontend/frontend-filters-links.php
-
-		-
-			message: "#^Parameter \\#1 \\$term of function get_term_feed_link expects int\\|object, int\\|false given\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
-			message: "#^Parameter \\#1 \\$term of function get_term_link expects int\\|string\\|WP_Term, int\\|false given\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of method PLL_Translated_Term\\:\\:get_language\\(\\) expects int\\|string, int\\|false given\\.$#"
 			count: 1
 			path: frontend/frontend-filters-links.php
 

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -36,7 +36,7 @@ class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 
 		$wp_rewrite->init();
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
-		$wp_rewrite->set_permalink_structure( $this->structure );
+		$wp_rewrite->set_permalink_structure( $structure );
 
 		// $wp_rewrite->flush_rules() is called in self::assertCanonical()
 	}

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -6,6 +6,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	private static $post_en;
 	private static $page_id;
 	private static $custom_post_id;
+	private static $unrewriting_cpt_id;
 	private static $term_en;
 	private static $tag_en;
 	private static $page_for_posts_en;
@@ -39,12 +40,34 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		add_action(
 			'registered_taxonomy',
 			function( $taxonomy ) {
+
+				if ( ! taxonomy_exists( 'custom_tax' ) ) {
+					register_taxonomy(
+						'custom_tax',
+						'post',
+						array(
+							'public'  => true,
+							'rewrite' => true,
+						)
+					);
+				}
+
 				if ( 'post_format' === $taxonomy && ! post_type_exists( 'pllcanonical' ) ) { // Last taxonomy registered in {@see https://github.com/WordPress/wordpress-develop/blob/36ef9cbca96fca46e7daf1ee687bb6a20788385c/src/wp-includes/taxonomy.php#L158-L174 create_initial_taxonomies()}
 					register_post_type(
 						'pllcanonical',
 						array(
 							'public' => true,
 							'has_archive' => true, // Implies to build the feed permastruct by default.
+						)
+					);
+				}
+
+				if ( ! post_type_exists( 'pll-unrewriting-cpt' ) ) {
+					register_post_type(
+						'pll-unrewriting-cpt',
+						array(
+							'public'  => true,
+							'rewrite' => false,
 						)
 					);
 				}
@@ -58,6 +81,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 			)
 		);
 		self::$model->post->set_language( self::$custom_post_id, 'en' );
+
+		self::$unrewriting_cpt_id = $factory->post->create( array( 'post_type' => 'pll-unrewriting-cpt', 'post_title' => 'custom-post' ) );
+		self::$model->post->set_language( self::$unrewriting_cpt_id, 'en' );
 
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$model->term->set_language( self::$term_en, 'en' );
@@ -89,6 +115,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		_unregister_post_type( 'pllcanonical' );
+		_unregister_post_type( 'pll-unrewriting-cpt' );
+		_unregister_taxonomy( 'custom_tax' );
 
 		parent::wpTearDownAfterClass();
 	}
@@ -108,6 +136,41 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				),
 			)
 		);
+
+		add_filter(
+			'pll_get_taxonomies',
+			function( $taxonomies ) {
+				$taxonomies['custom_tax'] = 'custom_tax';
+				return $taxonomies;
+			}
+		);
+		add_filter(
+			'pll_get_post_types',
+			function( $post_types ) {
+				$post_types[] = 'pll-unrewriting-cpt';
+				return $post_types;
+			}
+		);
+	}
+
+	/**
+	 * Creates a new custom taxonomy term for each test where it's required.
+	 *
+	 * @return void
+	 */
+	protected function create_custom_term() {
+		$custom_term_en = self::factory()->term->create( array( 'taxonomy' => 'custom_tax', 'name' => 'custom-term' ) );
+		self::$model->term->set_language( $custom_term_en, 'en' );
+	}
+
+	public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_with_trailing_slash() {
+		$this->set_permalink_structure( '/%category%/%postname%/' );
+		$this->assertCanonical( '/en/?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
+	}
+
+	public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_with_trailing_slash() {
+		$this->set_permalink_structure( '/%category%/%postname%/' );
+		$this->assertCanonical( '/fr/?pll-unrewriting-cpt=custom-post', '/en/?pll-unrewriting-cpt=custom-post' );
 	}
 
 	public function test_post_with_name_and_language() {
@@ -130,6 +193,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_post_from_plain_permalink() {
 		$this->assertCanonical( '?p=' . self::$post_en, '/en/post-format-test-audio/' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_post_plain_permalink_url() {
+		$this->assertCanonical( '?foo=bar&p=' . self::$post_en, '/en/post-format-test-audio/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_post_rewritten_url() {
+		$this->assertCanonical( '/en/post-format-test-audio/?foo=bar&p=' . self::$post_en, '/en/post-format-test-audio/?foo=bar' );
 	}
 
 	public function test_post_feed_with_incorrect_language() {
@@ -166,6 +237,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical( '?page_id=' . self::$page_id, '/en/parent-page/' );
 	}
 
+	public function test_should_not_remove_query_string_parameter_from_page_plain_permalink_url() {
+		$this->assertCanonical( '?foo=bar&page_id=' . self::$page_id, '/en/parent-page/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_page_rewritten_url() {
+		$this->assertCanonical( '/en/parent-page/?foo=bar&page_id=' . self::$page_id, '/en/parent-page/?foo=bar' );
+	}
+
 	public function test_page_feed_with_incorrect_language() {
 		$this->assertCanonical( '/fr/parent-page/feed/', '/en/parent-page/feed/' );
 	}
@@ -194,6 +273,15 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_custom_post_type_without_language() {
 		$this->assertCanonical( '/pllcanonical/custom-post/', '/en/pllcanonical/custom-post/' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_custom_post_type_plain_permalink_url() {
+		// WordPress redirect_canonical() doesn't rewrite plain permalink for custom post types.
+		$this->assertCanonical( '?foo=bar&pllcanonical=custom-post', '/en/?foo=bar&pllcanonical=custom-post' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_custom_post_type_rewritten_url() {
+		$this->assertCanonical( '/en/pllcanonical/custom-post/?foo=bar', '/en/pllcanonical/custom-post/?foo=bar' );
 	}
 
 	public function test_category_with_name_and_language() {
@@ -230,6 +318,45 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_category_from_plain_permalink() {
 		$this->assertCanonical( '?cat=' . self::$term_en, '/en/category/parent/' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_category_rewritten_url() {
+		$this->assertCanonical( '/en/category/parent/?foo=bar', '/en/category/parent/?foo=bar' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_tag_rewritten_url() {
+		$this->assertCanonical( '/en/tag/test-tag/?foo=bar', '/en/tag/test-tag/?foo=bar' );
+	}
+
+	public function test_custom_taxonomy_with_incorrect_language() {
+		$this->create_custom_term();
+		$this->assertCanonical( '/fr/custom_tax/custom-term/', '/en/custom_tax/custom-term/' );
+	}
+
+	public function test_custom_taxonomy_without_language() {
+		$this->create_custom_term();
+		$this->assertCanonical( '/custom_tax/custom-term/', '/en/custom_tax/custom-term/' );
+	}
+
+	public function test_custom_taxonomy_with_correct_language() {
+		$this->create_custom_term();
+		$this->assertCanonical( '/en/custom_tax/custom-term/', '/en/custom_tax/custom-term/' );
+	}
+
+	public function test_custom_taxonomy_from_plain_permalink() {
+		// WordPress redirect_canonical() doesn't rewrite plain permalink for custom taxonomies.
+		$this->create_custom_term();
+		$this->assertCanonical( '?custom_tax=custom-term', '/en/?custom_tax=custom-term' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_custom_taxonomy_plain_permalink_url() {
+		$this->create_custom_term();
+		$this->assertCanonical( '?foo=bar&custom_tax=custom-term', '/en/?foo=bar&custom_tax=custom-term' );
+	}
+
+	public function test_should_not_remove_query_string_parameter_from_custom_taxonomy_rewritten_url() {
+		$this->create_custom_term();
+		$this->assertCanonical( '/en/custom_tax/custom-term/?foo=bar', '/en/custom_tax/custom-term/?foo=bar' );
 	}
 
 	public function test_paged_category_from_plain_permalink() {
@@ -467,18 +594,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 	}
 
-	public function test_plain_cat_feed() {
-		$this->assertCanonical( '/?cat=' . self::$term_en . '&feed=rss2', '/en/category/parent/feed/' );
-	}
-
-	public function test_plain_tag_feed() {
-		$this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
-	}
-
-	public function test_untranslated_category_feed() {
-		$this->assertCanonical( '/fr/category/parent/feed/', '/en/category/parent/feed/' );
-	}
-
 	public function test_custom_post_type_feed_with_incorrect_language() {
 		$this->assertCanonical( '/fr/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
 	}
@@ -486,4 +601,34 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	public function test_custom_post_type_feed_without_language() {
 		$this->assertCanonical( '/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
 	}
+
+	// public function test_custom_post_type_without_rewriting_with_correct_language_and_permalink_structure_without_trailing_slash() {
+	// $this->set_permalink_structure( '/%category%/%postname%' );
+	// $this->assertCanonical( '/en?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
+	// }
+
+	// public function test_custom_post_type_without_rewriting_with_incorrect_language_and_permalink_structure_without_trailing_slash() {
+	// $this->set_permalink_structure( '/%category%/%postname%' );
+	// $this->assertCanonical( '/fr?pll-unrewriting-cpt=custom-post', '/en?pll-unrewriting-cpt=custom-post' );
+	// }
+
+	// public function test_should_not_remove_query_string_parameter_from_category_plain_permalink_url() {
+	// $this->assertCanonical( '?foo=bar&cat=' . self::$term_en, '/en/category/parent/?foo=bar' );
+	// }
+
+	// public function test_should_not_remove_query_string_parameter_from_tag_plain_permalink_url() {
+	// $this->assertCanonical( '?foo=bar&tag=test-tag', '/en/tag/test-tag/?foo=bar' );
+	// }
+
+	// public function test_plain_cat_feed() {
+	// $this->assertCanonical( '/?cat=' . self::$term_en . '&feed=rss2', '/en/category/parent/feed/' );
+	// }
+
+	// public function test_plain_tag_feed() {
+	// $this->assertCanonical( '/?tag=test-tag&feed=rss2', '/en/tag/test-tag/feed/' );
+	// }
+
+	// public function test_untranslated_category_feed() {
+	// $this->assertCanonical( '/fr/category/parent/feed/', '/en/category/parent/feed/' );
+	// }
 }


### PR DESCRIPTION
The following PRs opened the pandora box by trying to handle more redirection cases.
- https://github.com/polylang/polylang/pull/901
- https://github.com/polylang/polylang/pull/887
- https://github.com/polylang/polylang/pull/1017

Prior to Polylang 3.1.4, we didn't handle redirection for feed link. But since then we introduced several bugs...
To go back to a more stable state we decided to revert the modification made in `check_canonical_url()` and leave the new tests to improve them a bit. 

*Note: Some failing tests related to former fixed issues have been commented at the end of the file `tests/phpunit/includes/testcase-canonical.php`*