### PR TITLE
Synchronize with new wpseo behaviour

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -437,11 +437,11 @@ class PLL_WPSEO {
 			// Copy the image urls.
 			$keys[] = '_yoast_wpseo_opengraph-image';
 			$keys[] = '_yoast_wpseo_twitter-image';
-		}
 
-		$keys[] = '_yoast_wpseo_meta-robots-noindex';
-		$keys[] = '_yoast_wpseo_meta-robots-nofollow';
-		$keys[] = '_yoast_wpseo_meta-robots-adv';
+			$keys[] = '_yoast_wpseo_meta-robots-noindex';
+			$keys[] = '_yoast_wpseo_meta-robots-nofollow';
+			$keys[] = '_yoast_wpseo_meta-robots-adv';
+		}
 
 		$taxonomies = get_taxonomies(
 			array(


### PR DESCRIPTION
To follow up the Yoast/wordpress-seo [PR#18450](https://github.com/Yoast/wordpress-seo/pull/18450) merged for the future 19.8 release coming soon, we need to adapt the behaviour in the Polylang compatibility i.e. never synchronize the meta robots.
