### PR TITLE
Fix language comparison in tax query

### DIFF
--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -202,9 +202,10 @@ class PLL_Canonical {
 		$filtered_terms_by_lang = array_filter(
 			$term_ids,
 			function ( $term_id ) use ( $lang ) {
+				$lang      = $this->model->get_language( $lang );
 				$term_lang = $this->model->term->get_language( (int) $term_id );
 
-				return ! empty( $term_lang ) && $term_lang->slug === $lang;
+				return ! empty( $lang ) && ! empty( $term_lang ) && $term_lang->slug === $lang->slug;
 			}
 		);
 


### PR DESCRIPTION
In `PLL_Canonical::get_queried_term_id()` we suppose that the language tax query is made by term_id or by slug.
However, in #1068, we add a language tax query by term taxonomy id, even in themain query that we are checking here. This caused `get_queried_term_id() to fail to detect shared slugs.