### PR TITLE
Extract gutenberg-blocks tags from WPML config to be able to export and import strings to translate for blocks

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -329,26 +329,24 @@ class PLL_WPML_Config {
 			}
 			foreach ( $blocks as $block ) {
 				$attributes = $block->attributes();
-				if ( empty( $attributes ) ) {
+				if ( empty( $attributes ) || 1 !== (int) $attributes['translate'] ) {
 					continue;
 				}
-				if ( 1 === (int) $attributes['translate'] ) {
-					$block_name = (string) $attributes['type'];
-					foreach ( $block->children() as $child ) {
-						if ( $child_tag !== $child->getName() ) {
+				$block_name = (string) $attributes['type'];
+				foreach ( $block->children() as $child ) {
+					if ( $child_tag !== $child->getName() ) {
+						continue;
+					}
+					if ( $is_in_child_attribute ) {
+						$child_attributes = $child->attributes();
+						if ( empty( $child_attributes ) ) {
 							continue;
 						}
-						if ( $is_in_child_attribute ) {
-							$child_attributes = $child->attributes();
-							if ( empty( $child_attributes ) ) {
-								continue;
-							}
-							$rules = (string) $child_attributes[ $child_attribute_name ];
-						} else {
-							$rules = (string) $child;
-						}
-						$parsing_rules[ $block_name ][] = $rules;
+						$rules = (string) $child_attributes[ $child_attribute_name ];
+					} else {
+						$rules = (string) $child;
 					}
+					$parsing_rules[ $block_name ][] = $rules;
 				}
 			}
 		}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -284,11 +284,11 @@ class PLL_WPML_Config {
 	 *
 	 * @since 3.3
 	 *
-	 * @param array[] $parsing_rules Rules as Xpath expressions to evaluate in the blocks content.
-	 * @return array[] Rules completed with ones from wpml-config file.
+	 * @param string[][] $parsing_rules Rules as Xpath expressions to evaluate in the blocks content.
+	 * @return string[][] Rules completed with ones from wpml-config file.
 	 *
 	 * @phpstan-param array<string,array<string>> $parsing_rules
-	 * @phpstan-return array<string,array<string>> $parsing_rules
+	 * @phpstan-return array<string,array<string>>
 	 */
 	public function translate_blocks( $parsing_rules ) {
 		return $this->extract_blocks_parsing_rules( $parsing_rules, 'xpath' );
@@ -299,8 +299,8 @@ class PLL_WPML_Config {
 	 *
 	 * @since 3.3
 	 *
-	 * @param array[] $parsing_rules Rules for block attributes to translate.
-	 * @return array[] Rules completed with ones from wpml-config file.
+	 * @param string[][] $parsing_rules Rules for block attributes to translate.
+	 * @return string[][] Rules completed with ones from wpml-config file.
 	 *
 	 * @phpstan-param array<string,array<string>> $parsing_rules
 	 * @phpstan-return array<string,array<string>>

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -353,23 +353,26 @@ class PLL_WPML_Config {
 				if ( empty( $attributes ) || 1 !== (int) $attributes['translate'] ) {
 					continue;
 				}
-				$block_name = (string) $attributes['type'];
+				$block_name = trim( (string) $attributes['type'] );
+				if ( '' === $block_name ) {
+					continue;
+				}
 				foreach ( $block->children() as $child ) {
 					$rule = '';
 					$child_tag = $child->getName();
 					switch ( $child_tag ) {
 						case 'xpath':
-							$rule = (string) $child;
+							$rule = trim( (string) $child );
 							break;
 						case 'key':
 							$child_attributes = $child->attributes();
 							if ( empty( $child_attributes ) ) {
 								break;
 							}
-							$rule = (string) $child_attributes['name'];
+							$rule = trim( (string) $child_attributes['name'] );
 							break;
 					}
-					if ( ! empty( $rule ) ) {
+					if ( '' !== $rule ) {
 						$parsing_rules[ $child_tag ][ $block_name ][] = $rule;
 					}
 				}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -295,7 +295,7 @@ class PLL_WPML_Config {
 	}
 
 	/**
-	 * Translation management for blocks attributes.
+	 * Translation management for block attributes.
 	 *
 	 * @since 3.3
 	 *

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -302,11 +302,11 @@ class PLL_WPML_Config {
 	}
 
 	/**
-	 * Translation management for block attributes.
+	 * Translation management for blocks attributes.
 	 *
 	 * @since 3.3
 	 *
-	 * @param string[][] $parsing_rules Rules for block attributes to translate.
+	 * @param string[][] $parsing_rules Rules for blocks attributes to translate.
 	 * @return string[][] Rules completed with ones from wpml-config file.
 	 *
 	 * @phpstan-param array<string,array<string>> $parsing_rules

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -326,10 +326,10 @@ class PLL_WPML_Config {
 	 */
 	protected function get_blocks_parsing_rules( $rule_tag ) {
 
-		if ( null === $this->parsing_rules  ) {
+		if ( null === $this->parsing_rules ) {
 			$this->parsing_rules = $this->extract_blocks_parsing_rules();
 		}
-		
+
 		return isset( $this->parsing_rules[ $rule_tag ] ) ? $this->parsing_rules[ $rule_tag ] : array();
 	}
 

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -291,7 +291,7 @@ class PLL_WPML_Config {
 	 * @phpstan-return array<string,array<string>>
 	 */
 	public function translate_blocks( $parsing_rules ) {
-		return $this->extract_blocks_parsing_rules( $parsing_rules, 'xpath' );
+		return array_merge( $parsing_rules, $this->extract_blocks_parsing_rules( 'xpath' ) );
 	}
 
 	/**
@@ -306,7 +306,7 @@ class PLL_WPML_Config {
 	 * @phpstan-return array<string,array<string>>
 	 */
 	public function translate_blocks_attributes( $parsing_rules ) {
-		return $this->extract_blocks_parsing_rules( $parsing_rules, 'key', true );
+		return array_merge( $parsing_rules, $this->extract_blocks_parsing_rules( 'key', true ) );
 	}
 
 	/**
@@ -314,13 +314,14 @@ class PLL_WPML_Config {
 	 *
 	 * @since 3.3
 	 *
-	 * @param array[] $parsing_rules         Rules to complete with ones from wpml-config file..
 	 * @param string  $child_tag             Tag name to extract.
 	 * @param bool    $is_in_child_attribute Extract tag value in attribute or not. Default false.
 	 * @param string  $child_attribute_name  Attribute name where to extract the value. Default 'name'. Used if $is_in_child_attribute is set to true.
 	 * @return array[] Rules completed with ones from wpml-config file.
 	 */
-	protected function extract_blocks_parsing_rules( $parsing_rules, $child_tag, $is_in_child_attribute = false, $child_attribute_name = 'name' ) {
+	protected function extract_blocks_parsing_rules( $child_tag, $is_in_child_attribute = false, $child_attribute_name = 'name' ) {
+		$parsing_rules = array();
+
 		foreach ( $this->xmls as $xml ) {
 			$blocks = $xml->xpath( 'gutenberg-blocks/gutenberg-block' );
 			if ( ! is_array( $blocks ) ) {
@@ -346,9 +347,7 @@ class PLL_WPML_Config {
 						} else {
 							$rules = (string) $child;
 						}
-						if ( ! isset( $parsing_rules[ $block_name ] ) || ! in_array( $rules, $parsing_rules[ $block_name ] ) ) {
-							$parsing_rules[ $block_name ][] = $rules;
-						}
+						$parsing_rules[ $block_name ][] = $rules;
 					}
 				}
 			}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -316,7 +316,7 @@ class PLL_WPML_Config {
 	 *
 	 * @param array[] $parsing_rules         Rules to complete with ones from wpml-config file..
 	 * @param string  $child_tag             Tag name to extract.
-	 * @param bool $is_in_child_attribute Extract tag value in attribute or not. Default false.
+	 * @param bool    $is_in_child_attribute Extract tag value in attribute or not. Default false.
 	 * @param string  $child_attribute_name  Attribute name where to extract the value. Default 'name'. Used if $is_in_child_attribute is set to true.
 	 * @return array[] Rules completed with ones from wpml-config file.
 	 */

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -239,7 +239,7 @@ class PLL_WPML_Config {
 					if ( empty( $attributes ) ) {
 						continue;
 					}
-					if ( '1' === (string) $attributes['translate'] && ! $hide ) {
+					if ( 1 === (int) $attributes['translate'] && ! $hide ) {
 						$types[ (string) $pt ] = (string) $pt;
 					} else {
 						unset( $types[ (string) $pt ] ); // The theme/plugin author decided what to do with the post type so don't allow the user to change this
@@ -268,7 +268,7 @@ class PLL_WPML_Config {
 					if ( empty( $attributes ) ) {
 						continue;
 					}
-					if ( '1' === (string) $attributes['translate'] && ! $hide ) {
+					if ( 1 === (int) $attributes['translate'] && ! $hide ) {
 						$taxonomies[ (string) $tax ] = (string) $tax;
 					} else {
 						unset( $taxonomies[ (string) $tax ] ); // the theme/plugin author decided what to do with the taxonomy so don't allow the user to change this
@@ -331,7 +331,7 @@ class PLL_WPML_Config {
 				if ( empty( $attributes ) ) {
 					continue;
 				}
-				if ( '1' === (string) $attributes['translate'] ) {
+				if ( 1 === (int) $attributes['translate'] ) {
 					$block_name = (string) $attributes['type'];
 					foreach ( $block->children() as $child ) {
 						if ( $child_tag !== $child->getName() ) {

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -314,9 +314,9 @@ class PLL_WPML_Config {
 	 *
 	 * @since 3.3
 	 *
-	 * @param string  $child_tag             Tag name to extract.
-	 * @param bool    $is_in_child_attribute Extract tag value in attribute or not. Default false.
-	 * @param string  $child_attribute_name  Attribute name where to extract the value. Default 'name'. Used if $is_in_child_attribute is set to true.
+	 * @param string $child_tag             Tag name to extract.
+	 * @param bool   $is_in_child_attribute Extract tag value in attribute or not. Default false.
+	 * @param string $child_attribute_name  Attribute name where to extract the value. Default 'name'. Used if $is_in_child_attribute is set to true.
 	 * @return array[] Rules completed with ones from wpml-config file.
 	 */
 	protected function extract_blocks_parsing_rules( $child_tag, $is_in_child_attribute = false, $child_attribute_name = 'name' ) {

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -35,9 +35,9 @@ class PLL_WPML_Config {
 	/**
 	 * List of rules to extract strings to translate from blocks.
 	 *
-	 * @var string[][][]
+	 * @var string[][][]|null
 	 */
-	protected $parsing_rules;
+	protected $parsing_rules = null;
 
 	/**
 	 * Constructor
@@ -317,20 +317,20 @@ class PLL_WPML_Config {
 	}
 
 	/**
-	 * Returns rules to extract a kind of string for blocks.
+	 * Returns rules to extract translatable strings from blocks.
 	 *
 	 * @since 3.3
 	 *
 	 * @param string $rule_tag Tag name to extract.
-	 * @return string[][] Rules completed with ones from wpml-config file.
+	 * @return string[][] The rules.
 	 */
 	protected function get_blocks_parsing_rules( $rule_tag ) {
 
-		if ( isset( $this->parsing_rules[ $rule_tag ] ) ) {
-			return $this->parsing_rules[ $rule_tag ];
+		if ( null === $this->parsing_rules  ) {
+			$this->parsing_rules = $this->extract_blocks_parsing_rules();
 		}
-		$this->parsing_rules = $this->extract_blocks_parsing_rules();
-		return $this->parsing_rules[ $rule_tag ];
+		
+		return isset( $this->parsing_rules[ $rule_tag ] ) ? $this->parsing_rules[ $rule_tag ] : array();
 	}
 
 	/**

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -323,29 +323,31 @@ class PLL_WPML_Config {
 	protected function extract_blocks_parsing_rules( $parsing_rules, $child_tag, $is_in_child_attribute = false, $child_attribute_name = 'name' ) {
 		foreach ( $this->xmls as $xml ) {
 			$blocks = $xml->xpath( 'gutenberg-blocks/gutenberg-block' );
-			if ( is_array( $blocks ) ) {
-				foreach ( $blocks as $block ) {
-					$attributes = $block->attributes();
-					if ( empty( $attributes ) ) {
-						continue;
-					}
-					if ( '1' === (string) $attributes['translate'] ) {
-						$block_name = (string) $attributes['type'];
-						foreach ( $block->children() as $child ) {
-							if ( $child_tag === $child->getName() ) {
-								if ( $is_in_child_attribute ) {
-									$child_attributes = $child->attributes();
-									if ( empty( $child_attributes ) ) {
-										continue;
-									}
-									$rules = (string) $child_attributes[ $child_attribute_name ];
-								} else {
-									$rules = (string) $child;
-								}
-								if ( ! isset( $parsing_rules[ $block_name ] ) || ! in_array( $rules, $parsing_rules[ $block_name ] ) ) {
-									$parsing_rules[ $block_name ][] = $rules;
-								}
+			if ( ! is_array( $blocks ) ) {
+				continue;
+			}
+			foreach ( $blocks as $block ) {
+				$attributes = $block->attributes();
+				if ( empty( $attributes ) ) {
+					continue;
+				}
+				if ( '1' === (string) $attributes['translate'] ) {
+					$block_name = (string) $attributes['type'];
+					foreach ( $block->children() as $child ) {
+						if ( $child_tag !== $child->getName() ) {
+							continue;
+						}
+						if ( $is_in_child_attribute ) {
+							$child_attributes = $child->attributes();
+							if ( empty( $child_attributes ) ) {
+								continue;
 							}
+							$rules = (string) $child_attributes[ $child_attribute_name ];
+						} else {
+							$rules = (string) $child;
+						}
+						if ( ! isset( $parsing_rules[ $block_name ] ) || ! in_array( $rules, $parsing_rules[ $block_name ] ) ) {
+							$parsing_rules[ $block_name ][] = $rules;
 						}
 					}
 				}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -316,7 +316,7 @@ class PLL_WPML_Config {
 	 *
 	 * @param array[] $parsing_rules         Rules to complete with ones from wpml-config file..
 	 * @param string  $child_tag             Tag name to extract.
-	 * @param boolean $is_in_child_attribute Extract tag value in attribute or not. Default false.
+	 * @param bool $is_in_child_attribute Extract tag value in attribute or not. Default false.
 	 * @param string  $child_attribute_name  Attribute name where to extract the value. Default 'name'. Used if $is_in_child_attribute is set to true.
 	 * @return array[] Rules completed with ones from wpml-config file.
 	 */

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -21,9 +21,9 @@ class PLL_WPML_Config {
 	/**
 	 * The content of all read xml files.
 	 *
-	 * @var SimpleXMLElement[]|null
+	 * @var SimpleXMLElement[]
 	 */
-	protected $xmls;
+	protected $xmls = array();
 
 	/**
 	 * The list of xml files.
@@ -94,6 +94,9 @@ class PLL_WPML_Config {
 				if ( is_array( $keys ) ) {
 					foreach ( $keys as $key ) {
 						$attributes = $key->attributes();
+						if ( empty( $attributes ) ) {
+							continue;
+						}
 						$name = (string) $attributes['name'];
 
 						if ( false !== strpos( $name, '*' ) ) {
@@ -175,6 +178,9 @@ class PLL_WPML_Config {
 			if ( is_array( $cfs ) ) {
 				foreach ( $cfs as $cf ) {
 					$attributes = $cf->attributes();
+					if ( empty( $attributes ) ) {
+						continue;
+					}
 					if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], array( 'translate', 'copy-once' ) ) ) ) {
 						$metas[] = (string) $cf;
 					} else {
@@ -201,6 +207,9 @@ class PLL_WPML_Config {
 			if ( is_array( $cfs ) ) {
 				foreach ( $cfs as $cf ) {
 					$attributes = $cf->attributes();
+					if ( empty( $attributes ) ) {
+						continue;
+					}
 					if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], array( 'translate', 'copy-once' ) ) ) ) {
 						$metas[] = (string) $cf;
 					} else {
@@ -227,7 +236,10 @@ class PLL_WPML_Config {
 			if ( is_array( $pts ) ) {
 				foreach ( $pts as $pt ) {
 					$attributes = $pt->attributes();
-					if ( 1 == $attributes['translate'] && ! $hide ) {
+					if ( empty( $attributes ) ) {
+						continue;
+					}
+					if ( '1' === (string) $attributes['translate'] && ! $hide ) {
 						$types[ (string) $pt ] = (string) $pt;
 					} else {
 						unset( $types[ (string) $pt ] ); // The theme/plugin author decided what to do with the post type so don't allow the user to change this
@@ -253,7 +265,10 @@ class PLL_WPML_Config {
 			if ( is_array( $taxos ) ) {
 				foreach ( $taxos as $tax ) {
 					$attributes = $tax->attributes();
-					if ( 1 == $attributes['translate'] && ! $hide ) {
+					if ( empty( $attributes ) ) {
+						continue;
+					}
+					if ( '1' === (string) $attributes['translate'] && ! $hide ) {
 						$taxonomies[ (string) $tax ] = (string) $tax;
 					} else {
 						unset( $taxonomies[ (string) $tax ] ); // the theme/plugin author decided what to do with the taxonomy so don't allow the user to change this
@@ -311,13 +326,19 @@ class PLL_WPML_Config {
 			if ( is_array( $blocks ) ) {
 				foreach ( $blocks as $block ) {
 					$attributes = $block->attributes();
-					if ( 1 == $attributes['translate'] ) {
+					if ( empty( $attributes ) ) {
+						continue;
+					}
+					if ( '1' === (string) $attributes['translate'] ) {
 						$block_name = (string) $attributes['type'];
 						foreach ( $block->children() as $child ) {
 							if ( $child_tag === $child->getName() ) {
 								if ( $is_in_child_attribute ) {
 									$child_attributes = $child->attributes();
-									$rules            = (string) $child_attributes[ $child_attribute_name ];
+									if ( empty( $child_attributes ) ) {
+										continue;
+									}
+									$rules = (string) $child_attributes[ $child_attribute_name ];
 								} else {
 									$rules = (string) $child;
 								}
@@ -359,6 +380,9 @@ class PLL_WPML_Config {
 	 */
 	protected function xml_to_array( $key, &$arr = array() ) {
 		$attributes = $key->attributes();
+		if ( empty( $attributes ) ) {
+			return $arr;
+		}
 		$name = (string) $attributes['name'];
 		$children = $key->children();
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1571,16 +1571,6 @@ parameters:
 			path: modules/wpml/wpml-compat.php
 
 		-
-			message: "#^Argument of an invalid type array\\<SimpleXMLElement\\>\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 4
-			path: modules/wpml/wpml-config.php
-
-		-
-			message: "#^Offset 'name' does not exist on SimpleXMLElement\\|null\\.$#"
-			count: 1
-			path: modules/wpml/wpml-config.php
-
-		-
 			message: "#^Parameter \\#1 \\$path of function dirname expects string, mixed given\\.$#"
 			count: 2
 			path: modules/wpml/wpml-config.php

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -45,12 +45,23 @@
 				</key>
 				<key name="empty_option">
 					<key name="*">
-		            	<key name="label"/>
+						<key name="label"/>
 					</key>
 				</key>
 				<key name="simple_string_option" />
 				<key name="generic_option_*" />
 		</admin-texts>
+		<gutenberg-blocks>
+			<gutenberg-block type="core/image" translate="1">
+				<xpath>//figure/figcaption</xpath>
+				<xpath>//figure/img/@alt</xpath>
+			</gutenberg-block>
+		</gutenberg-blocks>
+		<gutenberg-blocks>
+			<gutenberg-block type="core/navigation-link" translate="1">
+				<key name="description" />
+			</gutenberg-block>
+		</gutenberg-blocks>
 		<language-switcher-settings>
 				<key name="icl_lang_sel_config">
 						<key name="font-current-normal">#444444</key>

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -52,14 +52,15 @@
 				<key name="generic_option_*" />
 		</admin-texts>
 		<gutenberg-blocks>
-			<gutenberg-block type="core/image" translate="1">
+			<gutenberg-block type="my-plugin/my-block" translate="1">
 				<xpath>//figure/figcaption</xpath>
 				<xpath>//figure/img/@alt</xpath>
+				<key name="headingTitle" />
+				<key name="text" />
 			</gutenberg-block>
-		</gutenberg-blocks>
-		<gutenberg-blocks>
-			<gutenberg-block type="core/navigation-link" translate="1">
-				<key name="description" />
+			<gutenberg-block type="my-plugin/my-block-2" translate="1">
+				<xpath>//div/p/a</xpath>
+				<key name="iconLabel" />
 			</gutenberg-block>
 		</gutenberg-blocks>
 		<language-switcher-settings>

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -62,6 +62,22 @@
 				<xpath>//div/p/a</xpath>
 				<key name="iconLabel" />
 			</gutenberg-block>
+			<gutenberg-block type=" " translate="1">
+				<xpath>//div/p/a</xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-4">
+				<xpath>//div/p/a</xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-5" translate="1">
+				<xpath> </xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-6" translate="1">
+				<xpath>//div/p/a</xpath>
+				<key name=" " />
+			</gutenberg-block>
 		</gutenberg-blocks>
 		<language-switcher-settings>
 				<key name="icl_lang_sel_config">

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -359,6 +359,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 			'my-plugin/my-block-2' => array(
 				'//div/p/a',
 			),
+			'my-plugin/my-block-6' => array(
+				'//div/p/a',
+			),
 		);
 		$expected_parsing_rules_for_attributes = array(
 			'my-plugin/my-block' => array(
@@ -368,12 +371,15 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 			'my-plugin/my-block-2' => array(
 				'iconLabel',
 			),
+			'my-plugin/my-block-5' => array(
+				'iconLabel',
+			),
 		);
 
 		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', $parsing_rules );
 		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', $parsing_rules_for_attributes );
 
 		$this->assertSameSets( $expected_parsing_rules, $parsing_rules, 'Rules from WPML config should be added and override the existing ones for each block.' );
-		$this->assertSameSets( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules from WPML config should be added and override the existing ones for each block.' );
+		$this->assertSameSets( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules for blocks attributes from WPML config should be added and override the existing ones for each block.' );
 	}
 }

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -336,4 +336,47 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->prepare_options( 'OBJECT' );
 		$this->_test_register_string();
 	}
+
+	public function test_gutenberg_blocks() {
+		PLL_WPML_Config::instance()->init();
+
+		$expected_parsing_rules                = array(
+			'core/image'        => array(
+				'//figure/figcaption',
+				'//figure/img/@alt',
+			),
+		);
+		$expected_parsing_rules_for_attributes = array(
+			'core/navigation-link'      => array(
+				'description',
+			),
+		);
+
+		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', array() );
+		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', array() );
+
+		$this->assertSameSets( $expected_parsing_rules, $parsing_rules, 'Rules should not be added to the existings ones' );
+		$this->assertSameSets( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules should not be added to the existing ones.' );
+	}
+
+	public function test_gutenberg_blocks_with_existing_parsing_rules() {
+		PLL_WPML_Config::instance()->init();
+
+		$existing_parsing_rules                = array(
+			'core/image'        => array(
+				'//figure/figcaption',
+				'//figure/img/@alt',
+			),
+		);
+		$existing_parsing_rules_for_attributes = array(
+			'core/navigation-link'      => array(
+				'description',
+			),
+		);
+		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', $existing_parsing_rules );
+		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', $existing_parsing_rules_for_attributes );
+
+		$this->assertSameSets( $existing_parsing_rules, $parsing_rules, 'Rules should not be added to the existings ones' );
+		$this->assertSameSets( $existing_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules should not be added to the existing ones.' );
+	}
 }

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -340,43 +340,40 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	public function test_gutenberg_blocks() {
 		PLL_WPML_Config::instance()->init();
 
+		$parsing_rules                = array(
+			'my-plugin/my-block' => array(
+				'//div/p',
+			),
+		);
+		$parsing_rules_for_attributes = array(
+			'my-plugin/my-block' => array(
+				'buttonText',
+			),
+		);
+
 		$expected_parsing_rules                = array(
-			'core/image'        => array(
+			'my-plugin/my-block' => array(
 				'//figure/figcaption',
 				'//figure/img/@alt',
+			),
+			'my-plugin/my-block-2' => array(
+				'//div/p/a',
 			),
 		);
 		$expected_parsing_rules_for_attributes = array(
-			'core/navigation-link'      => array(
-				'description',
+			'my-plugin/my-block' => array(
+				'headingTitle',
+				'text',
+			),
+			'my-plugin/my-block-2' => array(
+				'iconLabel',
 			),
 		);
 
-		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', array() );
-		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', array() );
+		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', $parsing_rules );
+		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', $parsing_rules_for_attributes );
 
-		$this->assertSameSets( $expected_parsing_rules, $parsing_rules, 'Rules should not be added to the existings ones' );
-		$this->assertSameSets( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules should not be added to the existing ones.' );
-	}
-
-	public function test_gutenberg_blocks_with_existing_parsing_rules() {
-		PLL_WPML_Config::instance()->init();
-
-		$existing_parsing_rules                = array(
-			'core/image'        => array(
-				'//figure/figcaption',
-				'//figure/img/@alt',
-			),
-		);
-		$existing_parsing_rules_for_attributes = array(
-			'core/navigation-link'      => array(
-				'description',
-			),
-		);
-		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', $existing_parsing_rules );
-		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', $existing_parsing_rules_for_attributes );
-
-		$this->assertSameSets( $existing_parsing_rules, $parsing_rules, 'Rules should not be added to the existings ones' );
-		$this->assertSameSets( $existing_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules should not be added to the existing ones.' );
+		$this->assertSameSets( $expected_parsing_rules, $parsing_rules, 'Rules from WPML config should be added and override the existing ones for each block.' );
+		$this->assertSameSets( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules from WPML config should be added and override the existing ones for each block.' );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1456

All is in the title.

The goal is to create rules for our xliff exporter/importer modules to be able to process strings inside blocks content or blocks attributes.

This PR deals only with simple cases documented in https://wpml.org/documentation/support/language-configuration-files/#gutenberg-blocks :
- `<xpath>` tag for blocks content
- simple `<key>` tag for blocks attributes

_Draft for the moment because we need to solve PHPStan issue with SimpleXMLElement_

## Going further

This PR doesn't deal with with more complex WPML configuration:
- attributes with sub-attributes
- attributes targeted by `search-method` attribute (`wildcards `or `regex`) or wildcard character `*`
- URL-Encoded JSON string attributes
- blocks targeted by namespace

