### PR TITLE
Filter search block

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -38,8 +38,12 @@ class PLL_Frontend_Filters_Search {
 		// Low priority in case the search form is created using the same filter as described in http://codex.wordpress.org/Function_Reference/get_search_form
 		add_filter( 'get_search_form', array( $this, 'get_search_form' ), 99 );
 
+		// Adds the language information in the search block.
+		add_filter( 'render_block_core/search', array( $this, 'get_search_form' ) );
+
 		// Adds the language information in admin bar search form
 		add_action( 'add_admin_bar_menus', array( $this, 'add_admin_bar_menus' ) );
+
 
 		// Adds javascript at the end of the document
 		// Was used for WP < 3.6. kept just in case

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -66,6 +66,21 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$this->assertStringContainsString( '<input type="hidden" name="lang" value="fr" />', $form );
 	}
 
+	public function test_search_block() {
+		global $wp_rewrite;
+
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
+		$form = do_blocks( '<!-- wp:search /-->' );
+
+		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form );
+
+		$wp_rewrite->set_permalink_structure( '' );
+		$this->frontend->links_model = self::$model->get_links_model();
+
+		$form = do_blocks( '<!-- wp:search /-->' );
+		$this->assertStringContainsString( '<input type="hidden" name="lang" value="fr" />', $form );
+	}
+
 	/**
 	 * Issue #829
 	 */


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1305

The block search doesn't honor the `get_search_form` filter, preventing our usual filter to work. I just discovered the filter `render_block_{$block_name}` which can replace it.