### PR TITLE
Fix term update with same slugs

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -661,8 +661,22 @@ class PLL_Admin_Filters_Term {
 				$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
 			}
 			$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
-			// If no term exists or if we are editing the existing term, trick WP to allow shared slugs.
+			// If no term exists.
 			if ( ! $term_id ) { // phpcs:ignore WordPress.Security.NonceVerification
+				return $lang;
+			}
+
+			$term = get_term( $term_id );
+			if ( is_wp_error( $term ) ) {
+				// Something bad happened...
+				return null;
+			}
+			if ( $term->slug === $slug ) {
+				// The slug is not modified, do nothing.
+				return null;
+			}
+			if ( ( ! empty( $_POST['tag_ID'] ) && (int) $_POST['tag_ID'] === $term_id ) || ( ! empty( $_POST['tax_ID'] ) && (int) $_POST['tax_ID'] === $term_id ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				// If we are editing the existing term.
 				return $lang;
 			}
 		}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -662,7 +662,7 @@ class PLL_Admin_Filters_Term {
 			}
 			$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
 			// If no term exists or if we are editing the existing term, trick WP to allow shared slugs.
-			if ( ! $term_id || ( ! empty( $_POST['tag_ID'] ) && (int) $_POST['tag_ID'] === $term_id ) || ( ! empty( $_POST['tax_ID'] ) && (int) $_POST['tax_ID'] === $term_id ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			if ( ! $term_id ) { // phpcs:ignore WordPress.Security.NonceVerification
 				return $lang;
 			}
 		}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -82,6 +82,7 @@ class PLL_Admin_Filters_Term {
 		add_action( 'edit_term', array( $this, 'save_term' ), 900, 3 ); // Late as it may conflict with other plugins, see http://wordpress.org/support/topic/polylang-and-wordpress-seo-by-yoast
 		add_action( 'pre_post_update', array( $this, 'pre_post_update' ) );
 		add_filter( 'pll_inserted_term_language', array( $this, 'get_inserted_term_language' ), 10, 3 );
+		add_filter( 'pll_inserted_term_parent', array( $this, 'get_inserted_term_parent' ), 10, 4 );
 
 		// Ajax response for edit term form
 		add_action( 'wp_ajax_term_lang_choice', array( $this, 'term_lang_choice' ) );
@@ -658,5 +659,28 @@ class PLL_Admin_Filters_Term {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Filters the subsequently inserted term parent in admin.
+	 *
+	 * @since 3.3
+	 *
+	 * @param int          $parent   Parent term ID, 0 if none found.
+	 * @param string       $slug     Term slug. Not used.
+	 * @param string       $taxonomy Term taxonomy.
+	 * @param PLL_Language $lang     Inserted term language object.
+	 * @return int Parent term ID if found, 0 otherwise.
+	 */
+	public function get_inserted_term_parent( $parent, $slug, $taxonomy, $lang ) {
+		if ( ! $parent ) {
+			if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) && $_POST['term_lang_choice'] === $lang->slug ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) && $_POST['term_lang_choice'] === $lang->slug ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
+			}
+		}
+
+		return $parent;
 	}
 }

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -669,12 +669,14 @@ class PLL_Admin_Filters_Term {
 	 * @return int Parent term ID if found, 0 otherwise.
 	 */
 	public function get_inserted_term_parent( $parent, $taxonomy ) {
-		if ( ! $parent ) {
-			if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
-			}
+		if ( $parent ) {
+			return $parent;
+		}
+
+		if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		return $parent;

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -81,8 +81,8 @@ class PLL_Admin_Filters_Term {
 		add_action( 'create_term', array( $this, 'save_term' ), 900, 3 );
 		add_action( 'edit_term', array( $this, 'save_term' ), 900, 3 ); // Late as it may conflict with other plugins, see http://wordpress.org/support/topic/polylang-and-wordpress-seo-by-yoast
 		add_action( 'pre_post_update', array( $this, 'pre_post_update' ) );
-		add_filter( 'pll_inserted_term_language', array( $this, 'get_inserted_term_language' ), 10, 3 );
-		add_filter( 'pll_inserted_term_parent', array( $this, 'get_inserted_term_parent' ), 10, 4 );
+		add_filter( 'pll_inserted_term_language', array( $this, 'get_inserted_term_language' ) );
+		add_filter( 'pll_inserted_term_parent', array( $this, 'get_inserted_term_parent' ), 10, 2 );
 
 		// Ajax response for edit term form
 		add_action( 'wp_ajax_term_lang_choice', array( $this, 'term_lang_choice' ) );
@@ -609,12 +609,10 @@ class PLL_Admin_Filters_Term {
 	 * @since 3.3
 	 *
 	 * @param PLL_Language|null $lang     Term language object if found, null otherwise.
-	 * @param string            $slug     Term slug.
-	 * @param string            $taxonomy Term taxonomy.
 	 * @return PLL_Language|null Language object, null if none found.
 	 */
-	public function get_inserted_term_language( $lang, $slug, $taxonomy ) {
-		if ( $lang instanceof PLL_Language || ! $this->model->is_translated_taxonomy( $taxonomy ) || ! term_exists( $slug, $taxonomy ) ) {
+	public function get_inserted_term_language( $lang ) {
+		if ( $lang instanceof PLL_Language ) {
 			return $lang;
 		}
 
@@ -666,17 +664,15 @@ class PLL_Admin_Filters_Term {
 	 *
 	 * @since 3.3
 	 *
-	 * @param int          $parent   Parent term ID, 0 if none found.
-	 * @param string       $slug     Term slug. Not used.
-	 * @param string       $taxonomy Term taxonomy.
-	 * @param PLL_Language $lang     Inserted term language object.
+	 * @param int    $parent   Parent term ID, 0 if none found.
+	 * @param string $taxonomy Term taxonomy.
 	 * @return int Parent term ID if found, 0 otherwise.
 	 */
-	public function get_inserted_term_parent( $parent, $slug, $taxonomy, $lang ) {
+	public function get_inserted_term_parent( $parent, $taxonomy ) {
 		if ( ! $parent ) {
-			if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) && $_POST['term_lang_choice'] === $lang->slug ) { // phpcs:ignore WordPress.Security.NonceVerification
+			if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) && $_POST['term_lang_choice'] === $lang->slug ) { // phpcs:ignore WordPress.Security.NonceVerification
+			} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
 			}
 		}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -665,20 +665,6 @@ class PLL_Admin_Filters_Term {
 			if ( ! $term_id ) { // phpcs:ignore WordPress.Security.NonceVerification
 				return $lang;
 			}
-
-			$term = get_term( $term_id );
-			if ( is_wp_error( $term ) ) {
-				// Something bad happened...
-				return null;
-			}
-			if ( $term->slug === $slug ) {
-				// The slug is not modified, do nothing.
-				return null;
-			}
-			if ( ( ! empty( $_POST['tag_ID'] ) && (int) $_POST['tag_ID'] === $term_id ) || ( ! empty( $_POST['tax_ID'] ) && (int) $_POST['tax_ID'] === $term_id ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				// If we are editing the existing term.
-				return $lang;
-			}
 		}
 
 		return null;

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -654,17 +654,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		if ( $lang instanceof PLL_Language ) {
-			$parent = 0;
-			if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
-			}
-			$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
-			// If no term exists.
-			if ( ! $term_id ) { // phpcs:ignore WordPress.Security.NonceVerification
-				return $lang;
-			}
+			return $lang;
 		}
 
 		return null;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -334,9 +334,7 @@ class PLL_CRUD_Terms {
 				$the_parent = $parent_term->parent;
 			}
 
-			if ( $parent_suffix ) {
-				return $slug .= $parent_suffix;
-			}
+			return $slug .= $parent_suffix;
 		}
 
 		$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -349,6 +349,9 @@ class PLL_CRUD_Terms {
 			return $parent_suffix;
 		}
 
+		/**
+		 * Mostly copied from {@see wp_unique_term_slug()}.
+		 */
 		while ( ! empty( $the_parent ) ) {
 			$parent_term = get_term( $the_parent, $taxonomy );
 			if ( ! $parent_term instanceof WP_Term ) {

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -312,7 +312,7 @@ class PLL_CRUD_Terms {
 
 		/**
 		 * Special case if the parent has the same slug.
-		 * Recursively append parent slug like WordPress do.
+		 * Recursively appends the parent slug like WordPress does.
 		 */
 		$parent_obj = get_term( $parent, $taxonomy );
 		if ( $parent_obj instanceof WP_Term && $parent_obj->slug === $slug && is_taxonomy_hierarchical( $taxonomy ) ) {
@@ -335,7 +335,7 @@ class PLL_CRUD_Terms {
 
 		$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
 
-		// If no term exists in the given language with that slug, it can be created.
+		// If no term exist in the given language with that slug, it can be created.
 		if ( ! $term_id ) {
 			$slug .= '-' . $lang->slug;
 		}

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -51,13 +51,6 @@ class PLL_CRUD_Terms {
 	private $pre_term_name = '';
 
 	/**
-	 * Used to append language to term slugs.
-	 *
-	 * @var string|null
-	 */
-	private $term_slugs_suffix_separator;
-
-	/**
 	 * Constructor
 	 *
 	 * @since 2.4
@@ -274,30 +267,6 @@ class PLL_CRUD_Terms {
 	}
 
 	/**
-	 * Returns the separator to append language to term slugs.
-	 *
-	 * @since 3.3
-	 *
-	 * @return string The separator.
-	 */
-	private function get_slug_separator() {
-		if ( is_string( $this->term_slugs_suffix_separator ) ) {
-			return $this->term_slugs_suffix_separator;
-		}
-
-		/**
-		 * Filters the separator to use to append language to term slugs.
-		 *
-		 * @since 3.3
-		 *
-		 * @param string $separator Default separator, '-'.
-		 */
-		$this->term_slugs_suffix_separator = apply_filters( 'pll_term_slug_suffix_separator', '-' );
-
-		return $this->term_slugs_suffix_separator;
-	}
-
-	/**
 	 * Appends language slug to the term slug if needed.
 	 *
 	 * @since 3.3
@@ -323,7 +292,31 @@ class PLL_CRUD_Terms {
 		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
 
 		if ( $lang instanceof PLL_Language ) {
-			$slug .= $this->get_slug_separator() . $lang->slug;
+			/**
+			 * Filters the subsequently inserted term parent.
+			 *
+			 * @since 3.3
+			 *
+			 * @param int    $parent   Parent term ID, 0 if none.
+			 * @param string $slug     Term slug
+			 * @param string $taxonomy Term taxonomy.
+			 */
+			$parent = apply_filters( 'pll_inserted_term_parent', 0, $slug, $taxonomy );
+
+			if ( ! $parent ) {
+				if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+					$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
+				} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+					$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
+				}
+			}
+
+			$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
+
+			// If no term exists in the given language with that slug, it can be created.
+			if ( ! $term_id ) {
+				$slug .= '-' . $lang->slug;
+			}
 		}
 
 		return $slug;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -300,7 +300,6 @@ class PLL_CRUD_Terms {
 		}
 
 		$parent = 0;
-
 		if ( is_taxonomy_hierarchical( $taxonomy ) ) {
 			/**
 			 * Filters the subsequently inserted term parent.
@@ -312,12 +311,6 @@ class PLL_CRUD_Terms {
 			 * @param string       $slug     Term slug
 			 */
 			$parent = apply_filters( 'pll_inserted_term_parent', 0, $taxonomy, $slug );
-
-			$parent_suffix = $this->maybe_get_parent_suffix( $parent, $taxonomy, $slug );
-
-			if ( ! empty( $parent_suffix ) ) {
-				return $slug .= $parent_suffix;
-			}
 		}
 
 		$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
@@ -328,42 +321,5 @@ class PLL_CRUD_Terms {
 		}
 
 		return $slug;
-	}
-
-	/**
-	 * Returns the parent suffix for the slug only if parent slug is the same as the given one.
-	 * Recursively appends the parent slug like WordPress does.
-	 *
-	 * @since 3.3
-	 *
-	 * @param int    $parent   Parent term ID.
-	 * @param string $taxonomy Parent taxonomy.
-	 * @param string $slug     Child term slug.
-	 * @return string Parents slugs if they are the same as the child slug.
-	 */
-	private function maybe_get_parent_suffix( $parent, $taxonomy, $slug ) {
-		$parent_suffix = '';
-		$the_parent    = get_term( $parent, $taxonomy );
-
-		if ( ! $the_parent instanceof WP_Term || $the_parent->slug !== $slug ) {
-			return $parent_suffix;
-		}
-
-		/**
-		 * Mostly copied from {@see wp_unique_term_slug()}.
-		 */
-		while ( ! empty( $the_parent ) ) {
-			$parent_term = get_term( $the_parent, $taxonomy );
-			if ( ! $parent_term instanceof WP_Term ) {
-				break;
-			}
-			$parent_suffix .= '-' . $parent_term->slug;
-			if ( ! term_exists( $slug . $parent_suffix ) ) {
-				break;
-			}
-			$the_parent = $parent_term->parent;
-		}
-
-		return $parent_suffix;
 	}
 }

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -297,19 +297,12 @@ class PLL_CRUD_Terms {
 			 *
 			 * @since 3.3
 			 *
-			 * @param int    $parent   Parent term ID, 0 if none.
-			 * @param string $slug     Term slug
-			 * @param string $taxonomy Term taxonomy.
+			 * @param int          $parent   Parent term ID, 0 if none.
+			 * @param string       $slug     Term slug
+			 * @param string       $taxonomy Term taxonomy.
+			 * @param PLL_Language $lang     Inserted term language object.
 			 */
-			$parent = apply_filters( 'pll_inserted_term_parent', 0, $slug, $taxonomy );
-
-			if ( ! $parent ) {
-				if ( isset( $_POST['parent'], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-					$parent = intval( $_POST['parent'] ); // phpcs:ignore WordPress.Security.NonceVerification
-				} elseif ( isset( $_POST[ "new{$taxonomy}_parent" ], $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-					$parent = intval( $_POST[ "new{$taxonomy}_parent" ] ); // phpcs:ignore WordPress.Security.NonceVerification
-				}
-			}
+			$parent = apply_filters( 'pll_inserted_term_parent', 0, $slug, $taxonomy, $lang );
 
 			$term_id = (int) $this->model->term_exists_by_slug( $slug, $lang, $taxonomy, $parent );
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -325,7 +325,7 @@ class PLL_CRUD_Terms {
 		if ( $lang instanceof PLL_Language ) {
 			$slug .= $this->get_slug_separator() . $lang->slug;
 		}
-		
+
 		return $slug;
 	}
 }

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -320,15 +320,11 @@ class PLL_CRUD_Terms {
 			$parent_suffix = '';
 			while ( ! empty( $the_parent ) ) {
 				$parent_term = get_term( $the_parent, $taxonomy );
-				if ( ! $parent_obj instanceof WP_Term ) {
+				if ( ! $parent_term instanceof WP_Term ) {
 					break;
 				}
 				$parent_suffix .= '-' . $parent_term->slug;
 				if ( ! term_exists( $slug . $parent_suffix ) ) {
-					break;
-				}
-
-				if ( empty( $parent_term->parent ) ) {
 					break;
 				}
 				$the_parent = $parent_term->parent;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -307,11 +307,9 @@ class PLL_CRUD_Terms {
 	 * @return string Slug with a language suffix if found.
 	 */
 	public function set_pre_term_slug( $slug, $taxonomy ) {
-		if ( ! empty( $slug ) ) {
-			return $slug;
+		if ( ! $slug ) {
+			$slug = sanitize_title( $this->pre_term_name );
 		}
-
-		$name = sanitize_title( $this->pre_term_name );
 
 		/**
 		 * Filters the subsequently inserted term language.
@@ -320,14 +318,14 @@ class PLL_CRUD_Terms {
 		 *
 		 * @param PLL_Language|null $lang     Found language object, null otherwise.
 		 * @param string            $slug     Term slug
-		 * @param string            $taxonomy Term taxonomy.
+		 * @param string            $taxonomy Term taonomy.
 		 */
-		$lang = apply_filters( 'pll_inserted_term_language', null, $name, $taxonomy );
+		$lang = apply_filters( 'pll_inserted_term_language', null, $slug, $taxonomy );
 
-		if ( $lang instanceof PLL_Language && ! $this->model->term_exists_by_slug( $name, $lang, $taxonomy ) ) {
-			$slug = $name . $this->get_slug_separator() . $lang->slug;
+		if ( $lang instanceof PLL_Language ) {
+			$slug .= $this->get_slug_separator() . $lang->slug;
 		}
-
+		
 		return $slug;
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -742,7 +742,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 		self::$model->term->set_language( $cat_en->term_id, 'en' );
 
-		$this->assertSame( sanitize_title( $original_name ), $cat_en->slug, 'The category slug is well created.' );
+		$this->assertSame( sanitize_title( $original_name ), $cat_en->slug, 'The category slug is not well created.' );
 
 		// Add globals like an admin request.
 		$_REQUEST = $_POST = array(

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -750,7 +750,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
 
-		// Now update the category with a new term.
+		// Now update the category with a new slug.
 		$updated_cat = wp_update_term(
 			$cat_en->term_id,
 			'category',
@@ -758,6 +758,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 				'slug' => $new_slug,
 			)
 		);
+		$this->assertIsArray( $updated_cat );
 		$updated_cat_obj = get_term( $updated_cat['term_id'] );
 
 		$this->assertSame( $new_slug, $updated_cat_obj->slug, 'The category slug should have been modified.' );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -696,7 +696,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertWPError( $error, 'Third term with the same slug shouldn\'t be created.' );
 	}
 
-	public function test_update_term_from_admin() {
+	public function test_update_term_name() {
 		$original_name = 'Test Me';
 		$new_name      = 'Well Tested';
 
@@ -727,6 +727,40 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$this->assertSame( $new_name, $updated_cat_obj->name, 'The category name should have been modified.' );
 		$this->assertSame( $cat_en->slug, $updated_cat_obj->slug, 'The category slug should remain the same.' );
+
+		unset( $_REQUEST, $_POST );
+	}
+
+	public function test_update_term_slug() {
+		$original_name = 'Test Me';
+		$new_slug      = 'well-tested';
+
+		$cat_en = $this->factory()->category->create_and_get(
+			array(
+				'name' => $original_name,
+			)
+		);
+		self::$model->term->set_language( $cat_en->term_id, 'en' );
+
+		$this->assertSame( sanitize_title( $original_name ), $cat_en->slug, 'The category slug is well created.' );
+
+		// Add globals like an admin request.
+		$_REQUEST = $_POST = array(
+			'term_lang_choice' => 'en',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+		);
+
+		// Now update the category with a new term.
+		$updated_cat = wp_update_term(
+			$cat_en->term_id,
+			'category',
+			array(
+				'slug' => $new_slug,
+			)
+		);
+		$updated_cat_obj = get_term( $updated_cat['term_id'] );
+
+		$this->assertSame( $new_slug, $updated_cat_obj->slug, 'The category slug should have been modified.' );
 
 		unset( $_REQUEST, $_POST );
 	}

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -228,4 +228,56 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertCount( 1, $response );
 		$this->assertEquals( 'Parent', $response[0]['value'] );
 	}
+
+	public function test_inline_save_tax_with_same_slugs() {
+		// Load WP ajax response action.
+		require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+		add_action( 'wp_ajax_inline-save-tax', 'wp_ajax_inline_save_tax', 1 );
+
+		wp_set_current_user( self::$editor ); // Set a user to pass check_ajax_referer test.
+
+		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'Test' ) );
+		self::$model->term->set_language( $en, 'en' );
+
+		// Create a category translation with the same name (i.e. the same slug).
+		$_REQUEST = $_POST = array(
+			'action'           => 'add-tag',
+			'term_lang_choice' => 'fr',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+		);
+		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'Test' ) );
+		self::$model->term->set_language( $fr, 'fr' );
+
+		$term = get_term( $fr );
+		$this->assertInstanceOf( WP_Term::class, $term, 'Expected the category to be an instance of WP_Term.' );
+		$this->assertSame( 'Test', $term->name, 'Expected the title of the category in secondary language to match the one sent via POST.' );
+		$this->assertSame( 'test-fr', $term->slug, 'Expected the slug of the category in secondary language to be suffixed.' );
+		$this->assertSame( 'fr', self::$model->term->get_language( $fr )->slug, 'The langue is not set correctly for the category.' );
+
+
+		$_REQUEST = $_POST = array(
+			'name'               => 'More test',
+			'slug'               => 'test-fr',
+			'inline_lang_choice' => 'fr',
+			'_inline_edit'       => wp_create_nonce( 'taxinlineeditnonce', '_inline_edit' ),
+			'taxonomy'           => 'category',
+			'post_type'          => 'post',
+			'action'             => 'inline-save-tax',
+			'tax_type'           => 'tag',
+			'tax_ID'             => $fr,
+			'pll_ajax_backend'   => '1',
+			'description'        => '',
+		);
+
+		try {
+			$this->_handleAjax( 'inline-save-tax' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$term = get_term( $fr );
+		$this->assertInstanceOf( WP_Term::class, $term, 'Expected the category to be an instance of WP_Term.' );
+		$this->assertSame( 'More test', $term->name, 'Expected the title of the category in secondary language to match the one sent via POST.' );
+		$this->assertSame( 'test-fr', $term->slug, 'Expected the slug of the category in secondary language to be suffixed.' );
+	}
 }

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -280,4 +280,56 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertSame( 'More test', $term->name, 'Expected the title of the category in secondary language to match the one sent via POST.' );
 		$this->assertSame( 'test-fr', $term->slug, 'Expected the slug of the category in secondary language to be suffixed.' );
 	}
+
+	public function test_inline_save_tax_with_new_slugs() {
+		// Load WP ajax response action.
+		require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+		add_action( 'wp_ajax_inline-save-tax', 'wp_ajax_inline_save_tax', 1 );
+
+		wp_set_current_user( self::$editor ); // Set a user to pass check_ajax_referer test.
+
+		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'Test' ) );
+		self::$model->term->set_language( $en, 'en' );
+
+		// Create a category translation with the same name (i.e. the same slug).
+		$_REQUEST = $_POST = array(
+			'action'           => 'add-tag',
+			'term_lang_choice' => 'fr',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+		);
+		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'Test' ) );
+		self::$model->term->set_language( $fr, 'fr' );
+
+		$term = get_term( $fr );
+		$this->assertInstanceOf( WP_Term::class, $term, 'Expected the category to be an instance of WP_Term.' );
+		$this->assertSame( 'Test', $term->name, 'Expected the title of the category in secondary language to match the one sent via POST.' );
+		$this->assertSame( 'test-fr', $term->slug, 'Expected the slug of the category in secondary language to be suffixed.' );
+		$this->assertSame( 'fr', self::$model->term->get_language( $fr )->slug, 'The langue is not set correctly for the category.' );
+
+
+		$_REQUEST = $_POST = array(
+			'name'               => 'Test',
+			'slug'               => 'test-new-fr',
+			'inline_lang_choice' => 'fr',
+			'_inline_edit'       => wp_create_nonce( 'taxinlineeditnonce', '_inline_edit' ),
+			'taxonomy'           => 'category',
+			'post_type'          => 'post',
+			'action'             => 'inline-save-tax',
+			'tax_type'           => 'tag',
+			'tax_ID'             => $fr,
+			'pll_ajax_backend'   => '1',
+			'description'        => '',
+		);
+
+		try {
+			$this->_handleAjax( 'inline-save-tax' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$term = get_term( $fr );
+		$this->assertInstanceOf( WP_Term::class, $term, 'Expected the category to be an instance of WP_Term.' );
+		$this->assertSame( 'Test', $term->name, 'Expected the title of the category in secondary language to remain the same.' );
+		$this->assertSame( 'test-new-fr', $term->slug, 'Expected the slug of the category in secondary language to be updated.' );
+	}
 }

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -14,4 +14,8 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	public function test_wp_admin_bar() {
 		$this->check_method( 'ab8f67e85e5623c4c211f67ecd57093a', '5.8', 'wp_admin_bar_search_menu' );
 	}
+
+	public function test_wp_unique_term_slug() {
+		$this->check_method( 'a6a6f8eb31efd91cf6eada6f089391f4', '2.3', 'wp_unique_term_slug' );
+	}
 }

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -14,8 +14,4 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	public function test_wp_admin_bar() {
 		$this->check_method( 'ab8f67e85e5623c4c211f67ecd57093a', '5.8', 'wp_admin_bar_search_menu' );
 	}
-
-	public function test_wp_unique_term_slug() {
-		$this->check_method( 'a6a6f8eb31efd91cf6eada6f089391f4', '2.3', 'wp_unique_term_slug' );
-	}
 }

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -1,6 +1,13 @@
 <?php
 
 class Slugs_Test extends PLL_UnitTestCase {
+	/**
+	 * Used to set our filters and to
+	 * manage languages or save translations.
+	 *
+	 * @var PLL_Admin
+	 */
+	private $pll_admin;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory
@@ -12,20 +19,122 @@ class Slugs_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	public function test_term_slugs() {
-		$links_model = self::$model->get_links_model();
-		$pll_admin = new PLL_Admin( $links_model );
-		$pll_admin->term = new PLL_CRUD_Terms( $pll_admin );
-		$pll_admin->filters_term = new PLL_Admin_Filters_Term( $pll_admin ); // activate our filters
+	public function set_up() {
+		parent::set_up();
 
+		$options                       = PLL_Install::get_default_options();
+		$options['default_lang']       = 'en'; // Default language is the first one created, see self::wpSetUpBeforeClass().
+		$model                         = new PLL_Admin_Model( $options );
+		$links_model                   = new PLL_Links_Default( $model );
+		$this->pll_admin               = new PLL_Admin( $links_model );
+		$this->pll_admin->term         = new PLL_CRUD_Terms( $this->pll_admin ); // Activates our generic term filters.
+		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );  // Activates our filters for admin.
+	}
+
+	public function test_term_slugs() {
 		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$model->term->set_language( $term_id, 'en' );
+		$this->pll_admin->model->term->set_language( $term_id, 'en' );
 
 		$_POST['term_lang_choice'] = 'fr';
-		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		self::$model->term->set_language( $term_id, 'fr' );
+		$term_id                   = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->pll_admin->model->term->set_language( $term_id, 'fr' );
 
 		$term = get_term( $term_id, 'category' );
 		$this->assertEquals( 'test-fr', $term->slug );
+	}
+
+	public function test_term_with_parents_sharing_same_name() {
+		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en_parent );
+		$this->assertEquals( 'test', $en_parent->slug );
+
+		$_POST['term_lang_choice'] = 'en';
+		$_POST['parent']           = $en_parent->term_id;
+		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
+		$this->pll_admin->model->term->set_language( $en, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en );
+		$this->assertEquals( 'test-test', $en->slug );
+	}
+
+	public function test_translated_terms_with_parents_sharing_same_name() {
+		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en_parent );
+		$this->assertEquals( 'test', $en_parent->slug );
+
+		$_POST['term_lang_choice'] = 'en';
+		$_POST['parent']           = $en_parent->term_id;
+		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
+		$this->pll_admin->model->term->set_language( $en, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en );
+		$this->assertEquals( 'test-test', $en->slug );
+
+		// Clean up before creating term in secondary language.
+		unset( $_POST );
+
+		$_POST['term_lang_choice'] = 'fr';
+		$fr_parent                 = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->pll_admin->model->term->set_language( $fr_parent->term_id, 'fr' );
+
+		$this->assertInstanceOf( WP_Term::class, $fr_parent );
+		$this->assertEquals( 'test-fr', $fr_parent->slug );
+
+		$_POST['parent'] = $fr_parent->term_id;
+		$fr              = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $fr_parent->term_id ) );
+		$this->pll_admin->model->term->set_language( $fr->term_id, 'fr' );
+
+		$this->assertInstanceOf( WP_Term::class, $fr );
+		$this->assertEquals( 'test-fr-test-fr', $fr->slug );
+	}
+
+	public function test_already_existing_term_slugs_with_parent() {
+		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en_parent );
+		$this->assertEquals( 'test', $en_parent->slug );
+
+		$_POST['term_lang_choice'] = 'en';
+		$_POST['parent']           = $en_parent->term_id;
+		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
+		$this->pll_admin->model->term->set_language( $en, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en );
+		$this->assertEquals( 'test-test', $en->slug );
+
+		// Let's create another child term with the same parent and the same name.
+		$en_new = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
+		$this->pll_admin->model->term->set_language( $en_new, 'en' );
+
+		$this->assertInstanceOf( WP_Error::class, $en_new );
+	}
+
+	public function test_update_existing_term_slugs_with_parent() {
+		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
+		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en_parent );
+		$this->assertEquals( 'test', $en_parent->slug );
+
+		$_POST['term_lang_choice'] = 'en';
+		$_POST['parent']           = $en_parent->term_id;
+		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
+		$this->pll_admin->model->term->set_language( $en, 'en' );
+
+		$this->assertInstanceOf( WP_Term::class, $en );
+		$this->assertEquals( 'test-test', $en->slug );
+
+		// Let's update the term.
+		wp_update_term( $en->term_id, $en->taxonomy, array( 'name' => 'New Test' ) );
+		$en_new = get_term( $en->term_id );
+
+		$this->assertInstanceOf( WP_Term::class, $en_new );
+		$this->assertEquals( 'New Test', $en_new->name );
+		$this->assertEquals( 'test-test', $en_new->slug );
 	}
 }

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -56,7 +56,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertSame( 'test-test', $en->slug );
+		$this->assertSame( 'test-en', $en->slug );
 
 		// Clean up before creating term in secondary language.
 		unset( $_POST );
