### PR TITLE
Make the Site Health report more human readable.

### DIFF
--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -179,6 +179,7 @@ class PLL_Admin_Site_Health {
 			case 'media_support':
 				if ( ! $value ) {
 					$value = esc_html__( 'The media are not translated (0)', 'polylang' );
+					break;
 				}
 				// translators: the placeholder is the option stored in database.
 				$value = esc_html__( 'The media are translated (%s)', 'polylang' );

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -118,7 +118,6 @@ class PLL_Admin_Site_Health {
 	 * @return mixed Option value.
 	 */
 	public function format_value( $key, $value ) {
-		$db_value = $value;
 		switch ( $key ) {
 			case 'browser':
 				if ( ! $value ) {

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -109,6 +109,96 @@ class PLL_Admin_Site_Health {
 	}
 
 	/**
+	 * Transform the option value to readable human sentence.
+	 *
+	 * @since 3.3
+	 *
+	 * @param string                $key option name.
+	 * @param string|array|bool|int $value option value.
+	 *
+	 * @return string|array $value option value.
+	 */
+	public function format_value( $key, $value ) {
+		$db_value = $value;
+		switch ( $key ) {
+			case 'browser':
+				if ( true === $value ) {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'Browser prefered language activated (%s)', 'polylang' );
+				} else {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'Browser prefered language deactivated (%s)', 'polylang' );
+				}
+				break;
+			case 'rewrite':
+				if ( 1 === $value ) {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'Remove /language/ in pretty permalinks (%s)', 'polylang' );
+				} else {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'Keep /language/ in pretty permalinks (%s)', 'polylang' );
+				}
+				break;
+			case 'hide_default':
+				if ( 1 === $value ) {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'Hide URL language information for default language (%s)', 'polylang' );
+				} else {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'Display URL language information for default language (%s)', 'polylang' );
+				}
+				break;
+			case 'force_lang':
+				switch ( $value ) {
+					case '0':
+						// translators: the placeholder is the option stored in database.
+						$value = __( 'The language is set from content (%s)', 'polylang' );
+						break;
+					case '1':
+						// translators: the placeholder is the option stored in database.
+						$value = __( 'The language is set from the directory name in pretty permalinks (%s)', 'polylang' );
+						break;
+					case '2':
+						// translators: the placeholder is the option stored in database.
+						$value = __( 'The language is set from the subdomain name in pretty permalinks (%s)', 'polylang' );
+						break;
+					case '3':
+						// translators: the placeholder is the option stored in database.
+						$value = __( 'The language is set from different domains (%s)', 'polylang' );
+						break;
+				}
+				break;
+			case 'redirect_lang':
+				if ( 1 === $value ) {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'The front page URL contains the language code instead of the page name or page id (%s)', 'polylang' );
+				} else {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'The front page URL contains the page name or page id instead of the language code (%s)', 'polylang' );
+				}
+				break;
+			case 'media_support':
+				if ( true === $value ) {
+					// translators: the placeholder is the option stored in database.
+					$value = __( 'The media are translated (%s)', 'polylang' );
+				} else {
+					$value = __( 'The media are not translated (0)', 'polylang' );
+				}
+				break;
+
+			case 'sync':
+				if ( is_array( $value ) && empty( $value ) ) {
+					$value = __( 'Synchronization disabled (0)', 'polylang' );
+				}
+				break;
+		}
+		if ( ! is_array( $value ) ) {
+			$value = sprintf( $value, $db_value );
+		}
+		return $value;
+	}
+
+	/**
 	 * Add Polylang Options to Site Health Informations tab.
 	 *
 	 * @since 2.8
@@ -122,7 +212,7 @@ class PLL_Admin_Site_Health {
 			if ( in_array( $key, $this->exclude_options_keys() ) ) {
 				continue;
 			}
-
+			$value = $this->format_value( $key, $value );
 			if ( ! is_array( $value ) ) {
 				if ( empty( $value ) ) {
 					$value = '0';

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -173,7 +173,7 @@ class PLL_Admin_Site_Health {
 				break;
 
 			case 'sync':
-				if ( is_array( $value ) && empty( $value ) ) {
+				if ( empty( $value ) ) {
 					$value = '0: ' . esc_html__( 'Synchronization disabled', 'polylang' );
 				}
 				break;

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -122,57 +122,45 @@ class PLL_Admin_Site_Health {
 		switch ( $key ) {
 			case 'browser':
 				if ( ! $value ) {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'Browser prefered language deactivated (0)', 'polylang' );
 					break;
 				}
-				// translators: the placeholder is the option stored in database.
 				$value = esc_html__( 'Browser prefered language activated (1)', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( 1 === $value ) {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'Remove /language/ in pretty permalinks (1)', 'polylang' );
 				} else {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'Keep /language/ in pretty permalinks (0)', 'polylang' );
 				}
 				break;
 			case 'hide_default':
 				if ( 1 === $value ) {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'Hide URL language information for default language (1)', 'polylang' );
 				} else {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'Display URL language information for default language (0)', 'polylang' );
 				}
 				break;
 			case 'force_lang':
 				switch ( $value ) {
 					case '0':
-						// translators: the placeholder is the option stored in database.
 						$value = esc_html__( 'The language is set from content (0)', 'polylang' );
 						break;
 					case '1':
-						// translators: the placeholder is the option stored in database.
 						$value = esc_html__( 'The language is set from the directory name in pretty permalinks (1)', 'polylang' );
 						break;
 					case '2':
-						// translators: the placeholder is the option stored in database.
 						$value = esc_html__( 'The language is set from the subdomain name in pretty permalinks (2)', 'polylang' );
 						break;
 					case '3':
-						// translators: the placeholder is the option stored in database.
 						$value = esc_html__( 'The language is set from different domains (3)', 'polylang' );
 						break;
 				}
 				break;
 			case 'redirect_lang':
 				if ( 1 === $value ) {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'The front page URL contains the language code instead of the page name or page id (1)', 'polylang' );
 				} else {
-					// translators: the placeholder is the option stored in database.
 					$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (0)', 'polylang' );
 				}
 				break;
@@ -181,7 +169,6 @@ class PLL_Admin_Site_Health {
 					$value = esc_html__( 'The media are not translated (0)', 'polylang' );
 					break;
 				}
-				// translators: the placeholder is the option stored in database.
 				$value = esc_html__( 'The media are translated (1)', 'polylang' );
 				break;
 

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -121,10 +121,10 @@ class PLL_Admin_Site_Health {
 		switch ( $key ) {
 			case 'browser':
 				if ( ! $value ) {
-					$value = '0: ' . esc_html__( 'Browser prefered language deactivated', 'polylang' );
+					$value = '0: ' . esc_html__( 'Detect browser language deactivated', 'polylang' );
 					break;
 				}
-				$value = '1: ' . esc_html__( 'Browser prefered language activated', 'polylang' );
+				$value = '1: ' . esc_html__( 'Detect browser language activated', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( $value ) {

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -127,14 +127,14 @@ class PLL_Admin_Site_Health {
 				$value = '1: ' . esc_html__( 'Browser prefered language activated', 'polylang' );
 				break;
 			case 'rewrite':
-				if ( 1 === $value ) {
+				if ( $value ) {
 					$value = '1: ' . esc_html__( 'Remove /language/ in pretty permalinks', 'polylang' );
 					break;
 				}
 				$value = '0: ' . esc_html__( 'Keep /language/ in pretty permalinks', 'polylang' );
 				break;
 			case 'hide_default':
-				if ( 1 === $value ) {
+				if ( $value ) {
 					$value = '1: ' . esc_html__( 'Hide URL language information for default language', 'polylang' );
 					break;
 				}
@@ -157,7 +157,7 @@ class PLL_Admin_Site_Health {
 				}
 				break;
 			case 'redirect_lang':
-				if ( 1 === $value ) {
+				if ( $value ) {
 					$value = '1: ' . esc_html__( 'The front page URL contains the language code instead of the page name or page id', 'polylang' );
 					break;
 				}

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -127,53 +127,53 @@ class PLL_Admin_Site_Health {
 					break;
 				}
 				// translators: the placeholder is the option stored in database.
-				$value = esc_html__( 'Browser prefered language activated (%s)', 'polylang' );
+				$value = esc_html__( 'Browser prefered language activated (1)', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( 1 === $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = esc_html__( 'Remove /language/ in pretty permalinks (%s)', 'polylang' );
+					$value = esc_html__( 'Remove /language/ in pretty permalinks (1)', 'polylang' );
 				} else {
 					// translators: the placeholder is the option stored in database.
-					$value = esc_html__( 'Keep /language/ in pretty permalinks (%s)', 'polylang' );
+					$value = esc_html__( 'Keep /language/ in pretty permalinks (0)', 'polylang' );
 				}
 				break;
 			case 'hide_default':
 				if ( 1 === $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = esc_html__( 'Hide URL language information for default language (%s)', 'polylang' );
+					$value = esc_html__( 'Hide URL language information for default language (1)', 'polylang' );
 				} else {
 					// translators: the placeholder is the option stored in database.
-					$value = esc_html__( 'Display URL language information for default language (%s)', 'polylang' );
+					$value = esc_html__( 'Display URL language information for default language (0)', 'polylang' );
 				}
 				break;
 			case 'force_lang':
 				switch ( $value ) {
 					case '0':
 						// translators: the placeholder is the option stored in database.
-						$value = esc_html__( 'The language is set from content (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from content (0)', 'polylang' );
 						break;
 					case '1':
 						// translators: the placeholder is the option stored in database.
-						$value = esc_html__( 'The language is set from the directory name in pretty permalinks (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from the directory name in pretty permalinks (1)', 'polylang' );
 						break;
 					case '2':
 						// translators: the placeholder is the option stored in database.
-						$value = esc_html__( 'The language is set from the subdomain name in pretty permalinks (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from the subdomain name in pretty permalinks (2)', 'polylang' );
 						break;
 					case '3':
 						// translators: the placeholder is the option stored in database.
-						$value = esc_html__( 'The language is set from different domains (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from different domains (3)', 'polylang' );
 						break;
 				}
 				break;
 			case 'redirect_lang':
 				if ( 1 === $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = esc_html__( 'The front page URL contains the language code instead of the page name or page id (%s)', 'polylang' );
+					$value = esc_html__( 'The front page URL contains the language code instead of the page name or page id (1)', 'polylang' );
 				} else {
 					// translators: the placeholder is the option stored in database.
-					$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (%s)', 'polylang' );
+					$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (0)', 'polylang' );
 				}
 				break;
 			case 'media_support':
@@ -182,7 +182,7 @@ class PLL_Admin_Site_Health {
 					break;
 				}
 				// translators: the placeholder is the option stored in database.
-				$value = esc_html__( 'The media are translated (%s)', 'polylang' );
+				$value = esc_html__( 'The media are translated (1)', 'polylang' );
 				break;
 
 			case 'sync':
@@ -191,9 +191,7 @@ class PLL_Admin_Site_Health {
 				}
 				break;
 		}
-		if ( ! is_array( $value ) ) {
-			$value = sprintf( $value, $db_value );
-		}
+
 		return $value;
 	}
 

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -115,7 +115,6 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @param string                $key option name.
 	 * @param string|array|bool|int $value option value.
-	 *
 	 * @return string|array $value option value.
 	 */
 	public function format_value( $key, $value ) {
@@ -124,70 +123,70 @@ class PLL_Admin_Site_Health {
 			case 'browser':
 				if ( ! $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'Browser prefered language deactivated (%s)', 'polylang' );
+					$value = esc_html__( 'Browser prefered language deactivated (0)', 'polylang' );
 					break;
 				}
 				// translators: the placeholder is the option stored in database.
-				$value = __( 'Browser prefered language activated (%s)', 'polylang' );
+				$value = esc_html__( 'Browser prefered language activated (%s)', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( 1 === $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'Remove /language/ in pretty permalinks (%s)', 'polylang' );
+					$value = esc_html__( 'Remove /language/ in pretty permalinks (%s)', 'polylang' );
 				} else {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'Keep /language/ in pretty permalinks (%s)', 'polylang' );
+					$value = esc_html__( 'Keep /language/ in pretty permalinks (%s)', 'polylang' );
 				}
 				break;
 			case 'hide_default':
 				if ( 1 === $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'Hide URL language information for default language (%s)', 'polylang' );
