### PR TITLE
Support custom fields in wpml-config.xml

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -95,8 +95,7 @@ class PLL_WPML_Config {
 				$keys = $xml->xpath( 'admin-texts/key' );
 				if ( is_array( $keys ) ) {
 					foreach ( $keys as $key ) {
-						$attributes = $key->attributes();
-						$name = (string) $attributes['name'];
+						$name = $this->get_field_attribute( $key, 'name' );
 
 						if ( false !== strpos( $name, '*' ) ) {
 							$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
@@ -174,17 +173,22 @@ class PLL_WPML_Config {
 	public function copy_post_metas( $metas, $sync ) {
 		foreach ( $this->xmls as $xml ) {
 			$cfs = $xml->xpath( 'custom-fields/custom-field' );
-			if ( is_array( $cfs ) ) {
-				foreach ( $cfs as $cf ) {
-					$attributes = $cf->attributes();
-					if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], array( 'translate', 'copy-once' ) ) ) ) {
-						$metas[] = (string) $cf;
-					} else {
-						$metas = array_diff( $metas, array( (string) $cf ) );
-					}
+
+			if ( ! is_array( $cfs ) ) {
+				continue;
+			}
+
+			foreach ( $cfs as $cf ) {
+				$action = $this->get_field_attribute( $cf, 'action' );
+
+				if ( 'copy' === $action || ( ! $sync && in_array( $action, array( 'translate', 'copy-once' ), true ) ) ) {
+					$metas[] = (string) $cf;
+				} else {
+					$metas = array_diff( $metas, array( (string) $cf ) );
 				}
 			}
 		}
+
 		return $metas;
 	}
 
@@ -200,17 +204,22 @@ class PLL_WPML_Config {
 	public function copy_term_metas( $metas, $sync ) {
 		foreach ( $this->xmls as $xml ) {
 			$cfs = $xml->xpath( 'custom-term-fields/custom-term-field' );
-			if ( is_array( $cfs ) ) {
-				foreach ( $cfs as $cf ) {
-					$attributes = $cf->attributes();
-					if ( 'copy' == $attributes['action'] || ( ! $sync && in_array( $attributes['action'], array( 'translate', 'copy-once' ) ) ) ) {
-						$metas[] = (string) $cf;
-					} else {
-						$metas = array_diff( $metas, array( (string) $cf ) );
-					}
+
+			if ( ! is_array( $cfs ) ) {
+				continue;
+			}
+
+			foreach ( $cfs as $cf ) {
+				$action = $this->get_field_attribute( $cf, 'action' );
+
+				if ( 'copy' === $action || ( ! $sync && in_array( $action, array( 'translate', 'copy-once' ), true ) ) ) {
+					$metas[] = (string) $cf;
+				} else {
+					$metas = array_diff( $metas, array( (string) $cf ) );
 				}
 			}
 		}
+
 		return $metas;
 	}
 
@@ -344,17 +353,22 @@ class PLL_WPML_Config {
 	public function translate_types( $types, $hide ) {
 		foreach ( $this->xmls as $xml ) {
 			$pts = $xml->xpath( 'custom-types/custom-type' );
-			if ( is_array( $pts ) ) {
-				foreach ( $pts as $pt ) {
-					$attributes = $pt->attributes();
-					if ( 1 == $attributes['translate'] && ! $hide ) {
-						$types[ (string) $pt ] = (string) $pt;
-					} else {
-						unset( $types[ (string) $pt ] ); // The theme/plugin author decided what to do with the post type so don't allow the user to change this
-					}
+
+			if ( ! is_array( $pts ) ) {
+				continue;
+			}
+
+			foreach ( $pts as $pt ) {
+				$translate = $this->get_field_attribute( $pt, 'translate' );
+
+				if ( '1' === $translate && ! $hide ) {
+					$types[ (string) $pt ] = (string) $pt;
+				} else {
+					unset( $types[ (string) $pt ] ); // The theme/plugin author decided what to do with the post type so don't allow the user to change this
 				}
 			}
 		}
+
 		return $types;
 	}
 
@@ -370,17 +384,22 @@ class PLL_WPML_Config {
 	public function translate_taxonomies( $taxonomies, $hide ) {
 		foreach ( $this->xmls as $xml ) {
 			$taxos = $xml->xpath( 'taxonomies/taxonomy' );
-			if ( is_array( $taxos ) ) {
-				foreach ( $taxos as $tax ) {
-					$attributes = $tax->attributes();
-					if ( 1 == $attributes['translate'] && ! $hide ) {
-						$taxonomies[ (string) $tax ] = (string) $tax;
-					} else {
-						unset( $taxonomies[ (string) $tax ] ); // the theme/plugin author decided what to do with the taxonomy so don't allow the user to change this
-					}
+
+			if ( ! is_array( $taxos ) ) {
+				continue;
+			}
+
+			foreach ( $taxos as $tax ) {
+				$translate = $this->get_field_attribute( $tax, 'translate' );
+
+				if ( '1' === $translate && ! $hide ) {
+					$taxonomies[ (string) $tax ] = (string) $tax;
+				} else {
+					unset( $taxonomies[ (string) $tax ] ); // the theme/plugin author decided what to do with the taxonomy so don't allow the user to change this
 				}
 			}
 		}
+
 		return $taxonomies;
 	}
 
@@ -412,13 +431,7 @@ class PLL_WPML_Config {
 	 * @return array
 	 */
 	protected function xml_to_array( SimpleXMLElement $key, array &$arr = array(), $fill_value = true ) {
-		$attributes = $key->attributes();
-
-		if ( empty( $attributes ) ) {
-			return $arr;
-		}
-
-		$name = trim( (string) $attributes['name'] );
+		$name = $this->get_field_attribute( $key, 'name' );
 
 		if ( '' === $name ) {
 			return $arr;

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -293,7 +293,7 @@ class PLL_WPML_Config {
 			$fields = $xml->xpath( 'custom-fields-texts/key' );
 
 			if ( ! is_array( $fields ) ) {
-				// Wrong configuration: no `<key>` nodes.
+				// No 'custom-fields-texts' nodes.
 				continue;
 			}
 

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -244,8 +244,8 @@ class PLL_WPML_Config {
 	 * }
 	 * @return array
 	 *
-	 * @phpstan-param array<string, int|array> $keys
-	 * @phpstan-return array<string, int|array>
+	 * @phpstan-param array<string, mixed> $keys
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function post_metas_to_export( $keys ) {
 		// Add keys that have the `action` attribute set to `translate`.
@@ -285,7 +285,7 @@ class PLL_WPML_Config {
 					continue;
 				}
 
-				if ( ! isset( $keys[ $name ] ) ) {
+				if ( ! array_key_exists( $name, $keys ) ) {
 					// Wrong configuration: the field is not in `custom-fields/custom-field`.
 					continue;
 				}
@@ -314,8 +314,8 @@ class PLL_WPML_Config {
 	 * }
 	 * @return array
 	 *
-	 * @phpstan-param array<string, int> $keys
-	 * @phpstan-return array<string, int>
+	 * @phpstan-param array<string, mixed> $keys
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function term_metas_to_export( $keys ) {
 		// Add keys that have the `action` attribute set to `translate`.

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -290,7 +290,7 @@ class PLL_WPML_Config {
 					continue;
 				}
 
-				$this->xml_to_array( $field, $keys, 1 );
+				$keys = $this->xml_to_array( $field, $keys, 1 );
 			}
 		}
 
@@ -423,6 +423,7 @@ class PLL_WPML_Config {
 	 *
 	 * @since 2.9
 	 * @since 3.3 Type-hinted the parameters `$key` and `$arr`.
+	 * @since 3.3 `$arr` is not passed by reference anymore.
 	 * @since 3.3 Added the parameter `$fill_value`.
 	 *
 	 * @param SimpleXMLElement $key        XML node.
@@ -430,7 +431,7 @@ class PLL_WPML_Config {
 	 * @param mixed            $fill_value Value to use when filling entries. Default is true.
 	 * @return array
 	 */
-	protected function xml_to_array( SimpleXMLElement $key, array &$arr = array(), $fill_value = true ) {
+	protected function xml_to_array( SimpleXMLElement $key, array $arr = array(), $fill_value = true ) {
 		$name = $this->get_field_attribute( $key, 'name' );
 
 		if ( '' === $name ) {

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -471,39 +471,45 @@ class PLL_WPML_Config {
 
 		foreach ( $this->xmls as $xml ) {
 			$blocks = $xml->xpath( 'gutenberg-blocks/gutenberg-block' );
+
 			if ( ! is_array( $blocks ) ) {
 				continue;
 			}
+
 			foreach ( $blocks as $block ) {
-				$attributes = $block->attributes();
-				if ( empty( $attributes ) || 1 !== (int) $attributes['translate'] ) {
+				$translate = $this->get_field_attribute( $block, 'translate' );
+
+				if ( '1' !== $translate ) {
 					continue;
 				}
-				$block_name = trim( (string) $attributes['type'] );
+
+				$block_name = $this->get_field_attribute( $block, 'type' );
+
 				if ( '' === $block_name ) {
 					continue;
 				}
+
 				foreach ( $block->children() as $child ) {
-					$rule = '';
+					$rule      = '';
 					$child_tag = $child->getName();
+
 					switch ( $child_tag ) {
 						case 'xpath':
 							$rule = trim( (string) $child );
 							break;
+
 						case 'key':
-							$child_attributes = $child->attributes();
-							if ( empty( $child_attributes ) ) {
-								break;
-							}
-							$rule = trim( (string) $child_attributes['name'] );
+							$rule = $this->get_field_attribute( $child, 'name' );
 							break;
 					}
+
 					if ( '' !== $rule ) {
 						$parsing_rules[ $child_tag ][ $block_name ][] = $rule;
 					}
 				}
 			}
 		}
+
 		return $parsing_rules;
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1567,12 +1567,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\<SimpleXMLElement\\>\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 4
-			path: modules/wpml/wpml-config.php
-
-		-
-			message: "#^Offset 'name' does not exist on SimpleXMLElement\\|null\\.$#"
-			count: 1
+			count: 7
 			path: modules/wpml/wpml-config.php
 
 		-

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -2,11 +2,28 @@
 		<custom-fields>
 				<custom-field action="copy">quantity</custom-field>
 				<custom-field action="translate">custom-title</custom-field>
+				<custom-field action="translate">custom|nested</custom-field>
 				<custom-field action="copy">weight</custom-field>
 				<custom-field action="copy-once">bg-color</custom-field>
 				<custom-field action="translate">custom-description</custom-field>
 				<custom-field action="ignore">date-added</custom-field>
 		</custom-fields>
+		<custom-fields-texts>
+			<key name="custom|nested">
+				<key name="sub-1" />
+				<key name="sub-2">
+					<key name="sub|21">
+						<key name="sub-211" />
+						<key name=" " />
+						<key name="" />
+						<key />
+					</key>
+				</key>
+			</key>
+			<key name="custom-nested-2">
+				<key name="sub-1" />
+			</key>
+		</custom-fields-texts>
 		<custom-term-fields>
 			<custom-term-field action="copy">term_meta_A</custom-term-field>
 			<custom-term-field action="translate">term_meta_B</custom-term-field>
@@ -45,7 +62,7 @@
 				</key>
 				<key name="empty_option">
 					<key name="*">
-		            	<key name="label"/>
+						<key name="label"/>
 					</key>
 				</key>
 				<key name="simple_string_option" />

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -199,6 +199,37 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'D', get_term_meta( $from, 'term_meta_D', true ) );
 	}
 
+	public function test_export_custom_fiels() {
+		$wpml_config = PLL_WPML_Config::instance();
+		$wpml_config->init();
+
+		// `custom-nested-2` is not expected because it is not in the `<custom-fields>` list.
+		$expected = array(
+			'previous-value'     => 1,
+			'custom-title'       => 1,
+			'custom|nested'      => array(
+				'sub-1' => 1,
+				'sub-2' => array(
+					'sub|21' => array(
+						'sub-211' => 1,
+					),
+				),
+			),
+			'custom-description' => 1,
+		);
+		$result   = $wpml_config->post_metas_to_export( array( 'previous-value' => 1 ) );
+
+		$this->assertSame( $expected, $result );
+
+		$expected = array(
+			'previous-value' => 1,
+			'term_meta_B'    => 1,
+		);
+		$result   = $wpml_config->term_metas_to_export( array( 'previous-value' => 1 ) );
+
+		$this->assertSame( $expected, $result );
+	}
+
 	public function test_cpt() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/210.
Related #535 (should be closed).

This PR allows to translate post and term metas listed in `wpml-config.xml` files.
This adds hooks to `'pll_post_metas_to_export'` and `'pll_term_metas_to_export'`. Post meta sub-keys are supported but not term meta sub-keys: WPML doesn't currently support this.
Wilcard (`*`) is not currently supported.
The `encoding` attribute is not supported.

Unit tests have been added but we should add integration tests to the xliff plugin.