@@ -89,7 +89,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertSame( 'test-test', $en->slug );
+		$this->assertSame( 'test-en', $en->slug );
 
 		// Let's create another child term with the same parent and the same name.
 		$en_new = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
@@ -111,7 +111,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertSame( 'test-test', $en->slug );
+		$this->assertSame( 'test-en', $en->slug );
 
 		// Let's update the term.
 		wp_update_term( $en->term_id, $en->taxonomy, array( 'name' => 'New Test' ) );
@@ -119,6 +119,6 @@ class Slugs_Test extends PLL_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Term::class, $en_new );
 		$this->assertSame( 'New Test', $en_new->name );
-		$this->assertSame( 'test-test', $en_new->slug );
+		$this->assertSame( 'test-en', $en_new->slug );
 	}
 }

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -43,22 +43,6 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'test-fr', $term->slug );
 	}
 
-	public function test_term_with_parents_sharing_same_name() {
-		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
-
-		$this->assertInstanceOf( WP_Term::class, $en_parent );
-		$this->assertSame( 'test', $en_parent->slug );
-
-		$_POST['term_lang_choice'] = 'en';
-		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
-		$this->pll_admin->model->term->set_language( $en, 'en' );
-
-		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertSame( 'test-test', $en->slug );
-	}
-
 	public function test_translated_terms_with_parents_sharing_same_name() {
 		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -40,7 +40,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $term_id, 'fr' );
 
 		$term = get_term( $term_id, 'category' );
