### PR TITLE
Split PLL_Translated_Object into 2 abstract classes

### DIFF
--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -68,9 +68,17 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 		else {
 			foreach ( $this->model->get_translated_taxonomies() as $taxonomy ) {
 				$tax_object = get_taxonomy( $taxonomy );
-				if ( ! empty( $tax_object ) && $var = get_query_var( $tax_object->query_var ) ) {
-					$lang = $this->model->term->get_language( $var, $taxonomy );
+				if ( empty( $tax_object ) ) {
+					continue;
 				}
+
+				$var = get_query_var( $tax_object->query_var );
+
+				if ( ! is_string( $var ) || empty( $var ) ) {
+					continue;
+				}
+
+				$lang = $this->model->term->get_language_by_term_slug( $var, $taxonomy );
 			}
 		}
 

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -68,6 +68,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 		else {
 			foreach ( $this->model->get_translated_taxonomies() as $taxonomy ) {
 				$tax_object = get_taxonomy( $taxonomy );
+
 				if ( empty( $tax_object ) ) {
 					continue;
 				}
@@ -78,7 +79,13 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 					continue;
 				}
 
-				$lang = $this->model->term->get_language_by_term_slug( $var, $taxonomy );
+				$term = get_term_by( 'slug', $var, $taxonomy );
+
+				if ( ! $term instanceof WP_Term ) {
+					continue;
+				}
+
+				$lang = $this->model->term->get_language( $term->term_id );
 			}
 		}
 

--- a/include/object-with-language.php
+++ b/include/object-with-language.php
@@ -38,6 +38,7 @@ abstract class PLL_Object_With_Language {
 
 	/**
 	 * Identifier that must be unique for each type of content.
+	 * Also used when checking capabilities.
 	 *
 	 * @var string
 	 *

--- a/include/object-with-language.php
+++ b/include/object-with-language.php
@@ -130,7 +130,7 @@ abstract class PLL_Object_With_Language {
 	}
 
 	/**
-	 * Add hooks.
+	 * Adds hooks.
 	 *
 	 * @since 3.4
 	 *

--- a/include/object-with-language.php
+++ b/include/object-with-language.php
@@ -1,0 +1,425 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Abstract class to use for object types that support at least one language.
+ *
+ * @since 3.4
+ */
+abstract class PLL_Object_With_Language {
+
+	/**
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * List of taxonomies to cache.
+	 *
+	 * @var string[]
+	 * @see PLL_Object_With_Language::get_object_term()
+	 *
+	 * @phpstan-var list<non-empty-string>
+	 */
+	protected $tax_to_cache = array();
+
+	/**
+	 * Taxonomy name for the languages.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $tax_language;
+
+	/**
+	 * Identifier that must be unique for each type of content.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $type;
+
+	/**
+	 * Object type to use when registering the taxonomy.
+	 * Left empty for posts.
+	 *
+	 * @var string|null
+	 *
+	 * @phpstan-var non-empty-string|null
+	 */
+	protected $object_type = null;
+
+	/**
+	 * Default alias corresponding to the object's DB table.
+	 *
+	 * @var string
+	 * @see PLL_Object_With_Language::join_clause()
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $db_default_alias;
+
+	/**
+	 * Name of the DB column containing the object's ID.
+	 *
+	 * @var string
+	 * @see PLL_Object_With_Language::join_clause()
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $db_id_column;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.4
+	 *
+	 * @param PLL_Model $model Instance of `PLL_Model`, passed by reference.
+	 */
+	public function __construct( PLL_Model &$model ) {
+		$this->model          = $model;
+		$this->tax_to_cache[] = $this->tax_language;
+
+		/*
+		 * Register our taxonomy as soon as possible.
+		 * This is early registration, not ready for rewrite rules as $wp_rewrite will be setup later.
+		 */
+		register_taxonomy(
+			$this->tax_language,
+			(array) $this->object_type,
+			array(
+				'label'     => false,
+				'public'    => false,
+				'query_var' => false,
+				'rewrite'   => false,
+				'_pll'      => true,
+			)
+		);
+	}
+
+	/**
+	 * Returns the language taxonomy name.
+	 *
+	 * @since 3.4
+	 *
+	 * @return string
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_tax_language() {
+		return $this->tax_language;
+	}
+
+	/**
+	 * Returns the type of object.
+	 *
+	 * @since 3.4
+	 *
+	 * @return string
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_type() {
+		return $this->type;
+	}
+
+	/**
+	 * Add hooks.
+	 *
+	 * @since 3.4
+	 *
+	 * @return static
+	 */
+	public function init() {
+		return $this;
+	}
+
+	/**
+	 * Stores the object's language into the database.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int                     $id   Object ID.
+	 * @param PLL_Language|string|int $lang Language (object, slug, or term ID).
+	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+	 *              the object).
+	 */
+	public function set_language( $id, $lang ) {
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		$old_lang = $this->get_language( $id );
+		$old_lang = $old_lang ? $old_lang->get_tax_prop( $this->tax_language, 'term_id' ) : 0;
+
+		$lang = $this->model->get_language( $lang );
+		$lang = $lang ? $lang->get_tax_prop( $this->tax_language, 'term_id' ) : 0;
+
+		if ( $old_lang === $lang ) {
+			return false;
+		}
+
+		return is_array( wp_set_object_terms( $id, $lang, $this->tax_language ) );
+	}
+
+	/**
+	 * Assigns a new language to an object.
+	 *
+	 * @since 3.1
+	 *
+	 * @param int          $id   Object ID.
+	 * @param PLL_Language $lang New language to assign to the object.
+	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+	 *              the object).
+	 */
+	public function update_language( $id, PLL_Language $lang ) {
+		return $this->set_language( $id, $lang );
+	}
+
+	/**
+	 * Returns the language of an object.
+	 *
+	 * @since 0.1
+	 * @since 3.4 Renamed the parameter $post_id into $id.
+	 *
+	 * @param int $id Object ID.
+	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that object or if the
+	 *                            ID is invalid.
+	 */
+	public function get_language( $id ) {
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		// Get the language and make sure it is a PLL_Language object.
+		$lang = $this->get_object_term( $id, $this->tax_language );
+
+		if ( empty( $lang ) ) {
+			return false;
+		}
+
+		return $this->model->get_language( $lang );
+	}
+
+	/**
+	 * Removes the term language from the database.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int $id Term ID.
+	 * @return void
+	 */
+	public function delete_language( $id ) {
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return;
+		}
+
+		wp_delete_object_term_relationships( $id, $this->tax_language );
+	}
+
+	/**
+	 * Wraps `wp_get_object_terms()` to cache it and return only one object.
+	 * Inspired by the WordPress function `get_the_terms()`.
+	 *
+	 * @since 1.2
+	 *
+	 * @param int    $id       Object ID.
+	 * @param string $taxonomy Polylang taxonomy depending if we are looking for a post (or term, or else) language.
+	 * @return WP_Term|false The term associated to the object in the requested taxonomy if it exists, `false` otherwise.
+	 */
+	public function get_object_term( $id, $taxonomy ) {
+		global $wp_version;
+
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		$term = get_object_term_cache( $id, $taxonomy );
+
+		if ( is_array( $term ) ) {
+			return ! empty( $term ) ? reset( $term ) : false;
+		}
+
+		// Query terms.
+		$terms        = array();
+		$term         = false;
+		$object_terms = wp_get_object_terms( $id, $this->tax_to_cache, array( 'update_term_meta_cache' => false ) );
+
+		if ( is_array( $object_terms ) ) {
+			foreach ( $object_terms as $t ) {
+				$terms[ $t->taxonomy ] = $t;
+				if ( $t->taxonomy === $taxonomy ) {
+					$term = $t;
+				}
+			}
+		}
+
+		// Stores it the way WP expects it. Set an empty cache if no term was found in the taxonomy.
+		$store_only_term_ids = version_compare( $wp_version, '6.0', '>=' );
+
+		foreach ( $this->tax_to_cache as $tax ) {
+			if ( empty( $terms[ $tax ] ) ) {
+				$to_cache = array();
+			} elseif ( $store_only_term_ids ) {
+				$to_cache = array( $terms[ $tax ]->term_id );
+			} else {
+				// Backward compatibility with WP < 6.0.
+				$to_cache = array( $terms[ $tax ] );
+			}
+
+			wp_cache_add( $id, $to_cache, "{$tax}_relationships" );
+		}
+
+		return $term;
+	}
+
+	/**
+	 * A JOIN clause to add to sql queries when filtering by language is needed directly in query.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $alias Optional alias for object table.
+	 * @return string The JOIN clause.
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	public function join_clause( $alias = '' ) {
+		global $wpdb;
+
+		if ( empty( $alias ) ) {
+			$alias = $this->db_default_alias;
+		}
+
+		return " INNER JOIN {$wpdb->term_relationships} AS pll_tr ON pll_tr.object_id = {$alias}.{$this->db_id_column}";
+	}
+
+	/**
+	 * A WHERE clause to add to sql queries when filtering by language is needed directly in query.
+	 *
+	 * @since 1.2
+	 *
+	 * @param PLL_Language|PLL_Language[]|string|string[] $lang A `PLL_Language` object, or a comma separated list of language slugs, or an array of language slugs or objects.
+	 * @return string The WHERE clause.
+	 *
+	 * @phpstan-param PLL_Language|PLL_Language[]|non-empty-string|non-empty-string[] $lang
+	 */
+	public function where_clause( $lang ) {
+		/*
+		 * $lang is an object.
+		 * This is generally the case if the query is coming from Polylang.
+		 */
+		if ( $lang instanceof PLL_Language ) {
+			return ' AND pll_tr.term_taxonomy_id = ' . absint( $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ) );
+		}
+
+		/*
+		 * $lang is an array of objects, an array of slugs, or a comma separated list of slugs.
+		 * The comma separated list of slugs can happen if the query is coming from outside with a 'lang' parameter.
+		 */
+		$languages        = is_array( $lang ) ? $lang : explode( ',', $lang );
+		$languages_tt_ids = array();
+
+		foreach ( $languages as $language ) {
+			$language = $this->model->get_language( $language );
+
+			if ( ! empty( $language ) ) {
+				$languages_tt_ids[] = absint( $language->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ) );
+			}
+		}
+
+		if ( empty( $languages_tt_ids ) ) {
+			return '';
+		}
+
+		return ' AND pll_tr.term_taxonomy_id IN ( ' . implode( ',', $languages_tt_ids ) . ' )';
+	}
+
+	/**
+	 * Returns object types that need to be translated.
+	 *
+	 * @since 3.4
+	 *
+	 * @param bool $filter True if we should return only valid registered object types.
+	 * @return string[] Object type names for which Polylang manages languages.
+	 *
+	 * @phpstan-return array<non-empty-string, non-empty-string>
+	 */
+	abstract public function get_translated_object_types( $filter = true );
+
+	/**
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	abstract public function is_translated_object_type( $object_type );
+
+	/**
+	 * Returns the IDs of the objects without language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string[] $object_types An array of object types.
+	 * @param int      $limit        Max number of objects to return. `-1` to return all of them.
+	 * @return int[] Array of object IDs.
+	 *
+	 * @phpstan-param non-empty-string[] $object_types
+	 * @phpstan-param -1|positive-int $limit
+	 * @phpstan-return list<positive-int>
+	 */
+	abstract public function get_objects_with_no_lang( array $object_types, $limit );
+
+	/**
+	 * Sanitizes an ID as positive integer.
+	 * Kind of similar to `absint()`, but rejects negetive integers instead of making them positive.
+	 *
+	 * @since 3.2
+	 *
+	 * @param mixed $id A supposedly numeric ID.
+	 * @return int A positive integer. `0` for non numeric values and negative integers.
+	 *
+	 * @phpstan-return int<0,max>
+	 */
+	public function sanitize_int_id( $id ) {
+		return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
+	}
+
+	/**
+	 * Sanitizes an array of IDs as positive integers.
+	 * `0` values are removed.
+	 *
+	 * @since 3.2
+	 *
+	 * @param mixed $ids An array of numeric IDs.
+	 * @return int[]
+	 *
+	 * @phpstan-return array<positive-int>
+	 */
+	public function sanitize_int_ids_list( $ids ) {
+		if ( empty( $ids ) || ! is_array( $ids ) ) {
+			return array();
+		}
+
+		$ids = array_map( array( $this, 'sanitize_int_id' ), $ids );
+
+		return array_filter( $ids );
+	}
+}

