### PR TITLE
Fix redirect when permalink structure has no trailing slash

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -101,9 +101,9 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		if ( ! empty( $languages ) ) {
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
-			$pattern = preg_quote( $root, '#' );
-			$pattern = '#' . $pattern . ( $this->options['rewrite'] ? '' : 'language/' ) . '(' . implode( '|', $languages ) . ')(/|$)#';
-			$url = preg_replace( $pattern, $root, $url );
+			$pattern = preg_quote( $root, '@' );
+			$pattern = '@' . $pattern . ( $this->options['rewrite'] ? '' : 'language/' ) . '(' . implode( '|', $languages ) . ')(([?#])|(/|$))@';
+			$url = preg_replace( $pattern, $root . '$3', $url );
 		}
 		return $url;
 	}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1036,11 +1036,6 @@ parameters:
 			path: include/links-directory.php
 
 		-
-			message: "#^Parameter \\#2 \\$replace of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: include/links-directory.php
-
-		-
 			message: "#^Method PLL_Links_Domain\\:\\:add_language_to_link\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: include/links-domain.php

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -6,6 +6,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	private static $post_en;
 	private static $page_id;
 	private static $custom_post_id;
+	private static $not_rewrited_cpt_id;
 	private static $term_en;
 	private static $second_term_en;
 	private static $custom_term_en;
@@ -50,6 +51,15 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		);
 		self::$model->post->set_language( self::$custom_post_id, 'en' );
 
+		self::$not_rewrited_cpt_id = $factory->post->create(
+			array(
+				'post_type'  => 'cptnotrewrited',
+				'post_title' => 'custom-post',
+			)
+		);
+		self::$model->post->set_language( self::$not_rewrited_cpt_id, 'en' );
+
+
 		self::$term_en = $factory->term->create( array( 'taxonomy' => 'category', 'name' => 'parent' ) );
 		self::$model->term->set_language( self::$term_en, 'en' );
 
@@ -86,6 +96,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		_unregister_post_type( 'pllcanonical' );
+		_unregister_post_type( 'cptnotrewrited' );
 		_unregister_taxonomy( 'custom_tax' );
 
 		parent::wpTearDownAfterClass();
@@ -99,6 +110,14 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 			array(
 				'public' => true,
 				'has_archive' => true, // Implies to build the feed permastruct by default.
+			)
+		);
+
+		register_post_type(
+			'cptnotrewrited',
+			array(
+				'public' => true,
+				'rewrite' => false,
 			)
 		);
 
