### PR TITLE
Fix term slug modification during update

### DIFF
--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -307,9 +307,7 @@ class PLL_CRUD_Terms {
 	 * @return string Slug with a language suffix if found.
 	 */
 	public function set_pre_term_slug( $slug, $taxonomy ) {
-		if ( ! $slug ) {
-			$slug = sanitize_title( $this->pre_term_name );
-		}
+		$name = sanitize_title( $this->pre_term_name );
 
 		/**
 		 * Filters the subsequently inserted term language.
@@ -320,10 +318,10 @@ class PLL_CRUD_Terms {
 		 * @param string            $slug     Term slug
 		 * @param string            $taxonomy Term taonomy.
 		 */
-		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
+		$lang = apply_filters( 'pll_inserted_term_language', null, $name, $taxonomy );
 
 		if ( $lang instanceof PLL_Language ) {
-			$slug .= $this->get_slug_separator() . $lang->slug;
+			$slug = $name . $this->get_slug_separator() . $lang->slug;
 		}
 
 		return $slug;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -320,7 +320,7 @@ class PLL_CRUD_Terms {
 		 *
 		 * @param PLL_Language|null $lang     Found language object, null otherwise.
 		 * @param string            $slug     Term slug
-		 * @param string            $taxonomy Term taonomy.
+		 * @param string            $taxonomy Term taxonomy.
 		 */
 		$lang = apply_filters( 'pll_inserted_term_language', null, $name, $taxonomy );
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -70,15 +70,6 @@ class PLL_CRUD_Terms {
 		$this->filter_lang = &$polylang->filter_lang;
 		$this->pref_lang   = &$polylang->pref_lang;
 
-		/**
-		 * Filters the separator to use to append language to term slugs.
-		 *
-		 * @since 3.3
-		 *
-		 * @param string $separator Default separator, '-'.
-		 */
-		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slugs_suffix_separator', $this->term_slugs_suffix_separator );
-
 		// Saving terms
 		add_action( 'create_term', array( $this, 'save_term' ), 999, 3 );
 		add_action( 'edit_term', array( $this, 'save_term' ), 999, 3 ); // After PLL_Admin_Filters_Term

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -307,6 +307,10 @@ class PLL_CRUD_Terms {
 	 * @return string Slug with a language suffix if found.
 	 */
 	public function set_pre_term_slug( $slug, $taxonomy ) {
+		if ( ! empty( $slug ) ) {
+			return $slug;
+		}
+
 		$name = sanitize_title( $this->pre_term_name );
 
 		/**
@@ -320,7 +324,7 @@ class PLL_CRUD_Terms {
 		 */
 		$lang = apply_filters( 'pll_inserted_term_language', null, $name, $taxonomy );
 
-		if ( $lang instanceof PLL_Language ) {
+		if ( $lang instanceof PLL_Language && ! $this->model->term_exists_by_slug( $name, $lang, $taxonomy ) ) {
 			$slug = $name . $this->get_slug_separator() . $lang->slug;
 		}
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -70,6 +70,15 @@ class PLL_CRUD_Terms {
 		$this->filter_lang = &$polylang->filter_lang;
 		$this->pref_lang   = &$polylang->pref_lang;
 
+		/**
+		 * Filters the separator to use to append language to term slugs.
+		 *
+		 * @since 3.3
+		 *
+		 * @param string $separator Default separator, '-'.
+		 */
+		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slugs_suffix_separator', $this->term_slugs_suffix_separator );
+
 		// Saving terms
 		add_action( 'create_term', array( $this, 'save_term' ), 999, 3 );
 		add_action( 'edit_term', array( $this, 'save_term' ), 999, 3 ); // After PLL_Admin_Filters_Term

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -594,50 +594,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'bulk_edit'          => 'Update',
 			'post'               => $en_post,
 		);
-		wp_update_term( $en_cat, 'category' );
-		$fr_object = get_term( $en_cat );
-		$expected_cats_translations = array(
-			'fr' => $en_cat,
-			'de' => $de_cat,
-			'es' => $es_cat,
-		);
-
-		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );
-		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug, 'The category language has not been change into French.' );
-		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The translation group has not been updated.' );
-
-		// Clean Up.
-		unset( $_REQUEST, $_GET );
-	}
-
-	public function test_child_categories_with_same_name() {
-		// Create parent categories.
-		$en_parent = self::factory()->category->create( array( 'name' => 'parent', 'slug' => 'parent' ) );
-		self::$model->term->set_language( $en_parent, 'en' );
-
-		$de_parent = self::factory()->category->create( array( 'name' => 'parent', 'slug' => 'parent-de' ) );
-		self::$model->term->set_language( $de_parent, 'de' );
-
-		self::$model->term->save_translations(
-			$en_parent,
-			array(
-				'en' => $en_parent,
-				'de' => $de_parent,
-			)
-		);
-
-		// Create only english child category for the moment.
-		$en_child = self::factory()->category->create( array( 'name' => 'child', 'slug' => 'child', 'parent' => $en_parent ) );
-		self::$model->term->set_language( $en_child, 'en' );
-
-		$_REQUEST = $_POST = array(
-			'parent'           => $de_parent,
-			'term_lang_choice' => 'de',
-			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
-			'term_tr_lang'     => array( 'en' => $en_child ),
-		);
-		$de_child     = wp_insert_term( 'child', 'category', array( 'parent' => $de_parent ) );
-		$de_child_obj = get_term( $de_child['term_id'], 'category' );
+		wp_update_term( $term_id, 'category' );
+		$fr = $term_id;
 
 		$this->assertIsInt( $de_child['term_id'], 'German category should be created.' );
 		$this->assertSame( 'de', self::$model->term->get_language( $de_child['term_id'] )->slug, 'German child category should has its language set.' );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -684,4 +684,37 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$this->assertWPError( $error, 'Third term with the same slug shouldn\'t be created.' );
 	}
+
+	public function test_update_term_from_admin() {
+		$original_name = 'Test Me';
+
+		$cat_en = $this->factory()->category->create_and_get(
+			array(
+				'name' => $original_name,
+			)
+		);
+		self::$model->term->set_language( $cat_en->term_id, 'en' );
+
+		$this->assertSame( sanitize_title( $original_name ), $cat_en->slug, 'The category slug is well created.' );
+
+		// Add globals like an admin request.
+		$_REQUEST = $_POST = array(
+			'term_lang_choice' => 'en',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+		);
+
+		// Now update the category with a new name.
+		$updated_cat = wp_update_term(
+			$cat_en->term_id,
+			'category',
+			array(
+				'name' => 'Well Tested',
+			)
+		);
+		$updated_cat_obj = get_term( $updated_cat['term_id'] );
+
+		$this->assertSame( sanitize_title( $original_name ), $updated_cat_obj->slug, 'The category slug should remain the same.' );
+
+		unset( $_REQUEST, $_POST );
+	}
 }

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -552,10 +552,13 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		// Create a category and its translations.
 		$en_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test' ) );
 		self::$model->term->set_language( $en_cat, 'en' );
+
 		$de_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test-de' ) );
 		self::$model->term->set_language( $de_cat, 'de' );
+
 		$es_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test-es' ) );
 		self::$model->term->set_language( $es_cat, 'es' );
+
 		self::$model->term->save_translations(
 			$en_cat,
 			array(
@@ -564,13 +567,17 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 				'es' => $es_cat,
 			)
 		);
+
 		// Create some posts.
 		$en_post = self::factory()->post->create( array( 'post_category' => array( $en_cat ) ) );
 		self::$model->post->set_language( $en_post, 'en' );
+
 		$de_post = self::factory()->post->create( array( 'post_category' => array( $de_cat ) ) );
 		self::$model->post->set_language( $de_post, 'de' );
+
 		$es_post = self::factory()->post->create( array( 'post_category' => array( $es_cat ) ) );
 		self::$model->post->set_language( $es_post, 'es' );
+
 		self::$model->post->save_translations(
 			$en_post,
 			array(
@@ -579,28 +586,28 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 				'es' => $es_post,
 			)
 		);
-		// Set globals like a language change in bluk edit and update a category.
+
 		$_REQUEST = $_GET = array(
 			'inline_lang_choice' => 'fr',
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
- 			'bulk_edit'          => 'Update',
- 			'post'               => $en_post,
- 		);
- 		wp_update_term( $en_cat, 'category' );
- 		$fr_object = get_term( $en_cat );
- 		$expected_cats_translations = array(
- 			'fr' => $en_cat,
- 			'de' => $de_cat,
- 			'es' => $es_cat,
- 		);
+			'bulk_edit'          => 'Update',
+			'post'               => $en_post,
+		);
+		wp_update_term( $en_cat, 'category' );
+		$fr_object = get_term( $en_cat );
+		$expected_cats_translations = array(
+			'fr' => $en_cat,
+			'de' => $de_cat,
+			'es' => $es_cat,
+		);
 
- 		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );
- 		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug, 'The category language has not been change into French.' );
- 		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The translation group has not been updated.' );
+		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );
+		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug, 'The category language has not been change into French.' );
+		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The translation group has not been updated.' );
 
