### PR TITLE
Names wizard page to avoid a fatal error with WooCommerce 6.9.x release

### DIFF
--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -271,7 +271,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function display_wizard_page() {
-		set_current_screen();
+		set_current_screen( 'pll-wizard' );
 		include __DIR__ . '/view-wizard-page.php';
 	}
 


### PR DESCRIPTION
All is the title

## Explanations

When we call [set_current_screen()](https://github.com/polylang/polylang/blob/master/modules/wizard/wizard.php#L274), in fact, we call `WP_Screen::get()` https://github.com/WordPress/WordPress/blob/6.0.2/wp-admin/includes/screen.php#L243 which returns a new `WP_Screen` object with `WP_Screen->id` set to `null` because our page doesn't correspond on any known case.

With a 'hook_name' pass to `set_ccurent_screen()` function `WP_Screen::get()` method assigns it as the `WP_Screen->id`
https://github.com/WordPress/WordPress/blob/6.0.2/wp-admin/includes/class-wp-screen.php#L220-L224