### PR TITLE
Fix error with custom taxonomies as array

### DIFF
--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -145,9 +145,14 @@ class PLL_Frontend_Auto_Translate {
 			$tax = get_taxonomy( $taxonomy );
 			$arr = array();
 			if ( ! empty( $tax ) && ! empty( $qv[ $tax->query_var ] ) ) {
-				$sep = is_array( $qv[ $tax->query_var ] ) || strpos( $qv[ $tax->query_var ], ',' ) !== false ? ',' : '+'; // Two possible separators
-				$slugarr = is_array( $qv[ $tax->query_var ] ) ? $qv[ $tax->query_var ] : explode( $sep, $qv[ $tax->query_var ] );
-				foreach ( $slugarr as $slug ) {
+				$slugs = array();
+				if ( is_array( $qv[ $tax->query_var ] ) ) {
+					$slugs = $qv[ $tax->query_var ];
+				} elseif ( is_string( $qv[ $tax->query_var ] ) ) {
+					$sep   = strpos( $qv[ $tax->query_var ], ',' ) !== false ? ',' : '+'; // Two possible separators.
+					$slugs = explode( $sep, $qv[ $tax->query_var ] );
+				}
+				foreach ( $slugs as $slug ) {
 					$arr[] = $this->get_translated_term_by( 'slug', $slug, $taxonomy );
 				}
 

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -145,8 +145,9 @@ class PLL_Frontend_Auto_Translate {
 			$tax = get_taxonomy( $taxonomy );
 			$arr = array();
 			if ( ! empty( $tax ) && ! empty( $qv[ $tax->query_var ] ) ) {
-				$sep = strpos( $qv[ $tax->query_var ], ',' ) !== false ? ',' : '+'; // Two possible separators
-				foreach ( explode( $sep, $qv[ $tax->query_var ] ) as $slug ) {
+				$sep = is_array( $qv[ $tax->query_var ] ) || strpos( $qv[ $tax->query_var ], ',' ) !== false ? ',' : '+'; // Two possible separators
+				$slugarr = is_array( $qv[ $tax->query_var ] ) ? $qv[ $tax->query_var ] : explode( $sep, $qv[ $tax->query_var ] );
+				foreach ( $slugarr as $slug ) {
 					$arr[] = $this->get_translated_term_by( 'slug', $slug, $taxonomy );
 				}
 


### PR DESCRIPTION
In some occassions, `$qv[ $tax->query_var ]` may be an array which then triggers a fatal error: `Uncaught TypeError: strpos(): Argument #1 ($haystack) must be of type string, array given in .../polylang/frontend/frontend-auto-translate.php:148`

In my case, triggered by `product_tag` in a woocommerce setup with [hyyan/woo-poly-integration](https://github.com/hyyan/woo-poly-integration/) as product tag translator.