### PR TITLE
Set language in tax query correctly when OR relation is used

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -316,7 +316,9 @@ abstract class PLL_Choose_Lang {
 	 * @return void
 	 */
 	protected function set_curlang_in_query( &$query ) {
-		$pll_query = new PLL_Query( $query, $this->model );
-		$pll_query->set_language( $this->curlang );
+		if ( ! empty( $this->curlang ) ) {
+			$pll_query = new PLL_Query( $query, $this->model );
+			$pll_query->set_language( $this->curlang );
+		}
 	}
 }

--- a/include/query.php
+++ b/include/query.php
@@ -203,21 +203,28 @@ class PLL_Query {
 	 * @return void
 	 */
 	protected function maybe_set_language_for_or_relation() {
-		if ( $this->query->tax_query instanceof WP_Tax_Query
-			&& 'OR' === $this->query->tax_query->relation
-			&& isset( $this->query->tax_query->queried_terms['language'] )
-			&& 'all' !== $this->query->tax_query->queried_terms['language']['terms'] ) {
-			$langs = $this->query->tax_query->queried_terms['language']['terms'];
-			if ( is_string( $langs ) ) {
-				$langs = explode( ',', $langs );
-			}
-			$langs = array_map( array( $this->model, 'get_language' ), $langs );
-			$langs = array_filter( $langs );
+		if ( ! $this->query->tax_query instanceof WP_Tax_Query ) {
+			return;
+		}
 
-			if ( ! empty( $langs ) ) {
-				$this->set_language( $langs );
-				unset( $this->query->query_vars['lang'] ); // Unset the language query var otherwise WordPress would add the language query by slug in WP_Query::parse_tax_query().
-			}
+		if ( 'OR' !== $this->query->tax_query->relation ) {
+			return;
+		}
+
+		if ( ! isset( $this->query->tax_query->queried_terms['language'] ) ) {
+			return;
+		}
+
+		$langs = $this->query->tax_query->queried_terms['language']['terms'];
+		if ( is_string( $langs ) ) {
+			$langs = explode( ',', $langs );
+		}
+		$langs = array_map( array( $this->model, 'get_language' ), $langs );
+		$langs = array_filter( $langs );
+
+		if ( ! empty( $langs ) ) {
+			$this->set_language( $langs );
+			unset( $this->query->query_vars['lang'] ); // Unset the language query var otherwise WordPress would add the language query by slug in WP_Query::parse_tax_query().
 		}
 	}
 }

--- a/include/query.php
+++ b/include/query.php
@@ -180,7 +180,7 @@ class PLL_Query {
 				}
 			}
 		} else {
-			$this->set_language_for_or_relation();
+			$this->maybe_set_language_for_or_relation();
 
 			// Do not filter untranslatable post types such as nav_menu_item
 			if ( isset( $qvars['post_type'] ) && ! $this->model->is_translated_post_type( $qvars['post_type'] ) && ( empty( $qvars['tax_query'] ) || ! $this->have_translated_taxonomy( $qvars['tax_query'] ) ) ) {
@@ -202,7 +202,7 @@ class PLL_Query {
 	 *
 	 * @return void
 	 */
-	protected function set_language_for_or_relation() {
+	protected function maybe_set_language_for_or_relation() {
 		if ( $this->query->tax_query instanceof WP_Tax_Query
 			&& 'OR' === $this->query->tax_query->relation
 			&& isset( $this->query->tax_query->queried_terms['language'] )

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -466,11 +466,6 @@ parameters:
 			path: frontend/choose-lang.php
 
 		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_Query\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|null given\\.$#"
-			count: 1
-			path: frontend/choose-lang.php
-
-		-
 			message: "#^Method PLL_Frontend_Auto_Translate\\:\\:get_post\\(\\) should return int but returns int\\|false\\.$#"
 			count: 1
 			path: frontend/frontend-auto-translate.php

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -64,6 +64,23 @@ class Query_Test extends PLL_UnitTestCase {
 		_unregister_taxonomy( 'trtax' );
 	}
 
+	/**
+	 * Asserts language in taxonomy query is removed.
+	 *
+	 * @param WP_Tax_Query $tax_query Taxonomy query.
+	 *
+	 * @throws AssertionFailedError
+	 *
+	 * @return void
+	 */
+	public function assert_no_lang_query_by_slug( $tax_query ) {
+		foreach ( $tax_query->queries as $query ) {
+			if ( isset( $query['taxonomy'] ) && 'language' === $query['taxonomy'] && isset( $query['field'] ) && 'slug' === $query['field'] ) {
+				$this->fail( 'Language is found in taxonomy query' . PHP_EOL );
+			}
+		}
+	}
+
 	public function test_home_latest_posts() {
 		$en = $this->factory->post->create();
 		self::$model->post->set_language( $en, 'en' );
@@ -703,5 +720,175 @@ class Query_Test extends PLL_UnitTestCase {
 
 		$this->go_to( home_url( '/fr/' ) );
 		$this->assertEquals( 1, $GLOBALS['wp_query']->post_count );
+	}
+
+	public function test_or_operator_on_category() {
+		// Categories.
+		$first_cat_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test1' ) );
+		self::$model->term->set_language( $first_cat_en, 'en' );
+
+		$first_cat_fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai1' ) );
+		self::$model->term->set_language( $first_cat_fr, 'fr' );
+
+		$second_cat_en = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test2' ) );
+		self::$model->term->set_language( $second_cat_en, 'en' );
+
+		$second_cat_fr = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'essai2' ) );
+		self::$model->term->set_language( $second_cat_fr, 'fr' );
+
+		// English Posts.
+		$eng_posts_cat_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_cat_1 as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+			wp_set_post_terms( $post, array( $first_cat_en ), 'category' );
+		}
+		$eng_posts_cat_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_cat_2 as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+			wp_set_post_terms( $post, array( $second_cat_en ), 'category' );
+		}
+		$eng_posts_no_cat = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_no_cat as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+		}
+
+		// French Posts.
+		$french_posts_cat_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $french_posts_cat_1 as $index => $post ) {
+			self::$model->post->set_language( $post, 'fr' );
+			wp_set_post_terms( $post, array( $first_cat_fr ), 'category' );
+		}
+		$french_posts_cat_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $french_posts_cat_2 as $post ) {
+			self::$model->post->set_language( $post, 'fr' );
+			wp_set_post_terms( $post, array( $second_cat_fr ), 'category' );
+		}
+		$french_posts_no_cat = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $french_posts_no_cat as $post ) {
+			self::$model->post->set_language( $post, 'fr' );
+		}
+
+		$args = array(
+			'post_type'      => 'post',
+			'lang'           => 'fr',
+			'posts_per_page' => 100,
+			'tax_query'      => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'category',
+					'field'    => 'name',
+					'terms'    => array( 'essai1' ),
+				),
+				array(
+					'taxonomy' => 'category',
+					'field'    => 'name',
+					'terms'    => array( 'essai2' ),
+				),
+			),
+		);
+		$query             = new WP_Query( $args );
+		$queried_posts     = $query->posts;
+		$queried_posts_ids = wp_list_pluck( $queried_posts, 'ID' );
+		$expected_posts    = array_merge( $french_posts_cat_1, $french_posts_cat_2 );
+
+		$this->assertNotEmpty( $queried_posts, 'The query should return posts.' );
+		$this->assertEmpty( array_intersect( $french_posts_no_cat, $queried_posts_ids ), 'The query should not return french posts without the category.' );
+		$this->assertSameSets( $expected_posts, $queried_posts_ids, 'The query should return french posts with the category.' );
+		$this->assert_no_lang_query_by_slug( $query->tax_query );
+	}
+
+	public function test_or_operator_on_untranslated_tax() {
+		// Taxonomies.
+		$first_tax  = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test1' ) );
+		$second_tax = $this->factory->term->create( array( 'taxonomy' => 'tax', 'name' => 'test2' ) );
+
+		// English Posts.
+		$eng_posts_tax_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_tax_1 as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+			wp_set_post_terms( $post, array( $first_tax ), 'tax' );
+		}
+		$eng_posts_tax_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_tax_2 as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+			wp_set_post_terms( $post, array( $second_tax ), 'tax' );
+		}
+		$eng_posts_no_tax = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $eng_posts_no_tax as $post ) {
+			self::$model->post->set_language( $post, 'en' );
+		}
+
+		// French Posts.
+		$french_posts_tax_1 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $french_posts_tax_1 as $index => $post ) {
+			self::$model->post->set_language( $post, 'fr' );
+			wp_set_post_terms( $post, array( $first_tax ), 'tax' );
+		}
+		$french_posts_tax_2 = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $french_posts_tax_2 as $post ) {
+			self::$model->post->set_language( $post, 'fr' );
+			wp_set_post_terms( $post, array( $second_tax ), 'tax' );
+		}
+		$french_posts_no_tax = $this->factory->post->create_many( 3, array( 'post_type' => 'post' ) );
+		foreach ( $french_posts_no_tax as $post ) {
+			self::$model->post->set_language( $post, 'fr' );
+		}
+
+		// Query with language parameter set.
+		$args = array(
+			'post_type'      => 'post',
+			'lang'           => 'fr',
+			'posts_per_page' => 100,
+			'tax_query'      => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'tax',
+					'field'    => 'name',
+					'terms'    => array( 'test1' ),
+				),
+				array(
+					'taxonomy' => 'tax',
+					'field'    => 'name',
+					'terms'    => array( 'test2' ),
+				),
+			),
+		);
+		$query             = new WP_Query( $args );
+		$queried_posts     = $query->posts;
+		$queried_posts_ids = wp_list_pluck( $queried_posts, 'ID' );
+		$expected_posts    = array_merge( $french_posts_tax_1, $french_posts_tax_2 );
+
+		$this->assertNotEmpty( $queried_posts, 'The query should return posts.' );
+		$this->assertEmpty( array_intersect( $french_posts_no_tax, $queried_posts_ids ), 'The query should not return french posts without the taxonomy.' );
+		$this->assertEqualSets( $expected_posts, $queried_posts_ids, 'The query should return french posts with the taxonomy.' );
+
+		// Query with language parameter not set.
+		$args = array(
+			'post_type'      => 'post',
+			'posts_per_page' => 100,
+			'tax_query'      => array(
+				'relation' => 'OR',
+				array(
+					'taxonomy' => 'tax',
+					'field'    => 'name',
+					'terms'    => array( 'test1' ),
+				),
+				array(
+					'taxonomy' => 'tax',
+					'field'    => 'name',
+					'terms'    => array( 'test2' ),
+				),
+			),
+		);
+		$this->frontend->curlang = null; // Remove current language.
+		$query                   = new WP_Query( $args );
+		$queried_posts           = $query->posts;
+		$queried_posts_ids       = wp_list_pluck( $queried_posts, 'ID' );
+		$expected_posts          = array_merge( $french_posts_tax_1, $french_posts_tax_2, $eng_posts_tax_1, $eng_posts_tax_2 );
+
+		$this->assertNotEmpty( $queried_posts, 'The query should return posts.' );
+		$this->assertEmpty( array_intersect( $french_posts_no_tax, $queried_posts_ids ), 'The query should not return french posts without the taxonomy.' );
+		$this->assertEmpty( array_intersect( $eng_posts_no_tax, $queried_posts_ids ), 'The query should not return english posts without the taxonomy.' );
+		$this->assertEqualSets( $expected_posts, $queried_posts_ids, 'The query should return french and english posts with the taxonomy.' );
 	}
 }

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -73,7 +73,7 @@ class Query_Test extends PLL_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function assert_no_lang_query_by_slug( $tax_query ) {
+	protected function assert_no_lang_query_by_slug( $tax_query ) {
 		foreach ( $tax_query->queries as $query ) {
 			if ( isset( $query['taxonomy'] ) && 'language' === $query['taxonomy'] && isset( $query['field'] ) && 'slug' === $query['field'] ) {
 				$this->fail( 'Language query by slug is found in taxonomy query' . PHP_EOL );
@@ -95,7 +95,7 @@ class Query_Test extends PLL_UnitTestCase {
 	 *     @type int[] $fr_posts_no_tax    French post IDs without the taxonomy.
 	 * }
 	 */
-	public function create_posts_with_tax( $taxonomy ) {
+	protected function create_posts_with_tax( $taxonomy ) {
 		// Taxonomies.
 		$is_translated_tax = 'tax' !== $taxonomy; // See self::set_up().
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1389

## Changes:
- Add a new method that checks the current query contains a `OR` relation, if so set the language(s) correctly in the taxonomy query and unset the `lang` parameter (so WordPress doesn't merge it with the other queried terms once again...).
- `PLL_Query::set_language()` now accepts an array of languages.
- Remove an ignored error in the phpstan baseline.
- Fix a phpstan error in `choose-lang.php`.
- Add tests for query with OR relations on category, untranslated custom taxonomy, translated taxonomy and with several languages.

## Notes:
Once it's merged, we will have to take care of shared slugs. See this PR: https://github.com/polylang/polylang/pull/1092