- 		// Clean Up.
- 		unset( $_REQUEST, $_GET );
- 	}
+		// Clean Up.
+		unset( $_REQUEST, $_GET );
+	}
 
 	public function test_child_categories_with_same_name() {
 		// Create parent categories.

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -630,12 +630,15 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'parent'           => $de_parent,
 			'term_lang_choice' => 'de',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+			'term_tr_lang'     => array( 'en' => $en_child ),
 		);
 		$de_child     = wp_insert_term( 'child', 'category', array( 'parent' => $de_parent ) );
 		$de_child_obj = get_term( $de_child['term_id'], 'category' );
 
-		$this->assertIsInt( $de_child['term_id'] );
-		$this->assertSame( 'child-de', $de_child_obj->slug );
+		$this->assertIsInt( $de_child['term_id'], 'German category should be created.' );
+		$this->assertSame( 'de', self::$model->term->get_language( $de_child['term_id'] )->slug, 'German child category should has its language set.' );
+		$this->assertSameSetsWithIndex( array( 'en' => $en_child, 'de' => $de_child['term_id'] ), self::$model->term->get_translations( $de_child['term_id'], 'German category has no translations group.' ) );
+		$this->assertSame( 'child-de', $de_child_obj->slug, 'German category slug should be suffixed with the language.' );
 
 		// Clean Up.
 		unset( $_REQUEST, $_POST );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -604,6 +604,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		bulk_edit_posts( $_REQUEST );
 
 		$fr_object = wp_get_object_terms( $en_post, 'category' );
