### PR TITLE
Handle OR operator in WP_Tax_Query

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -317,6 +317,9 @@ abstract class PLL_Choose_Lang {
 	 */
 	protected function set_curlang_in_query( &$query ) {
 		$pll_query = new PLL_Query( $query, $this->model );
-		$pll_query->set_language( $this->curlang );
+
+		if ( $this->curlang instanceof PLL_Language ) {
+			$pll_query->set_language( $this->curlang );
+		}
 	}
 }

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -316,9 +316,8 @@ abstract class PLL_Choose_Lang {
 	 * @return void
 	 */
 	protected function set_curlang_in_query( &$query ) {
-		$pll_query = new PLL_Query( $query, $this->model );
-
-		if ( $this->curlang instanceof PLL_Language ) {
+		if ( ! empty( $this->curlang ) ) {
+			$pll_query = new PLL_Query( $query, $this->model );
 			$pll_query->set_language( $this->curlang );
 		}
 	}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -157,36 +157,6 @@ class PLL_Frontend extends PLL_Base {
 		if ( ! empty( $queried_taxonomies ) && 'language' == reset( $queried_taxonomies ) ) {
 			$query->tax_query->queried_terms['language'] = array_shift( $query->tax_query->queried_terms );
 		}
-
-		// If the OR operator is used, the language is not the queried object.
-		/** @var WP_Tax_Query $tax_query */
-		$tax_query = $query->tax_query;
-		if ( ! empty( $tax_query->queried_terms ) && 'OR' === $tax_query->relation && array_key_exists( 'language', $tax_query->queried_terms ) ) {
-			// First remove the language from the queried terms.
-			$tax_query->queries = array_filter(
-				$tax_query->queries,
-				function( $query ) {
-					return ! isset( $query['taxonomy'] ) || 'language' !== $query['taxonomy'];
-				}
-			);
-
-			// Then add the language to the queried terms with the AND operator between it and the orther terms.
-			$lang = $this->curlang;
-			$lang_query = array(
-				'taxonomy' => 'language',
-				'field'    => 'slug',
-				'terms'    => $lang,
-				'operator' => 'IN',
-			);
-			$tax_query = array(
-				$lang_query,
-				get_object_vars( $query->tax_query ),
-				'relation' => 'AND',
-			);
-			$tax_query        = new WP_Tax_Query( $tax_query );
-			$query->tax_query = $tax_query;
-		}
-
 	}
 
 	/**

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -157,6 +157,36 @@ class PLL_Frontend extends PLL_Base {
 		if ( ! empty( $queried_taxonomies ) && 'language' == reset( $queried_taxonomies ) ) {
 			$query->tax_query->queried_terms['language'] = array_shift( $query->tax_query->queried_terms );
 		}
+
+		// If the OR operator is used, the language is not the queried object.
+		/** @var WP_Tax_Query $tax_query */
+		$tax_query = $query->tax_query;
+		if ( ! empty( $tax_query->queried_terms ) && 'OR' === $tax_query->relation && array_key_exists( 'language', $tax_query->queried_terms ) ) {
+			// First remove the language from the queried terms.
+			$tax_query->queries = array_filter(
+				$tax_query->queries,
+				function( $query ) {
+					return ! isset( $query['taxonomy'] ) || 'language' !== $query['taxonomy'];
+				}
+			);
+
+			// Then add the language to the queried terms with the AND operator between it and the orther terms.
+			$lang = $this->curlang;
+			$lang_query = array(
+				'taxonomy' => 'language',
+				'field'    => 'slug',
+				'terms'    => $lang,
+				'operator' => 'IN',
+			);
+			$tax_query = array(
+				$lang_query,
+				get_object_vars( $query->tax_query ),
+				'relation' => 'AND',
+			);
+			$tax_query        = new WP_Tax_Query( $tax_query );
+			$query->tax_query = $tax_query;
+		}
+
 	}
 
 	/**

--- a/include/query.php
+++ b/include/query.php
@@ -30,6 +30,7 @@ class PLL_Query {
 	public function __construct( &$query, &$model ) {
 		$this->query = &$query;
 		$this->model = &$model;
+		add_action( 'parse_tax_query', array( $this, 'parse_tax_query' ) );
 	}
 
 	/**
@@ -183,6 +184,51 @@ class PLL_Query {
 			if ( isset( $qvars['lang'] ) && 'all' === $qvars['lang'] ) {
 				unset( $qvars['lang'] );
 			}
+		}
+	}
+
+	/**
+	 * Filters the taxonomy query to add the language properly when the 'OR' operator is used.
+	 *
+	 * @since 3.3
+	 *
+	 * @param WP_Query $query The current query object to filter.
+	 * @return void
+	 */
+	public function parse_tax_query( $query ) {
+		// If the OR operator is used, the language is not the queried object.
+		/** @var WP_Tax_Query $tax_query */
+		$tax_query = $query->tax_query;
+		if ( ! empty( $tax_query->queried_terms ) && 'OR' === $tax_query->relation && array_key_exists( 'language', $tax_query->queried_terms ) ) {
+			// First get the queried language.
+			if ( ! isset( $tax_query->queried_terms['language']['terms'][0] ) ) {
+				// No language is queried.
+				return;
+			}
+			$lang = $this->model->get_language( $tax_query->queried_terms['language']['terms'][0] );
+
+			// Then remove the language from the queried terms.
+			$tax_query->queries = array_filter(
+				$tax_query->queries,
+				function( $query ) {
+					return ! isset( $query['taxonomy'] ) || 'language' !== $query['taxonomy'];
+				}
+			);
+
+			// Finally add the language to the queried terms with the AND operator between it and the orther terms.
+			$lang_query = array(
+				'taxonomy' => 'language',
+				'field'    => 'slug',
+				'terms'    => $lang,
+				'operator' => 'IN',
+			);
+			$tax_query = array(
+				$lang_query,
+				get_object_vars( $query->tax_query ),
+				'relation' => 'AND',
+			);
+			$tax_query        = new WP_Tax_Query( $tax_query );
+			$query->tax_query = $tax_query;
 		}
 	}
 }

