### PR TITLE
Remove temporary fix in PHPUnit test for WP ticket 55575

### DIFF
--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -258,8 +258,6 @@ class Columns_Test extends PLL_UnitTestCase {
 		ob_start();
 		$list_table->inline_edit();
 		$form = ob_get_clean();
-		// Temporarily fix issue https://core.trac.wordpress.org/ticket/55575.
-		$form = preg_replace( '@ (aria-labelledby|id)="inline-edit-legend"@', '', $form );
 		$doc  = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );


### PR DESCRIPTION
#1010 introduced a temporary fix in our test due to https://core.trac.wordpress.org/ticket/55575
This WordPress issue has been fixed in WordPress 6.0 RC2 and thus is not useful anymore.