+		$this->assertIsArray( $fr_object, 'Expected wp_get_object_terms() to return an array of categories.' );
+		$this->assertCount( 1, $fr_object, 'Expected the post to have one category, and only one.' );
 		$fr_object = reset( $fr_object );
 
 		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -587,6 +587,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			)
 		);
 
+		// Set globals like a language change in bluk edit and update a category
 		$_REQUEST = $_GET = array(
 			'inline_lang_choice' => 'fr',
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -552,13 +552,10 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		// Create a category and its translations.
 		$en_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test' ) );
 		self::$model->term->set_language( $en_cat, 'en' );
-
 		$de_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test-de' ) );
 		self::$model->term->set_language( $de_cat, 'de' );
-
 		$es_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test-es' ) );
 		self::$model->term->set_language( $es_cat, 'es' );
-
 		self::$model->term->save_translations(
 			$en_cat,
 			array(
@@ -567,17 +564,13 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 				'es' => $es_cat,
 			)
 		);
-
 		// Create some posts.
 		$en_post = self::factory()->post->create( array( 'post_category' => array( $en_cat ) ) );
 		self::$model->post->set_language( $en_post, 'en' );
-
 		$de_post = self::factory()->post->create( array( 'post_category' => array( $de_cat ) ) );
 		self::$model->post->set_language( $de_post, 'de' );
-
 		$es_post = self::factory()->post->create( array( 'post_category' => array( $es_cat ) ) );
 		self::$model->post->set_language( $es_post, 'es' );
-
 		self::$model->post->save_translations(
 			$en_post,
 			array(
@@ -586,25 +579,28 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 				'es' => $es_post,
 			)
 		);
-
 		// Set globals like a language change in bluk edit and update a category.
 		$_REQUEST = $_GET = array(
 			'inline_lang_choice' => 'fr',
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
-			'bulk_edit'          => 'Update',
-			'post'               => $en_post,
-		);
-		wp_update_term( $term_id, 'category' );
-		$fr = $term_id;
+ 			'bulk_edit'          => 'Update',
+ 			'post'               => $en_post,
+ 		);
+ 		wp_update_term( $en_cat, 'category' );
+ 		$fr_object = get_term( $en_cat );
+ 		$expected_cats_translations = array(
+ 			'fr' => $en_cat,
+ 			'de' => $de_cat,
+ 			'es' => $es_cat,
+ 		);
 
