### PR TITLE
Prevent warning

### DIFF
--- a/include/links.php
+++ b/include/links.php
@@ -59,6 +59,9 @@ class PLL_Links {
 	 */
 	public function get_home_url( $language, $is_search = false ) {
 		$language = is_object( $language ) ? $language : $this->model->get_language( $language );
+		if (!$language) {
+            		return null;
+        	}
 		return $is_search ? $language->search_url : $language->home_url;
 	}
 }


### PR DESCRIPTION
I am using an error notify plugin, and i keep receiving this error:
       Attempt to read property "home_url" on bool
As well, wordpress admin dashboard loading with php-error class;

This simple change prevent the warning being triggered.