### PR TITLE
Fix ABSPATH in tests

### DIFF
--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -116,8 +116,8 @@ install_test_suite() {
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
 		# remove all forward slashes in the end
 		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':dirname( __DIR__ ) . '/wordpress/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':dirname( __DIR__ ) . '/wordpress/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php


### PR DESCRIPTION
Our tests used to work with a relative `ABSPATH` `tmp/wordpress`. This worked until this [test](https://github.com/polylang/polylang/blob/3.2.5/tests/phpunit/tests/test-media.php#L39) broke due to https://core.trac.wordpress.org/ticket/55443. See https://app.travis-ci.com/github/polylang/polylang/builds/253516437
This PR fixes the `ABSPATH` definition in `wp-tests-config.php` to make sure that it's absolute.