### PR TITLE
Rework auto-translation of term slugs list in WP_Query

### DIFF
--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -86,6 +86,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test' ) ) );
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test,test2' ) ) );
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => 'test+test2' ) ) );
+		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag' => array( 'test', 'test2' ) ) ) );
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'tag_slug__in' => array( 'test' ) ) ) );
 	}
 
@@ -123,6 +124,7 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test' ) ) );
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test,test2' ) ) );
 		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => 'test+test2' ) ) );
+		$this->assertEquals( array( get_post( $post_fr ) ), get_posts( array( 'post_type' => 'trcpt', 'trtax' => array( 'test', 'test2' ) ) ) );
 
 		// tax query
 		$args = array(


### PR DESCRIPTION
This is a follow-uo of #1119. 

After it has been merged, I noticed:
- [An error reported by PHPStan](https://app.travis-ci.com/github/polylang/polylang/jobs/584360634).
- The tag list has the same issue fixed by #1119 for custom taxonomies but wasn't fixed.

This PR introduces a new method to avoid repeating ourselves between tags and custom taxonomies.
In this method, I fix the undefined variable issue reported by PHPStan.