### PR TITLE
Use WP format for arrays doc

### DIFF
--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -243,7 +243,7 @@ class PLL_Admin_Model extends PLL_Model {
 		 * @since 1.9
 		 * @since 3.2 Added $lang parameter.
 		 *
-		 * @param array<mixed> $args {
+		 * @param array $args {
 		 *   Arguments used to modify the language. @see PLL_Admin_Model::update_language().
 		 *
 		 *   @type string $name           Language name (used only for display).
@@ -473,15 +473,15 @@ class PLL_Admin_Model extends PLL_Model {
 				 *
 				 * @since 3.2
 				 *
-				 * @param array<int|array<string>> $tr {
+				 * @param (int|string[])[] $tr {
 				 *     List of translations with lang codes as array keys and IDs as array values.
 				 *     Also in this array:
 				 *
-				 *     @type array<string> $sync List of synchronized translations with lang codes as array keys and array values.
+				 *     @type string[] $sync List of synchronized translations with lang codes as array keys and array values.
 				 * }
-				 * @param string                   $old_slug The old language slug.
-				 * @param string                   $new_slug The new language slug.
-				 * @param WP_Term                  $term     The term containing the post or term translation group.
+				 * @param string           $old_slug The old language slug.
+				 * @param string           $new_slug The new language slug.
+				 * @param WP_Term          $term     The term containing the post or term translation group.
 				 */
 				$tr = apply_filters( 'update_translation_group', $tr, $old_slug, $new_slug, $term );
 

--- a/include/db-tools.php
+++ b/include/db-tools.php
@@ -18,8 +18,8 @@ class PLL_Db_Tools {
 	 *
 	 * @since 3.2
 	 *
-	 * @param  array<int|string> $values An array of values.
-	 * @return string                    A comma separated list of values.
+	 * @param (int|string)[] $values An array of values.
+	 * @return string A comma separated list of values.
 	 */
 	public static function prepare_values_list( $values ) {
 		$values = array_map( array( __CLASS__, 'prepare_value' ), (array) $values );
@@ -31,10 +31,11 @@ class PLL_Db_Tools {
 	 * Wraps a value in escaped double quotes or casts as an integer.
 	 * Only string and integers and supported for now.
 	 *
-	 * @since  3.2
+	 * @since 3.2
+	 *
 	 * @global wpdb $wpdb
 	 *
-	 * @param  int|string $value A value.
+	 * @param int|string $value A value.
 	 * @return int|string
 	 */
 	public static function prepare_value( $value ) {

--- a/include/filters.php
+++ b/include/filters.php
@@ -425,10 +425,10 @@ class PLL_Filters {
 	 *
 	 * @since 3.2
 	 *
-	 * @param  array<mixed> $defaults An array of arguments passed to get_terms().
-	 * @param  int|string   $term     The term to check. Accepts term ID, slug, or name.
-	 * @param  string       $taxonomy The taxonomy name to use. An empty string indicates the search is against all taxonomies.
-	 * @return array<mixed>
+	 * @param  array      $defaults An array of arguments passed to get_terms().
+	 * @param  int|string $term     The term to check. Accepts term ID, slug, or name.
+	 * @param  string     $taxonomy The taxonomy name to use. An empty string indicates the search is against all taxonomies.
+	 * @return array
 	 */
 	public function term_exists_default_query_args( $defaults, $term, $taxonomy ) {
 		if ( ! empty( $taxonomy ) && ! $this->model->is_translated_taxonomy( $taxonomy ) ) {

--- a/include/model.php
+++ b/include/model.php
@@ -785,7 +785,7 @@ class PLL_Model {
 	 *
 	 * @since 3.2.3
 	 *
-	 * @return array<WP_Term>
+	 * @return WP_Term[]
 	 */
 	protected function get_language_terms() {
 		add_filter( 'get_terms_orderby', array( $this, 'filter_language_terms_orderby' ), 10, 3 );

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -171,8 +171,8 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @since 3.2
 	 *
-	 * @param  int $term_id Term ID.
-	 * @return array<int>   An associative array of translations with language code as key and translation id as value.
+	 * @param int $term_id Term ID.
+	 * @return int[] An associative array of translations with language code as key and translation id as value.
 	 */
 	public function get_translations_from_term_id( $term_id ) {
 		$term_id = $this->sanitize_int_id( $term_id );
@@ -216,7 +216,7 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @param int   $id           Object id ( typically a post_id or term_id ).
 	 * @param int[] $translations An associative array of translations with language code as key and translation id as value.
-	 * @return int[]              An associative array with language codes as key and post ids as values.
+	 * @return int[] An associative array with language codes as key and post ids as values.
 	 */
 	public function save_translations( $id, $translations ) {
 		$id = $this->sanitize_int_id( $id );
@@ -496,8 +496,9 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @since 3.2
 	 *
-	 * @param  mixed $id  A supposedly numeric ID.
-	 * @return int<0,max> A positive integer. `0` for non numeric values and negative integers.
+	 * @param mixed $id A supposedly numeric ID.
+	 * @return int A positive integer. `0` for non numeric values and negative integers.
+	 * @phpstan-return int<0,max>
 	 */
 	public function sanitize_int_id( $id ) {
 		return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
@@ -509,8 +510,8 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @since 3.2
 	 *
-	 * @param  mixed $ids An associative array of translations with language code as key and translation ID as value.
-	 * @return array<int> An associative array of translations with language code as key and translation ID as value.
+	 * @param mixed $ids An associative array of translations with language code as key and translation ID as value.
+	 * @return int[] An associative array of translations with language code as key and translation ID as value.
 	 */
 	public function sanitize_int_ids_list( $ids ) {
 		if ( empty( $ids ) || ! is_array( $ids ) ) {
@@ -534,13 +535,13 @@ abstract class PLL_Translated_Object {
 	 * @since 3.2 Doesn't return `0` ID values.
 	 * @since 3.2 Added parameters `$id` and `$context`.
 	 *
-	 * @param  int[]  $translations An associative array of translations with language code as key and translation ID as
-	 *                              value.
-	 * @param  int    $id           Optional. The object ID for which the translations are validated. When provided, the
-	 *                              process makes sure it is added to the list. Default 0.
-	 * @param  string $context      Optional. The operation for which the translations are validated. When set to
-	 *                              'save', a check is done to verify that the IDs and langs correspond.
-	 *                              'display' should be used otherwise. Default 'save'.
+	 * @param int[]  $translations An associative array of translations with language code as key and translation ID as
+	 *                             value.
+	 * @param int    $id           Optional. The object ID for which the translations are validated. When provided, the
+	 *                             process makes sure it is added to the list. Default 0.
+	 * @param string $context      Optional. The operation for which the translations are validated. When set to
+	 *                             'save', a check is done to verify that the IDs and langs correspond.
+	 *                             'display' should be used otherwise. Default 'save'.
 	 * @return int[]
 	 */
 	protected function validate_translations( $translations, $id = 0, $context = 'save' ) {

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -498,6 +498,7 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @param mixed $id A supposedly numeric ID.
 	 * @return int A positive integer. `0` for non numeric values and negative integers.
+	 *
 	 * @phpstan-return int<0,max>
 	 */
 	public function sanitize_int_id( $id ) {


### PR DESCRIPTION
This PR replaces usage of `array<..>` in doc blocks.