### PR TITLE
Fix is_front_page() when a static front page is not translated

### DIFF
--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -298,13 +298,28 @@ abstract class PLL_Choose_Lang {
 			$this->set_language( $lang );
 			$this->set_curlang_in_query( $query );
 		} elseif ( ( count( $query->query ) == 1 || ( is_paged() && count( $query->query ) == 2 ) ) && $lang = get_query_var( 'lang' ) ) {
-			// Set is_home on translated home page when it displays posts. It must be true on page 2, 3... too.
 			$lang = $this->model->get_language( $lang );
 			$this->set_language( $lang ); // Set the language now otherwise it will be too late to filter sticky posts!
-			$query->is_home = true;
-			$query->is_tax = false;
+
+			// Set is_home on translated home page when it displays posts. It must be true on page 2, 3... too.
+			$query->is_home    = true;
+			$query->is_tax     = false;
 			$query->is_archive = false;
+
+			// Filters is_front_page() in case a static front page is not translated in this language.
+			add_filter( 'option_show_on_front', array( $this, 'filter_option_show_on_front' ) );
 		}
+	}
+
+	/**
+	 * Filters the option show_on_front when the current front page displays posts.
+	 *
+	 * This is useful when a static front page is not translated in all languages.
+	 *
+	 * @return string
+	 */
+	public function filter_option_show_on_front() {
+		return 'posts';
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/283

When a front page displays posts, `is_home()` and `is_front_page()` must be true. We alread used to set `WP_Query::is_home` on translated front pages, however it appears that ther is no `is_front_page` property and `is_front_page()` returns a wrong value if the front page displays a static front page in other languages.

In this PR, we filter the option `show_on_front` to make sure that `is_front_page()` always returns the correct value when the front page page is not translated in the current language. 