### PR TITLE
Translate Yoast SEO metas

### DIFF
--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -482,7 +482,7 @@ class PLL_WPSEO {
 	 * Adds the yoast translatable metas to export.
 	 *
 	 * @param  array $metas An array of post metas (keyed with meta keys) to export.
-	 * @return array  The modified array of post metas to export.
+	 * @return array The modified array of post metas to export.
 	 */
 	public function export_post_metas( $metas ) {
 		$metas_to_export = array_fill_keys( $this->get_translatable_meta_keys(), 1 );

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -46,6 +46,7 @@ class PLL_WPSEO {
 		} else {
 			add_filter( 'pll_copy_post_metas', array( $this, 'copy_post_metas' ), 10, 4 );
 			add_filter( 'pll_translate_post_meta', array( $this, 'translate_post_meta' ), 10, 3 );
+			add_filter( 'pll_post_metas_to_export', array( $this, 'export_post_metas' ) );
 
 			// Yoast SEO adds the columns hooks only for the 'inline-save' action. We need them for 'pll_update_post_rows' too.
 			if ( wp_doing_ajax() && isset( $_POST['action'] ) && 'pll_update_post_rows' === $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -425,14 +426,7 @@ class PLL_WPSEO {
 	public function copy_post_metas( $keys, $sync, $from, $to ) {
 		if ( ! $sync ) {
 			// Text requiring translation.
-			$keys[] = '_yoast_wpseo_title';
-			$keys[] = '_yoast_wpseo_metadesc';
-			$keys[] = '_yoast_wpseo_bctitle';
-			$keys[] = '_yoast_wpseo_focuskw';
-			$keys[] = '_yoast_wpseo_opengraph-title';
-			$keys[] = '_yoast_wpseo_opengraph-description';
-			$keys[] = '_yoast_wpseo_twitter-title';
-			$keys[] = '_yoast_wpseo_twitter-description';
+			$keys = array_merge( $keys, $this->get_translatable_meta_keys() );
 
 			// Copy the image urls.
 			$keys[] = '_yoast_wpseo_opengraph-image';
@@ -482,5 +476,40 @@ class PLL_WPSEO {
 		}
 
 		return pll_get_term( $value, $lang );
+	}
+
+	/**
+	 * Adds the yoast translatable metas to export.
+	 *
+	 * @param  array $metas An array of post metas (keyed with meta keys) to export.
+	 * @return array        A potentially modified array of post metas to export.
+	 *
+	 * @phpstan-param  array<string,int> $parsing_rules
+	 * @phpstan-return array<string,int> $parsing_rules
+	 */
+	public function export_post_metas( $metas ) {
+		$metas_to_export = array_fill_keys( $this->get_translatable_meta_keys(), 1 );
+
+		return array_merge( $metas, $metas_to_export );
+	}
+
+	/**
+	 * Returns the meta keys with translatable text.
+	 *
+	 * @since 3.3
+	 *
+	 * @return string[]
+	 */
+	protected function get_translatable_meta_keys() {
+		return array(
+			'_yoast_wpseo_title',
+			'_yoast_wpseo_metadesc',
+			'_yoast_wpseo_bctitle',
+			'_yoast_wpseo_focuskw',
+			'_yoast_wpseo_opengraph-title',
+			'_yoast_wpseo_opengraph-description',
+			'_yoast_wpseo_twitter-title',
+			'_yoast_wpseo_twitter-description',
+		);
 	}
 }

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -482,10 +482,7 @@ class PLL_WPSEO {
 	 * Adds the yoast translatable metas to export.
 	 *
 	 * @param  array $metas An array of post metas (keyed with meta keys) to export.
-	 * @return array        A potentially modified array of post metas to export.
-	 *
-	 * @phpstan-param  array<string,int> $parsing_rules
-	 * @phpstan-return array<string,int> $parsing_rules
+	 * @return array  The modified array of post metas to export.
 	 */
 	public function export_post_metas( $metas ) {
 		$metas_to_export = array_fill_keys( $this->get_translatable_meta_keys(), 1 );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1462

Uses the existing filter `pll_post_metas_to_export` to add yoast metas to export, and so, to the translation when importing.

_Replaces https://github.com/polylang/xliff-exporter/pull/413_