### PR TITLE
Remove 2 WPCS exclusions

### DIFF
--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -230,7 +230,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 			if ( ! empty( $page_id ) && in_array( $page_id, $pages = $this->model->get_languages_list( array( 'fields' => 'page_for_posts' ) ) ) ) {
 				// Fill the cache with all pages for posts to avoid one query per page later
 				// The posts_per_page limit is a trick to avoid splitting the query
-				get_posts( array( 'posts_per_page' => 999, 'post_type' => 'page', 'post__in' => $pages, 'lang' => '' ) );
+				get_posts( array( 'posts_per_page' => 99, 'post_type' => 'page', 'post__in' => $pages, 'lang' => '' ) );
 
 				$lang = $this->model->post->get_language( $page_id );
 				$query->is_singular = $query->is_page = false;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -57,14 +57,12 @@
 		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_key"/>
 		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_tax_query"/>
 		<exclude name="WordPress.Files.FileName"/>
-		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores"/>
 		<exclude name="WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode" />
 		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
 		<exclude name="WordPress.PHP.StrictComparisons.LooseComparison" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedScript" />
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.NotInFooter" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
-		<exclude name="WordPress.WP.PostsPerPage.posts_per_page_posts_per_page" />
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">
@@ -111,6 +109,10 @@
 	</rule>
 
 	<rule ref="Squiz.PHP.CommentedOutCode.Found" >
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
- Excluding `WordPress.NamingConventions.ValidHookName.UseUnderscores` is meaninful only for tests.
- `WordPress.WP.PostsPerPage.posts_per_page_posts_per_page` reported only one error that is fixed by this PR. 