### PR TITLE
Improve documentation for sanitize_int_id()

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -492,7 +492,7 @@ abstract class PLL_Translated_Object {
 	 * @return int<0,max> A positive integer. `0` for non numeric values and negative integers.
 	 */
 	public function sanitize_int_id( $id ) {
-		return is_numeric( $id ) && $id >= 1 ? (int) $id : 0;
+		return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
 	}
 
 	/**

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -488,8 +488,8 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @since 3.2
 	 *
-	 * @param  mixed $id A supposedly numeric ID.
-	 * @return int       A positive integer. `0` for non numeric values and negative integers.
+	 * @param  mixed $id  A supposedly numeric ID.
+	 * @return int<0,max> A positive integer. `0` for non numeric values and negative integers.
 	 */
 	public function sanitize_int_id( $id ) {
 		return is_numeric( $id ) && $id >= 1 ? (int) $id : 0;

--- a/modules/sync/sync-metas.php
+++ b/modules/sync/sync-metas.php
@@ -255,6 +255,7 @@ abstract class PLL_Sync_Metas {
 	 */
 	public function update_meta( $mid, $id, $meta_key, $meta_value ) {
 		static $avoid_recursion = false;
+		$id = (int) $id;
 
 		if ( ! $avoid_recursion ) {
 			$avoid_recursion = true;


### PR DESCRIPTION
This specifies that the return value of `PLL_Translated_Object->sanitize_int_id()` is an integer >= to 0. This is useful for PHPStan when this method is used somewhere a non-negative integer is expected.

Also while at it: in `PLL_Sync_Metas->update_meta()`, cast `$id` as an integer.