### PR TITLE
Checks if current language is set in walker dropdown

### DIFF
--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -104,7 +104,13 @@ class PLL_Walker_Dropdown extends Walker {
 
 		if ( ! empty( $args['flag'] ) ) {
 			$current = wp_list_filter( $elements, array( $args['value'] => $args['selected'] ) );
-			$lang = reset( $current );
+			
+			if (empty($current)) {
+				$lang = reset($elements);
+		    	} else {
+				$lang = reset( $current );
+		    	}
+			
 			$output = sprintf(
 				'<span class="pll-select-flag">%s</span>',
 				empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag


### PR DESCRIPTION
In case languages are filtered it might occure, that the default language is not accessible. In this case $current might be empty. In this case I use the first avaliable language.

Context: I created a plugin to restrict editable languages for certain users.