--- a/include/object-with-language.php
+++ b/include/object-with-language.php
@@ -76,12 +76,7 @@ abstract class PLL_Object_With_Language {
 	 *     default_alias: non-empty-string,
 	 * }
 	 */
-	protected $db = array(
-		'table'         => null,
-		'id_column'     => null,
-		'type_column'   => null,
-		'default_alias' => null,
-	);
+	protected $db;
 
 	/**
 	 * Constructor.

--- a/include/translatable-object-with-types-interface.php
+++ b/include/translatable-object-with-types-interface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface to use for objects that can have one or more types.
+ *
+ * @since 3.4
+ */
+interface PLL_Translatable_Object_With_Types_Interface {
+
+	/**
+	 * Returns object types that need to be translated.
+	 *
+	 * @since 3.4
+	 *
+	 * @param bool $filter True if we should return only valid registered object types.
+	 * @return string[] Object type names for which Polylang manages languages.
+	 *
+	 * @phpstan-return array<non-empty-string, non-empty-string>
+	 */
+	public function get_translated_object_types( $filter = true );
+
+	/**
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	public function is_translated_object_type( $object_type );
+}

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait to use for objects that can have one or more types.
+ * This must be used with {@see PLL_Translatable_Object_With_Types_Interface}.
+ *
+ * @since 3.4
+ *
+ * @property string[] $db {
+ *     @type string $table         Name of the table.
+ *     @type string $id_column     Name of the column containing the object's ID.
+ *     @type string $type_column   Name of the column containing the object's type.
+ *     @type string $default_alias Default alias corresponding to the object's table.
+ * }
+ *
+ * @phpstan-property array{
+ *     table: non-empty-string,
+ *     id_column: non-empty-string,
+ *     type_column: non-empty-string,
+ *     default_alias: non-empty-string
+ * } $db
+ */
+trait PLL_Translatable_Object_With_Types_Trait {
+
+	/**
+	 * Returns SQL query that fetches the IDs of the objects without language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int[] $language_ids List of language `term_taxonomy_id`.
+	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @return string
+	 *
+	 * @phpstan-param array<positive-int> $language_ids
+	 * @phpstan-param -1|positive-int $limit
+	 */
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit ) {
+		$object_types = $this->get_translated_object_types();
+
+		if ( empty( $object_types ) ) {
+			return '';
+		}
+
+		return sprintf(
+			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
+			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (
+				SELECT object_id FROM {$GLOBALS['wpdb']->term_relationships} WHERE term_taxonomy_id IN (%s)
+			)
+			AND {$this->db['type_column']} IN (%s)
+			%s",
+			PLL_Db_Tools::prepare_values_list( $language_ids ),
+			PLL_Db_Tools::prepare_values_list( $object_types ),
+			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
+		);
+	}
+}

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -212,7 +212,7 @@ abstract class PLL_Translatable_Object {
 			return false;
 		}
 
-		return $this->model->get_language( $lang );
+		return $this->model->get_language( $lang->term_id );
 	}
 
 	/**

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.4
  */
