### PR TITLE
Replace deprecated function mb_convert_encoding() in tests

### DIFF
--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -263,7 +263,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		ob_start();
 		$this->pll_admin->classic_editor->post_language();
 		$form = ob_get_clean();
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
@@ -296,7 +296,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		ob_start();
 		$this->pll_admin->classic_editor->post_language();
 		$form = ob_get_clean();
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
@@ -339,7 +339,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		ob_start();
 		$this->pll_admin->classic_editor->post_language();
 		$form = ob_get_clean();
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -264,7 +264,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$lang = self::$model->get_language( 'fr' );
 		$form = $this->get_edit_term_form( $fr, 'category' );
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
@@ -355,7 +355,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		ob_start();
 		do_action( 'category_add_form_fields' );
 		$form = ob_get_clean();
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
@@ -376,7 +376,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		ob_start();
 		do_action( 'category_add_form_fields' );
 		$form = ob_get_clean();
-		$form = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -62,7 +62,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$default = self::$model->term->get( get_option( 'default_category' ), 'de' );
 		$de      = self::$model->get_language( 'de' );
 		$form    = $this->get_edit_term_form( $default, 'category' );
-		$form    = mb_convert_encoding( $form, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$form    = htmlspecialchars_decode( htmlentities( $form ) ); // Due to "Français".
 		$doc     = new DomDocument();
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -292,7 +292,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$doc = new DomDocument();
 		$menu = wp_nav_menu( $args );
 		$menu = preg_replace( '#<svg(.+)</svg>#', '', $menu ); // Remove SVG Added by Twenty Seventeen to avoid an error in loadHTML()
-		$menu = mb_convert_encoding( $menu, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$menu = htmlspecialchars_decode( htmlentities( $menu ) ); // Due to "Français".
 		$doc->loadHTML( $menu );
 		$xpath = new DOMXpath( $doc );
 

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -48,7 +48,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$pll_env = new PLL_Settings( $links_model );
 		$pll_env->languages_page();
 		$out = ob_get_clean();
-		$out = mb_convert_encoding( $out, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$out = htmlspecialchars_decode( htmlentities( $out ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $out );
 		$xpath = new DOMXpath( $doc );

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -178,7 +178,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 			'echo'     => 0,
 		);
 		$switcher = $this->switcher->the_languages( $this->frontend->links, $args );
-		$switcher = mb_convert_encoding( $switcher, 'HTML-ENTITIES', 'UTF-8' ); // Due to "Français"
+		$switcher = htmlspecialchars_decode( htmlentities( $switcher ) ); // Due to "Français".
 		$doc = new DomDocument();
 		$doc->loadHTML( $switcher );
 		$xpath = new DOMXpath( $doc );


### PR DESCRIPTION
Follow-up of #1143 
`HTML-ENTITIES` encoding for `mb_convert_encoding()` is deprecated in PHP 8.2.

The recommended replacement is `htmlentities()`. However, in tests, we used `mb_convert_encoding()` *because* it does not encode the characters `'"<>&` (to be able to use `DomDocument` on hte converted string).
Thus in this special case we need to pass the string to `htmlspecialchars_decode()` after `htmlentities()` to restore the characters `'"<>&`.

See https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html