### PR TITLE
Fix Behat tests

### DIFF
--- a/tests/features/bootstrap/BrowserPreferredLanguageContext.php
+++ b/tests/features/bootstrap/BrowserPreferredLanguageContext.php
@@ -38,6 +38,17 @@ class BrowserPreferredLanguageContext implements Context {
 	}
 
 	/**
+	 * Copy of WP_UnitTestCase::factory().
+	 */
+	protected static function factory() {
+		static $factory = null;
+		if ( ! $factory ) {
+			$factory = new WP_UnitTest_Factory();
+		}
+		return $factory;
+	}
+
+	/**
 	 * Initializes context and test framework.
 	 */
 	public function __construct() {
@@ -68,7 +79,7 @@ class BrowserPreferredLanguageContext implements Context {
 		$args = empty( $language_slug ) ? array() : array( 'slug' => $language_slug );
 		PLL_UnitTestCase::create_language( Locale::canonicalize( $language_code ), $args );
 
-		$post_id = $this->test_case->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		$default_slug = explode( '-', $language_code )[0];
 		PLL_UnitTestCase::$model->post->set_language( $post_id, empty( $language_slug ) ? $default_slug : $language_slug );


### PR DESCRIPTION
This PR is a consequence of  https://core.trac.wordpress.org/ticket/56514#comment:6

Our tests took profit of the magic method `__get()` to access to the factory object which is now protected.
In this PR, I now copy the `factory()` method and use it instead.