-		$this->assertEquals( 'test-fr', $term->slug );
+		$this->assertSame( 'test-fr', $term->slug );
 	}
 
 	public function test_term_with_parents_sharing_same_name() {
@@ -48,7 +48,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
-		$this->assertEquals( 'test', $en_parent->slug );
+		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
@@ -56,7 +56,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertEquals( 'test-test', $en->slug );
+		$this->assertSame( 'test-test', $en->slug );
 	}
 
 	public function test_translated_terms_with_parents_sharing_same_name() {
@@ -64,7 +64,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
-		$this->assertEquals( 'test', $en_parent->slug );
+		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
@@ -72,7 +72,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertEquals( 'test-test', $en->slug );
+		$this->assertSame( 'test-test', $en->slug );
 
 		// Clean up before creating term in secondary language.
 		unset( $_POST );
@@ -82,14 +82,14 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $fr_parent->term_id, 'fr' );
 
 		$this->assertInstanceOf( WP_Term::class, $fr_parent );
-		$this->assertEquals( 'test-fr', $fr_parent->slug );
+		$this->assertSame( 'test-fr', $fr_parent->slug );
 
 		$_POST['parent'] = $fr_parent->term_id;
 		$fr              = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $fr_parent->term_id ) );
 		$this->pll_admin->model->term->set_language( $fr->term_id, 'fr' );
 
 		$this->assertInstanceOf( WP_Term::class, $fr );