--- a/include/query.php
+++ b/include/query.php
@@ -175,8 +175,8 @@ class PLL_Query {
 			}
 		} else {
 			// Set the language correctly in the query, since WordPress merges the language with the other query vars when the operator is OR.
-			if ( isset( $qvars['lang'] ) ) {
-				$lang = $this->model->get_language( $qvars['lang'] );
+			if ( isset( $this->query->tax_query->queried_terms['language'] ) && 1 === count( $this->query->tax_query->queried_terms['language']['terms'] ) ) {
+				$lang = $this->model->get_language( reset( $this->query->tax_query->queried_terms['language']['terms'] ) );
 				unset( $qvars['lang'] );
 				if ( $lang instanceof PLL_Language ) {
 					$this->set_language( $lang );

--- a/include/query.php
+++ b/include/query.php
@@ -102,19 +102,14 @@ class PLL_Query {
 	 * @since 2.2
 	 * @since 3.3 Accepts now an array of languages.
 	 *
-	 * @param PLL_Language|PLL_Language[] $langs Language object(s).
+	 * @param PLL_Language|PLL_Language[] $languages Language object(s).
 	 * @return void
 	 */
-	public function set_language( $langs ) {
-		if ( $langs instanceof PLL_Language ) {
-			$langs = array( $langs );
+	public function set_language( $languages ) {
+		if ( ! is_array( $languages ) ) {
+			$languages = array( $languages );
 		}
-		$tt_ids = array_map(
-			function( $lang ) {
-				return $lang->term_taxonomy_id;
-			},
-			$langs
-		);
+		$tt_ids = wp_list_pluck( $languages, 'term_taxonomy_id' );
 
 		// Defining directly the tax_query ( rather than setting 'lang' avoids transforming the query by WP )
 		$lang_query = array(

--- a/include/query.php
+++ b/include/query.php
@@ -188,7 +188,6 @@ class PLL_Query {
 				}
 				$langs = array_map( array( $this->model, 'get_language' ), $langs );
 				$langs = array_filter( $langs );
-				unset( $qvars['lang'] );
 
 				if ( ! empty( $langs ) ) {
 					$this->set_language( $langs );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -466,11 +466,6 @@ parameters:
 			path: frontend/choose-lang.php
 
 		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_Query\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|null given\\.$#"
-			count: 1
-			path: frontend/choose-lang.php
-
-		-
 			message: "#^Method PLL_Frontend_Auto_Translate\\:\\:get_post\\(\\) should return int but returns int\\|false\\.$#"
 			count: 1
 			path: frontend/frontend-auto-translate.php

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -772,7 +772,7 @@ class Query_Test extends PLL_UnitTestCase {
 			);
 		}
 
-		$this->frontend->curlang = 'fr';
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
 		$args = array(
 			'post_type' => 'post',

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -795,8 +795,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$queried_posts_ids = wp_list_pluck( $queried_posts, 'ID' );
 		$expected_posts    = array_merge( $french_posts_cat_1, $french_posts_cat_2 );
 
-		$this->assertNotEmpty( $queried_posts );
-		$this->assertSameSets( $expected_posts, $queried_posts_ids );
+		$this->assertNotEmpty( $queried_posts, 'The query should return posts.' );
+		$this->assertEmpty( array_intersect( $french_posts_no_cat, $queried_posts_ids ), 'The query should not return french posts without the category.' );
+		$this->assertSameSets( $expected_posts, $queried_posts_ids, 'The query should return french posts with the category.' );
 	}
 
 	public function test_or_operator_on_untranslated_tax() {
@@ -824,37 +825,16 @@ class Query_Test extends PLL_UnitTestCase {
 		$french_posts_tax_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_tax_1 as $index => $post ) {
 			self::$model->post->set_language( $post, 'fr' );
-			self::$model->post->save_translations(
-				$post,
-				array(
-					'en' => $eng_posts_tax_1[ $index ],
-					'fr' => $post,
-				)
-			);
 			wp_set_post_terms( $post, array( $first_tax ), 'tax' );
 		}
 		$french_posts_tax_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_tax_2 as $post ) {
 			self::$model->post->set_language( $post, 'fr' );
-			self::$model->post->save_translations(
-				$post,
-				array(
-					'en' => $eng_posts_tax_2[ $index ],
-					'fr' => $post,
-				)
-			);
 			wp_set_post_terms( $post, array( $second_tax ), 'tax' );
 		}
 		$french_posts_no_tax = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_no_tax as $post ) {
 			self::$model->post->set_language( $post, 'fr' );
-			self::$model->post->save_translations(
-				$post,
-				array(
-					'en' => $eng_posts_no_tax[ $index ],
-					'fr' => $post,
-				)
-			);
 		}
 
 		// Query with language parameter set.
@@ -881,8 +861,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$queried_posts_ids = wp_list_pluck( $queried_posts, 'ID' );
 		$expected_posts    = array_merge( $french_posts_tax_1, $french_posts_tax_2 );
 
-		$this->assertNotEmpty( $queried_posts );
-		$this->assertEqualSets( $expected_posts, $queried_posts_ids );
+		$this->assertNotEmpty( $queried_posts, 'The query should return posts.' );
+		$this->assertEmpty( array_intersect( $french_posts_no_tax, $queried_posts_ids ), 'The query should not return french posts without the taxonomy.' );
+		$this->assertEqualSets( $expected_posts, $queried_posts_ids, 'The query should return french posts with the taxonomy.' );
 
 		// Query with language parameter not set.
 		$args = array(
@@ -908,7 +889,9 @@ class Query_Test extends PLL_UnitTestCase {
 		$queried_posts_ids       = wp_list_pluck( $queried_posts, 'ID' );
 		$expected_posts          = array_merge( $french_posts_tax_1, $french_posts_tax_2, $eng_posts_tax_1, $eng_posts_tax_2 );
 
-		$this->assertNotEmpty( $queried_posts );
-		$this->assertEqualSets( $expected_posts, $queried_posts_ids );
+		$this->assertNotEmpty( $queried_posts, 'The query should return posts.' );
+		$this->assertEmpty( array_intersect( $french_posts_no_tax, $queried_posts_ids ), 'The query should not return french posts without the taxonomy.' );
+		$this->assertEmpty( array_intersect( $eng_posts_no_tax, $queried_posts_ids ), 'The query should not return english posts without the taxonomy.' );
+		$this->assertEqualSets( $expected_posts, $queried_posts_ids, 'The query should return french and english posts with the taxonomy.' );
 	}
 }

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -731,21 +731,45 @@ class Query_Test extends PLL_UnitTestCase {
 			wp_set_post_terms( $post, array( $second_cat_en ), 'category' );
 		}
 		$eng_posts_no_cat = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_no_cat as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+		}
 
 		// French Posts.
 		$french_posts_cat_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
-		foreach ( $french_posts_cat_1 as $post ) {
+		foreach ( $french_posts_cat_1 as $index => $post ) {
 			self::$model->post->set_language( $post, 'fr' );
+			self::$model->post->save_translations(
+				$post,
+				array(
+					'en' => $eng_posts_cat_1[ $index ],
+					'fr' => $post,
+				)
+			);
 			wp_set_post_terms( $post, array( $first_cat_fr ), 'category' );
 		}
 		$french_posts_cat_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_cat_2 as $post ) {
 			self::$model->post->set_language( $post, 'fr' );
+			self::$model->post->save_translations(
+				$post,
+				array(
+					'en' => $eng_posts_cat_2[ $index ],
+					'fr' => $post,
+				)
+			);
 			wp_set_post_terms( $post, array( $second_cat_fr ), 'category' );
 		}
 		$french_posts_no_cat = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_no_cat as $post ) {
 			self::$model->post->set_language( $post, 'fr' );
+			self::$model->post->save_translations(
+				$post,
+				array(
+					'en' => $eng_posts_no_cat[ $index ],
+					'fr' => $post,
+				)
+			);
 		}
 
 		$this->frontend->curlang = 'fr';

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -739,37 +739,16 @@ class Query_Test extends PLL_UnitTestCase {
 		$french_posts_cat_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_cat_1 as $index => $post ) {
 			self::$model->post->set_language( $post, 'fr' );
-			self::$model->post->save_translations(
-				$post,
-				array(
-					'en' => $eng_posts_cat_1[ $index ],
-					'fr' => $post,
-				)
-			);
 			wp_set_post_terms( $post, array( $first_cat_fr ), 'category' );
 		}
 		$french_posts_cat_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_cat_2 as $post ) {
 			self::$model->post->set_language( $post, 'fr' );
-			self::$model->post->save_translations(
-				$post,
-				array(
-					'en' => $eng_posts_cat_2[ $index ],
-					'fr' => $post,
-				)
-			);
 			wp_set_post_terms( $post, array( $second_cat_fr ), 'category' );
 		}
 		$french_posts_no_cat = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
 		foreach ( $french_posts_no_cat as $post ) {
 			self::$model->post->set_language( $post, 'fr' );
-			self::$model->post->save_translations(
-				$post,
-				array(
-					'en' => $eng_posts_no_cat[ $index ],
-					'fr' => $post,
-				)
-			);
 		}
 
 		$args = array(


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1389

## Issue
Given this query:
```
$args = array(
	'post_type' => 'post',
	'lang' => 'fr',
	'posts_per_page' => 10,
	'tax_query' => array(
		'relation' => 'OR',
		array(
			'taxonomy' => 'category',
			'field' => 'name',
			'terms' => array( '25' )
		),
		array(
			'taxonomy' => 'category',
			'field' => 'name',
			'terms' => array( 'FR' )
		)
	)
);
$loop = new WP_Query( $args );
```
WordPress will merge the `language` taxonomy with the queried ones [here](https://github.com/WordPress/wordpress-develop/blob/1c0a2efa5eac05dfd3b7d2b9cfe68e02da55b966/src/wp-includes/class-wp-query.php#L1131-L1170). Resulting in a taxonomy query like this:
```
'tax_query' => array(
		'relation' => 'OR',
		array(
			'taxonomy' => 'category',
			'field' => 'name',
			'terms' => array( '25' )
		),
		array(
			'taxonomy' => 'category',
			'field' => 'name',
			'terms' => array( 'FR' )
		),
		array(
			'taxonomy' => 'language',
			'field' => 'name',
			'terms' => array( 'fr' )
		)
	)
```
Unfortunately, `PLL_Query::set_language()` is not called when such a query is made since the language parameter is already existing, and thus the code handling the `OR` operator is not read. See: https://github.com/polylang/polylang/blob/3.2.5/include/query.php#L118-L123


## Changes
- Add a test to confirm the bug.
- In `PLL_Frontend::parse_tax_query()` add a `AND` operator between the language and the other queried terms if the `OR` operator is found in the first place. Seems to be a good place to do that, since this kind of query is made on front only, right?