### PR TITLE
Force empty string translation to empty string

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -146,7 +146,11 @@ function pll_register_string( $name, $string, $context = 'Polylang', $multiline 
  * @return string The string translated in the current language.
  */
 function pll__( $string ) {
-	return is_scalar( $string ) ? __( $string, 'pll_string' ) : $string; // PHPCS:ignore WordPress.WP.I18n
+	if ( ! is_scalar( $string ) || '' === $string ) {
+		return $string;
+	}
+
+	return __( $string, 'pll_string' ); // PHPCS:ignore WordPress.WP.I18n
 }
 
 /**
@@ -230,7 +234,7 @@ function pll_translate_string( $string, $lang ) {
 		return pll__( $string );
 	}
 
-	if ( ! is_scalar( $string ) ) {
+	if ( ! is_scalar( $string ) || '' === $string ) {
 		return $string;
 	}
 

--- a/include/mo.php
+++ b/include/mo.php
@@ -34,8 +34,6 @@ class PLL_MO extends MO {
 	 * @return void
 	 */
 	public function export_to_db( $lang ) {
-		$this->add_entry( $this->make_entry( '', '' ) ); // Empty string translation, just in case
-
 		/*
 		 * It would be convenient to store the whole object but it would take a huge space in DB.
 		 * So let's keep only the strings in an array.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,12 +33,6 @@ parameters:
 			count: 1
 			path: admin/admin-base.php
 
-		# Ignored because of https://github.com/polylang/polylang/commit/fedd9b62354ae4179e39e1fd822cfee1a12643d5
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: include/api.php
-
 		# Ignored because of https://wordpress.org/support/topic/detect-browser-language-sometimes-setting-null-language
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -137,6 +137,7 @@ class Strings_Test extends PLL_UnitTestCase {
 	public function test_html_string() {
 		update_option( 'use_balanceTags', 1 ); // To break malformed html in versions < 2.1
 		$language = self::$model->get_language( 'fr' );
+
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( '<p>test</p>', '<p>test fr</p>' ) );
 		$_mo->add_entry( $_mo->make_entry( '<p>malformed<p>', '<p>malformed fr<p>' ) );
@@ -160,6 +161,7 @@ class Strings_Test extends PLL_UnitTestCase {
 	 */
 	public function test_slashed_string() {
 		$language = self::$model->get_language( 'fr' );
+
 		$_mo = new PLL_MO();
 		$_mo->add_entry( $_mo->make_entry( '\slashed', '\slashed fr' ) );
 		$_mo->add_entry( $_mo->make_entry( '\\slashed', '\\slashed fr' ) );
@@ -177,6 +179,28 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '\slashed fr', pll__( '\slashed' ) );
 		$this->assertEquals( '\\slashed fr', pll__( '\\slashed' ) );
 		$this->assertEquals( '\\\slashed fr', pll__( '\\\slashed' ) );
+	}
+
+	/**
+	 * Tests workaround of https://core.trac.wordpress.org/ticket/55941
+	 */
+	public function test_empty_string() {
+		$language = self::$model->get_language( 'fr' );
+
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( '0', '0' ) );
+		$_mo->export_to_db( $language );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$GLOBALS['l10n']['pll_string'] = &$mo;
+
+		$frontend = new PLL_Frontend( $this->links_model );
+		$frontend->curlang = $language;
+		do_action( 'pll_language_defined' );
+
+		$this->assertEquals( '0', pll__( '0' ) );
+		$this->assertEquals( '', pll__( '' ) );
 	}
 
 	public function test_switch_to_locale() {

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -10,6 +10,7 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
+		self::create_language( 'de_DE' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
 	}
@@ -201,7 +202,7 @@ class Strings_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_translate_string_with_empty_string() {
-		foreach ( array( 'en', 'fr' ) as $lang ) {
+		foreach ( array( 'de', 'fr' ) as $lang ) {
 			$language = self::$model->get_language( $lang );
 			$mo = new PLL_MO();
 			$mo->import_from_db( $language );
@@ -219,8 +220,8 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '', pll_translate_string( '', 'fr' ) );
 
 		// Secondary language.
-		$this->assertEquals( '0 - en', pll_translate_string( '0', 'en' ) );
-		$this->assertEquals( '', pll_translate_string( '', 'en' ) );
+		$this->assertEquals( '0 - de', pll_translate_string( '0', 'de' ) );
+		$this->assertEquals( '', pll_translate_string( '', 'de' ) );
 	}
 
 	public function test_switch_to_locale() {

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -145,7 +145,6 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
-		$GLOBALS['l10n']['pll_string'] = &$mo;
 
 		$frontend = new PLL_Frontend( $this->links_model );
 		$frontend->curlang = $language;
@@ -170,7 +169,6 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
-		$GLOBALS['l10n']['pll_string'] = &$mo;
 
 		$frontend = new PLL_Frontend( $this->links_model );
 		$frontend->curlang = $language;
@@ -193,7 +191,6 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		$mo = new PLL_MO();
 		$mo->import_from_db( $language );
-		$GLOBALS['l10n']['pll_string'] = &$mo;
 
 		$frontend = new PLL_Frontend( $this->links_model );
 		$frontend->curlang = $language;

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -200,6 +200,29 @@ class Strings_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '', pll__( '' ) );
 	}
 
+	public function test_translate_string_with_empty_string() {
+		foreach ( array( 'en', 'fr' ) as $lang ) {
+			$language = self::$model->get_language( $lang );
+			$mo = new PLL_MO();
+			$mo->import_from_db( $language );
+			$mo->add_entry( $mo->make_entry( '0', "0 - {$lang}" ) );
+			$mo->export_to_db( $language );
+		}
+
+		$frontend = new PLL_Frontend( $this->links_model );
+		$GLOBALS['polylang'] = $frontend;
+		$frontend->curlang = self::$model->get_language( 'fr' );
+		do_action( 'pll_language_defined' );
+
+		// Current language.
+		$this->assertEquals( '0 - fr', pll_translate_string( '0', 'fr' ) );
+		$this->assertEquals( '', pll_translate_string( '', 'fr' ) );
+
+		// Secondary language.
+		$this->assertEquals( '0 - en', pll_translate_string( '0', 'en' ) );
+		$this->assertEquals( '', pll_translate_string( '', 'en' ) );
+	}
+
 	public function test_switch_to_locale() {
 		// Strings translations
 		$mo = new PLL_MO();


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1387

The issue was originally reported by https://secure.helpscout.net/conversation/1903439781/19600

Basically, when the strings translations include a translation for `'0'`, let say `'0'`, the empty string is translated to `'0'`.

https://github.com/polylang/polylang/blob/3.2.4/include/mo.php#L37 was probably intended to avoid this kind of issue, but this doesn't work. 

The root cause is explained in https://core.trac.wordpress.org/ticket/55941. However, we can work around this WP bug directly in Polylang, at least for string translations.
