### PR TITLE
New tool to run PHPCS only on modified files.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -12,6 +12,3 @@ echo "Running Polylang build..."
 npm install && npm run build
 
 echo "Build done!"
-
-echo "Cleanup" # Discard composer.lock and package-lock.json changings to ensure they'll never be pushed on repository.
-git checkout -- composer.lock package-lock.json

--- a/bin/git-cs.sh
+++ b/bin/git-cs.sh
@@ -6,7 +6,7 @@ MODIFIED_FILES=$(git ls-files -om --exclude-standard)
 if [ ! -z "$MODIFIED_FILES" ]; then
 	echo -e "Running PHPCS on files:\n$MODIFIED_FILES"
 else
-	echo "Running PHPCS on all files"
+	echo "Running PHPCS on all files."
 fi
 
 vendor/bin/phpcs $MODIFIED_FILES

--- a/bin/git-cs.sh
+++ b/bin/git-cs.sh
@@ -3,4 +3,10 @@
 # If there is none unstaged or uncommitted files, 'MODIFIED_FILES' will be empty (i.e. PHPCS will analyze all files).
 MODIFIED_FILES=$(git ls-files -om --exclude-standard)
 
+if [ ! -z "$MODIFIED_FILES" ]; then
+	echo -e "Running PHPCS on files:\n$MODIFIED_FILES"
+else
+	echo "Running PHPCS on all files"
+fi
+
 vendor/bin/phpcs $MODIFIED_FILES

--- a/bin/git-cs.sh
+++ b/bin/git-cs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# If there is none unstaged or uncommitted files, 'MODIFIED_FILES' will be empty (i.e. PHPCS will analyze all files).
+MODIFIED_FILES=$(git ls-files -om --exclude-standard)
+
+vendor/bin/phpcs $MODIFIED_FILES

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	},
 	"scripts": {
 		"test":"vendor/bin/phpunit",
-		"cs":"vendor/bin/phpcs",
+		"cs":"bin/git-cs.sh",
 		"stan": "vendor/bin/phpstan analyze --memory-limit=400M",
 		"lint": [
 			"@cs",


### PR DESCRIPTION
## Description
New bash script to run PHPCS only on modified files. The purpose is to make our life easier, nothing more. 😄 

## Note
If modified files are committed, then PHPCS will run as usual. That's why I changed the composer script `composer cs`.