### PR TITLE
CPT and Tax settings: display slug of CPT or Tax

### DIFF
--- a/settings/settings-cpt.php
+++ b/settings/settings-cpt.php
@@ -105,11 +105,12 @@ class PLL_Settings_CPT extends PLL_Settings_Module {
 					if ( ! empty( $pt ) ) {
 						$disabled = in_array( $post_type, $this->disabled_post_types );
 						printf(
-							'<li><label><input name="post_types[%s]" type="checkbox" value="1" %s %s/> %s</label></li>',
+							'<li><label><input name="post_types[%s]" type="checkbox" value="1" %s %s/> %s %s</label></li>',
 							esc_attr( $post_type ),
 							checked( in_array( $post_type, $this->options['post_types'] ) || $disabled, true, false ),
 							disabled( $disabled, true, false ),
-							esc_html( $pt->labels->name )
+							esc_html( $pt->labels->name ),
+							'(' . esc_html( $pt->name ) . ')'
 						);
 					}
 				}


### PR DESCRIPTION
In the Polylang Settings, in order to easily understand where the CPT or Taxonomies come from, this PR adds to the label, the slug of the CPT or Taxonomy. See image below.

![image](https://user-images.githubusercontent.com/108828/189866964-77206f98-e2f0-4edc-b6d9-4db09f7c24c4.png)
