### PR TITLE
Fix PHPStan errors since szepeviktor/phpstan-wordpress new release

### DIFF
--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -34,7 +34,7 @@ class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
 			$this->set_language_from_url();
 		}
 
-		add_action( 'request', array( $this, 'request' ) );
+		add_filter( 'request', array( $this, 'request' ) );
 	}
 
 	/**

--- a/include/filters.php
+++ b/include/filters.php
@@ -210,11 +210,12 @@ class PLL_Filters {
 			// Take care that 'exclude' argument accepts integer or strings too.
 			$args['exclude'] = array_merge( wp_parse_id_list( $args['exclude'] ), $this->get_related_page_ids( $language, 'NOT IN', $args ) ); // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 			$pages = get_pages( $args );
+			$pages = ! $pages ? array() : $pages;
 		}
 
 		$ids = wp_list_pluck( $pages, 'ID' );
 
-		if ( ! $once ) {
+		if ( ! $once && is_array( $pages ) ) {
 			// Filters the queried list of pages by language.
 			$ids = array_intersect( $ids, $this->get_related_page_ids( $language, 'IN', $args ) );
 

--- a/include/filters.php
+++ b/include/filters.php
@@ -209,13 +209,13 @@ class PLL_Filters {
 
 			// Take care that 'exclude' argument accepts integer or strings too.
 			$args['exclude'] = array_merge( wp_parse_id_list( $args['exclude'] ), $this->get_related_page_ids( $language, 'NOT IN', $args ) ); // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-			$pages = get_pages( $args );
-			$pages = ! $pages ? array() : $pages;
+			$numbered_pages  = get_pages( $args );
+			$pages           = ! $numbered_pages ? $pages : $numbered_pages;
 		}
 
 		$ids = wp_list_pluck( $pages, 'ID' );
 
-		if ( ! $once && is_array( $pages ) ) {
+		if ( ! $once ) {
 			// Filters the queried list of pages by language.
 			$ids = array_intersect( $ids, $this->get_related_page_ids( $language, 'IN', $args ) );
 

--- a/include/license.php
+++ b/include/license.php
@@ -172,11 +172,10 @@ class PLL_License {
 	 *
 	 * @since 1.9
 	 *
-	 * @return PLL_License Updated PLL_License object.
+	 * @return void
 	 */
 	public function check_license() {
 		$this->api_request( 'check_license' );
-		return $this;
 	}
 
 	/**

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -51,7 +51,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		}
 
 		// Make sure to prepare rewrite rules when flushing.
-		add_action( 'pre_option_rewrite_rules', array( $this, 'prepare_rewrite_rules' ) );
+		add_filter( 'pre_option_rewrite_rules', array( $this, 'prepare_rewrite_rules' ) );
 	}
 
 	/**

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -194,7 +194,7 @@ class PLL_Translate_Option {
 		// Stores the unfiltered old option value before it is updated in DB.
 		remove_filter( 'option_' . $name, array( $this, 'translate' ) );
 		$unfiltered_old_value = get_option( $name );
-		add_filter( 'option_' . $name, array( $this, 'translate' ), 20 );
+		add_filter( 'option_' . $name, array( $this, 'translate' ), 20, 2 );
 
 		// Load strings translations according to the admin language filter
 		$locale = pll_current_language( 'locale' );

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -194,7 +194,7 @@ class PLL_Translate_Option {
 		// Stores the unfiltered old option value before it is updated in DB.
 		remove_filter( 'option_' . $name, array( $this, 'translate' ) );
 		$unfiltered_old_value = get_option( $name );
-		add_filter( 'option_' . $name, array( $this, 'translate' ), 20, 2 );
+		add_filter( 'option_' . $name, array( $this, 'translate' ), 20 );
 
 		// Load strings translations according to the admin language filter
 		$locale = pll_current_language( 'locale' );

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -231,7 +231,7 @@ class PLL_Sync_Tax {
 			}
 		}
 
-		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 6 );
+		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 5 );
 	}
 
 	/**

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -28,7 +28,7 @@ class PLL_WPML_API {
 		// Site Wide Language informations
 
 		add_filter( 'wpml_active_languages', array( $this, 'wpml_active_languages' ), 10, 2 );
-		add_filter( 'wpml_display_language_names', array( $this, 'wpml_display_language_names' ), 10, 2 );
+		add_filter( 'wpml_display_language_names', array( $this, 'wpml_display_language_names' ), 10, 2 ); // Because we don't translate language names, 3rd to 5th parameters are not supported.
 		// wpml_translated_language_name           => not applicable
 		add_filter( 'wpml_current_language', 'pll_current_language', 10, 0 );
 		add_filter( 'wpml_default_language', 'pll_default_language', 10, 0 );

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -28,7 +28,7 @@ class PLL_WPML_API {
 		// Site Wide Language informations
 
 		add_filter( 'wpml_active_languages', array( $this, 'wpml_active_languages' ), 10, 2 );
-		add_filter( 'wpml_display_language_names', array( $this, 'wpml_display_language_names' ), 10, 5 );
+		add_filter( 'wpml_display_language_names', array( $this, 'wpml_display_language_names' ), 10, 2 );
 		// wpml_translated_language_name           => not applicable
 		add_filter( 'wpml_current_language', 'pll_current_language', 10, 0 );
 		add_filter( 'wpml_default_language', 'pll_default_language', 10, 0 );
@@ -52,7 +52,7 @@ class PLL_WPML_API {
 
 		add_filter( 'wpml_post_language_details', 'wpml_get_language_information', 10, 2 );
 		add_action( 'wpml_switch_language', array( __CLASS__, 'wpml_switch_language' ), 10, 2 );
-		add_filter( 'wpml_element_language_code', array( $this, 'wpml_element_language_code' ), 10, 3 );
+		add_filter( 'wpml_element_language_code', array( $this, 'wpml_element_language_code' ), 10, 2 );
 		// wpml_element_language_details           => not applicable
 
 		// Retrieving Localized Content

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -826,27 +826,12 @@ parameters:
 			path: include/filters-links.php
 
 		-
-			message: "#^Argument of an invalid type array\\<int\\|WP_Post\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: include/filters.php
-
-		-
-			message: "#^Method PLL_Filters\\:\\:get_pages\\(\\) should return array\\<WP_Post\\> but returns array\\|false\\.$#"
-			count: 1
-			path: include/filters.php
-
-		-
 			message: "#^Method PLL_Filters\\:\\:translate_page_for_privacy_policy\\(\\) should return int but returns int\\|false\\.$#"
 			count: 1
 			path: include/filters.php
 
 		-
 			message: "#^Parameter \\#1 \\$id of method PLL_Translated_Object\\:\\:get_translations\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: include/filters.php
-
-		-
-			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<int\\|WP_Post\\>\\|false given\\.$#"
 			count: 1
 			path: include/filters.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -43,3 +43,9 @@ parameters:
 
 		# Ignored because the WordPress stubs doesn't know a dynamic key in the associative array passed to the get_terms() parameter
 		- "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\> given\\.$#"
+
+		# Ignored PLL_Canonical::check_canonical_url() is used both as action callback and classic method.
+		-
+			message: "#^Action callback returns string\\|void but should not return anything\\.$#"
+			count: 1
+			path: frontend/frontend.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,3 +49,9 @@ parameters:
 			message: "#^Action callback returns string\\|void but should not return anything\\.$#"
 			count: 1
 			path: frontend/frontend.php
+
+		# Ignored temporarily while https://github.com/polylang/polylang/pull/1111 is merged.
+		-
+			message: "#^Callback expects 1 parameter, \\$accepted_args is set to 2\\.$#"
+			count: 1
+			path: include/translate-option.php


### PR DESCRIPTION
New szepeviktor/phpstan-wordpress releases have shown new errors in PHPStan.

Some errors are trivial and concerns number of required parameters not matching callbacks.

But others concern mixed between actions and filters. See these pieces of documentation:
- [`pre_option_{$option}`](https://developer.wordpress.org/reference/hooks/pre_option_option/)
- [`request`](https://developer.wordpress.org/reference/hooks/request/)


Special case for `template_redirect` action, where I ignored the error since `PLL_Canonical::check_canonical_url()` is used as an action callback (which shouldn't return anything)  but also inside itself here:
https://github.com/polylang/polylang/blob/3.3-beta1/frontend/canonical.php#L156