### PR TITLE
Remove ignored PHPStan errors after WP 6.0.1 doc improvement

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -891,11 +891,6 @@ parameters:
 			path: include/crud-posts.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function wp_slash expects array\\|string, mixed given\\.$#"
-			count: 1
-			path: include/crud-posts.php
-
-		-
 			message: "#^Parameter \\#2 \\$lang of method PLL_Translated_Post\\:\\:set_language\\(\\) expects int\\|PLL_Language\\|string, PLL_Language\\|null given\\.$#"
 			count: 1
 			path: include/crud-posts.php
@@ -1551,11 +1546,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$data of function maybe_unserialize expects string, mixed given\\.$#"
 			count: 3
-			path: modules/sync/sync-metas.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function wp_slash expects array\\|string, mixed given\\.$#"
-			count: 5
 			path: modules/sync/sync-metas.php
 
 		-


### PR DESCRIPTION
All is in the title.