### PR TITLE
Only store term_ids in taxonomy relationships cache

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -166,9 +166,9 @@ abstract class PLL_Translated_Object {
 			if ( empty( $terms[ $tax ] ) ) {
 				$to_cache = array();
 			} elseif ( $store_only_term_ids ) {
-				$to_cache = wp_list_pluck( $terms[ $tax ], 'term_id' );
+				$to_cache = array( $terms[ $tax ]->term_id );
 			} else {
-				$to_cache = $terms[ $tax ];
+				$to_cache = array( $terms[ $tax ] );
 			}
 
 			wp_cache_add( $object_id, $to_cache, $tax . '_relationships' );


### PR DESCRIPTION
In WordPress 6.0 the cache value of the `{$taxonomy}_relationships` has been simplified to only store term IDs instead of full `WP_Term` objects, see https://core.trac.wordpress.org/changeset/52836 and https://make.wordpress.org/core/2022/04/28/taxonomy-performance-improvements-in-wordpress-6-0/.

This PR adjusts `PLL_Translated_Object::get_object_term()` to only store term IDs in 6.0+ to keep the cache small and to avoid potential fatal errors in the future. This was noticed while working on https://github.com/WordPress/wordpress-develop/pull/3647.
So far this is not an issue due to the back-compat handling in [get_object_term_cache()](https://github.com/WordPress/wordpress-develop/blob/cfd09a412765e072b842e3216605c577f667d462/src/wp-includes/taxonomy.php#L3677).

While #1149 also touches the function it's not changing the caching.