-abstract class PLL_Object_With_Language {
+abstract class PLL_Translatable_Object {
 
 	/**
 	 * @var PLL_Model
@@ -21,7 +21,7 @@ abstract class PLL_Object_With_Language {
 	 * List of taxonomies to cache.
 	 *
 	 * @var string[]
-	 * @see PLL_Object_With_Language::get_object_term()
+	 * @see PLL_Translatable_Object::get_object_term()
 	 *
 	 * @phpstan-var list<non-empty-string>
 	 */
@@ -66,8 +66,8 @@ abstract class PLL_Object_With_Language {
 	 *     @type string $type_column   Name of the column containing the object's type.
 	 *     @type string $default_alias Default alias corresponding to the object's table.
 	 * }
-	 * @see PLL_Object_With_Language::join_clause()
-	 * @see PLL_Object_With_Language::get_objects_with_no_lang()
+	 * @see PLL_Translatable_Object::join_clause()
+	 * @see PLL_Translatable_Object::get_objects_with_no_lang()
 	 *
 	 * @phpstan-var array{
 	 *     table: non-empty-string,

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -313,10 +313,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 			return 0;
 		}
 
-		$lang_term_id     = $lang->get_tax_prop( $this->get_tax_language(), 'term_id' );
-		$obj_lang_term_id = $obj_lang->get_tax_prop( $this->get_tax_language(), 'term_id' );
-
-		return $lang_term_id === $obj_lang_term_id ? $id : (int) $this->get_translation( $id, $lang );
+		return $obj_lang->term_id === $lang->term_id ? $id : (int) $this->get_translation( $id, $lang );
 	}
 
 	/**

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -45,7 +45,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 				'query_var'             => false,
 				'rewrite'               => false,
 				'_pll'                  => true,
-				'update_count_callback' => '_update_generic_term_count', // Count *all* objects to avoid deleting in clean_translations_terms.
+				'update_count_callback' => '_update_generic_term_count', // Count *all* objects to correctly detect unused terms.
 			)
 		);
 	}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -22,15 +22,6 @@ abstract class PLL_Translated_Object extends PLL_Object_With_Language {
 	protected $tax_translations;
 
 	/**
-	 * Object type to use when checking capabilities.
-	 *
-	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
-	 */
-	protected $cap_type;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 1.8
@@ -351,18 +342,18 @@ abstract class PLL_Translated_Object extends PLL_Object_With_Language {
 		 *                         Defaults to true.
 		 * @param int       $id    The synchronization source object ID.
 		 */
-		$check = apply_filters( "pll_pre_current_user_can_synchronize_{$this->cap_type}", true, $id );
+		$check = apply_filters( "pll_pre_current_user_can_synchronize_{$this->type}", true, $id );
 
 		if ( null !== $check ) {
 			return (bool) $check;
 		}
 
-		if ( ! current_user_can( "edit_{$this->cap_type}", $id ) ) {
+		if ( ! current_user_can( "edit_{$this->type}", $id ) ) {
 			return false;
 		}
 
 		foreach ( $this->get_translations( $id ) as $tr_id ) {
-			if ( $tr_id !== $id && ! current_user_can( "edit_{$this->cap_type}", $tr_id ) ) {
+			if ( $tr_id !== $id && ! current_user_can( "edit_{$this->type}", $tr_id ) ) {
 				return false;
 			}
 		}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -3,188 +3,113 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
- * Setups the objects languages and translations model.
+ * Abstract class to use for object types that support translations.
  *
  * @since 1.8
  */
-abstract class PLL_Translated_Object {
-	/**
-	 * @var PLL_Model
-	 */
-	public $model;
-
-	/**
-	 * Object type to use when registering the taxonomies.
-	 * Left empty for posts.
-	 *
-	 * @var string|null
-	 */
-	protected $object_type;
-
-	/**
-	 * Object type to use when checking capabilities.
-	 *
-	 * @var string
-	 */
-	protected $type;
-
-	/**
-	 * Taxonomy name for the languages.
-	 *
-	 * @var string
-	 */
-	protected $tax_language;
+abstract class PLL_Translated_Object extends PLL_Object_With_Language {
 
 	/**
 	 * Taxonomy name for the translation groups.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	protected $tax_translations;
 
 	/**
-	 * PLL_Language property name for the term_taxonomy id.
+	 * Object type to use when checking capabilities.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
-	protected $tax_tt;
+	protected $cap_type;
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Model $model Instance of PLL_Model.
+	 * @param PLL_Model $model Instance of `PLL_Model`.
 	 */
-	public function __construct( &$model ) {
-		$this->model = &$model;
+	public function __construct( PLL_Model &$model ) {
+		parent::__construct( $model );
+
+		$this->tax_to_cache[] = $this->tax_translations;
 
 		/*
-		 * Register our taxonomies as soon as possible.
-		 * This is early registration, not ready for rewrite rules as $wp_rewrite will be setup later.
+		 * Register our taxonomy as soon as possible.
 		 */
-		$args = array( 'label' => false, 'public' => false, 'query_var' => false, 'rewrite' => false, '_pll' => true );
-		register_taxonomy( $this->tax_language, $this->object_type, $args );
-		$args['update_count_callback'] = '_update_generic_term_count'; // Count *all* objects to avoid deleting in clean_translations_terms.
-		register_taxonomy( $this->tax_translations, $this->object_type, $args );
+		register_taxonomy(
+			$this->tax_translations,
+			(array) $this->object_type,
+			array(
+				'label'                 => false,
+				'public'                => false,
+				'query_var'             => false,
+				'rewrite'               => false,
+				'_pll'                  => true,
+				'update_count_callback' => '_update_generic_term_count', // Count *all* objects to avoid deleting in clean_translations_terms.
+			)
+		);
 	}
 
 	/**
-	 * Stores the language in the database.
+	 * Returns the translations group taxonomy name.
 	 *
-	 * @since 0.6
+	 * @since 3.4
 	 *
-	 * @param int                     $id   Object id.
-	 * @param int|string|PLL_Language $lang Language (term_id or slug or object).
-	 * @return void
+	 * @return string
+	 *
+	 * @phpstan-return non-empty-string
 	 */
-	abstract public function set_language( $id, $lang );
-
-	/**
-	 * Returns the language of an object.
-	 *
-	 * @since 0.1
-	 *
-	 * @param int $id Object id.
-	 * @return PLL_Language|false PLL_Language object, false if no language is associated to that object.
-	 */
-	abstract public function get_language( $id );
+	public function get_tax_translations() {
+		return $this->tax_translations;
+	}
 
 	/**
 	 * Assigns a new language to an object, taking care of the translations group.
 	 *
 	 * @since 3.1
 	 *
-	 * @param int          $id   Object id.
+	 * @param int          $id   Object ID.
 	 * @param PLL_Language $lang New language to assign to the object.
-	 * @return void
+	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+	 *              the object).
 	 */
-	public function update_language( $id, $lang ) {
-		$id = $this->sanitize_int_id( $id );
-
-		if ( empty( $id ) || $this->get_language( $id ) === $lang ) {
-			return;
-		}
-
-		$this->set_language( $id, $lang );
-
-		$translations = $this->get_translations( $id );
-
-		if ( $translations ) {
-			// Remove the post's former language from the new translations group.
-			$translations = array_diff( $translations, array( $id ) );
-			$this->save_translations( $id, $translations );
-		}
-	}
-
-	/**
-	 * Wraps wp_get_object_terms() to cache it and return only one object.
-	 * Inspired by the WordPress function get_the_terms().
-	 *
-	 * @since 1.2
-	 *
-	 * @param int    $object_id Object id ( typically a post_id or term_id ).
-	 * @param string $taxonomy  Polylang taxonomy depending if we are looking for a post ( or term ) language ( or translation ).
-	 * @return WP_Term|false The term associated to the object in the requested taxonomy if it exists, false otherwise.
-	 */
-	public function get_object_term( $object_id, $taxonomy ) {
-		global $wp_version;
-
-		$object_id = $this->sanitize_int_id( $object_id );
-
-		if ( empty( $object_id ) ) {
+	public function update_language( $id, PLL_Language $lang ) {
+		if ( ! $this->set_language( $id, $lang ) ) {
 			return false;
 		}
 
-		$term = get_object_term_cache( $object_id, $taxonomy );
+		$id = $this->sanitize_int_id( $id );
 
-		if ( is_array( $term ) ) {
-			return ! empty( $term ) ? reset( $term ) : false;
+		$translations = $this->get_translations( $id );
+
+		// Don't create translation groups with only 1 value.
+		if ( ! empty( $translations ) ) {
+			// Remove the object's former language from the new translations group before adding the new value.
+			$translations = array_diff( $translations, array( $id ) );
+			$this->save_translations( $id, $translations );
 		}
 
-		// Query language and translations at the same time.
-		$taxonomies = array( $this->tax_language, $this->tax_translations );
-
-		// Query terms.
-		$terms        = array();
-		$term         = false;
-		$object_terms = wp_get_object_terms( $object_id, $taxonomies, array( 'update_term_meta_cache' => false ) );
-
-		if ( is_array( $object_terms ) ) {
-			foreach ( $object_terms as $t ) {
-				$terms[ $t->taxonomy ] = $t;
-				if ( $t->taxonomy === $taxonomy ) {
-					$term = $t;
-				}
-			}
-		}
-
-		// Stores it the way WP expects it. Set an empty cache if no term was found in the taxonomy.
-		$store_only_term_ids = version_compare( $wp_version, '6.0', '>=' );
-		foreach ( $taxonomies as $tax ) {
-			if ( empty( $terms[ $tax ] ) ) {
-				$to_cache = array();
-			} elseif ( $store_only_term_ids ) {
-				$to_cache = array( $terms[ $tax ]->term_id );
-			} else {
-				// Backward compatibility with WP < 6.0.
-				$to_cache = array( $terms[ $tax ] );
-			}
-
-			wp_cache_add( $object_id, $to_cache, $tax . '_relationships' );
-		}
-
-		return $term;
+		return true;
 	}
 
 	/**
-	 * Returns a list of post translations, given a `tax_translations` term ID.
+	 * Returns a list of object translations, given a `tax_translations` term ID.
 	 *
 	 * @since 3.2
 	 *
-	 * @param int $term_id Term ID.
-	 * @return int[] An associative array of translations with language code as key and translation id as value.
+	 * @param int $term_id A `tax_translations` term ID.
+	 * @return int[] An associative array of translations with language code as key and translation ID as value.
+	 *
+	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	public function get_translations_from_term_id( $term_id ) {
 		$term_id = $this->sanitize_int_id( $term_id );
@@ -199,38 +124,24 @@ abstract class PLL_Translated_Object {
 			return array();
 		}
 
-		// Lang slugs as array keys, template IDs as array values.
+		// Lang slugs as array keys, translation IDs as array values.
 		$translations = maybe_unserialize( $translations_term->description );
 
 		return $this->validate_translations( $translations, 0, 'display' );
 	}
 
 	/**
-	 * Tells whether a translation term must be updated.
-	 *
-	 * @since 2.3
-	 *
-	 * @param int   $id           Object id ( typically a post_id or term_id ).
-	 * @param int[] $translations An associative array of translations with language code as key and translation id as
-	 *                            value. Make sure to sanitize this.
-	 * @return bool
-	 */
-	protected function should_update_translation_group( $id, $translations ) {
-		// Don't do anything if no translations have been added to the group.
-		$old_translations = $this->get_translations( $id ); // Includes at least $id itself.
-		return ! empty( array_diff_assoc( $translations, $old_translations ) );
-	}
-
-	/**
-	 * Saves translations for posts or terms.
+	 * Saves the object's translations.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int   $id           Object id ( typically a post_id or term_id ).
-	 * @param int[] $translations An associative array of translations with language code as key and translation id as value.
-	 * @return int[] An associative array with language codes as key and post ids as values.
+	 * @param int   $id           Object ID.
+	 * @param int[] $translations An associative array of translations with language code as key and translation ID as value.
+	 * @return int[] An associative array with language codes as key and object IDs as values.
+	 *
+	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
-	public function save_translations( $id, $translations ) {
+	public function save_translations( $id, array $translations = array() ) {
 		$id = $this->sanitize_int_id( $id );
 
 		if ( empty( $id ) ) {
@@ -249,11 +160,11 @@ abstract class PLL_Translated_Object {
 		// Unlink removed translations.
 		$old_translations = $this->get_translations( $id );
 
-		foreach ( array_diff_assoc( $old_translations, $translations ) as $object_id ) {
-			$this->delete_translation( $object_id );
+		foreach ( array_diff_assoc( $old_translations, $translations ) as $id ) {
+			$this->delete_translation( $id );
 		}
 
-		// Check id we need to create or update the translation group.
+		// Check ID we need to create or update the translation group.
 		if ( ! $this->should_update_translation_group( $id, $translations ) ) {
 			return $translations;
 		}
@@ -297,11 +208,11 @@ abstract class PLL_Translated_Object {
 	}
 
 	/**
-	 * Deletes a translation of a post or term.
+	 * Deletes a translation of an object.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int $id Object id ( typically a post_id or term_id ).
+	 * @param int $id Object ID.
 	 * @return void
 	 */
 	public function delete_translation( $id ) {
@@ -335,12 +246,14 @@ abstract class PLL_Translated_Object {
 	}
 
 	/**
-	 * Returns an array of translations of a post or term.
+	 * Returns an array of translations of an object.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int $id Object id ( typically a post_id or term_id ).
-	 * @return int[] An associative array of translations with language code as key and translation id as value.
+	 * @param int $id Object ID.
+	 * @return int[] An associative array of translations with language code as key and translation ID as value.
+	 *
+	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	public function get_translations( $id ) {
 		$id = $this->sanitize_int_id( $id );
@@ -356,13 +269,15 @@ abstract class PLL_Translated_Object {
 	}
 
 	/**
-	 * Returns the id of the translation of a post or term.
+	 * Returns the ID of the translation of an object.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int                 $id   Object id ( typically a post_id or term_id ).
-	 * @param PLL_Language|string $lang Language ( slug or object ).
-	 * @return int|false Object id of the translation, false if there is none.
+	 * @param int                 $id   Object ID.
+	 * @param PLL_Language|string $lang Language (slug or object).
+	 * @return int|false Object ID of the translation, `false` if there is none.
+	 *
+	 * @phpstan-return positive-int|false
 	 */
 	public function get_translation( $id, $lang ) {
 		$lang = $this->model->get_language( $lang );
@@ -377,84 +292,37 @@ abstract class PLL_Translated_Object {
 	}
 
 	/**
-	 * Among the object and its translations, returns the id of the object which is in $lang
+	 * Among the object and its translations, returns the ID of the object which is in `$lang`.
 	 *
 	 * @since 0.1
+	 * @since 3.4 Returns 0 instead of false.
 	 *
-	 * @param int                     $id   Object id ( typically a post_id or term_id ).
-	 * @param int|string|PLL_Language $lang Language ( term_id or slug or object ).
-	 * @return int|false The translation object id if exists, otherwise the passed id, false if the passed object has no language.
+	 * @param int                     $id   Object ID.
+	 * @param PLL_Language|string|int $lang Language (object, slug, or term ID).
+	 * @return int The translation object ID if exists, otherwise the passed ID. `0` if the passed object has no language.
+	 *
+	 * @phpstan-return int<0, max>
 	 */
 	public function get( $id, $lang ) {
 		$id = $this->sanitize_int_id( $id );
 
 		if ( empty( $id ) ) {
-			return false;
+			return 0;
 		}
 
 		$lang = $this->model->get_language( $lang );
 
 		if ( empty( $lang ) ) {
-			return false;
+			return 0;
 		}
 
 		$obj_lang = $this->get_language( $id );
 
 		if ( empty( $obj_lang ) ) {
-			return false;
+			return 0;
 		}
 
-		return $obj_lang->term_id === $lang->term_id ? $id : $this->get_translation( $id, $lang );
-	}
-
-	/**
-	 * A join clause to add to sql queries when filtering by language is needed directly in query.
-	 *
-	 * @since 1.2
-	 *
-	 * @param string $alias Optional alias for object table.
-	 * @return string Join clause.
-	 */
-	abstract public function join_clause( $alias = '' );
-
-	/**
-	 * A where clause to add to sql queries when filtering by language is needed directly in query.
-	 *
-	 * @since 1.2
-	 *
-	 * @param PLL_Language|PLL_Language[]|string|string[] $lang PLL_Language object or a comma separated list of language slug or an array of language slugs or objects.
-	 * @return string Where clause.
-	 */
-	public function where_clause( $lang ) {
-		$tt_id = $this->tax_tt;
-
-		/*
-		 * $lang is an object.
-		 * This is generally the case if the query is coming from Polylang.
-		 */
-		if ( is_object( $lang ) ) {
-			return ' AND pll_tr.term_taxonomy_id = ' . absint( $lang->$tt_id );
-		}
-
-		/*
-		 * $lang is an array of objects, an array of slugs, or a comma separated list of slugs.
-		 * The comma separated list of slugs can happen if the query is coming from outside with a 'lang' parameter.
-		 */
-		$languages        = is_array( $lang ) ? $lang : explode( ',', $lang );
-		$languages_tt_ids = array();
-		foreach ( $languages as $language ) {
-			$language = $this->model->get_language( $language );
-
-			if ( ! empty( $language ) ) {
-				$languages_tt_ids[] = absint( $language->$tt_id );
-			}
-		}
-
-		if ( empty( $languages_tt_ids ) ) {
-			return '';
-		}
-
-		return ' AND pll_tr.term_taxonomy_id IN ( ' . implode( ',', $languages_tt_ids ) . ' )';
+		return $obj_lang->get_tax_prop( 'language', 'term_id' ) === $lang->get_tax_prop( 'language', 'term_id' ) ? $id : (int) $this->get_translation( $id, $lang );
 	}
 
 	/**
@@ -462,7 +330,7 @@ abstract class PLL_Translated_Object {
 	 *
 	 * @since 2.6
 	 *
-	 * @param int $id Object id.
+	 * @param int $id Object ID.
 	 * @return bool
 	 */
 	public function current_user_can_synchronize( $id ) {
@@ -481,20 +349,20 @@ abstract class PLL_Translated_Object {
 		 *                         true to always allow the synchronization,
 		 *                         false to always disallow the synchronization.
 		 *                         Defaults to true.
-		 * @param int       $id    The synchronization source object id.
+		 * @param int       $id    The synchronization source object ID.
 		 */
-		$check = apply_filters( "pll_pre_current_user_can_synchronize_{$this->type}", true, $id );
+		$check = apply_filters( "pll_pre_current_user_can_synchronize_{$this->cap_type}", true, $id );
 
 		if ( null !== $check ) {
 			return (bool) $check;
 		}
 
-		if ( ! current_user_can( "edit_{$this->type}", $id ) ) {
+		if ( ! current_user_can( "edit_{$this->cap_type}", $id ) ) {
 			return false;
 		}
 
 		foreach ( $this->get_translations( $id ) as $tr_id ) {
-			if ( $tr_id !== $id && ! current_user_can( "edit_{$this->type}", $tr_id ) ) {
+			if ( $tr_id !== $id && ! current_user_can( "edit_{$this->cap_type}", $tr_id ) ) {
 				return false;
 			}
 		}
@@ -503,37 +371,21 @@ abstract class PLL_Translated_Object {
 	}
 
 	/**
-	 * Sanitizes an ID as positive integer.
-	 * Kind of similar to `absint()`, but rejects negetive integers instead of making them positive.
+	 * Tells whether a translation term must be updated.
 	 *
-	 * @since 3.2
+	 * @since 2.3
 	 *
-	 * @param mixed $id A supposedly numeric ID.
-	 * @return int A positive integer. `0` for non numeric values and negative integers.
+	 * @param int   $id           Object ID.
+	 * @param int[] $translations An associative array of translations with language code as key and translation ID as
+	 *                            value. Make sure to sanitize this.
+	 * @return bool
 	 *
-	 * @phpstan-return int<0,max>
+	 * @phpstan-param array<non-empty-string, positive-int> $translations
 	 */
-	public function sanitize_int_id( $id ) {
-		return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
-	}
-
-	/**
-	 * Sanitizes an array of IDs as positive integers.
-	 * `0` values are removed.
-	 *
-	 * @since 3.2
-	 *
-	 * @param mixed $ids An associative array of translations with language code as key and translation ID as value.
-	 * @return int[] An associative array of translations with language code as key and translation ID as value.
-	 */
-	public function sanitize_int_ids_list( $ids ) {
-		if ( empty( $ids ) || ! is_array( $ids ) ) {
-			return array();
-		}
-
-		$ids = array_map( array( $this, 'sanitize_int_id' ), $ids );
-
-		return array_filter( $ids );
+	protected function should_update_translation_group( $id, $translations ) {
+		// Don't do anything if no translations have been added to the group.
+		$old_translations = $this->get_translations( $id ); // Includes at least $id itself.
+		return ! empty( array_diff_assoc( $translations, $old_translations ) );
 	}
 
 	/**
@@ -556,6 +408,9 @@ abstract class PLL_Translated_Object {
 	 *                             'save', a check is done to verify that the IDs and langs correspond.
 	 *                             'display' should be used otherwise. Default 'save'.
 	 * @return int[]
+	 *
+	 * @phpstan-param non-empty-string $context
+	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	protected function validate_translations( $translations, $id = 0, $context = 'save' ) {
 		if ( ! is_array( $translations ) ) {
@@ -572,6 +427,7 @@ abstract class PLL_Translated_Object {
 		);
 
 		// Make sure values are clean before working with them.
+		/** @phpstan-var array<non-empty-string, positive-int> $translations */
 		$translations = $this->sanitize_int_ids_list( $translations );
 
 		if ( 'save' === $context ) {
@@ -606,6 +462,7 @@ abstract class PLL_Translated_Object {
 			return $translations;
 		}
 
+		/** @phpstan-var array<non-empty-string, positive-int> */
 		return array_merge( array( $lang->slug => $id ), $translations );
 	}
 }

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.8
  */
-abstract class PLL_Translated_Object extends PLL_Object_With_Language {
+abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 
 	/**
 	 * Taxonomy name for the translation groups.

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -313,7 +313,10 @@ abstract class PLL_Translated_Object extends PLL_Object_With_Language {
 			return 0;
 		}
 
-		return $obj_lang->get_tax_prop( 'language', 'term_id' ) === $lang->get_tax_prop( 'language', 'term_id' ) ? $id : (int) $this->get_translation( $id, $lang );
+		$lang_term_id     = $lang->get_tax_prop( $this->get_tax_language(), 'term_id' );
+		$obj_lang_term_id = $obj_lang->get_tax_prop( $this->get_tax_language(), 'term_id' );
+
+		return $lang_term_id === $obj_lang_term_id ? $id : (int) $this->get_translation( $id, $lang );
 	}
 
 	/**

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -168,55 +168,6 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
-	 * Returns the IDs of the objects without language.
-	 *
-	 * @since 3.4
-	 *
-	 * @param int $limit Max number of objects to return. `-1` to return all of them.
-	 * @return int[] Array of object IDs.
-	 *
-	 * @phpstan-param -1|positive-int $limit
-	 * @phpstan-return list<positive-int>
-	 */
-	public function get_objects_with_no_lang( $limit ) {
-		$object_types = $this->get_translated_object_types();
-
-		if ( empty( $object_types ) ) {
-			return array();
-		}
-
-		$languages = $this->model->get_languages_list();
-
-		foreach ( $languages as $i => $language ) {
-			$languages[ $i ] = $language->get_tax_prop( $this->get_tax_language(), 'term_id' );
-		}
-
-		$languages = array_filter( $languages );
-
-		if ( empty( $languages ) ) {
-			return array();
-		}
-
-		/** @var list<positive-int> */
-		return get_posts(
-			array(
-				'numberposts' => $limit,
-				'nopaging'    => $limit <= 0,
-				'post_type'   => $object_types,
-				'post_status' => 'any',
-				'fields'      => 'ids',
-				'tax_query'   => array(
-					array(
-						'taxonomy' => $this->get_tax_language(),
-						'terms'    => $languages,
-						'operator' => 'NOT IN',
-					),
-				),
-			)
-		);
-	}
-
-	/**
 	 * Registers the language taxonomy.
 	 *
 	 * @since 1.2

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -12,6 +12,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
 
+	use PLL_Translatable_Object_With_Types_Trait;
+
 	/**
 	 * Taxonomy name for the languages.
 	 *

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -191,7 +191,13 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 			return array();
 		}
 
-		$languages = $this->model->get_languages_list( array( 'fields' => 'term_id' ) );
+		$languages = $this->model->get_languages_list();
+
+		foreach ( $languages as $i => $language ) {
+			$languages[ $i ] = $language->get_tax_prop( $this->get_tax_language(), 'term_id' );
+		}
+
+		$languages = array_filter( $languages );
 
 		if ( empty( $languages ) ) {
 			return array();

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -23,6 +23,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 
 	/**
 	 * Identifier that must be unique for each type of content.
+	 * Also used when checking capabilities.
 	 *
 	 * @var string
 	 *
@@ -38,15 +39,6 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 * @phpstan-var non-empty-string
 	 */
 	protected $tax_translations = 'post_translations';
-
-	/**
-	 * Object type to use when checking capabilities.
-	 *
-	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
-	 */
-	protected $cap_type = 'post';
 
 	/**
 	 * Constructor.

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -49,16 +49,6 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	protected $cap_type = 'post';
 
 	/**
-	 * Name of the DB column containing the post's ID.
-	 *
-	 * @var string
-	 * @see PLL_Object_With_Language::join_clause()
-	 *
-	 * @phpstan-var non-empty-string
-	 */
-	protected $db_id_column = 'ID';
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 1.8
@@ -66,7 +56,12 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 * @param PLL_Model $model Instance of `PLL_Model`.
 	 */
 	public function __construct( PLL_Model &$model ) {
-		$this->db_default_alias = $GLOBALS['wpdb']->posts;
+		$this->db = array(
+			'table'         => $GLOBALS['wpdb']->posts,
+			'id_column'     => 'ID',
+			'type_column'   => 'post_type',
+			'default_alias' => $GLOBALS['wpdb']->posts,
+		);
 
 		parent::__construct( $model );
 

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -205,7 +205,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 				'fields'      => 'ids',
 				'tax_query'   => array(
 					array(
-						'taxonomy' => 'language',
+						'taxonomy' => $this->get_tax_language(),
 						'terms'    => $languages,
 						'operator' => 'NOT IN',
 					),

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.8
  */
-class PLL_Translated_Post extends PLL_Translated_Object {
+class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
 
 	/**
 	 * Taxonomy name for the languages.
@@ -170,15 +170,15 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param string[] $object_types An array of object types (post types).
-	 * @param int      $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param int $limit Max number of objects to return. `-1` to return all of them.
 	 * @return int[] Array of object IDs.
 	 *
-	 * @phpstan-param non-empty-string[] $object_types
 	 * @phpstan-param -1|positive-int $limit
 	 * @phpstan-return list<positive-int>
 	 */
-	public function get_objects_with_no_lang( array $object_types, $limit ) {
+	public function get_objects_with_no_lang( $limit ) {
+		$object_types = $this->get_translated_object_types();
+
 		if ( empty( $object_types ) ) {
 			return array();
 		}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.8
  */
-class PLL_Translated_Term extends PLL_Translated_Object {
+class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
 
 	/**
 	 * Taxonomy name for the languages.

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -305,7 +305,13 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 			return array();
 		}
 
-		$languages = $this->model->get_languages_list( array( 'fields' => 'tl_term_taxonomy_id' ) );
+		$languages = $this->model->get_languages_list();
+
+		foreach ( $languages as $i => $language ) {
+			$languages[ $i ] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
+		}
+
+		$languages = array_filter( $languages );
 
 		if ( empty( $languages ) ) {
 			return array();

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -3,179 +3,338 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
- * Setups the taxonomies languages and translations model
+ * Sets the taxonomies languages and translations model up.
  *
  * @since 1.8
  */
 class PLL_Translated_Term extends PLL_Translated_Object {
 
 	/**
-	 * Constructor
+	 * Taxonomy name for the languages.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $tax_language = 'term_language';
+
+	/**
+	 * Object type to use when registering the taxonomy.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $object_type = 'term';
+
+	/**
+	 * Identifier that must be unique for each type of content.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $type = 'term';
+
+	/**
+	 * Taxonomy name for the translation groups.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $tax_translations = 'term_translations';
+
+	/**
+	 * Object type to use when checking capabilities.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $cap_type = 'term';
+
+	/**
+	 * Default alias corresponding to the term's DB table.
+	 *
+	 * @var string
+	 * @see PLL_Object_With_Language::join_clause()
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $db_default_alias = 't';
+
+	/**
+	 * Name of the DB column containing the term's ID.
+	 *
+	 * @var string
+	 * @see PLL_Object_With_Language::join_clause()
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $db_id_column = 'term_id';
+
+	/**
+	 * Constructor.
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $model
+	 * @param PLL_Model $model Instance of `PLL_Model`.
 	 */
-	public function __construct( &$model ) {
-		$this->object_type = 'term'; // For taxonomies
-		$this->type = 'term'; // For capabilities
-		$this->tax_language = 'term_language';
-		$this->tax_translations = 'term_translations';
-		$this->tax_tt = 'tl_term_taxonomy_id';
-
+	public function __construct( PLL_Model &$model ) {
 		parent::__construct( $model );
 
+		// Keep hooks in constructor for backward compatibility.
+		$this->init();
+	}
+
+	/**
+	 * Adds hooks.
+	 *
+	 * @since 3.4
+	 *
+	 * @return static
+	 */
+	public function init() {
 		add_filter( 'get_terms', array( $this, '_prime_terms_cache' ), 10, 2 );
 		add_action( 'clean_term_cache', array( $this, 'clean_term_cache' ) );
+		return parent::init();
 	}
 
 	/**
-	 * Stores the term language in the database.
+	 * Stores the term's language into the database.
 	 *
 	 * @since 0.6
+	 * @since 3.4 Renamed the parameter $term_id into $id.
 	 *
-	 * @param int                     $term_id Term id.
-	 * @param int|string|PLL_Language $lang    Language (term_id or slug or object).
-	 * @return void
+	 * @param int                     $id   Term ID.
+	 * @param PLL_Language|string|int $lang Language (object, slug, or term ID).
+	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+	 *              the object).
 	 */
-	public function set_language( $term_id, $lang ) {
-		$term_id = $this->sanitize_int_id( $term_id );
-
-		if ( empty( $term_id ) ) {
-			return;
+	public function set_language( $id, $lang ) {
+		if ( ! parent::set_language( $id, $lang ) ) {
+			return false;
 		}
 
-		$old_lang = $this->get_language( $term_id );
-		$old_lang = $old_lang ? $old_lang->tl_term_id : '';
-
-		$lang = $this->model->get_language( $lang );
-		$lang = $lang ? $lang->tl_term_id : '';
-
-		if ( $old_lang === $lang ) {
-			return;
-		}
-
-		wp_set_object_terms( $term_id, $lang, $this->tax_language );
+		$id = $this->sanitize_int_id( $id );
 
 		// Add translation group for correct WXR export.
-		$translations = $this->get_translations( $term_id );
-		$slug         = array_search( $term_id, $translations );
+		$translations = $this->get_translations( $id );
 
-		if ( ! empty( $slug ) ) {
-			unset( $translations[ $slug ] );
+		if ( ! empty( $translations ) ) {
+			$translations = array_diff( $translations, array( $id ) );
 		}
 
-		$this->save_translations( $term_id, $translations );
+		$this->save_translations( $id, $translations );
+
+		return true;
 	}
 
 	/**
-	 * Removes the term language in database
-	 *
-	 * @since 0.5
-	 *
-	 * @param int $term_id term id
-	 * @return void
-	 */
-	public function delete_language( $term_id ) {
-		wp_delete_object_term_relationships( $this->sanitize_int_id( $term_id ), $this->tax_language );
-	}
-
-	/**
-	 * Returns the language of a term
+	 * Returns the language of a term.
 	 *
 	 * @since 0.1
+	 * @since 3.4 Renamed the parameter $value into $id.
+	 * @since 3.4 Deprecated to retrieve the language by term slug + taxonomy anymore.
 	 *
-	 * @param int|string $value    term id or term slug
-	 * @param string     $taxonomy optional taxonomy needed when the term slug is passed as first parameter
-	 * @return PLL_Language|false PLL_Language object, false if no language is associated to that term
+	 * @param int $id Term ID.
+	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that term or if the
+	 *                            ID is invalid.
 	 */
-	public function get_language( $value, $taxonomy = '' ) {
-		if ( is_numeric( $value ) ) {
-			$term_id = $this->sanitize_int_id( $value );
+	public function get_language( $id ) {
+		if ( func_num_args() > 1 ) {
+			// Backward compatibility.
+			_deprecated_argument(
+				__METHOD__ . '()',
+				'3.4',
+				esc_html(
+					sprintf(
+						/* translators: %s is a function name. */
+						__( 'Please use %s instead.', 'polylang' ),
+						get_class( $this ) . '::get_language_by_term_slug( $slug, $taxonomy )'
+					)
+				)
+			);
+			return $this->get_language_by_term_slug( $id, func_get_arg( 1 ) ); // @phpstan-ignore-line
 		}
 
-		// get_term_by still not cached in WP 3.5.1 but internally, the function is always called by term_id
-		elseif ( is_string( $value ) && $taxonomy ) {
-			$term = get_term_by( 'slug', $value, $taxonomy );
-			if ( $term instanceof WP_Term ) {
-				$term_id = $term->term_id;
-			}
-		}
-
-		if ( empty( $term_id ) ) {
-			return false;
-		}
-
-		// Get the language and make sure it is a PLL_Language object.
-		$lang = $this->get_object_term( $term_id, $this->tax_language );
-
-		if ( empty( $lang ) ) {
-			return false;
-		}
-
-		return $this->model->get_language( $lang->term_id );
+		return parent::get_language( $id );
 	}
 
 	/**
-	 * Tells whether a translation term must updated.
+	 * Returns the language of a term by slug and taxonomy.
 	 *
-	 * @since 2.3
+	 * @since 3.4
 	 *
-	 * @param int   $id           Post id or term id.
-	 * @param int[] $translations An associative array of translations with language code as key and translation id as
-	 *                            value. Make sure to sanitize this.
-	 * @return bool
+	 * @param string $slug     Term slug.
+	 * @param string $taxonomy Taxonomy.
+	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that term.
 	 */
-	protected function should_update_translation_group( $id, $translations ) {
-		// Don't do anything if no translations have been added to the group
-		$old_translations = $this->get_translations( $id );
-		if ( count( $translations ) > 1 && ! empty( array_diff_assoc( $translations, $old_translations ) ) ) {
-			return true;
+	public function get_language_by_term_slug( $slug, $taxonomy ) {
+		if ( empty( $slug ) || empty( $taxonomy ) ) {
+			return false;
 		}
 
-		// But we need a translation group for terms to allow relationships remap when importing from a WXR file
-		$term = $this->get_object_term( $id, $this->tax_translations );
-		return empty( $term ) || ! empty( array_diff_assoc( $translations, $old_translations ) );
+		// `get_term_by()` still not cached in WP 3.5.1 but internally, the function is always called by term_id.
+		$term = get_term_by( 'slug', $slug, $taxonomy );
+
+		if ( ! $term instanceof WP_Term ) {
+			return false;
+		}
+
+		return parent::get_language( $term->term_id );
 	}
 
 	/**
-	 * Deletes a translation
+	 * Deletes a translation of a term.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int $id term id
+	 * @param int $id Term ID.
 	 * @return void
 	 */
 	public function delete_translation( $id ) {
 		global $wpdb;
-		$id   = $this->sanitize_int_id( $id );
-		$slug = array_search( $id, $this->get_translations( $id ) ); // in case some plugin stores the same value with different key
+
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return;
+		}
+
+		$slug = array_search( $id, $this->get_translations( $id ) ); // In case some plugin stores the same value with different key.
 
 		parent::delete_translation( $id );
 		wp_delete_object_term_relationships( $id, $this->tax_translations );
 
-		if ( ! doing_action( 'pre_delete_term' ) && $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM $wpdb->terms WHERE term_id = %d;", $id ) ) ) {
-			// Always keep a group for terms to allow relationships remap when importing from a WXR file
-			$group        = uniqid( 'pll_' );
-			$translations = array( $slug => $id );
-			wp_insert_term( $group, $this->tax_translations, array( 'description' => maybe_serialize( $translations ) ) );
-			wp_set_object_terms( $id, $group, $this->tax_translations );
+		if ( doing_action( 'pre_delete_term' ) ) {
+			return;
 		}
+
+		if ( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM $wpdb->terms WHERE term_id = %d;", $id ) ) ) {
+			return;
+		}
+
+		// Always keep a group for terms to allow relationships remap when importing from a WXR file.
+		$group        = uniqid( 'pll_' );
+		$translations = array( $slug => $id );
+		wp_insert_term( $group, $this->tax_translations, array( 'description' => maybe_serialize( $translations ) ) );
+		wp_set_object_terms( $id, $group, $this->tax_translations );
 	}
 
 	/**
-	 * A join clause to add to sql queries when filtering by language is needed directly in query
+	 * Returns object types (taxonomy names) that need to be translated.
+	 * The taxonomies list is cached for better better performance.
+	 * The method waits for 'after_setup_theme' to apply the cache to allow themes adding the filter in functions.php.
 	 *
-	 * @since 1.2
-	 * @since 2.6 The `$alias` parameter was added.
+	 * @since 3.4
 	 *
-	 * @param string $alias Alias for $wpdb->terms table
-	 * @return string join clause
+	 * @param bool $filter True if we should return only valid registered object types.
+	 * @return string[] Object type names for which Polylang manages languages.
+	 *
+	 * @phpstan-return array<non-empty-string, non-empty-string>
 	 */
-	public function join_clause( $alias = 't' ) {
+	public function get_translated_object_types( $filter = true ) {
+		$taxonomies = $this->model->cache->get( 'taxonomies' );
+
+		if ( false === $taxonomies ) {
+			$taxonomies = array( 'category' => 'category', 'post_tag' => 'post_tag' );
+
+			if ( ! empty( $this->model->options['taxonomies'] ) && is_array( $this->model->options['taxonomies'] ) ) {
+				$taxonomies = array_merge( $taxonomies, array_combine( $this->model->options['taxonomies'], $this->model->options['taxonomies'] ) );
+			}
+
+			/**
+			 * Filters the list of taxonomies available for translation.
+			 * The default are taxonomies which have the parameter ‘public’ set to true.
+			 * The filter must be added soon in the WordPress loading process:
+			 * in a function hooked to ‘plugins_loaded’ or directly in functions.php for themes.
+			 *
+			 * @since 0.8
+			 *
+			 * @param string[] $taxonomies  List of taxonomy names (as array keys and values).
+			 * @param bool     $is_settings True when displaying the list of custom taxonomies in Polylang settings.
+			 */
+			$taxonomies = apply_filters( 'pll_get_taxonomies', $taxonomies, false );
+
+			if ( did_action( 'after_setup_theme' ) ) {
+				$this->model->cache->set( 'taxonomies', $taxonomies );
+			}
+		}
+
+		/** @var array<non-empty-string, non-empty-string> $taxonomies */
+		return $filter ? array_intersect( $taxonomies, get_taxonomies() ) : $taxonomies;
+	}
+
+	/**
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type (taxonomy name) name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	public function is_translated_object_type( $object_type ) {
+		$taxonomies = $this->get_translated_object_types( false );
+		return ( is_array( $object_type ) && array_intersect( $object_type, $taxonomies ) || in_array( $object_type, $taxonomies ) );
+	}
+
+	/**
+	 * Returns the IDs of the objects without language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string[] $object_types An array of object types (toxonomies).
+	 * @param int      $limit        Max number of objects to return. `-1` to return all of them.
+	 * @return int[] Array of object IDs.
+	 *
+	 * @phpstan-param non-empty-string[] $object_types
+	 * @phpstan-param -1|positive-int $limit
+	 * @phpstan-return list<positive-int>
+	 */
+	public function get_objects_with_no_lang( array $object_types, $limit ) {
 		global $wpdb;
-		return " INNER JOIN $wpdb->term_relationships AS pll_tr ON pll_tr.object_id = $alias.term_id";
+
+		if ( empty( $object_types ) ) {
+			return array();
+		}
+
+		$languages = $this->model->get_languages_list( array( 'fields' => 'tl_term_taxonomy_id' ) );
+
+		if ( empty( $languages ) ) {
+			return array();
+		}
+
+		$sql = sprintf(
+			"SELECT {$wpdb->term_taxonomy}.{$this->db_id_column} FROM {$wpdb->term_taxonomy}
+			WHERE taxonomy IN (%s)
+			AND {$wpdb->term_taxonomy}.{$this->db_id_column} NOT IN (
+				SELECT object_id FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN (%s)
+			)
+			%s",
+			PLL_Db_Tools::prepare_values_list( $object_types ),
+			PLL_Db_Tools::prepare_values_list( $languages ),
+			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
+		);
+
+		$key          = md5( $sql );
+		$last_changed = wp_cache_get_last_changed( 'terms' );
+		$cache_key    = "terms_no_lang:{$key}:{$last_changed}";
+
+		$term_ids = wp_cache_get( $cache_key, 'terms' );
+
+		if ( ! is_array( $term_ids ) ) {
+			$term_ids = array_values( $this->sanitize_int_ids_list( $wpdb->get_col( $sql ) ) ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+			wp_cache_set( $cache_key, $term_ids, 'terms' );
+		}
+
+		return $term_ids;
 	}
 
 	/**
@@ -186,18 +345,22 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	 * @param WP_Term[]|int[] $terms      Queried terms.
 	 * @param string[]        $taxonomies Queried taxonomies.
 	 * @return WP_Term[]|int[] Unmodified $terms.
+	 *
+	 * @phpstan-param array<WP_Term|positive-int> $terms
+	 * @phpstan-param array<non-empty-string> $taxonomies
+	 * @phpstan-return array<WP_Term|positive-int>
 	 */
 	public function _prime_terms_cache( $terms, $taxonomies ) {
-		$term_ids = array();
+		$ids = array();
 
 		if ( is_array( $terms ) && $this->model->is_translated_taxonomy( $taxonomies ) ) {
 			foreach ( $terms as $term ) {
-				$term_ids[] = is_object( $term ) ? $term->term_id : (int) $term;
+				$ids[] = is_object( $term ) ? $term->term_id : (int) $term;
 			}
 		}
 
-		if ( ! empty( $term_ids ) ) {
-			update_object_term_cache( array_unique( $term_ids ), 'term' ); // Adds language and translation of terms to cache
+		if ( ! empty( $ids ) ) {
+			update_object_term_cache( array_unique( $ids ), 'term' ); // Adds language and translation of terms to cache.
 		}
 		return $terms;
 	}
@@ -209,8 +372,34 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	 *
 	 * @param int[] $ids An array of term IDs.
 	 * @return void
+	 *
+	 * @phpstan-param array<positive-int> $ids
 	 */
 	public function clean_term_cache( $ids ) {
 		clean_object_term_cache( $this->sanitize_int_ids_list( $ids ), 'term' );
+	}
+
+	/**
+	 * Tells whether a translation term must be updated.
+	 *
+	 * @since 2.3
+	 *
+	 * @param int   $id           Term ID.
+	 * @param int[] $translations An associative array of translations with language code as key and translation ID as
+	 *                            value. Make sure to sanitize this.
+	 * @return bool
+	 *
+	 * @phpstan-param array<non-empty-string, positive-int> $translations
+	 */
+	protected function should_update_translation_group( $id, $translations ) {
+		// Don't do anything if no translations have been added to the group.
+		$old_translations = $this->get_translations( $id );
+		if ( count( $translations ) > 1 && ! empty( array_diff_assoc( $translations, $old_translations ) ) ) {
+			return true;
+		}
+
+		// But we need a translation group for terms to allow relationships remap when importing from a WXR file
+		$term = $this->get_object_term( $id, $this->tax_translations );
+		return empty( $term ) || ! empty( array_diff_assoc( $translations, $old_translations ) );
 	}
 }

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -158,7 +158,6 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return false;
 		}
 
-		// `get_term_by()` still not cached in WP 3.5.1 but internally, the function is always called by term_id.
 		$term = get_term_by( 'slug', $slug, $taxonomy );
 
 		if ( ! $term instanceof WP_Term ) {

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -119,7 +119,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @since 0.1
 	 * @since 3.4 Renamed the parameter $value into $id.
 	 * @since 3.4 Deprecated to retrieve the language by term slug + taxonomy anymore.
-	 *
+	 * @custom-param int $id
 	 * @param int $id Term ID.
 	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that term or if the
 	 *                            ID is invalid.
@@ -127,44 +127,13 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	public function get_language( $id ) {
 		if ( func_num_args() > 1 ) {
 			// Backward compatibility.
-			_deprecated_argument(
-				__METHOD__ . '()',
-				'3.4',
-				esc_html(
-					sprintf(
-						/* translators: %s is a function name. */
-						__( 'Please use %s instead.', 'polylang' ),
-						get_class( $this ) . '::get_language_by_term_slug( $slug, $taxonomy )'
-					)
-				)
-			);
-			return $this->get_language_by_term_slug( $id, func_get_arg( 1 ) ); // @phpstan-ignore-line
+			_deprecated_argument( __METHOD__ . '()', '3.4' );
+
+			$term = get_term_by( 'slug', $id, func_get_arg( 1 ) ); // @phpstan-ignore-line
+			$id   = $term instanceof WP_Term ? $term->term_id : 0;
 		}
 
 		return parent::get_language( $id );
-	}
-
-	/**
-	 * Returns the language of a term by slug and taxonomy.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string $slug     Term slug.
-	 * @param string $taxonomy Taxonomy.
-	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that term.
-	 */
-	public function get_language_by_term_slug( $slug, $taxonomy ) {
-		if ( empty( $slug ) || empty( $taxonomy ) ) {
-			return false;
-		}
-
-		$term = get_term_by( 'slug', $slug, $taxonomy );
-
-		if ( ! $term instanceof WP_Term ) {
-			return false;
-		}
-
-		return parent::get_language( $term->term_id );
 	}
 
 	/**

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -12,6 +12,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
 
+	use PLL_Translatable_Object_With_Types_Trait;
+
 	/**
 	 * Taxonomy name for the languages.
 	 *

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -32,6 +32,7 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 
 	/**
 	 * Identifier that must be unique for each type of content.
+	 * Also used when checking capabilities.
 	 *
 	 * @var string
 	 *
@@ -47,15 +48,6 @@ class PLL_Translated_Term extends PLL_Translated_Object {
 	 * @phpstan-var non-empty-string
 	 */
 	protected $tax_translations = 'term_translations';
-
-	/**
-	 * Object type to use when checking capabilities.
-	 *
-	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
-	 */
-	protected $cap_type = 'term';
 
 	/**
 	 * Constructor.

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -121,7 +121,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @since 0.1
 	 * @since 3.4 Renamed the parameter $value into $id.
 	 * @since 3.4 Deprecated to retrieve the language by term slug + taxonomy anymore.
-	 * @custom-param int $id
+	 *
 	 * @param int $id Term ID.
 	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that term or if the
 	 *                            ID is invalid.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1251,11 +1251,6 @@ parameters:
 			path: include/translated-object.php
 
 		-
-			message: "#^Parameter \\#2 \\$object_type of function register_taxonomy expects array\\|string, string\\|null given\\.$#"
-			count: 2
-			path: include/translated-object.php
-
-		-
 			message: "#^Parameter \\#3 \\$args of function wp_insert_term expects array\\{alias_of\\?\\: string, description\\?\\: string, parent\\?\\: int, slug\\?\\: string\\}, array\\{description\\: mixed\\} given\\.$#"
 			count: 1
 			path: include/translated-object.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,3 +49,15 @@ parameters:
 			message: "#^Action callback returns string\\|void but should not return anything\\.$#"
 			count: 1
 			path: frontend/frontend.php
+
+		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
+			count: 1
+			path: include/translated-post.php
+
+		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
+			count: 1
+			path: include/translated-term.php


### PR DESCRIPTION
Related #1149, https://github.com/polylang/polylang-wc/issues/502.

The aim of this PR is to split the class `PLL_Translated_Object` into 2 classes: one that deals with the language, one with the translations. This will allow to create objects without the translations feature.

1. New architecture:
```text
abstract class PLL_Translatable_Object:
	get_language(), set_language(), update_language(), delete_language(),
	get_object_term(), join_clause(), where_clause()
	New: get_tax_language(), get_type(),
	get_translated_object_types(), is_translated_object_type(), get_objects_with_no_lang()
	 ┃
	 ┗━ abstract class PLL_Translated_Object:
	    	save_translations(), delete_translation(), get_translations(), get_translation(),
	    	get(), get_translations_from_term_id(), current_user_can_synchronize()
	    	New: get_tax_translations()
	    	 ┃
	    	 ┣━ class PLL_Translated_Post :
	    	 ┃  	Declare class properties, init() (launch hooks)
	    	 ┃
	    	 ┗━ class PLL_Translated_Term :
	    	    	Declare class properties, init() (launch hooks)
	    	    	New: get_language_by_term_slug()
```

2. Some method parameters (`$object_id`, `$post_id`, `$term_id`) have been renamed into `$id`:
  - named parameters with php 8,
  - consistency.
3. PHPStan: documentation (types) is now stricter. For example the class property `$type`, originally declared as `string`, is now `non-empty-string`. This brings new issues found by PHPStan that will be fixed in a later PR.
4. The classes use an unknown method `PLL_Language::get_tax_prop()`: this method exists in #1158.
5. `PLL_Translated_Term::get_language()` must be called with a term ID only now, like in `PLL_Translatable_Object`. If we want a term language by providing a slug and taxonomy name, `PLL_Translated_Term::get_language_by_term_slug()` must be used instead. A deprecation notice has been added to `PLL_Translated_Term::get_language()` if it called with slug + taxonomy.
6. The new methods `get_translated_object_types()`, `is_translated_object_type()`, and `get_objects_with_no_lang()` will be used in `PLL_Model` and `PLL_Admin_Model` (#1160).
    - `get_objects_with_no_lang()` has been made generic and moved from `PLL_Translated_Term` to `PLL_Translatable_Object`. `PLL_Translated_Post::get_objects_with_no_lang()` has been kept so far, but I think it could benefit from the generic version in term of performance.
    - `get_translated_object_types()` and `is_translated_object_type()` are part of a new interface `PLL_Translatable_Object_With_Types_Interface` because all translatable objects does not necessarily have sub-types. An interface has been used because it seems cleaner to use `$object instance of PLL_Translatable_Object_With_Types_Interface` over `method_exists( $object, 'get_translated_object_types' )`.
7. `PLL_Translated_Term`'s methods `_prime_terms_cache()` and `clean_term_cache()` would also benefit to the other non-post contents: maybe there is a way to use them for these contents by moving them to a parent class.