### PR TITLE
Set current language just after saving a post type

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -345,7 +345,9 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		// Edit Post
 		if ( isset( $_REQUEST['pll_post_id'] ) && $lang = $this->model->post->get_language( (int) $_REQUEST['pll_post_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = $lang;
-		} elseif ( 'post.php' === $GLOBALS['pagenow'] && isset( $_GET['post'] ) && $this->model->is_translated_post_type( get_post_type( (int) $_GET['post'] ) ) && $lang = $this->model->post->get_language( (int) $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( 'post.php' === $GLOBALS['pagenow'] && isset( $_GET['post'] ) && false !== get_post_type( (int) $_GET['post'] ) && $this->model->is_translated_post_type( get_post_type( (int) $_GET['post'] ) ) && $lang = $this->model->post->get_language( (int) $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->curlang = $lang;
+		} elseif ( 'post.php' === $GLOBALS['pagenow'] && isset( $_POST['post_ID'] ) && false !== get_post_type( (int) $_POST['post_ID'] ) && $this->model->is_translated_post_type( get_post_type( (int) $_POST['post_ID'] ) ) && $lang = $this->model->post->get_language( (int) $_POST['post_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = $lang;
 		} elseif ( 'post-new.php' === $GLOBALS['pagenow'] && ( empty( $_GET['post_type'] ) || $this->model->is_translated_post_type( sanitize_key( $_GET['post_type'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = empty( $_GET['new_lang'] ) ? $this->pref_lang : $this->model->get_language( sanitize_key( $_GET['new_lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -356,8 +356,8 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		// Edit Term
 		elseif ( isset( $_REQUEST['pll_term_id'] ) && $lang = $this->model->term->get_language( (int) $_REQUEST['pll_term_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->curlang = $lang;
-		} elseif ( in_array( $GLOBALS['pagenow'], array( 'edit-tags.php', 'term.php' ) ) && isset( $_GET['taxonomy'] ) && $this->model->is_translated_taxonomy( sanitize_key( $_GET['taxonomy'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			if ( isset( $_GET['tag_ID'] ) && $lang = $this->model->term->get_language( (int) $_GET['tag_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( in_array( $GLOBALS['pagenow'], array( 'edit-tags.php', 'term.php' ) ) && isset( $_REQUEST['taxonomy'] ) && $this->model->is_translated_taxonomy( sanitize_key( $_REQUEST['taxonomy'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			if ( isset( $_REQUEST['tag_ID'] ) && $lang = $this->model->term->get_language( (int) $_REQUEST['tag_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$this->curlang = $lang;
 			} elseif ( ! empty( $_GET['new_lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$this->curlang = $this->model->get_language( sanitize_key( $_GET['new_lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: admin/admin-base.php
 
 		-
-			message: "#^Parameter \\#1 \\$post_type of method PLL_Model\\:\\:is_translated_post_type\\(\\) expects array\\<string\\>\\|string, string\\|false given\\.$#"
-			count: 1
-			path: admin/admin-base.php
-
-		-
 			message: "#^Parameter \\#2 \\$callback of function add_action expects callable\\(\\)\\: mixed, array\\{mixed, 'admin_bar_menu'\\} given\\.$#"
 			count: 1
 			path: admin/admin-base.php

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -480,4 +480,18 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$this->assertNotFalse( strpos( $footer, 'var pll_page_languages = ' . wp_json_encode( $pages ) ) );
 	}
+
+	public function test_current_language_when_saving_post() {
+		$en = $this->factory->post->create();
+		self::$model->post->set_language( $en, 'en' );
+
+		$GLOBALS['pagenow'] = 'post.php';
+
+		$_POST = array(
+			'post_ID' => $en,
+		);
+		$this->pll_admin->set_current_language();
+
+		$this->assertEquals( 'en', $this->pll_admin->curlang->slug );
+	}
 }

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -200,8 +200,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		// Prepare all needed info before loading the entire form
 		$GLOBALS['post_type'] = 'post';
 		$tax = get_taxonomy( $taxonomy );
-		$_GET['taxonomy'] = $taxonomy;
-		$_REQUEST['tag_ID'] = $_GET['tag_ID'] = $tag_ID;
+		$_REQUEST['taxonomy'] = $taxonomy;
+		$_REQUEST['tag_ID'] = $tag_ID;
 		$tag = get_term( $tag_ID, $taxonomy, OBJECT, 'edit' );
 		$wp_http_referer = home_url( '/wp-admin/edit-tags.php?taxonomy=category' );
 		$message = '';
@@ -302,7 +302,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	public function test_parent_dropdown_in_new_tag() {
 		$this->pll_admin->pref_lang = self::$model->get_language( 'en' );
-		$_GET['taxonomy'] = 'category';
+		$_REQUEST['taxonomy'] = 'category';
 
 		$fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
 		self::$model->term->set_language( $fr, 'fr' );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -532,4 +532,19 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertIsArray( $term, 'The list of translation terms should be an array.' );
 		$this->assertEmpty( $term, 'The list of translation terms should be empty.' );
 	}
+
+	public function test_current_language_when_saving_term() {
+		$en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai' ) );
+		self::$model->term->set_language( $en, 'en' );
+
+		$GLOBALS['pagenow'] = 'term.php';
+
+		$_REQUEST = $_POST = array(
+			'taxonomy' => 'category',
+			'tag_ID'   => $en,
+		);
+		$this->pll_admin->set_current_language();
+
+		$this->assertEquals( 'en', $this->pll_admin->curlang->slug );
+	}
 }


### PR DESCRIPTION
By studying the [Polylang For WooCommerce #445 issue](https://github.com/polylang/polylang-wc/issues/445) it appears that attributes lookup table update process is run during the post save process and so when the edit post form is submitted.

Until now Polylang set the post current language only when the edit post page is requested by its URL `post.php?post=...`
See https://github.com/polylang/polylang/blob/3.2.4/admin/admin-base.php#L348

So the attributes lookup table update doesn't save the attribute values in the correct language because its `get_terms()` request 
isn't filtered by the correct language.
See https://github.com/woocommerce/woocommerce/blob/6.6.1/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php#L506-L520
In fact it is filtered by the Polylang admin filter language which could be different from the post ( product ) language.

This PR propose to also set the current language with the post language when it is saved.

This PR is only a part of the problem because it needs that the "Direct updates" is checked in the WooCommerce product advanced settings.

![image](https://user-images.githubusercontent.com/1003778/175557651-179f7d39-509a-49ef-977b-d738d3931702.png)

I will propose another Polylang For WooCommerce PR to solve the problem for scheduled attributes lookup table updates.

Even if there is no issue reported yet, this PR also fixes this kind of case which would probably cause issue on terms.

## Changes
- add a conditions to set the post  language as the current one when an edit post form is submitted
- remove an ignored PHPStan errors by adding a condition as in the new piece of code
- PHPunit test to cover this case
- form terms at the opposite of posts, the form input fields have the same names as the query string parameters. So I used `$_REQUEST` global variable to process both of `$_GET` and `$_POST` ones.