-		$this->assertEquals( 'test-fr-test-fr', $fr->slug );
+		$this->assertSame( 'test-fr-test-fr', $fr->slug );
 	}
 
 	public function test_already_existing_term_slugs_with_parent() {
@@ -97,7 +97,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
-		$this->assertEquals( 'test', $en_parent->slug );
+		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
@@ -105,7 +105,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertEquals( 'test-test', $en->slug );
+		$this->assertSame( 'test-test', $en->slug );
 
 		// Let's create another child term with the same parent and the same name.
 		$en_new = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
@@ -119,7 +119,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
-		$this->assertEquals( 'test', $en_parent->slug );
+		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
@@ -127,14 +127,14 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->pll_admin->model->term->set_language( $en, 'en' );
 
 		$this->assertInstanceOf( WP_Term::class, $en );
-		$this->assertEquals( 'test-test', $en->slug );
+		$this->assertSame( 'test-test', $en->slug );
 
 		// Let's update the term.
 		wp_update_term( $en->term_id, $en->taxonomy, array( 'name' => 'New Test' ) );
 		$en_new = get_term( $en->term_id );
 
 		$this->assertInstanceOf( WP_Term::class, $en_new );
-		$this->assertEquals( 'New Test', $en_new->name );
-		$this->assertEquals( 'test-test', $en_new->slug );
+		$this->assertSame( 'New Test', $en_new->name );
+		$this->assertSame( 'test-test', $en_new->slug );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1468

## Changes
- Use `term_exists_by_slug()` directly in `PLL_CRUD_Terms::set_pre_term_slug()`.
- Do not suffix with language if we are editing the term (i.e. `$_POST['tag_id']` is set and equal to result of `term_exists_by_slug()`)
- Handle post parent with same slug by prepending it to itself like WordPress does.
- Add some tests.