### PR TITLE
Replace first parameter of WordPress get_terms() function passed as a string with an array

### DIFF
--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -69,7 +69,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			}
 
 			if ( ! empty( $hierarchical_taxonomies ) ) {
-				$terms          = get_terms( $hierarchical_taxonomies, array( 'get' => 'all' ) );
+				$terms          = get_terms( array( 'taxonomy' => $hierarchical_taxonomies, 'get' => 'all' ) );
 				$term_languages = array();
 
 				if ( is_array( $terms ) ) {

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -516,7 +516,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// It is more efficient to use one common query for all languages as soon as there are more than 2.
-		$all_terms = get_terms( array( 'taxonomy' => $taxonomy ), 'hide_empty=0&lang=0&name__like=' . $s );
+		$all_terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => false, 'lang' => '', 'name__like' => $s ) );
 		if ( is_array( $all_terms ) ) {
 			foreach ( $all_terms as $term ) {
 				$lang = $this->model->term->get_language( $term->term_id );

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -516,7 +516,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// It is more efficient to use one common query for all languages as soon as there are more than 2.
-		$all_terms = get_terms( $taxonomy, 'hide_empty=0&lang=0&name__like=' . $s );
+		$all_terms = get_terms( array( 'taxonomy' => $taxonomy ), 'hide_empty=0&lang=0&name__like=' . $s );
 		if ( is_array( $all_terms ) ) {
 			foreach ( $all_terms as $term ) {
 				$lang = $this->model->term->get_language( $term->term_id );

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -416,7 +416,7 @@ class PLL_Admin_Model extends PLL_Model {
 		}
 
 		// Get all terms with term_taxonomy_id
-		$terms = get_terms( array( 'taxonomy' => $taxonomy ), array( 'hide_empty' => false ) );
+		$terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => false ) );
 		$trs   = array();
 
 		// Prepare objects relationships.
@@ -456,7 +456,7 @@ class PLL_Admin_Model extends PLL_Model {
 	public function update_translations( $old_slug, $new_slug = '' ) {
 		global $wpdb;
 
-		$terms    = get_terms( array( 'post_translations', 'term_translations' ) );
+		$terms    = get_terms( array( 'taxonomy' => array( 'post_translations', 'term_translations' ) ) );
 		$term_ids = array();
 		$dr       = array();
 		$dt       = array();

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -416,7 +416,7 @@ class PLL_Admin_Model extends PLL_Model {
 		}
 
 		// Get all terms with term_taxonomy_id
-		$terms = get_terms( $taxonomy, array( 'hide_empty' => false ) );
+		$terms = get_terms( array( 'taxonomy' => $taxonomy ), array( 'hide_empty' => false ) );
 		$trs   = array();
 
 		// Prepare objects relationships.

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -277,8 +277,11 @@ class PLL_Frontend_Auto_Translate {
 		} else {
 			$terms = get_terms( array( 'taxonomy' => $taxonomy, $field => $term, 'lang' => '' ) );
 
-			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+			if ( ! empty( $terms ) && is_array( $terms ) ) {
 				$t = reset( $terms );
+				if ( ! $t instanceof WP_Term ) {
+					return $term;
+				}
 				$tr_id = $this->get_term( $t->term_id );
 
 				if ( ! is_wp_error( $tr = get_term( $tr_id, $taxonomy ) ) ) {

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -275,7 +275,7 @@ class PLL_Frontend_Auto_Translate {
 				return $tr_id;
 			}
 		} else {
-			$terms = get_terms( $taxonomy, array( $field => $term, 'lang' => '' ) );
+			$terms = get_terms( array( 'taxonomy' => $taxonomy ), array( $field => $term, 'lang' => '' ) );
 
 			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 				$t = reset( $terms );

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -275,7 +275,7 @@ class PLL_Frontend_Auto_Translate {
 				return $tr_id;
 			}
 		} else {
-			$terms = get_terms( array( 'taxonomy' => $taxonomy ), array( $field => $term, 'lang' => '' ) );
+			$terms = get_terms( array( 'taxonomy' => $taxonomy, $field => $term, 'lang' => '' ) );
 
 			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 				$t = reset( $terms );

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -89,7 +89,7 @@ class PLL_Frontend_Links extends PLL_Links {
 						if ( ! empty( $tax_query['taxonomy'] ) && $this->model->is_translated_taxonomy( $tax_query['taxonomy'] ) ) {
 
 							$tax = get_taxonomy( $tax_query['taxonomy'] );
-							$terms = get_terms( array( 'taxonomy' => $tax->name ), array( 'fields' => 'id=>slug' ) ); // Filtered by current language
+							$terms = get_terms( array( 'taxonomy' => $tax->name, 'fields' => 'id=>slug' ) ); // Filtered by current language
 
 							foreach ( $tax_query['terms'] as $slug ) {
 								$term_id = array_search( $slug, $terms ); // What is the term_id corresponding to taxonomy term?
@@ -115,7 +115,7 @@ class PLL_Frontend_Links extends PLL_Links {
 				elseif ( $tr_id = $this->model->term->get_translation( $term->term_id, $language ) ) {
 					if ( $tr_term = get_term( $tr_id, $term->taxonomy ) ) {
 						// Check if translated term ( or children ) have posts
-						$count = $tr_term->count || ( is_taxonomy_hierarchical( $term->taxonomy ) && array_sum( wp_list_pluck( get_terms( array( 'taxonomy' => $term->taxonomy ), array( 'child_of' => $tr_term->term_id, 'lang' => $language->slug ) ), 'count' ) ) );
+						$count = $tr_term->count || ( is_taxonomy_hierarchical( $term->taxonomy ) && array_sum( wp_list_pluck( get_terms( array( 'taxonomy' => $term->taxonomy, 'child_of' => $tr_term->term_id, 'lang' => $language->slug ) ), 'count' ) ) );
 
 						/**
 						 * Filter whether to hide an archive translation url

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -115,7 +115,7 @@ class PLL_Frontend_Links extends PLL_Links {
 				elseif ( $tr_id = $this->model->term->get_translation( $term->term_id, $language ) ) {
 					if ( $tr_term = get_term( $tr_id, $term->taxonomy ) ) {
 						// Check if translated term ( or children ) have posts
-						$count = $tr_term->count || ( is_taxonomy_hierarchical( $term->taxonomy ) && array_sum( wp_list_pluck( get_terms( array( 'taxonomy' => $term->taxonomy), array( 'child_of' => $tr_term->term_id, 'lang' => $language->slug ) ), 'count' ) ) );
+						$count = $tr_term->count || ( is_taxonomy_hierarchical( $term->taxonomy ) && array_sum( wp_list_pluck( get_terms( array( 'taxonomy' => $term->taxonomy ), array( 'child_of' => $tr_term->term_id, 'lang' => $language->slug ) ), 'count' ) ) );
 
 						/**
 						 * Filter whether to hide an archive translation url

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -89,7 +89,7 @@ class PLL_Frontend_Links extends PLL_Links {
 						if ( ! empty( $tax_query['taxonomy'] ) && $this->model->is_translated_taxonomy( $tax_query['taxonomy'] ) ) {
 
 							$tax = get_taxonomy( $tax_query['taxonomy'] );
-							$terms = get_terms( $tax->name, array( 'fields' => 'id=>slug' ) ); // Filtered by current language
+							$terms = get_terms( array( 'taxonomy' => $tax->name ), array( 'fields' => 'id=>slug' ) ); // Filtered by current language
 
 							foreach ( $tax_query['terms'] as $slug ) {
 								$term_id = array_search( $slug, $terms ); // What is the term_id corresponding to taxonomy term?
@@ -115,7 +115,7 @@ class PLL_Frontend_Links extends PLL_Links {
 				elseif ( $tr_id = $this->model->term->get_translation( $term->term_id, $language ) ) {
 					if ( $tr_term = get_term( $tr_id, $term->taxonomy ) ) {
 						// Check if translated term ( or children ) have posts
-						$count = $tr_term->count || ( is_taxonomy_hierarchical( $term->taxonomy ) && array_sum( wp_list_pluck( get_terms( $term->taxonomy, array( 'child_of' => $tr_term->term_id, 'lang' => $language->slug ) ), 'count' ) ) );
+						$count = $tr_term->count || ( is_taxonomy_hierarchical( $term->taxonomy ) && array_sum( wp_list_pluck( get_terms( array( 'taxonomy' => $term->taxonomy), array( 'child_of' => $tr_term->term_id, 'lang' => $language->slug ) ), 'count' ) ) );
 
 						/**
 						 * Filter whether to hide an archive translation url

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -165,13 +165,8 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 			return $lang;
 		}
 
-		// The home page is requested
-		if ( did_action( 'home_requested' ) ) {
-			$query->set( 'page_id', $lang->page_on_front );
-		}
-
 		// Redirect the language page to the homepage when using a static front page
-		elseif ( ( $this->options['redirect_lang'] || $this->options['hide_default'] ) && $this->is_front_page( $query ) && $lang = $this->model->get_language( get_query_var( 'lang' ) ) ) {
+		if ( ( $this->options['redirect_lang'] || $this->options['hide_default'] ) && $this->is_front_page( $query ) && $lang = $this->model->get_language( get_query_var( 'lang' ) ) ) {
 			$query->is_archive = $query->is_tax = false;
 			if ( ! empty( $lang->page_on_front ) ) {
 				$query->set( 'page_id', $lang->page_on_front );
@@ -186,6 +181,9 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 		// Fix paged static front page in plain permalinks when Settings > Reading doesn't match the default language
 		elseif ( ! $this->links_model->using_permalinks && count( $query->query ) === 1 && ! empty( $query->query['page'] ) ) {
 			$lang = $this->model->get_language( $this->options['default_lang'] );
+			if ( empty( $lang ) ) {
+				return $lang;
+			}
 			$query->set( 'page_id', $lang->page_on_front );
 			$query->is_singular = $query->is_page = true;
 			$query->is_archive = $query->is_tax = false;

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -139,7 +139,7 @@ class PLL_CRUD_Posts {
 				// Convert to term ids if we got tag names
 				$strings = array_filter( $terms, 'is_string' );
 				if ( ! empty( $strings ) ) {
-					$_terms = get_terms( array( 'taxonomy' => $taxonomy ), array( 'name' => $strings, 'object_ids' => $object_id, 'fields' => 'ids' ) );
+					$_terms = get_terms( array( 'taxonomy' => $taxonomy, 'name' => $strings, 'object_ids' => $object_id, 'fields' => 'ids' ) );
 					$terms = array_merge( array_diff( $terms, $strings ), $_terms );
 				}
 

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -139,7 +139,7 @@ class PLL_CRUD_Posts {
 				// Convert to term ids if we got tag names
 				$strings = array_filter( $terms, 'is_string' );
 				if ( ! empty( $strings ) ) {
-					$_terms = get_terms( $taxonomy, array( 'name' => $strings, 'object_ids' => $object_id, 'fields' => 'ids' ) );
+					$_terms = get_terms( array( 'taxonomy' => $taxonomy ), array( 'name' => $strings, 'object_ids' => $object_id, 'fields' => 'ids' ) );
 					$terms = array_merge( array_diff( $terms, $strings ), $_terms );
 				}
 

--- a/include/model.php
+++ b/include/model.php
@@ -107,7 +107,7 @@ class PLL_Model {
 
 				$post_languages = $this->get_language_terms();
 
-				$term_languages = get_terms( 'term_language', array( 'hide_empty' => false ) );
+				$term_languages = get_terms( array( 'taxonomy' => 'term_language' ), array( 'hide_empty' => false ) );
 				$term_languages = empty( $term_languages ) || is_wp_error( $term_languages ) ?
 					array() : array_combine( wp_list_pluck( $term_languages, 'slug' ), $term_languages );
 

--- a/include/model.php
+++ b/include/model.php
@@ -107,7 +107,7 @@ class PLL_Model {
 
 				$post_languages = $this->get_language_terms();
 
-				$term_languages = get_terms( array( 'taxonomy' => 'term_language' ), array( 'hide_empty' => false ) );
+				$term_languages = get_terms( array( 'taxonomy' => 'term_language', 'hide_empty' => false ) );
 				$term_languages = empty( $term_languages ) || is_wp_error( $term_languages ) ?
 					array() : array_combine( wp_list_pluck( $term_languages, 'slug' ), $term_languages );
 

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -41,7 +41,7 @@ class PLL_WP_Import extends WP_Import {
 
 		// Assign the default language in case the importer created the first language.
 		if ( empty( PLL()->options['default_lang'] ) ) {
-			$languages = get_terms( 'language', array( 'hide_empty' => false, 'orderby' => 'term_id' ) );
+			$languages = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false, 'orderby' => 'term_id' ) );
 			$default_lang = reset( $languages );
 			PLL()->options['default_lang'] = $default_lang->slug;
 			update_option( 'polylang', PLL()->options );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -146,16 +146,6 @@ parameters:
 			path: admin/admin-filters-media.php
 
 		-
-			message: "#^Cannot access property \\$taxonomy on int\\|string\\|WP_Term\\.$#"
-			count: 1
-			path: admin/admin-filters-post.php
-
-		-
-			message: "#^Cannot access property \\$term_id on int\\|string\\|WP_Term\\.$#"
-			count: 2
-			path: admin/admin-filters-post.php
-
-		-
 			message: "#^Parameter \\#1 \\$lang of method PLL_Query\\:\\:filter_query\\(\\) expects PLL_Language\\|false, PLL_Language\\|null given\\.$#"
 			count: 1
 			path: admin/admin-filters-post.php
@@ -271,11 +261,6 @@ parameters:
 			path: admin/admin-model.php
 
 		-
-			message: "#^@param WP_Term \\$term does not accept actual type of parameter\\: int\\|string\\|WP_Term\\.$#"
-			count: 1
-			path: admin/admin-model.php
-
-		-
 			message: "#^@param array\\<array\\<string\\>\\|int\\> \\$tr does not accept actual type of parameter\\: mixed\\.$#"
 			count: 1
 			path: admin/admin-model.php
@@ -286,33 +271,13 @@ parameters:
 			path: admin/admin-model.php
 
 		-
-			message: "#^Cannot access property \\$description on int\\|string\\|WP_Term\\.$#"
-			count: 1
-			path: admin/admin-model.php
-
-		-
 			message: "#^Cannot access property \\$slug on PLL_Language\\|false\\.$#"
-			count: 1
-			path: admin/admin-model.php
-
-		-
-			message: "#^Cannot access property \\$taxonomy on int\\|string\\|WP_Term\\.$#"
 			count: 1
 			path: admin/admin-model.php
 
 		-
 			message: "#^Cannot access property \\$term_id on PLL_Language\\|false\\.$#"
 			count: 1
-			path: admin/admin-model.php
-
-		-
-			message: "#^Cannot access property \\$term_id on int\\|string\\|WP_Term\\.$#"
-			count: 4
-			path: admin/admin-model.php
-
-		-
-			message: "#^Cannot access property \\$term_taxonomy_id on int\\|string\\|WP_Term\\.$#"
-			count: 2
 			path: admin/admin-model.php
 
 		-
@@ -676,7 +641,7 @@ parameters:
 			path: frontend/frontend-links.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of function array_search expects array, array\\<int, WP_Term\\>\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#2 \\$haystack of function array_search expects array, array\\<int, string\\>\\|WP_Error given\\.$#"
 			count: 1
 			path: frontend/frontend-links.php
 
@@ -826,7 +791,7 @@ parameters:
 			path: include/crud-posts.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\<int, WP_Term>\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\<int, int>\\|WP_Error given\\.$#"
 			count: 1
 			path: include/crud-posts.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,11 +181,6 @@ parameters:
 			path: admin/admin-filters-term.php
 
 		-
-			message: "#^Cannot access property \\$term_id on int\\|string\\|WP_Term\\.$#"
-			count: 2
-			path: admin/admin-filters-term.php
-
-		-
 			message: "#^Cannot access property \\$term_taxonomy_id on array\\|WP_Error\\|WP_Term\\|null\\.$#"
 			count: 1
 			path: admin/admin-filters-term.php
@@ -292,7 +287,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$description on int\\|string\\|WP_Term\\.$#"
-			count: 2
+			count: 1
 			path: admin/admin-model.php
 
 		-
@@ -317,7 +312,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$term_taxonomy_id on int\\|string\\|WP_Term\\.$#"
-			count: 3
+			count: 2
 			path: admin/admin-model.php
 
 		-
@@ -511,11 +506,6 @@ parameters:
 			path: frontend/frontend-auto-translate.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, array\\<int, int\\|string\\|WP_Term\\>\\|string given\\.$#"
-			count: 1
-			path: frontend/frontend-auto-translate.php
-
-		-
 			message: "#^Parameter \\#1 \\$term_id of method PLL_Frontend_Auto_Translate\\:\\:get_term\\(\\) expects int, float\\|int\\<0, max\\> given\\.$#"
 			count: 1
 			path: frontend/frontend-auto-translate.php
@@ -671,7 +661,7 @@ parameters:
 			path: frontend/frontend-links.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<int, int\\|string\\|WP_Term\\>\\|string\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<int, WP_Term\\>\\|WP_Error given\\.$#"
 			count: 1
 			path: frontend/frontend-links.php
 
@@ -686,7 +676,7 @@ parameters:
 			path: frontend/frontend-links.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of function array_search expects array, array\\<int, int\\|string\\|WP_Term\\>\\|string\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#2 \\$haystack of function array_search expects array, array\\<int, WP_Term\\>\\|WP_Error given\\.$#"
 			count: 1
 			path: frontend/frontend-links.php
 
@@ -836,7 +826,7 @@ parameters:
 			path: include/crud-posts.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\<int, int\\|string\\|WP_Term\\>\\|string\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\<int, WP_Term>\\|WP_Error given\\.$#"
 			count: 1
 			path: include/crud-posts.php
 
@@ -1186,11 +1176,6 @@ parameters:
 			path: include/model.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<int, int\\|string\\|WP_Term\\>\\|string given\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
 			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, mixed given\\.$#"
 			count: 1
 			path: include/model.php
@@ -1207,11 +1192,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, array\\{mixed, 'get_terms_args'\\} given\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
-			message: "#^Parameter \\#2 \\$values of function array_combine expects array, array\\<int, int\\|string\\|WP_Term\\>\\|string given\\.$#"
 			count: 1
 			path: include/model.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -666,11 +666,6 @@ parameters:
 			path: frontend/frontend-nav-menu.php
 
 		-
-			message: "#^Cannot access property \\$page_on_front on PLL_Language\\|false\\.$#"
-			count: 2
-			path: frontend/frontend-static-pages.php
-
-		-
 			message: "#^Cannot access property \\$page_on_front on PLL_Language\\|null\\.$#"
 			count: 2
 			path: frontend/frontend-static-pages.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,8 +38,14 @@ parameters:
 			count: 1
 			path: frontend/choose-lang.php
 
-		# Ignored because the WordPress stubs don't know our added 'lang' parameter in get_posts() and PLL_Model::get_languages_list() seems not to always return int[] as expected by 'post__in' parameter
+		# Ignored because the WordPress stubs doesn't know our added 'lang' parameter in get_posts() and PLL_Model::get_languages_list() seems not to always return int[] as expected by 'post__in' parameter
 		-
-			message: "#^Parameter \\#1 \\$args of function get_posts expects array\\{numberposts\\?: int, category\\?: int\\|string, include\\?: array\\<int\\>, exclude\\?: array\\<int\\>, suppress_filters\\?: bool, attachment_id\\?: int, author\\?: int\\|string, author_name\\?: string, \\.\\.\\.\\}\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$args of function get_posts expects array(.+)\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
 			count: 1
 			path: frontend/frontend-static-pages.php
+
+		# Ignored because the WordPress stubs doesn't know a dynamic key in the associative array passed to the get_terms() parameter
+		-
+			message: "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\>given.$#"
+			count: 1
+			path: frontend/frontend-auto-translate.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,6 +46,6 @@ parameters:
 
 		# Ignored because the WordPress stubs doesn't know a dynamic key in the associative array passed to the get_terms() parameter
 		-
-			message: "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\>given.$#"
+			message: "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\> given\\.$#"
 			count: 1
 			path: frontend/frontend-auto-translate.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,3 +37,9 @@ parameters:
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: frontend/choose-lang.php
+
+		# Ignored because the WordPress stubs don't know our added 'lang' parameter in get_posts() and PLL_Model::get_languages_list() seems not to always return int[] as expected by 'post__in' parameter
+		-
+			message: "#^Parameter \\#1 \\$args of function get_posts expects array\\{numberposts\\?: int, category\\?: int\\|string, include\\?: array\\<int\\>, exclude\\?: array\\<int\\>, suppress_filters\\?: bool, attachment_id\\?: int, author\\?: int\\|string, author_name\\?: string, \\.\\.\\.\\}\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
+			count: 1
+			path: frontend/frontend-static-pages.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,13 +39,7 @@ parameters:
 			path: frontend/choose-lang.php
 
 		# Ignored because the WordPress stubs doesn't know our added 'lang' parameter in get_posts() and PLL_Model::get_languages_list() seems not to always return int[] as expected by 'post__in' parameter
-		-
-			message: "#^Parameter \\#1 \\$args of function get_posts expects array(.+)\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
-			count: 1
-			path: frontend/frontend-static-pages.php
+		- "#^Parameter \\#1 \\$args of function get_posts expects array(.+)\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
 
 		# Ignored because the WordPress stubs doesn't know a dynamic key in the associative array passed to the get_terms() parameter
-		-
-			message: "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\> given\\.$#"
-			count: 1
-			path: frontend/frontend-auto-translate.php
+		- "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\> given\\.$#"

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -456,16 +456,16 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$es = self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) );
 		self::$model->term->set_language( $es, 'es' );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
 		$this->assertEqualSets( array( $en ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'en', 'fr' ) ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'en', 'fr' ) ) );
 		$this->assertEqualSets( array( $fr, $en ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 0 ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => 0 ) );
 		$this->assertEqualSets( array( $en, $fr, $es ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
 		$this->assertEqualSets( array( $en, $fr ), $terms );
 	}
 

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -456,16 +456,16 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$es = self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) );
 		self::$model->term->set_language( $es, 'es' );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
 		$this->assertEqualSets( array( $en ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'en', 'fr' ) ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'en', 'fr' ) ) );
 		$this->assertEqualSets( array( $fr, $en ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 0 ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 0 ) );
 		$this->assertEqualSets( array( $en, $fr, $es ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
 		$this->assertEqualSets( array( $en, $fr ), $terms );
 	}
 

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -123,7 +123,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$tags = self::factory()->tag->create_many( 2 );
 		self::$model->set_language_in_mass( 'term', $tags, 'fr' );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'hide_empty' => false, 'fields' => 'ids' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'hide_empty' => false, 'fields' => 'ids' ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->term, 'get_language' ), $terms ), 'slug' );
 		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
 		$this->assertCount( 7, get_terms( array( 'taxonomy' => 'term_translations' ) ) ); // one translation group per tag + 1 for default categories

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -108,7 +108,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$posts = get_posts( array( 'fields' => 'ids', 'posts_per_page' => -1 ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $posts ), 'slug' );
 		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
-		$this->assertEmpty( get_terms( 'post_translations' ) ); // no translation group for posts
+		$this->assertEmpty( get_terms( array( 'taxonomy' => 'post_translations' ) ) ); // no translation group for posts
 	}
 
 	public function test_set_language_in_mass_for_terms() {
@@ -123,9 +123,9 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		$tags = self::factory()->tag->create_many( 2 );
 		self::$model->set_language_in_mass( 'term', $tags, 'fr' );
 
-		$terms = get_terms( 'post_tag', array( 'hide_empty' => false, 'fields' => 'ids' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'hide_empty' => false, 'fields' => 'ids' ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->term, 'get_language' ), $terms ), 'slug' );
 		$this->assertEquals( array( 'fr' => 4, 'en' => 2 ), array_count_values( $languages ) );
-		$this->assertCount( 7, get_terms( 'term_translations' ) ); // one translation group per tag + 1 for default categories
+		$this->assertCount( 7, get_terms( array( 'taxonomy' => 'term_translations' ) ) ); // one translation group per tag + 1 for default categories
 	}
 }

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -244,14 +244,14 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$expected = get_term( $fr, 'category' );
-		$terms = get_terms( 'category', array( 'hide_empty' => 0, 'include' => array( $en ) ) );
+		$terms = get_terms( array( 'taxonomy' => 'category' ), array( 'hide_empty' => 0, 'include' => array( $en ) ) );
 		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
 
 		$terms = get_terms( array( 'hide_empty' => 0, 'include' => array( $en ) ) );
 		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
 
 		$expected = get_term( $en, 'category' );
-		$terms = get_terms( 'category', array( 'hide_empty' => 0, 'include' => array( $en ), 'lang' => '' ) );
+		$terms = get_terms( array( 'taxonomy' => 'category' ), array( 'hide_empty' => 0, 'include' => array( $en ), 'lang' => '' ) );
 		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
 	}
 }

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -244,14 +244,14 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		$expected = get_term( $fr, 'category' );
-		$terms = get_terms( array( 'taxonomy' => 'category' ), array( 'hide_empty' => 0, 'include' => array( $en ) ) );
+		$terms = get_terms( array( 'taxonomy' => 'category', 'hide_empty' => 0, 'include' => array( $en ) ) );
 		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
 
 		$terms = get_terms( array( 'hide_empty' => 0, 'include' => array( $en ) ) );
 		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
 
 		$expected = get_term( $en, 'category' );
-		$terms = get_terms( array( 'taxonomy' => 'category' ), array( 'hide_empty' => 0, 'include' => array( $en ), 'lang' => '' ) );
+		$terms = get_terms( array( 'taxonomy' => 'category', 'hide_empty' => 0, 'include' => array( $en ), 'lang' => '' ) );
 		$this->assertEquals( array( $expected->term_id ), wp_list_pluck( $terms, 'term_id' ) );
 	}
 }

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -175,19 +175,19 @@ class Filters_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		new PLL_CRUD_Terms( $this->frontend );
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false ) );
 		$this->assertEqualSets( array( $fr ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
 		$this->assertEqualSets( array( $en ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
 		$this->assertEqualSets( array( $en, $fr ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'fr', 'de' ) ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'fr', 'de' ) ) );
 		$this->assertEqualSets( array( $de, $fr ), $terms );
 
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => '' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'fields' => 'ids', 'hide_empty' => false, 'lang' => '' ) );
 		$this->assertEqualSets( array( $en, $fr, $de ), $terms );
 	}
 
@@ -338,7 +338,7 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	public function _action_pre_get_posts() {
-		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'hide_empty' => false ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'hide_empty' => false ) );
 		$language = self::$model->term->get_language( $terms[0]->term_id );
 
 		$this->assertCount( 1, $terms );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -175,19 +175,19 @@ class Filters_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		new PLL_CRUD_Terms( $this->frontend );
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false ) );
 		$this->assertEqualSets( array( $fr ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en' ) );
 		$this->assertEqualSets( array( $en ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => 'en,fr' ) );
 		$this->assertEqualSets( array( $en, $fr ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'fr', 'de' ) ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => array( 'fr', 'de' ) ) );
 		$this->assertEqualSets( array( $de, $fr ), $terms );
 
-		$terms = get_terms( 'post_tag', array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => '' ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'fields' => 'ids', 'hide_empty' => false, 'lang' => '' ) );
 		$this->assertEqualSets( array( $en, $fr, $de ), $terms );
 	}
 
@@ -338,7 +338,7 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	public function _action_pre_get_posts() {
-		$terms = get_terms( 'post_tag', array( 'hide_empty' => false ) );
+		$terms = get_terms( array( 'taxonomy' => 'post_tag' ), array( 'hide_empty' => false ) );
 		$language = self::$model->term->get_language( $terms[0]->term_id );
 
 		$this->assertCount( 1, $terms );

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -100,7 +100,7 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_option( 'polylang' ) );
 
 		// No languages
-		$this->assertEmpty( get_terms( array( 'taxonomy' => 'language' ), array( 'hide_empty' => false ) ) );
+		$this->assertEmpty( get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false ) ) );
 		$this->assertEmpty( get_terms( array( 'taxonomy' => 'term_language' ) ) );
 
 		// No languages for posts and terms

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -60,10 +60,10 @@ class Install_Test extends PLL_UnitTestCase {
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		self::$model->term->set_language( $en, 'en' );
 
-		$post_translations_groups = get_terms( 'post_translations' );
+		$post_translations_groups = get_terms( array( 'taxonomy' => 'post_translations' ) );
 		$post_group = reset( $post_translations_groups );
 
-		$term_translations_groups = get_terms( 'term_translations' );
+		$term_translations_groups = get_terms( array( 'taxonomy' => 'term_translations' ) );
 		$term_group = reset( $term_translations_groups );
 
 		// User metas
@@ -100,16 +100,16 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_option( 'polylang' ) );
 
 		// No languages
-		$this->assertEmpty( get_terms( 'language', array( 'hide_empty' => false ) ) );
-		$this->assertEmpty( get_terms( 'term_language' ) );
+		$this->assertEmpty( get_terms( array( 'taxonomy' => 'language' ), array( 'hide_empty' => false ) ) );
+		$this->assertEmpty( get_terms( array( 'taxonomy' => 'term_language' ) ) );
 
 		// No languages for posts and terms
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $english->term_taxonomy_id ) ) );
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $english->tl_term_taxonomy_id ) ) );
 
 		// No translations for posts and terms
-		$this->assertEmpty( get_terms( 'post_translations' ) );
-		$this->assertEmpty( get_terms( 'term_translations' ) );
+		$this->assertEmpty( get_terms( array( 'taxonomy' => 'post_translations' ) ) );
+		$this->assertEmpty( get_terms( array( 'taxonomy' => 'term_translations' ) ) );
 
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $post_group->term_taxonomy_id ) ) );
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $term_group->term_taxonomy_id ) ) );

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -23,7 +23,7 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 		self::$model->term->set_language( $term_id, 'fr' );
 
 		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
-		$this->assertCount( 2, get_terms( 'term_translations' ) ); // 1 translation group per term + 1 for default categories
+		$this->assertCount( 2, get_terms( array( 'taxonomy' => 'term_translations' ) ) ); // 1 translation group per term + 1 for default categories
 	}
 
 	public function test_term_translation() {

--- a/uninstall.php
+++ b/uninstall.php
@@ -58,7 +58,7 @@ class PLL_Uninstall {
 			register_taxonomy( $taxonomy, null, array( 'label' => false, 'public' => false, 'query_var' => false, 'rewrite' => false ) );
 		}
 
-		$languages = get_terms( 'language', array( 'hide_empty' => false ) );
+		$languages = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false ) );
 
 		// Delete users options
 		foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
@@ -103,7 +103,7 @@ class PLL_Uninstall {
 		$term_ids = array();
 		$tt_ids   = array();
 
-		foreach ( get_terms( $pll_taxonomies, array( 'hide_empty' => false ) ) as $term ) {
+		foreach ( get_terms( array( 'taxonomy' => $pll_taxonomies, 'hide_empty' => false ) ) as $term ) {
 			$term_ids[] = (int) $term->term_id;
 			$tt_ids[] = (int) $term->term_taxonomy_id;
 		}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1474

First step to fix the issue by replacing the first parameter of get_terms() WordPress function with an array instead of a string.

Accordingly : 
- Clean up the baseline 
- Update some existing ignored PHPStan errors because the count decreases.
- Update some existing ignored PHPStan errors because only the error messages are different due to this fix.

This error is ignored in config file:

```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   frontend\frontend-static-pages.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    
  233    Parameter #1 $args of function get_posts expects array{numberposts?: int, category?: int|string, include?: array<int>, exclude?: array<int>, suppress_filters?: bool, attachment_id?: int, author?: int|string, author_name?: string, ...}|null, array{posts_per_page: 99, post_type: 'page', post__in: array<int, int|null>, lang: ''} given.     
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    

```
- due to the Polylang `lang` parameter unknown in the WordPress stubs documentation of `get_posts()`
- and also probably due to `post__in` parameter expected as `int[]` but not always returned as this by `PLL_Model::get_languages_list()` method.

This PR also removes deprecated usage of `get_terms()` in PHPUnit tests.