### PR TITLE
Display again default language icon in wizard

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -30,7 +30,8 @@
 	width : 10%;
 }
 
-td.column-default_lang .icon-default-lang:before {
+td.column-default_lang .icon-default-lang:before,
+.pll-wizard-content .icon-default-lang:before {
 	font-family: 'dashicons';
 	content: "\f155";
 }


### PR DESCRIPTION
Regression introduced by https://github.com/polylang/polylang/pull/1060 because the parent CSS class doesn't target the wizard cases.

This PR introduces a new rule to target both of the specific languages and home step in the wizard and make the default language icon display again.

![image](https://user-images.githubusercontent.com/1003778/194529118-f7e2b6cc-e43b-481a-ac99-030854320e9a.png)

![image](https://user-images.githubusercontent.com/1003778/194529177-288e972a-e07b-432d-9cdb-0543e52fc4d6.png)
