### PR TITLE
Various improvements for assets tests

### DIFF
--- a/tests/phpunit/includes/testcase-assets.php
+++ b/tests/phpunit/includes/testcase-assets.php
@@ -2,59 +2,28 @@
 require POLYLANG_DIR . '/include/api.php';
 
 class PLL_Assets_UnitTestCase extends PLL_UnitTestCase {
-	protected static $editor;
-	protected static $stylesheet;
-	protected $polylang_assets = array(
+	private $polylang_assets = array(
 		'header' => array(
-			'user' => 'source',
-			'polylang_admin-css' => 'name',
+			'pll_user-js',
+			'polylang_admin-css',
 		),
 		'footer' => array(
-			'pll_ajax_backend'   => 'name',
-			'post'               => 'source',
-			'term'               => 'source',
-			'classic-editor'     => 'source',
-			'block-editor'       => 'source',
+			'pll_ajax_backend',
+			'pll_post-js',
+			'pll_term-js',
+			'pll_classic-editor-js',
+			'pll_block-editor-js',
 		),
 	);
-
-	/**
-	 * @param WP_UnitTest_Factory $factory
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
-
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
-
-		self::$editor = $factory->user->create( array( 'role' => 'administrator' ) );
-
-		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
-	}
-
-	public function set_up() {
-		parent::set_up();
-
-		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
-	}
-
-	public function tear_down() {
-		parent::tear_down();
-
-		remove_action( 'customize_register', array( $this, 'whatever' ) );
-
-		switch_theme( self::$stylesheet );
-	}
 
 	/**
 	 * Tests that given scripts or stylesheets are well enqueued.
 	 * And tests that remaining Polylang files are not enqueued.
 	 *
 	 * @param array $scripts {
-	 *      @type string   $key   Whether the assets is enqueued in the header or in the footer. Accepts 'header' or 'footer'.
-	 *      @type string[] $value The assets names to test against the given position.
+	 *   @type string   $key   Whether the assets is enqueued in the header or in the footer. Accepts 'header' or 'footer'.
+	 *   @type string[] $value The assets names to test against the given position.
 	 * }
-	 *
 	 * @return void
 	 */
 	protected function _test_scripts( $scripts ) {
@@ -62,92 +31,45 @@ class PLL_Assets_UnitTestCase extends PLL_UnitTestCase {
 		$pll_admin        = new PLL_Admin( $links_model );
 		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
 		$pll_admin->init();
+
 		$GLOBALS['wp_styles']  = new WP_Styles();
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		wp_default_scripts( $GLOBALS['wp_scripts'] );
 
-		do_action( 'admin_enqueue_scripts' );
-
 		ob_start();
 		// Based on what's done in wp-admin/admin-header.php
+		do_action( 'admin_enqueue_scripts' );
 		do_action( 'admin_print_styles' );
 		do_action( 'admin_print_scripts' );
-		$head = ob_get_clean();
+		$this->assert_scripts_are_enqueued_correctly( $scripts, ob_get_clean(), 'header' );
 
 		ob_start();
 		// Based on what's done in wp-admin/admin-footer.php
 		do_action( 'admin_print_footer_scripts' );
-		$footer = ob_get_clean();
+		$this->assert_scripts_are_enqueued_correctly( $scripts, ob_get_clean(), 'footer' );
+	}
 
+	/**
+	 * Asserts a scripts are enqueued or not.
+	 *
+	 * @param string[] $scripts  The script names.
+	 * @param string   $content  The content to look into.
+	 * @param string   $position The position of the script. Used for more accurate error message.
+	 * @return void
+	 */
+	protected function assert_scripts_are_enqueued_correctly( $scripts, $content, $position ) {
 		$polylang_assets = $this->get_polylang_assets();
 
-		if ( isset( $scripts['header'] ) ) {
-			foreach ( $scripts['header'] as $script ) {
-				$is_name = isset( $polylang_assets['header'][ $script ] ) && 'name' === $polylang_assets['header'][ $script ];
-				$this->assert_script_is_enqueued( $script, $head, $is_name, 'header' );
-				unset( $polylang_assets['header'][ $script ] );
+		if ( isset( $scripts[ $position ] ) ) {
+			foreach ( $scripts[ $position ] as $script ) {
+				$this->assertStringContainsString( $script , $content, "$script script is not enqueued in the $position as it should." );
+				$polylang_assets[ $position ] = array_diff( $polylang_assets[ $position ], array( $script ) );
 			}
 		}
 
-		foreach ( $polylang_assets['header'] as $script => $type ) {
-			$is_name = 'name' === $type;
-			$this->assert_script_is_not_enqueued( $script, $head, $is_name, 'header' );
+		foreach ( $polylang_assets[ $position ] as $script ) {
+			$this->assertStringNotContainsString( $script , $content, "$script script is enqueued in the $position but it should not." );
 		}
-
-		if ( isset( $scripts['footer'] ) ) {
-			foreach ( $scripts['footer'] as $script ) {
-				$is_name = isset( $polylang_assets['footer'][ $script ] ) && 'name' === $polylang_assets['footer'][ $script ];
-				$this->assert_script_is_enqueued( $script, $footer, $is_name, 'footer' );
-				unset( $polylang_assets['footer'][ $script ] );
-			}
-		}
-
-		foreach ( $polylang_assets['footer'] as $script => $type ) {
-			$is_name = 'name' === $type;
-			$this->assert_script_is_not_enqueued( $script, $footer, $is_name, 'footer' );
-		}
-	}
-
-	/**
-	 * Asserts a script is not enqueued.
-	 *
-	 * @param string $script   The script name or source.
-	 * @param string $content  The content to look into.
-	 * @param bool   $is_name  Whether the script is given with name or source. True for name.
-	 * @param string $position The position of the script. Used for more accurate error message.
-	 *
-	 * @return void
-	 */
-	private function assert_script_is_not_enqueued( $script, $content, $is_name, $position ) {
-		if ( $is_name ) {
-			// The current script is a name.
-			$test = strpos( $content, $script );
-		} else {
-			// The current script is a source.
-			$test = strpos( $content, plugins_url( "/js/build/$script.min.js", POLYLANG_FILE ) );
-		}
-		$this->assertFalse( $test, "$script script is enqueued in the $position but it should not." );
-	}
-
-	/**
-	 * Asserts a script is enqueued.
-	 *
-	 * @param string $script   The script name or source.
-	 * @param string $content  The content to look into.
-	 * @param bool   $is_name  Whether the script is given with name or source. True for name.
-	 * @param string $position The position of the script. Used for more accurate error message.
-	 *
-	 * @return void
-	 */
-	private function assert_script_is_enqueued( $script, $content, $is_name, $position ) {
-		if ( $is_name ) {
-			// The current script is a name.
-			$test = strpos( $content, $script );
-		} else {
-			// The current script is a source.
-			$test = strpos( $content, plugins_url( "/js/build/$script.min.js", POLYLANG_FILE ) );
-		}
-		$this->assertIsInt( $test, "$script script is not enqueued in the $position as it should." );
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-assets.php
+++ b/tests/phpunit/includes/testcase-assets.php
@@ -62,13 +62,13 @@ class PLL_Assets_UnitTestCase extends PLL_UnitTestCase {
 
 		if ( isset( $scripts[ $position ] ) ) {
 			foreach ( $scripts[ $position ] as $script ) {
-				$this->assertStringContainsString( $script , $content, "$script script is not enqueued in the $position as it should." );
+				$this->assertStringContainsString( $script, $content, "$script script is not enqueued in the $position as it should." );
 				$polylang_assets[ $position ] = array_diff( $polylang_assets[ $position ], array( $script ) );
 			}
 		}
 
 		foreach ( $polylang_assets[ $position ] as $script ) {
-			$this->assertStringNotContainsString( $script , $content, "$script script is enqueued in the $position but it should not." );
+			$this->assertStringNotContainsString( $script, $content, "$script script is enqueued in the $position but it should not." );
 		}
 	}
 

--- a/tests/phpunit/tests/test-admin-assets.php
+++ b/tests/phpunit/tests/test-admin-assets.php
@@ -1,0 +1,213 @@
+<?php
+class Admin_Assets_Test extends PLL_Assets_UnitTestCase {
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' ); // We need at least one language to "activate" Polylang on all screens.
+	}
+
+	public function test_scripts_in_post_list_table() {
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+				'pll_post-js',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_untranslated_cpt_list_table() {
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type'] = 'cpt';
+		register_post_type( 'cpt' );
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_edit_post_classic_editor() {
+		$GLOBALS['hook_suffix'] = 'post.php';
+		set_current_screen();
+
+		global $current_screen;
+		$current_screen->is_block_editor = false;
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+				'pll_classic-editor-js',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_edit_post_block_editor() {
+		$GLOBALS['hook_suffix'] = 'post.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+				'pll_block-editor-js',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_edit_untranslated_cpt() {
+		$GLOBALS['hook_suffix'] = 'post.php';
+		$_REQUEST['post_type'] = 'cpt';
+		register_post_type( 'cpt' );
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+
+	public function test_scripts_in_media_list_table() {
+		$GLOBALS['hook_suffix'] = 'upload.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+				'pll_post-js',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_terms_list_table() {
+		$GLOBALS['hook_suffix'] = 'edit-tags.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+				'pll_term-js',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_untranslated_custom_tax_list_table() {
+		$GLOBALS['hook_suffix'] = 'edit-tags.php';
+		$_REQUEST['taxonomy'] = 'tax';
+		register_taxonomy( 'tax', 'post' );
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_edit_term() {
+		$GLOBALS['hook_suffix'] = 'term.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+				'pll_term-js',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_edit_unstranslated_custom_tax() {
+		$GLOBALS['hook_suffix'] = 'term.php';
+		$_REQUEST['taxonomy'] = 'tax';
+		register_taxonomy( 'tax', 'post' );
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+			),
+			'header' => array(
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+
+	public function test_scripts_in_user_profile() {
+		$GLOBALS['hook_suffix'] = 'profile.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+			),
+			'header' => array(
+				'pll_user-js',
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+
+	public function test_scripts_in_edit_widgets() {
+		$GLOBALS['hook_suffix'] = 'widgets.php';
+		set_current_screen();
+
+		$scripts = array(
+			'footer' => array(
+				'pll_ajax_backend',
+			),
+			'header' => array(
+				'pll_widgets-js',
+				'polylang_admin-css',
+			),
+		);
+		$this->_test_scripts( $scripts );
+	}
+}

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -1,8 +1,36 @@
 <?php
-class Admin_Test extends PLL_Assets_UnitTestCase {
+class Admin_Test extends PLL_UnitTestCase {
+	protected static $stylesheet;
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+
+		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( 1 ); // Set a user to pass current_user_can tests
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		remove_action( 'customize_register', array( $this, 'whatever' ) );
+
+		switch_theme( self::$stylesheet );
+	}
+
 	public function test_admin_bar_menu() {
 		global $wp_admin_bar;
-		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
+		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
 
 		$this->go_to( home_url( '/wp-admin/edit.php' ) );
 		$links_model = self::$model->get_links_model();
@@ -23,207 +51,6 @@ class Admin_Test extends PLL_Assets_UnitTestCase {
 		$fr = $wp_admin_bar->get_node( 'fr' );
 		$this->assertEquals( 'languages', $fr->parent );
 		$this->assertEquals( '/wp-admin/edit.php?lang=fr', $fr->href );
-	}
-
-	public function test_scripts_in_post_list_table() {
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-				'post',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_untranslated_cpt_list_table() {
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type'] = 'cpt';
-		register_post_type( 'cpt' );
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_edit_post_classic_editor() {
-		$GLOBALS['hook_suffix'] = 'post.php';
-		set_current_screen();
-
-		global $current_screen;
-		$current_screen->is_block_editor = false;
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-				'classic-editor',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_edit_post_block_editor() {
-		$GLOBALS['hook_suffix'] = 'post.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-				'block-editor',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_edit_untranslated_cpt() {
-		$GLOBALS['hook_suffix'] = 'post.php';
-		$_REQUEST['post_type'] = 'cpt';
-		register_post_type( 'cpt' );
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-
-	public function test_scripts_in_media_list_table() {
-		$GLOBALS['hook_suffix'] = 'upload.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-				'post',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_terms_list_table() {
-		$GLOBALS['hook_suffix'] = 'edit-tags.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-				'term',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_untranslated_custom_tax_list_table() {
-		$GLOBALS['hook_suffix'] = 'edit-tags.php';
-		$_REQUEST['taxonomy'] = 'tax';
-		register_taxonomy( 'tax', 'post' );
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_edit_term() {
-		$GLOBALS['hook_suffix'] = 'term.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-				'term',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_edit_unstranslated_custom_tax() {
-		$GLOBALS['hook_suffix'] = 'term.php';
-		$_REQUEST['taxonomy'] = 'tax';
-		register_taxonomy( 'tax', 'post' );
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-			),
-			'header' => array(
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-
-	public function test_scripts_in_user_profile() {
-		$GLOBALS['hook_suffix'] = 'profile.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-			),
-			'header' => array(
-				'user',
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
-	}
-
-	public function test_scripts_in_edit_widgets() {
-		$GLOBALS['hook_suffix'] = 'widgets.php';
-		set_current_screen();
-
-		$scripts = array(
-			'footer' => array(
-				'pll_ajax_backend',
-			),
-			'header' => array(
-				'widgets',
-				'polylang_admin-css',
-			),
-		);
-		$this->_test_scripts( $scripts );
 	}
 
 	public function test_remove_customize_submenu_with_block_base_theme() {


### PR DESCRIPTION
This PR aims to improve #1087.

1. Don't include initialization in the test case, especially when not related to what the test case is aimed for.
2. As there is new test case dedicate to test assets, separate the assets tests from the other admin tests.
3. **Proposal** not to test the file links but only the asset id. That way, we can simplify the code to test all assets the same way.
4. Dont repeat ourselves between header and footer.
5. Use more modern assertions `assertStringContainsString()` and `assertStringNotContainsString()`
6. Set `$polylang_assets` to private as there is an accessor.