### PR TITLE
Revert PR #1125 set_pre_term_slug() method code

### DIFF
--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -307,7 +307,7 @@ class PLL_CRUD_Terms {
 	 * @return string Slug with a language suffix if found.
 	 */
 	public function set_pre_term_slug( $slug, $taxonomy ) {
-		if ( ! $slug ) {
+		if ( empty( $slug ) ) {
 			$slug = sanitize_title( $this->pre_term_name );
 		}
 
@@ -318,14 +318,13 @@ class PLL_CRUD_Terms {
 		 *
 		 * @param PLL_Language|null $lang     Found language object, null otherwise.
 		 * @param string            $slug     Term slug
-		 * @param string            $taxonomy Term taonomy.
+		 * @param string            $taxonomy Term taxonomy.
 		 */
 		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
 
 		if ( $lang instanceof PLL_Language ) {
 			$slug .= $this->get_slug_separator() . $lang->slug;
 		}
-		
 		return $slug;
 	}
 }

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -307,11 +307,9 @@ class PLL_CRUD_Terms {
 	 * @return string Slug with a language suffix if found.
 	 */
 	public function set_pre_term_slug( $slug, $taxonomy ) {
-		if ( ! empty( $slug ) ) {
-			return $slug;
+		if ( ! $slug ) {
+			$slug = sanitize_title( $this->pre_term_name );
 		}
-
-		$name = sanitize_title( $this->pre_term_name );
 
 		/**
 		 * Filters the subsequently inserted term language.
@@ -320,14 +318,14 @@ class PLL_CRUD_Terms {
 		 *
 		 * @param PLL_Language|null $lang     Found language object, null otherwise.
 		 * @param string            $slug     Term slug
-		 * @param string            $taxonomy Term taxonomy.
+		 * @param string            $taxonomy Term taonomy.
 		 */
-		$lang = apply_filters( 'pll_inserted_term_language', null, $name, $taxonomy );
+		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
 
-		if ( $lang instanceof PLL_Language && ! $this->model->term_exists_by_slug( $name, $lang, $taxonomy ) ) {
-			$slug = $name . $this->get_slug_separator() . $lang->slug;
+		if ( $lang instanceof PLL_Language ) {
+			$slug .= $this->get_slug_separator() . $lang->slug;
 		}
-
+		
 		return $slug;
 	}
 }


### PR DESCRIPTION
All is in the title.

Even if the PR #1125 fixed the https://github.com/polylang/polylang-pro/issues/1468 it triggers some other issues especailly revealed by some Polylang Pro shared slugs PHPUnit tests which break.

Accordingly the issue has been [reopened](https://github.com/polylang/polylang-pro/issues/1468#issuecomment-1271206929) and need to be fixed another way.