-		$this->assertIsInt( $de_child['term_id'], 'German category should be created.' );
-		$this->assertSame( 'de', self::$model->term->get_language( $de_child['term_id'] )->slug, 'German child category should has its language set.' );
-		$this->assertSameSetsWithIndex( array( 'en' => $en_child, 'de' => $de_child['term_id'] ), self::$model->term->get_translations( $de_child['term_id'], 'German category has no translations group.' ) );
-		$this->assertSame( 'child-de', $de_child_obj->slug, 'German category slug should be suffixed with the language.' );
+ 		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );
+ 		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug, 'The category language has not been change into French.' );
+ 		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The translation group has not been updated.' );
 
-		// Clean Up.
-		unset( $_REQUEST, $_POST );
-	}
+ 		// Clean Up.
+ 		unset( $_REQUEST, $_GET );
+ 	}
 
 	public function test_child_categories_with_same_name() {
 		// Create parent categories.

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -21,12 +21,15 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
-		$links_model = self::$model->get_links_model();
+
+		$links_model     = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 
-		$this->pll_admin->filters      = new PLL_Admin_Filters( $this->pll_admin );       // To activate the fix_delete_default_category() filter
+		$this->pll_admin->filters      = new PLL_Admin_Filters( $this->pll_admin ); // To activate the fix_delete_default_category() filter
 		$this->pll_admin->terms        = new PLL_CRUD_Terms( $this->pll_admin );
 		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );
+		$this->pll_admin->posts        = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin );
 	}
 
 	public function test_default_language() {
@@ -559,13 +562,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$es_cat = self::factory()->category->create( array( 'name' => 'test', 'slug' => 'test-es' ) );
 		self::$model->term->set_language( $es_cat, 'es' );
 
+		$expected_cats_translations = array(
+			'en' => $en_cat,
+			'de' => $de_cat,
+			'es' => $es_cat,
+		);
 		self::$model->term->save_translations(
 			$en_cat,
-			array(
-				'en' => $en_cat,
-				'de' => $de_cat,
-				'es' => $es_cat,
-			)
+			$expected_cats_translations
 		);
 
 		// Create some posts.
@@ -593,18 +597,19 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
 			'bulk_edit'          => 'Update',
 			'post'               => $en_post,
-		);
-		wp_update_term( $en_cat, 'category' );
-		$fr_object = get_term( $en_cat );
-		$expected_cats_translations = array(
-			'fr' => $en_cat,
-			'de' => $de_cat,
-			'es' => $es_cat,
+			'_status'            => 'publish',
 		);
 
+		do_action( 'load-edit.php' );
+		bulk_edit_posts( $_REQUEST );
+
+		$fr_object = wp_get_object_terms( $en_post, 'category' );
+		$fr_object = reset( $fr_object );
+
 		$this->assertSame( 'test-fr', $fr_object->slug, 'The slug should be suffixed with the french language.' );