+					$value = esc_html__( 'Hide URL language information for default language (%s)', 'polylang' );
 				} else {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'Display URL language information for default language (%s)', 'polylang' );
+					$value = esc_html__( 'Display URL language information for default language (%s)', 'polylang' );
 				}
 				break;
 			case 'force_lang':
 				switch ( $value ) {
 					case '0':
 						// translators: the placeholder is the option stored in database.
-						$value = __( 'The language is set from content (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from content (%s)', 'polylang' );
 						break;
 					case '1':
 						// translators: the placeholder is the option stored in database.
-						$value = __( 'The language is set from the directory name in pretty permalinks (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from the directory name in pretty permalinks (%s)', 'polylang' );
 						break;
 					case '2':
 						// translators: the placeholder is the option stored in database.
-						$value = __( 'The language is set from the subdomain name in pretty permalinks (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from the subdomain name in pretty permalinks (%s)', 'polylang' );
 						break;
 					case '3':
 						// translators: the placeholder is the option stored in database.
-						$value = __( 'The language is set from different domains (%s)', 'polylang' );
+						$value = esc_html__( 'The language is set from different domains (%s)', 'polylang' );
 						break;
 				}
 				break;
 			case 'redirect_lang':
 				if ( 1 === $value ) {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'The front page URL contains the language code instead of the page name or page id (%s)', 'polylang' );
