### PR TITLE
Refactor term slugs defined with language

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -677,7 +677,7 @@ class PLL_Admin_Filters_Term {
 			// Bulk edit does not modify the language
 			if ( -1 === (int) $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->post->get_language( $this->post_id );
-			} elseif ( is_string( $_POST['inline_lang_choice'] ) ) {
+			} elseif ( is_string( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
 				if ( ! empty( $lang_slug ) ) {
 					$lang = $this->model->get_language( $lang_slug );

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -668,12 +668,6 @@ class PLL_Admin_Filters_Term {
 		}
 		if ( isset( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->get_language( sanitize_key( $_POST['term_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-
-			if ( isset( $_POST['parent'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
-			}
 		}
 
 		elseif ( isset( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -658,12 +658,18 @@ class PLL_Admin_Filters_Term {
 	public function get_subsequently_inserted_term_language( $slug, $taxonomy ) {
 		$lang = false;
 
-		if ( isset( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$lang = $this->model->get_language( sanitize_key( $_POST['term_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_POST['term_lang_choice'] ) && is_string( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$lang_slug = sanitize_key( $_POST['term_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			if ( ! empty( $lang_slug ) ) {
+				$lang = $this->model->get_language( $lang_slug );
+			}
 		}
 
-		elseif ( isset( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['inline_lang_choice'] ) && is_string( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			if ( ! empty( $lang_slug ) ) {
+				$lang = $this->model->get_language( $lang_slug );
+			}
 		}
 
 		// *Post* bulk edit, in case a new term is created
@@ -672,15 +678,11 @@ class PLL_Admin_Filters_Term {
 			if ( -1 === (int) $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->post->get_language( $this->post_id );
 			} else {
-				$lang = $this->model->get_language( sanitize_key( $_GET['inline_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+				$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
+				if ( ! empty( $lang_slug ) ) {
+					$lang = $this->model->get_language( $lang_slug );
+				}
 			}
-		}
-		if ( isset( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$lang = $this->model->get_language( sanitize_key( $_POST['term_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-		}
-
-		elseif ( isset( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// Special cases for default categories as the select is disabled.

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -686,11 +686,11 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Special cases for default categories as the select is disabled.
-		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( (int) get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
-		elseif ( ! empty( $_POST['tax_ID'] ) && in_array( get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tax_ID'] ) && in_array( (int) get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -636,8 +636,8 @@ class PLL_Admin_Filters_Term {
 			// Bulk edit does not modify the language
 			if ( -1 === (int) $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->post->get_language( $this->post_id );
-			} elseif ( is_string( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			} elseif ( is_string( $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$lang_slug = sanitize_key( $_GET['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
 				if ( ! empty( $lang_slug ) ) {
 					$lang = $this->model->get_language( $lang_slug );
 				}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -686,11 +686,11 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Special cases for default categories as the select is disabled.
-		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( (int) get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( intval( get_option( 'default_category' ) ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
-		elseif ( ! empty( $_POST['tax_ID'] ) && in_array( (int) get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tax_ID'] ) && in_array( intval( get_option( 'default_category' ) ), $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -646,8 +646,17 @@ class PLL_Admin_Filters_Term {
 		$avoid_recursion = false;
 	}
 
+	/**
+	 * Returns the language for subsequently inserted term.
+	 *
+	 * @since 3.3
+	 *
+	 * @param string $slug     Term slug.
+	 * @param string $taxonomy Term taxonomy.
+	 * @return PLL_Language|false Language object, false if none found.
+	 */
 	public function get_subsequently_inserted_term_language( $slug, $taxonomy ) {
-		$lang = null;
+		$lang = false;
 
 		if ( isset( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->get_language( sanitize_key( $_POST['term_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
@@ -683,6 +692,15 @@ class PLL_Admin_Filters_Term {
 			$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
+		/**
+		 * Filters the subsequently inserted term language.
+		 *
+		 * @since 3.3
+		 *
+		 * @param PLL_Language|false $lang     Found language object, false otherwise.
+		 * @param string             $slug     Term slug.
+		 * @param string             $taxonomy Term taxonomy.
+		 */
 		return apply_filters( 'pll_subsequently_inserted_term_language', $lang, $slug, $taxonomy );
 	}
 }

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -250,7 +250,7 @@ class PLL_Admin_Filters_Term {
 	}
 
 	/**
-	 * Stores the current post_id when bulk editing posts for use in save_language and pre_term_slug
+	 * Stores the current post_id when bulk editing posts for use in save_language and get_inserted_term_language.
 	 *
 	 * @since 1.7
 	 *

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -677,7 +677,7 @@ class PLL_Admin_Filters_Term {
 			// Bulk edit does not modify the language
 			if ( -1 === (int) $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->post->get_language( $this->post_id );
-			} else {
+			} elseif ( is_string( $_POST['inline_lang_choice'] ) ) {
 				$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
 				if ( ! empty( $lang_slug ) ) {
 					$lang = $this->model->get_language( $lang_slug );

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -612,7 +612,7 @@ class PLL_Admin_Filters_Term {
 	 * @param string             $taxonomy Term taxonomy.
 	 * @return PLL_Language|false Language object, false if none found.
 	 */
-	public function get_subsequently_inserted_term_language( $lang, $slug, $taxonomy ) {
+	public function get_inserted_term_language( $lang, $slug, $taxonomy ) {
 		if ( $lang instanceof PLL_Language || ! $this->model->is_translated_taxonomy( $taxonomy ) || ! term_exists( $slug, $taxonomy ) ) {
 			return $lang;
 		}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -81,7 +81,7 @@ class PLL_Admin_Filters_Term {
 		add_action( 'create_term', array( $this, 'save_term' ), 900, 3 );
 		add_action( 'edit_term', array( $this, 'save_term' ), 900, 3 ); // Late as it may conflict with other plugins, see http://wordpress.org/support/topic/polylang-and-wordpress-seo-by-yoast
 		add_action( 'pre_post_update', array( $this, 'pre_post_update' ) );
-		add_filter( 'pll_subsequently_inserted_term_language', array( $this, 'get_subsequently_inserted_term_language' ), 10, 3 );
+		add_filter( 'pll_inserted_term_language', array( $this, 'get_inserted_term_language' ), 10, 3 );
 
 		// Ajax response for edit term form
 		add_action( 'wp_ajax_term_lang_choice', array( $this, 'term_lang_choice' ) );
@@ -607,10 +607,10 @@ class PLL_Admin_Filters_Term {
 	 *
 	 * @since 3.3
 	 *
-	 * @param PLL_Language|false $lang     Term language object if found, false otherwise.
-	 * @param string             $slug     Term slug.
-	 * @param string             $taxonomy Term taxonomy.
-	 * @return PLL_Language|false Language object, false if none found.
+	 * @param PLL_Language|null $lang     Term language object if found, null otherwise.
+	 * @param string            $slug     Term slug.
+	 * @param string            $taxonomy Term taxonomy.
+	 * @return PLL_Language|null Language object, null if none found.
 	 */
 	public function get_inserted_term_language( $lang, $slug, $taxonomy ) {
 		if ( $lang instanceof PLL_Language || ! $this->model->is_translated_taxonomy( $taxonomy ) || ! term_exists( $slug, $taxonomy ) ) {
@@ -667,6 +667,6 @@ class PLL_Admin_Filters_Term {
 			}
 		}
 
-		return false;
+		return null;
 	}
 }

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -669,7 +669,7 @@ class PLL_Admin_Filters_Term {
 		// *Post* bulk edit, in case a new term is created
 		elseif ( isset( $_GET['bulk_edit'], $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// Bulk edit does not modify the language
-			if ( -1 == $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+			if ( -1 === (int) $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->post->get_language( $this->post_id );
 			} else {
 				$lang = $this->model->get_language( sanitize_key( $_GET['inline_lang_choice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
@@ -684,7 +684,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Special cases for default categories as the select is disabled.
-		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( get_option( 'default_category' ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -316,9 +316,9 @@ class PLL_CRUD_Terms {
 		 *
 		 * @since 3.3
 		 *
-		 * @param PLL_Language|false $lang     Found language object, false otherwise.
-		 * @param string             $slug     Term slug.
-		 * @param string             $taxonomy Term taxonomy.
+		 * @param PLL_Language|null $lang     Found language object, null otherwise.
+		 * @param string            $slug     Term slug
+		 * @param string            $taxonomy Term taonomy.
 		 */
 		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -46,9 +46,9 @@ class PLL_CRUD_Terms {
 	/**
 	 * Stores the term name before creating a slug if needed.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	private $pre_term_name;
+	private $pre_term_name = '';
 
 	/**
 	 * Used to append language to term slugs.

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -53,9 +53,9 @@ class PLL_CRUD_Terms {
 	/**
 	 * Used to append language to term slugs.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	private $term_slugs_suffix_separator = '-';
+	private $term_slugs_suffix_separator;
 
 	/**
 	 * Constructor
@@ -69,15 +69,6 @@ class PLL_CRUD_Terms {
 		$this->curlang     = &$polylang->curlang;
 		$this->filter_lang = &$polylang->filter_lang;
 		$this->pref_lang   = &$polylang->pref_lang;
-
-		/**
-		 * Filters the separator to use to append language to term slugs.
-		 *
-		 * @since 3.3
-		 *
-		 * @param string $separator Default separator, '-'.
-		 */
-		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slugs_suffix_separator', $this->term_slugs_suffix_separator );
 
 		// Saving terms
 		add_action( 'create_term', array( $this, 'save_term' ), 999, 3 );
@@ -283,6 +274,30 @@ class PLL_CRUD_Terms {
 	}
 
 	/**
+	 * Returns the separator to append language to term slugs.
+	 *
+	 * @since 3.3
+	 *
+	 * @return string The separator.
+	 */
+	private function get_slug_separator() {
+		if ( is_string( $this->term_slugs_suffix_separator ) ) {
+			return $this->term_slugs_suffix_separator;
+		}
+
+		/**
+		 * Filters the separator to use to append language to term slugs.
+		 *
+		 * @since 3.3
+		 *
+		 * @param string $separator Default separator, '-'.
+		 */
+		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slugs_suffix_separator', '-' );
+
+		return $this->term_slugs_suffix_separator;
+	}
+
+	/**
 	 * Appends language slug to the term slug if needed.
 	 *
 	 * @since 3.3
@@ -308,7 +323,7 @@ class PLL_CRUD_Terms {
 		$lang = apply_filters( 'pll_subsequently_inserted_term_language', false, $slug, $taxonomy );
 
 		if ( $lang instanceof PLL_Language ) {
-			$slug .= $this->term_slugs_suffix_separator . $lang->slug;
+			$slug .= $this->get_slug_separator() . $lang->slug;
 		}
 
 		return $slug;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -44,6 +44,20 @@ class PLL_CRUD_Terms {
 	private $tax_query_lang;
 
 	/**
+	 * Stores the term name before creating a slug if needed.
+	 *
+	 * @var string|null
+	 */
+	private $pre_term_name;
+
+	/**
+	 * Used to append language to term slugs.
+	 *
+	 * @var string
+	 */
+	private $term_slugs_suffix_separator = '-';
+
+	/**
 	 * Constructor
 	 *
 	 * @since 2.4
@@ -51,14 +65,25 @@ class PLL_CRUD_Terms {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
-		$this->model = &$polylang->model;
-		$this->curlang = &$polylang->curlang;
+		$this->model       = &$polylang->model;
+		$this->curlang     = &$polylang->curlang;
 		$this->filter_lang = &$polylang->filter_lang;
-		$this->pref_lang = &$polylang->pref_lang;
+		$this->pref_lang   = &$polylang->pref_lang;
+
+		/**
+		 * Filters the separator to use to append language to term slugs.
+		 *
+		 * @since 3.3
+		 *
+		 * @param string $separator Default separator, '-'.
+		 */
+		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slugs_suffix_separator', $this->term_slugs_suffix_separator );
 
 		// Saving terms
 		add_action( 'create_term', array( $this, 'save_term' ), 999, 3 );
 		add_action( 'edit_term', array( $this, 'save_term' ), 999, 3 ); // After PLL_Admin_Filters_Term
+		add_filter( 'pre_term_name', array( $this, 'set_pre_term_name' ) );
+		add_filter( 'pre_term_slug', array( $this, 'set_pre_term_slug' ), 10, 2 );
 
 		// Adds cache domain when querying terms
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ), 10, 2 );
@@ -243,5 +268,49 @@ class PLL_CRUD_Terms {
 	public function delete_term( $term_id ) {
 		$this->model->term->delete_translation( $term_id );
 		$this->model->term->delete_language( $term_id );
+	}
+
+	/**
+	 * Stores the term name for use in pre_term_slug
+	 *
+	 * @since 0.9.5
+	 *
+	 * @param string $name term name
+	 * @return string unmodified term name
+	 */
+	public function set_pre_term_name( $name ) {
+		return $this->pre_term_name = $name;
+	}
+
+	/**
+	 * Appends language slug to the term slug if needed.
+	 *
+	 * @since 3.3
+	 *
+	 * @param string $slug     Term slug.
+	 * @param string $taxonomy Term taxonomy.
+	 * @return string Slug with a language suffix if found.
+	 */
+	public function set_pre_term_slug( $slug, $taxonomy ) {
+		if ( ! $slug ) {
+			$slug = sanitize_title( $this->pre_term_name );
+		}
+
+		/**
+		 * Filters the subsequently inserted term language.
+		 *
+		 * @since 3.3
+		 *
+		 * @param PLL_Language|false $lang     Found language object, false otherwise.
+		 * @param string             $slug     Term slug.
+		 * @param string             $taxonomy Term taxonomy.
+		 */
+		$lang = apply_filters( 'pll_subsequently_inserted_term_language', false, $slug, $taxonomy );
+
+		if ( $lang instanceof PLL_Language ) {
+			$slug .= $this->term_slugs_suffix_separator . $lang->slug;
+		}
+
+		return $slug;
 	}
 }

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -292,7 +292,7 @@ class PLL_CRUD_Terms {
 		 *
 		 * @param string $separator Default separator, '-'.
 		 */
-		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slugs_suffix_separator', '-' );
+		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slug_suffix_separator', '-' );
 
 		return $this->term_slugs_suffix_separator;
 	}
@@ -320,7 +320,7 @@ class PLL_CRUD_Terms {
 		 * @param string             $slug     Term slug.
 		 * @param string             $taxonomy Term taxonomy.
 		 */
-		$lang = apply_filters( 'pll_subsequently_inserted_term_language', false, $slug, $taxonomy );
+		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
 
 		if ( $lang instanceof PLL_Language ) {
 			$slug .= $this->get_slug_separator() . $lang->slug;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,11 +216,6 @@ parameters:
 			path: admin/admin-filters-term.php
 
 		-
-			message: "#^Parameter \\#1 \\$title of function sanitize_title expects string, string\\|null given\\.$#"
-			count: 1
-			path: admin/admin-filters-term.php
-
-		-
 			message: "#^Parameter \\#2 \\$lang of method PLL_Translated_Object\\:\\:get_translation\\(\\) expects PLL_Language\\|string, PLL_Language\\|false given\\.$#"
 			count: 3
 			path: admin/admin-filters-term.php

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -566,19 +566,22 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
-		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug, 'English term has not its language set.' );
+		$en_lang = self::$model->term->get_language( $en );
+
+		$this->assertInstanceOf( PLL_Language::class, $en_lang, 'Expected the English term to have a language.' );
+		$this->assertSame( 'en', $en_lang->slug, 'English term has not the right language set.' );
 
 		// Let's create a translated term with the same name.
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
-		$term = get_term( $fr, 'category' );
+		$term    = get_term( $fr, 'category' );
+		$fr_lang = self::$model->term->get_language( $fr );
 
-		$this->assertEquals( 'test-fr', $term->slug, 'French term slug is not suffixed with language.' );
-		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug, 'French term has not its language set.' );
-
-		// Second category in French with the same name.
-		$error = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->assertInstanceOf( WP_Term::class, $term, 'Expected the French term to have a category.' );
+		$this->assertSame( 'test-fr', $term->slug, 'French term slug is not suffixed with language.' );
+		$this->assertInstanceOf( PLL_Language::class, $fr_lang, 'Expected the French term to have a language.' );
+		$this->assertSame( 'fr', $fr_lang->slug, 'French term has not the right language set.' );
 
 		$this->assertWPError( $error, 'Third term with the same slug shouldn\'t be created.' );
 	}

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -548,6 +548,32 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->pll_admin->curlang->slug );
 	}
 
+	public function test_change_language_bulk_edit_with_same_name() {
+		$term_id = $en = self::factory()->category->create();
+		self::$model->term->set_language( $en, 'en' );
+
+		$de = self::factory()->category->create();
+		self::$model->term->set_language( $de, 'de' );
+
+		$es = self::factory()->category->create();
+		self::$model->term->set_language( $es, 'es' );
+
+		self::$model->term->save_translations( $en, compact( 'en', 'de', 'es' ) );
+
+		$_POST['inline_lang_choice'] = 'fr';
+		$_GET = array(
+			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
+			'bulk_edit'          => 'Update',
+			'post'               => $term_id,
+			'_status'            => 'publish',
+		);
+		wp_update_term( $term_id, 'category' );
+		$fr = $term_id;
+
+		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
+		$this->assertEqualSetsWithIndex( compact( 'fr', 'de', 'es' ), self::$model->term->get_translations( $es ) );
+	}
+
 	public function test_filter_language_for_terms_with_same_slug() {
 		$fr_lang = self::$model->get_language( 'fr' );
 

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -547,4 +547,35 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$this->assertEquals( 'en', $this->pll_admin->curlang->slug );
 	}
+
+	public function test_filter_language_for_terms_with_same_slug() {
+		$fr_lang = self::$model->get_language( 'fr' );
+
+		// Filter the language. Do not set any globals!
+		add_filter(
+			'pll_subsequently_inserted_term_language',
+			function () use ( $fr_lang ) {
+				return $fr_lang;
+			}
+		);
+
+		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
+
+		// Second category in English with the same name.
+		$error = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
+		$this->assertWPError( $error );
+
+		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
+		$term = get_term( $fr, 'category' );
+		$this->assertEquals( 'test-fr', $term->slug );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
+
+		// Second category in French with the same name.
+		$error = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
+		$this->assertWPError( $error );
+	}
 }

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -661,7 +661,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		// Filter the language for the newt inserted term. Do not set any globals!
 		add_filter(
-			'pll_subsequently_inserted_term_language',
+			'pll_inserted_term_language',
 			function ( $found_language ) use ( $fr_lang ) {
 				if ( $found_language instanceof PLL_Language ) {
 					return $found_language;

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -566,19 +566,20 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
-		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
+		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug, 'English term has not its language set.' );
 
 		// Let's create a translated term with the same name.
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
 		$term = get_term( $fr, 'category' );
-		$this->assertEquals( 'test-fr', $term->slug );
-		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
+
+		$this->assertEquals( 'test-fr', $term->slug, 'French term slug is not suffixed with language.' );
+		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug, 'French term has not its language set.' );
 
 		// Second category in French with the same name.
 		$error = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 
-		$this->assertWPError( $error );
+		$this->assertWPError( $error, 'Third term with the same slug shouldn\'t be created.' );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -583,6 +583,9 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertInstanceOf( PLL_Language::class, $fr_lang, 'Expected the French term to have a language.' );
 		$this->assertSame( 'fr', $fr_lang->slug, 'French term has not the right language set.' );
 
+		// Let's create a third term with the same name.
+		$error = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+
 		$this->assertWPError( $error, 'Third term with the same slug shouldn\'t be created.' );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -551,7 +551,15 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	public function test_filter_language_for_terms_with_same_slug() {
 		$fr_lang = self::$model->get_language( 'fr' );
 
-		// Filter the language. Do not set any globals!
+		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		self::$model->term->set_language( $en, 'en' );
+
+		$en_lang = self::$model->term->get_language( $en );
+
+		$this->assertInstanceOf( PLL_Language::class, $en_lang, 'Expected the English term to have a language.' );
+		$this->assertSame( 'en', $en_lang->slug, 'English term has not the right language set.' );
+
+		// Filter the language for the newt inserted term. Do not set any globals!
 		add_filter(
 			'pll_subsequently_inserted_term_language',
 			function ( $found_language ) use ( $fr_lang ) {
@@ -562,14 +570,6 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 				return $fr_lang;
 			}
 		);
-
-		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$model->term->set_language( $en, 'en' );
-
-		$en_lang = self::$model->term->get_language( $en );
-
-		$this->assertInstanceOf( PLL_Language::class, $en_lang, 'Expected the English term to have a language.' );
-		$this->assertSame( 'en', $en_lang->slug, 'English term has not the right language set.' );
 
 		// Let's create a translated term with the same name.
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -602,9 +602,9 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'es' => $es_cat,
 		);
 
-		$this->assertSame( 'test-fr', $fr_object->slug );
-		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug );
-		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ) );
+		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );
+		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug, 'The category language has not been change into French.' );
+		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The translation group has not been updated.' );
 
 		// Clean Up.
 		unset( $_REQUEST, $_GET );
@@ -634,12 +634,15 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'parent'           => $de_parent,
 			'term_lang_choice' => 'de',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+			'term_tr_lang'     => array( 'en' => $en_child ),
 		);
 		$de_child     = wp_insert_term( 'child', 'category', array( 'parent' => $de_parent ) );
 		$de_child_obj = get_term( $de_child['term_id'], 'category' );
 
-		$this->assertIsInt( $de_child['term_id'] );
-		$this->assertSame( 'child-de', $de_child_obj->slug );
+		$this->assertIsInt( $de_child['term_id'], 'German category should be created.' );
+		$this->assertSame( 'de', self::$model->term->get_language( $de_child['term_id'] )->slug, 'German child category should has its language set.' );
+		$this->assertSameSetsWithIndex( array( 'en' => $en_child, 'de' => $de_child['term_id'] ), self::$model->term->get_translations( $de_child['term_id'], 'German category has no translations group.' ) );
+		$this->assertSame( 'child-de', $de_child_obj->slug, 'German category slug should be suffixed with the language.' );
 
 		// Clean Up.
 		unset( $_REQUEST, $_POST );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -554,20 +554,23 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		// Filter the language. Do not set any globals!
 		add_filter(
 			'pll_subsequently_inserted_term_language',
-			function () use ( $fr_lang ) {
+			function ( $found_language ) use ( $fr_lang ) {
+				if ( $found_language instanceof PLL_Language ) {
+					return $found_language;
+				}
+
 				return $fr_lang;
 			}
 		);
 
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		self::$model->term->set_language( $en, 'en' );
+
 		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
 
-		// Second category in English with the same name.
-		$error = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-
-		$this->assertWPError( $error );
-
+		// Let's create a translated term with the same name.
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		self::$model->term->set_language( $fr, 'fr' );
 
 		$term = get_term( $fr, 'category' );
 		$this->assertEquals( 'test-fr', $term->slug );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -15,7 +15,8 @@ class Slugs_Test extends PLL_UnitTestCase {
 	public function test_term_slugs() {
 		$links_model = self::$model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
-		new PLL_Admin_Filters_Term( $pll_admin ); // activate our filters
+		$pll_admin->term = new PLL_CRUD_Terms( $pll_admin );
+		$pll_admin->filters_term = new PLL_Admin_Filters_Term( $pll_admin ); // activate our filters
 
 		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $term_id, 'en' );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/687

## Description
This PR is motivated by the necessity to find a way to tell `PLL_Admin_Filters_Term` and `PLL_Admin_Share_Term_Slug` which term language to choose before inserting it (i.e. to suffix term slugs with language when they already exists).
The current way to do it is with globals, and works perfectly well with classic `GET` and `POST` requests. But when trying to import terms, we have to hack it by setting these globals ourselves...
To prevent it, I propose a new method processing globals as usual and allowing to filter the returned language.