-		$this->assertSame( 'fr', self::$model->term->get_language( $en_cat )->slug, 'The category language has not been change into French.' );
-		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The translation group has not been updated.' );
+		$this->assertSame( 'fr', self::$model->term->get_language( $fr_object->term_id )->slug, 'The category language should be French.' );
+		$this->assertSameSetsWithIndex( $expected_cats_translations, self::$model->term->get_translations( $en_cat ), 'The original translation group should not have been updated.' );
+		$this->assertSameSetsWithIndex( array( 'fr' => $fr_object->term_id ), self::$model->term->get_translations( $fr_object->term_id ), 'The translation group of the new term should contain only this term.' );
 
 		// Clean Up.
 		unset( $_REQUEST, $_GET );
@@ -691,6 +696,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 	public function test_update_term_from_admin() {
 		$original_name = 'Test Me';
+		$new_name      = 'Well Tested';
 
 		$cat_en = $this->factory()->category->create_and_get(
 			array(
@@ -712,12 +718,13 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			$cat_en->term_id,
 			'category',
 			array(
-				'name' => 'Well Tested',
+				'name' => $new_name,
 			)
 		);
 		$updated_cat_obj = get_term( $updated_cat['term_id'] );
 
-		$this->assertSame( sanitize_title( $original_name ), $updated_cat_obj->slug, 'The category slug should remain the same.' );
+		$this->assertSame( $new_name, $updated_cat_obj->name, 'The category name should have been modified.' );
+		$this->assertSame( $cat_en->slug, $updated_cat_obj->slug, 'The category slug should remain the same.' );
 
 		unset( $_REQUEST, $_POST );
 	}

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -606,6 +606,41 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		unset( $_REQUEST, $_POST );
 	}
 
+	public function test_child_categories_with_same_name() {
+		// Create parent categories.
+		$en_parent = self::factory()->category->create( array( 'name' => 'parent', 'slug' => 'parent' ) );
+		self::$model->term->set_language( $en_parent, 'en' );
+
+		$de_parent = self::factory()->category->create( array( 'name' => 'parent', 'slug' => 'parent-de' ) );
+		self::$model->term->set_language( $de_parent, 'de' );
+
+		self::$model->term->save_translations(
+			$en_parent,
+			array(
+				'en' => $en_parent,
+				'de' => $de_parent,
+			)
+		);
+
+		// Create only english child category for the moment.
+		$en_child = self::factory()->category->create( array( 'name' => 'child', 'slug' => 'child', 'parent' => $en_parent ) );
+		self::$model->term->set_language( $en_child, 'en' );
+
+		$_REQUEST = $_POST = array(
+			'parent'           => $de_parent,
+			'term_lang_choice' => 'de',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+		);
+		$de_child     = wp_insert_term( 'child', 'category', array( 'parent' => $de_parent ) );
+		$de_child_obj = get_term( $de_child['term_id'], 'category' );
+
+		$this->assertIsInt( $de_child['term_id'] );
+		$this->assertSame( 'child-de', $de_child_obj->slug );
+
+		// Clean Up.
+		unset( $_REQUEST, $_POST );
+	}
+
 	public function test_filter_language_for_terms_with_same_slug() {
 		$fr_lang = self::$model->get_language( 'fr' );
 

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -587,7 +587,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			)
 		);
 
-		// Set globals like a language change in bluk edit and update a category
+		// Set globals like a language change in bluk edit and update a category.
 		$_REQUEST = $_GET = array(
 			'inline_lang_choice' => 'fr',
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1468

This https://github.com/polylang/polylang/pull/1113 introduced a bug by changing the behavior. Indeed, before that we were using the updated sanitized term name as slug. See: https://github.com/polylang/polylang/blob/fefc34807c3187dd1749384c64b2eb4fd7641b3a/admin/admin-filters-term.php#L469

This PR propose to use the inserted/updated term name again and add a test to confirm the bug.