### PR TITLE
Don't report objects without languages when no language exist

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -679,6 +679,11 @@ class PLL_Model {
 	 * @return int[]
 	 */
 	public function get_posts_with_no_lang( $post_types, $limit ) {
+		$languages = $this->get_languages_list( array( 'fields' => 'term_id' ) );
+		if ( empty( $languages ) ) {
+			return array(); // Don't report if no languages have been defined yet.
+		}
+
 		return get_posts(
 			array(
 				'numberposts' => $limit,
@@ -689,7 +694,7 @@ class PLL_Model {
 				'tax_query'   => array(
 					array(
 						'taxonomy' => 'language',
-						'terms'    => $this->get_languages_list( array( 'fields' => 'term_id' ) ),
+						'terms'    => $languages,
 						'operator' => 'NOT IN',
 					),
 				),
@@ -709,6 +714,11 @@ class PLL_Model {
 	public function get_terms_with_no_lang( $taxonomies, $limit ) {
 		global $wpdb;
 
+		$languages = $this->get_languages_list( array( 'fields' => 'tl_term_taxonomy_id' ) );
+		if ( empty( $languages ) ) {
+			return array(); // Don't report if no languages have been defined yet.
+		}
+
 		$taxonomies = (array) $taxonomies;
 
 		$sql = sprintf(
@@ -719,7 +729,7 @@ class PLL_Model {
 			)
 			%s",
 			implode( "','", esc_sql( $taxonomies ) ),
-			implode( ',', array_map( 'intval', $this->get_languages_list( array( 'fields' => 'tl_term_taxonomy_id' ) ) ) ),
+			implode( ',', array_map( 'intval', $languages ) ),
 			$limit > 0 ? sprintf( 'LIMIT %d', intval( $limit ) ) : ''
 		);
 


### PR DESCRIPTION
Fix #1121

When no languages exist, `get_objects_with_no_lang()` was not supposed to be called. This was protected [by the test of the existence of the default language](https://github.com/polylang/polylang/blob/3.2.7/settings/settings.php#L347). This protection proved not to be sufficient. This PR prevents an SQL error by checking that languages exist before injecting them in the SQL query. This check is also made for posts even if we don't use a direct SQL query in this case.