### PR TITLE
Free PHPStan version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ jobs:
       install:
         - "composer update"
       script:
-        - "vendor/bin/phpcs -s --extensions=php,js ./"
-        - "vendor/bin/phpstan analyze --memory-limit=512M"
+        - "composer lint"
 
     - name: "WP 5.7 - PHP 7.2"
       php: "7.2"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"scripts": {
 		"test":"vendor/bin/phpunit",
 		"cs":"vendor/bin/phpcs",
-		"stan": "vendor/bin/phpstan analyze --memory-limit=1200M",
+		"stan": "vendor/bin/phpstan analyze --memory-limit=1500M",
 		"lint": [
 			"@cs",
 			"@stan"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 		"php": ">=5.6"
 	},
 	"require-dev": {
-		"phpstan/phpstan": "<1.7",
 		"wpsyntex/polylang-phpstan": "^1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"wp-coding-standards/wpcs": "*",
@@ -33,7 +32,7 @@
 	"scripts": {
 		"test":"vendor/bin/phpunit",
 		"cs":"vendor/bin/phpcs",
-		"stan": "vendor/bin/phpstan analyze --memory-limit=400M",
+		"stan": "vendor/bin/phpstan analyze --memory-limit=1200M",
 		"lint": [
 			"@cs",
 			"@stan"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -396,6 +396,46 @@ parameters:
 			path: admin/admin-strings.php
 
 		-
+			message: "#^Property PLL_Admin\\:\\:\\$block_editor \\(PLL_Admin_Block_Editor\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$classic_editor \\(PLL_Admin_Classic_Editor\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$filters \\(PLL_Admin_Filters\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$filters_columns \\(PLL_Admin_Filters_Columns\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$filters_media \\(PLL_Admin_Filters_Media\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$filters_post \\(PLL_Admin_Filters_Post\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$filters_term \\(PLL_Admin_Filters_Term\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
+			message: "#^Property PLL_Admin\\:\\:\\$nav_menu \\(PLL_Admin_Nav_Menu\\|null\\) does not accept object\\.$#"
+			count: 1
+			path: admin/admin.php
+
+		-
 			message: "#^Parameter \\#1 \\$subtags of class PLL_Accept_Language constructor expects array\\<string\\>, array\\<string, string\\>\\|false given\\.$#"
 			count: 1
 			path: frontend/accept-language.php


### PR DESCRIPTION
- Stop requiring PHPStan < 1.7
- Increase the allowed memory for new versions to be able to run :/
- Add new reported from PHPStan 1.8.2 to the baseline.
- Travis config uses composer scripts for PHPCS and PHPStan