### PR TITLE
Fix PHPStan errors.

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -63,17 +63,25 @@ class PLL_Frontend_Filters_Search {
 	 * @return string Modified search form.
 	 */
 	public function get_search_form( $form ) {
-		if ( $form ) {
-			if ( $this->links_model->using_permalinks ) {
-				// Take care to modify only the url in the <form> tag.
-				preg_match( '#<form.+?>#', $form, $matches );
-				$old = reset( $matches );
-				// Replace action attribute (a text with no space and no closing tag within double quotes or simple quotes or without quotes).
-				$new = preg_replace( '#\saction=("[^"\r\n]+"|\'[^\'\r\n]+\'|[^\'"][^>\s]+)#', ' action="' . esc_url( $this->curlang->search_url ) . '"', $old );
-				$form = str_replace( $old, $new, $form );
-			} else {
-				$form = str_replace( '</form>', '<input type="hidden" name="lang" value="' . esc_attr( $this->curlang->slug ) . '" /></form>', $form );
+		if ( empty( $form ) ) {
+			return $form;
+		}
+
+		if ( $this->links_model->using_permalinks ) {
+			// Take care to modify only the url in the <form> tag.
+			preg_match( '#<form.+?>#', $form, $matches );
+			$old = reset( $matches );
+			if ( empty( $old ) ) {
+				return $form;
 			}
+			// Replace action attribute (a text with no space and no closing tag within double quotes or simple quotes or without quotes).
+			$new = preg_replace( '#\saction=("[^"\r\n]+"|\'[^\'\r\n]+\'|[^\'"][^>\s]+)#', ' action="' . esc_url( $this->curlang->search_url ) . '"', $old );
+			if ( empty( $new ) ) {
+				return $form;
+			}
+			$form = str_replace( $old, $new, $form );
+		} else {
+			$form = str_replace( '</form>', '<input type="hidden" name="lang" value="' . esc_attr( $this->curlang->slug ) . '" /></form>', $form );
 		}
 
 		return $form;

--- a/include/model.php
+++ b/include/model.php
@@ -550,7 +550,10 @@ class PLL_Model {
 			$groupby = ' GROUP BY pll_tr.term_taxonomy_id';
 
 			if ( ! empty( $q['m'] ) ) {
-				$q['m'] = '' . preg_replace( '|[^0-9]|', '', $q['m'] );
+				$date_query = preg_replace( '|[^0-9]|', '', $q['m'] );
+				if ( is_string( $date_query ) ) {
+					$q['m'] = '' . $date_query;
+				}
 				$where .= $wpdb->prepare( " AND YEAR( {$wpdb->posts}.post_date ) = %d", substr( $q['m'], 0, 4 ) );
 				if ( strlen( $q['m'] ) > 5 ) {
 					$where .= $wpdb->prepare( " AND MONTH( {$wpdb->posts}.post_date ) = %d", substr( $q['m'], 4, 2 ) );

--- a/include/model.php
+++ b/include/model.php
@@ -552,7 +552,7 @@ class PLL_Model {
 			if ( ! empty( $q['m'] ) ) {
 				$date_query = preg_replace( '|[^0-9]|', '', $q['m'] );
 				if ( is_string( $date_query ) ) {
-					$q['m'] = '' . $date_query;
+					$q['m'] = $date_query;
 				}
 				$where .= $wpdb->prepare( " AND YEAR( {$wpdb->posts}.post_date ) = %d", substr( $q['m'], 0, 4 ) );
 				if ( strlen( $q['m'] ) > 5 ) {

--- a/include/model.php
+++ b/include/model.php
@@ -550,10 +550,7 @@ class PLL_Model {
 			$groupby = ' GROUP BY pll_tr.term_taxonomy_id';
 
 			if ( ! empty( $q['m'] ) ) {
-				$date_query = preg_replace( '|[^0-9]|', '', $q['m'] );
-				if ( is_string( $date_query ) ) {
-					$q['m'] = $date_query;
-				}
+				$q['m'] = '' . preg_replace( '|[^0-9]|', '', $q['m'] );
 				$where .= $wpdb->prepare( " AND YEAR( {$wpdb->posts}.post_date ) = %d", substr( $q['m'], 0, 4 ) );
 				if ( strlen( $q['m'] ) > 5 ) {
 					$where .= $wpdb->prepare( " AND MONTH( {$wpdb->posts}.post_date ) = %d", substr( $q['m'], 4, 2 ) );


### PR DESCRIPTION
Since PHPStan 1.9.0, the following errors are raised:
```
------ ------------------------------------------------------------------------------------------ 
  Line   frontend/frontend-filters-search.php                                                      
 ------ ------------------------------------------------------------------------------------------ 
  :72    Parameter #3 $subject of function preg_replace expects array|string, string|false given.  
  :73    Parameter #1 $search of function str_replace expects array|string, string|false given.    
  :73    Parameter #2 $replace of function str_replace expects array|string, string|null given.    
 ------ ------------------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------------------------- 
  Line   include/model.php                                                                        
 ------ ----------------------------------------------------------------------------------------- 
  :553   Binary operation "." between '' and array<int, string>|string|null results in an error.  
 ------ -----------------------------------------------------------------------------------------
 ```