@@ -123,7 +142,8 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 				'default_lang' => 'en',
 				'hide_default' => 0,
 				'post_types'   => array(
-					'pllcanonical' => 'pllcanonical',
+					'pllcanonical'   => 'pllcanonical',
+					'cptnotrewrited' => 'cptnotrewrited',
 				),
 				'taxonomies'   => array(
 					'custom_tax' => 'custom_tax',
@@ -303,6 +323,26 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_custom_post_type_feed_without_language() {
 		$this->assertCanonical( '/pllcanonical/custom-post/feed/', '/en/pllcanonical/custom-post/feed/' );
+	}
+
+	public function test_cpt_not_rewrited_and_permalinks_without_trailing_slash() {
+		$this->set_permalink_structure( '/%postname%' );
+		$this->assertCanonical(
+			'/en/?cptnotrewrited=custom-post',
+			array(
+				'url' => 	'/en/?cptnotrewrited=custom-post',
+				'qv'  => array(
+					'lang'           => 'en',
+					'cptnotrewrited' => 'custom-post',
+					'post_type'      => 'cptnotrewrited',
+				),
+			)
+		);
+	}
+
+	public function test_incorrect_language_for_cpt_not_rewrited_and_permalinks_without_trailing_slash() {
+		$this->set_permalink_structure( '/%postname%' );
+		$this->assertCanonical( '/fr/?cptnotrewrited=custom-post', '/en/?cptnotrewrited=custom-post' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -330,7 +330,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		$this->assertCanonical(
 			'/en/?cptnotrewrited=custom-post',
 			array(
-				'url' => 	'/en/?cptnotrewrited=custom-post',
+				'url' => '/en/?cptnotrewrited=custom-post',
 				'qv'  => array(
 					'lang'           => 'en',
 					'cptnotrewrited' => 'custom-post',

--- a/tests/phpunit/tests/test-links-directory.php
+++ b/tests/phpunit/tests/test-links-directory.php
@@ -55,6 +55,16 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $this->root . '/en/test/', $this->links_model->remove_language_from_link( $this->root . '/en/test/' ) );
 		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_language_from_link( $this->root . '/fr/test/' ) );
 
+		$this->assertEquals( $this->root . '/frtest/', $this->links_model->remove_language_from_link( $this->root . '/fr/frtest/' ) );
+
+		// Tests with language code at the end of the path.
+		$this->assertEquals( $this->root . '/', $this->links_model->remove_language_from_link( $this->root . '/fr/' ) );
+		$this->assertEquals( $this->root . '/', $this->links_model->remove_language_from_link( $this->root . '/fr' ) );
+		$this->assertEquals( $this->root . '/?query=string', $this->links_model->remove_language_from_link( $this->root . '/fr/?query=string' ) );
+		$this->assertEquals( $this->root . '/?query=string', $this->links_model->remove_language_from_link( $this->root . '/fr?query=string' ) );
+		$this->assertEquals( $this->root . '/#fragment', $this->links_model->remove_language_from_link( $this->root . '/fr/#fragment' ) );
+		$this->assertEquals( $this->root . '/#fragment', $this->links_model->remove_language_from_link( $this->root . '/fr#fragment' ) );
+
 		self::$model->options['rewrite'] = 0;
 		$this->assertEquals( $this->root . '/language/en/test/', $this->links_model->remove_language_from_link( $this->root . '/language/en/test/' ) );
 		$this->assertEquals( $this->root . '/test/', $this->links_model->remove_language_from_link( $this->root . '/language/fr/test/' ) );
@@ -65,6 +75,16 @@ class Links_Directory_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $this->root . '/test/', $this->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( $this->root . '/de/test/', $this->links_model->switch_language_in_link( $this->root . '/fr/test/', self::$model->get_language( 'de' ) ) );
 		$this->assertEquals( $this->root . '/fr/test/', $this->links_model->switch_language_in_link( $this->root . '/test/', self::$model->get_language( 'fr' ) ) );
+
+		$this->assertEquals( $this->root . '/de/frtest/', $this->links_model->switch_language_in_link( $this->root . '/fr/frtest/', self::$model->get_language( 'de' ) ) );
+
+		// Tests with language code at the end of the path.
+		$this->assertEquals( $this->root . '/fr/', $this->links_model->switch_language_in_link( $this->root . '/de/', self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->root . '/fr/', $this->links_model->switch_language_in_link( $this->root . '/de', self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->root . '/fr/?query=string', $this->links_model->switch_language_in_link( $this->root . '/de/?query=string', self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->root . '/fr/?query=string', $this->links_model->switch_language_in_link( $this->root . '/de?query=string', self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->root . '/fr/#fragment', $this->links_model->switch_language_in_link( $this->root . '/de/#fragment', self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( $this->root . '/fr/#fragment', $this->links_model->switch_language_in_link( $this->root . '/de#fragment', self::$model->get_language( 'fr' ) ) );
 	}
 
 	protected function _test_add_paged_to_link() {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1340
Replaces and closes #1024

This PR fixes `PLL_Links_Directory::remove_language_from_link()` when the path ends with a language code without trailing slash. This could cause wrong redirects due to the [call to `switch_language_in_link()` in `check_canonical_url()`](https://github.com/polylang/polylang/blob/39ca7d4c09f69497a505f99976378a6e4784a855/frontend/canonical.php#L132). 

It adds several tests for `remove_language_from_link()` and `switch_language_in_link()` and also adds tests for the edge case which allowed us to detect the bug (redirect of a custom post with `rewrite` set to `false` and permalink structure without trailing slash). 