### PR TITLE
Fix media translation setting has no effect

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -262,12 +262,14 @@ class PLL_Model {
 		if ( false === $post_types = $this->cache->get( 'post_types' ) ) {
 			$post_types = array( 'post' => 'post', 'page' => 'page', 'wp_block' => 'wp_block' );
 
-			if ( ! empty( $this->options['media_support'] ) ) {
-				$post_types['attachment'] = 'attachment';
-			}
-
 			if ( ! empty( $this->options['post_types'] ) && is_array( $this->options['post_types'] ) ) {
 				$post_types = array_merge( $post_types, array_combine( $this->options['post_types'], $this->options['post_types'] ) );
+			}
+
+			if ( empty( $this->options['media_support'] ) ) {
+				unset( $post_types['attachment'] ); // In case the post type attachment is stored in the option.
+			} else {
+				$post_types['attachment'] = 'attachment';
 			}
 
 			/**

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -143,7 +143,6 @@ class Model_Test extends PLL_UnitTestCase {
 			'trcpt' => 'trcpt',
 		);
 
-
 		register_post_type( 'trcpt' ); // translated custom post type
 		register_post_type( 'cpt' ); // *untranslated* custom post type
 
@@ -191,6 +190,19 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertTrue( self::$model->is_filtered_taxonomy( array( 'post_format' ) ) );
 		$this->assertFalse( self::$model->is_filtered_taxonomy( array( 'category' ) ) );
 		$this->assertTrue( self::$model->is_filtered_taxonomy( array( 'post_format', 'category' ) ) );
+	}
+
+	/**
+	 * Bug fixed in 3.2.6
+	 */
+	public function test_untranslated_media_when_post_type_wrongly_stored_in_option() {
+		self::$model->options['post_types'] = array(
+			'attachment' => 'attachment',
+		);
+
+		self::$model->options['media_support'] = 0;
+
+		$this->assertFalse( self::$model->is_translated_post_type( 'attachment' ) );
 	}
 }
 


### PR DESCRIPTION
If the `attachement` post type is added in the database (in the `polylang` option) as a translated post type, then deactivating the media translation in the settings screen has no effect. The media are always translatable whatever the option value.

NB: The `attachement` post type may come from WPML imports. The bug was fixed in [WPML to Polylang 0.4](https://github.com/polylang/wpml-to-polylang/issues/7) but many sites may have been imported with this bug, so it's better to fix things in Polylang too.