+					$value = esc_html__( 'The front page URL contains the language code instead of the page name or page id (%s)', 'polylang' );
 				} else {
 					// translators: the placeholder is the option stored in database.
-					$value = __( 'The front page URL contains the page name or page id instead of the language code (%s)', 'polylang' );
+					$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (%s)', 'polylang' );
 				}
 				break;
 			case 'media_support':
 				if ( ! $value ) {
-					$value = __( 'The media are not translated (0)', 'polylang' );
+					$value = esc_html__( 'The media are not translated (0)', 'polylang' );
 				}
 				// translators: the placeholder is the option stored in database.
-				$value = __( 'The media are translated (%s)', 'polylang' );
+				$value = esc_html__( 'The media are translated (%s)', 'polylang' );
 				break;
 
 			case 'sync':
 				if ( is_array( $value ) && empty( $value ) ) {
-					$value = __( 'Synchronization disabled (0)', 'polylang' );
+					$value = esc_html__( 'Synchronization disabled (0)', 'polylang' );
 				}
 				break;
 		}

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -122,13 +122,13 @@ class PLL_Admin_Site_Health {
 		$db_value = $value;
 		switch ( $key ) {
 			case 'browser':
-				if ( true === $value ) {
-					// translators: the placeholder is the option stored in database.
-					$value = __( 'Browser prefered language activated (%s)', 'polylang' );
-				} else {
+				if ( ! $value ) {
 					// translators: the placeholder is the option stored in database.
 					$value = __( 'Browser prefered language deactivated (%s)', 'polylang' );
+					break;
 				}
+				// translators: the placeholder is the option stored in database.
+				$value = __( 'Browser prefered language activated (%s)', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( 1 === $value ) {

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -122,60 +122,60 @@ class PLL_Admin_Site_Health {
 		switch ( $key ) {
 			case 'browser':
 				if ( ! $value ) {
-					$value = esc_html__( 'Browser prefered language deactivated (0)', 'polylang' );
+					$value = '0: ' . esc_html__( 'Browser prefered language deactivated', 'polylang' );
 					break;
 				}
-				$value = esc_html__( 'Browser prefered language activated (1)', 'polylang' );
+				$value = '1: ' . esc_html__( 'Browser prefered language activated', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( 1 === $value ) {
-					$value = esc_html__( 'Remove /language/ in pretty permalinks (1)', 'polylang' );
+					$value = '1: ' . esc_html__( 'Remove /language/ in pretty permalinks', 'polylang' );
 					break;
 				}
-				$value = esc_html__( 'Keep /language/ in pretty permalinks (0)', 'polylang' );
+				$value = '0: ' . esc_html__( 'Keep /language/ in pretty permalinks', 'polylang' );
 				break;
 			case 'hide_default':
 				if ( 1 === $value ) {
-					$value = esc_html__( 'Hide URL language information for default language (1)', 'polylang' );
+					$value = '1: ' . esc_html__( 'Hide URL language information for default language', 'polylang' );
 					break;
 				}
-				$value = esc_html__( 'Display URL language information for default language (0)', 'polylang' );
+				$value = '0: ' . esc_html__( 'Display URL language information for default language', 'polylang' );
 				break;
 			case 'force_lang':
 				switch ( $value ) {
 					case '0':
-						$value = esc_html__( 'The language is set from content (0)', 'polylang' );
+						$value = '0: ' . esc_html__( 'The language is set from content', 'polylang' );
 						break;
 					case '1':
-						$value = esc_html__( 'The language is set from the directory name in pretty permalinks (1)', 'polylang' );
+						$value = '1: ' . esc_html__( 'The language is set from the directory name in pretty permalinks', 'polylang' );
 						break;
 					case '2':
-						$value = esc_html__( 'The language is set from the subdomain name in pretty permalinks (2)', 'polylang' );
+						$value = '2: ' . esc_html__( 'The language is set from the subdomain name in pretty permalinks', 'polylang' );
 						break;
 					case '3':
-						$value = esc_html__( 'The language is set from different domains (3)', 'polylang' );
+						$value = '3: ' . esc_html__( 'The language is set from different domains', 'polylang' );
 						break;
 				}
 				break;
 			case 'redirect_lang':
 				if ( 1 === $value ) {
-					$value = esc_html__( 'The front page URL contains the language code instead of the page name or page id (1)', 'polylang' );
+					$value = '1: ' . esc_html__( 'The front page URL contains the language code instead of the page name or page id', 'polylang' );
 					break;
 				}
-				$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (0)', 'polylang' );
+				$value = '0: ' . esc_html__( 'The front page URL contains the page name or page id instead of the language code', 'polylang' );
 
 				break;
 			case 'media_support':
 				if ( ! $value ) {
-					$value = esc_html__( 'The media are not translated (0)', 'polylang' );
+					$value = '0: ' . esc_html__( 'The media are not translated', 'polylang' );
 					break;
 				}
-				$value = esc_html__( 'The media are translated (1)', 'polylang' );
+				$value = '1: ' . esc_html__( 'The media are translated', 'polylang' );
 				break;
 
 			case 'sync':
 				if ( is_array( $value ) && empty( $value ) ) {
-					$value = esc_html__( 'Synchronization disabled (0)', 'polylang' );
+					$value = '0: ' . esc_html__( 'Synchronization disabled', 'polylang' );
 				}
 				break;
 		}

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -109,7 +109,7 @@ class PLL_Admin_Site_Health {
 	}
 
 	/**
-	 * Transform the option value to readable human sentence.
+	 * Transforms the option value to readable human sentence.
 	 *
 	 * @since 3.3
 	 *

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -113,8 +113,8 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @since 3.3
 	 *
-	 * @param string                $key option name.
-	 * @param string|array|bool|int $value option value.
+	 * @param string $key   Option name.
+	 * @param mixed  $value Option value.
 	 * @return mixed Option value.
 	 */
 	public function format_value( $key, $value ) {

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -115,7 +115,7 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @param string                $key option name.
 	 * @param string|array|bool|int $value option value.
-	 * @return string|array $value option value.
+	 * @return array|bool|int|string $value option value.
 	 */
 	public function format_value( $key, $value ) {
 		$db_value = $value;
@@ -130,16 +130,16 @@ class PLL_Admin_Site_Health {
 			case 'rewrite':
 				if ( 1 === $value ) {
 					$value = esc_html__( 'Remove /language/ in pretty permalinks (1)', 'polylang' );
-				} else {
-					$value = esc_html__( 'Keep /language/ in pretty permalinks (0)', 'polylang' );
+					break;
 				}
+				$value = esc_html__( 'Keep /language/ in pretty permalinks (0)', 'polylang' );
 				break;
 			case 'hide_default':
 				if ( 1 === $value ) {
 					$value = esc_html__( 'Hide URL language information for default language (1)', 'polylang' );
-				} else {
-					$value = esc_html__( 'Display URL language information for default language (0)', 'polylang' );
+					break;
 				}
+				$value = esc_html__( 'Display URL language information for default language (0)', 'polylang' );
 				break;
 			case 'force_lang':
 				switch ( $value ) {
@@ -160,9 +160,10 @@ class PLL_Admin_Site_Health {
 			case 'redirect_lang':
 				if ( 1 === $value ) {
 					$value = esc_html__( 'The front page URL contains the language code instead of the page name or page id (1)', 'polylang' );
-				} else {
-					$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (0)', 'polylang' );
+					break;
 				}
+				$value = esc_html__( 'The front page URL contains the page name or page id instead of the language code (0)', 'polylang' );
+
 				break;
 			case 'media_support':
 				if ( ! $value ) {

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -115,7 +115,7 @@ class PLL_Admin_Site_Health {
 	 *
 	 * @param string                $key option name.
 	 * @param string|array|bool|int $value option value.
-	 * @return array|bool|int|string $value option value.
+	 * @return mixed Option value.
 	 */
 	public function format_value( $key, $value ) {
 		$db_value = $value;

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -178,12 +178,11 @@ class PLL_Admin_Site_Health {
 				}
 				break;
 			case 'media_support':
-				if ( true === $value ) {
-					// translators: the placeholder is the option stored in database.
-					$value = __( 'The media are translated (%s)', 'polylang' );
-				} else {
+				if ( ! $value ) {
 					$value = __( 'The media are not translated (0)', 'polylang' );
 				}
+				// translators: the placeholder is the option stored in database.
+				$value = __( 'The media are translated (%s)', 'polylang' );
 				break;
 
 			case 'sync':


### PR DESCRIPTION
Some options in Polylang are stored with info which are  boolean or integer and are not easy to understand to non developer.
This PR will add the options text available in the Polylang settings with the old value.
Thanks to the old value, the developers will be able to debug their development easily.