### PR TITLE
Add support for wpml-config.xml to MU plugins

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -629,16 +629,22 @@ class PLL_WPML_Config {
 	 */
 	private function get_plugin_files() {
 		$files   = array();
-		$plugins = get_option( 'active_plugins', array() );
-		$plugins = is_array( $plugins ) ? $plugins : array();
+		$plugins = array();
 
 		if ( is_multisite() ) {
 			// Don't forget sitewide active plugins thanks to Reactorshop http://wordpress.org/support/topic/polylang-and-yoast-seo-plugin/page/2?replies=38#post-4801829.
 			$sitewide_plugins = get_site_option( 'active_sitewide_plugins', array() );
 
 			if ( ! empty( $sitewide_plugins ) && is_array( $sitewide_plugins ) ) {
-				$plugins = array_merge( $plugins, array_keys( $sitewide_plugins ) );
+				$plugins = array_keys( $sitewide_plugins );
 			}
+		}
+
+		// By-site plugins.
+		$active_plugins = get_option( 'active_plugins', array() );
+
+		if ( ! empty( $active_plugins ) && is_array( $active_plugins ) ) {
+			$plugins = array_merge( $plugins, $active_plugins );
 		}
 
 		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . '%s/wpml-config.xml';

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -603,20 +603,16 @@ class PLL_WPML_Config {
 		}
 
 		// Search in proxy loaded MU plugins.
-		try {
-			foreach ( new DirectoryIterator( WPMU_PLUGIN_DIR ) as $file_info ) {
-				if ( $file_info->isDot() || ! $file_info->isDir() ) {
-					continue;
-				}
-
-				$file_path = $file_info->getPathname() . '/wpml-config.xml';
-
-				if ( file_exists( $file_path ) ) {
-					$files[ 'mu-plugins/' . $file_info->getFilename() ] = $file_path;
-				}
+		foreach ( new DirectoryIterator( WPMU_PLUGIN_DIR ) as $file_info ) {
+			if ( $file_info->isDot() || ! $file_info->isDir() ) {
+				continue;
 			}
-		} catch ( Exception $e ) {
-			unset( $e );
+
+			$file_path = $file_info->getPathname() . '/wpml-config.xml';
+
+			if ( file_exists( $file_path ) ) {
+				$files[ 'mu-plugins/' . $file_info->getFilename() ] = $file_path;
+			}
 		}
 
 		return $files;

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -589,7 +589,7 @@ class PLL_WPML_Config {
 	 * @phpstan-return array<string, string>
 	 */
 	private function get_mu_plugin_files() {
-		if ( ! file_exists( WPMU_PLUGIN_DIR ) || ! is_dir( WPMU_PLUGIN_DIR ) ) {
+		if ( ! is_dir( WPMU_PLUGIN_DIR ) ) {
 			return array();
 		}
 

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -152,12 +152,12 @@ class PLL_WPML_Config {
 		}
 
 		$this->files = array_merge(
-			// MU Plugins.
-			$this->get_mu_plugin_files(),
 			// Plugins.
 			$this->get_plugin_files(),
 			// Theme and child theme.
 			$this->get_theme_files(),
+			// MU Plugins.
+			$this->get_mu_plugin_files(),
 			// Custom.
 			$this->get_custom_files()
 		);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1506,16 +1506,6 @@ parameters:
 			path: modules/wpml/wpml-compat.php
 
 		-
-			message: "#^Parameter \\#1 \\$path of function dirname expects string, mixed given\\.$#"
-			count: 2
-			path: modules/wpml/wpml-config.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, mixed given\\.$#"
-			count: 1
-			path: modules/wpml/wpml-config.php
-
-		-
 			message: "#^Cannot call method get_home_url\\(\\) on PLL_Admin_Links\\|PLL_Frontend_Links\\|null\\.$#"
 			count: 1
 			path: modules/wpml/wpml-legacy-api.php


### PR DESCRIPTION
Closes #1088.

This PR brings support for `wpml-config.xml` to Must-Use plugins.
The whole method `get_files()` has been reworked to improve code readability: it has been split into 4 other private methods that handle different `wpml-config.xml` files (1 for MU plugins, 1 for plugins, 1 for themes, 1 for custom PLL file).