### PR TITLE
Fix - Generate links alternate hreflang for front page static only if is actived for that

### DIFF
--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -63,7 +63,7 @@ class PLL_Frontend_Links extends PLL_Links {
 		 *
 		 * @since 1.8
 		 *
-		 * @param string       $url               Empty or the url of the translation of teh current page.
+		 * @param string       $url               Empty or the url of the translation of the current page.
 		 * @param PLL_Language $language          Language of the translation.
 		 * @param int          $queried_object_id Queried object id.
 		 */

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -161,7 +161,7 @@ class PLL_Frontend_Links extends PLL_Links {
 			}
 
 			// Front page when it is the list of posts
-			elseif ( is_front_page() ) {
+			elseif ( is_front_page() && $language->page_on_front ) {
 				$url = $this->get_home_url( $language );
 			}
 		}


### PR DESCRIPTION
## Problem
When you have a Front Page configured with an static page, all links  alternate:
like:
```<link rel="alternate" href="http://localhost:8080/pt/" hreflang="pt-PT" />```
 are printed on head HTML,  even it is not bound to all languages
 
<p align="center"> <img  width="auto" height="360px" src="https://user-images.githubusercontent.com/48767108/178686542-ee0d07a6-c13d-4ebb-8ea0-e5a373966528.png">
<br/><i>Columbia and Mexico Lang isnt bound to front page 1/2</i>
</p>

<br><br>

<p align="center"> <img  src="https://user-images.githubusercontent.com/48767108/178686553-1685aa15-1a0b-4e17-8d5e-c86fe34503e2.png">
<br/><i>Columbia and Mexico Lang isnt bound to front page 2/2</i>
</p>

<br><br>

![Captura de Tela 2022-07-13 às 05 18 40](https://user-images.githubusercontent.com/48767108/178686558-d1fad712-c7fe-462a-85c4-e0a4b8cc14e7.png)

<p align="center">
<i>HTML <code>head</code> printed with all languagues actived on Polylang, ignoring the configs of front-page atribuation.</i></p>

<br><br>
# Solution

Checkk, when is a page is front page, if the language has `page_on_front`
```php
// Front page when it is the list of posts
elseif ( is_front_page() && $language->page_on_front) {
    $url = $this->get_home_url( $language );
}
```

### After this fix, printed only tags of langs with front page are configured:
![Captura de Tela 2022-07-13 às 05 18 03](https://user-images.githubusercontent.com/48767108/178686562-672b4826-8325-475b-b249-e596b6100927.png)

