### PR TITLE
Remove useless PLL_Translatable_Object::update_language()

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -182,7 +182,7 @@ class PLL_Admin_Classic_Editor {
 			wp_die( 'You are not allowed to edit this post.' );
 		}
 
-		$this->model->post->update_language( $post_ID, $lang );
+		$this->model->post->set_language( $post_ID, $lang );
 
 		ob_start();
 		if ( 'attachment' === $post_type ) {

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -116,7 +116,7 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 		// Language is filled in attachment by the function applying the filter 'attachment_fields_to_save'
 		// All security checks have been done by functions applying this filter
 		if ( ! empty( $attachment['language'] ) && current_user_can( 'edit_post', $post['ID'] ) ) {
-			$this->model->post->update_language( $post['ID'], $this->model->get_language( $attachment['language'] ) );
+			$this->model->post->set_language( $post['ID'], $this->model->get_language( $attachment['language'] ) );
 		}
 
 		return $post;

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -169,7 +169,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 				$post_ids = array_map( 'intval', (array) $_REQUEST['post'] );
 				foreach ( $post_ids as $post_id ) {
 					if ( current_user_can( 'edit_post', $post_id ) ) {
-						$this->model->post->update_language( $post_id, $lang );
+						$this->model->post->set_language( $post_id, $lang );
 					}
 				}
 			}
@@ -190,7 +190,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			$post_id = (int) $_POST['post_ID'];
 			$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) );
 			if ( $post_id && $lang && current_user_can( 'edit_post', $post_id ) ) {
-				$this->model->post->update_language( $post_id, $lang );
+				$this->model->post->set_language( $post_id, $lang );
 			}
 		}
 	}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -342,7 +342,7 @@ class PLL_Admin_Filters_Term {
 			);
 
 			$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) );
-			$this->model->term->update_language( $term_id, $lang );
+			$this->model->term->set_language( $term_id, $lang );
 		}
 
 		// Edit post

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -172,20 +172,6 @@ abstract class PLL_Translatable_Object {
 	}
 
 	/**
-	 * Assigns a new language to an object.
-	 *
-	 * @since 3.1
-	 *
-	 * @param int          $id   Object ID.
-	 * @param PLL_Language $lang New language to assign to the object.
-	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
-	 *              the object).
-	 */
-	public function update_language( $id, PLL_Language $lang ) {
-		return $this->set_language( $id, $lang );
-	}
-
-	/**
 	 * Returns the language of an object.
 	 *
 	 * @since 0.1

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -78,6 +78,8 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 			return false;
 		}
 
+		$id = $this->sanitize_int_id( $id );
+
 		$translations = $this->get_translations( $id );
 
 		// Don't create translation groups with only 1 value.

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -68,8 +68,8 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param int          $id   Object ID.
-	 * @param PLL_Language $lang Language to assign to the object.
+	 * @param int                     $id   Object ID.
+	 * @param PLL_Language|string|int $lang Language to assign to the object.
 	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
 	 *              the object).
 	 */

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -69,16 +69,14 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @since 3.1
 	 *
 	 * @param int          $id   Object ID.
-	 * @param PLL_Language $lang New language to assign to the object.
+	 * @param PLL_Language $lang Language to assign to the object.
 	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
 	 *              the object).
 	 */
-	public function update_language( $id, PLL_Language $lang ) {
-		if ( ! $this->set_language( $id, $lang ) ) {
+	public function set_language( $id, $lang ) {
+		if ( ! parent::set_language( $id, $lang ) ) {
 			return false;
 		}
-
-		$id = $this->sanitize_int_id( $id );
 
 		$translations = $this->get_translations( $id );
 

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -64,9 +64,9 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	}
 
 	/**
-	 * Assigns a new language to an object, taking care of the translations group.
+	 * Assigns a language to an object, taking care of the translations group.
 	 *
-	 * @since 3.1
+	 * @since 3.4
 	 *
 	 * @param int          $id   Object ID.
 	 * @param PLL_Language $lang Language to assign to the object.

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -161,7 +161,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		$post_id = array_shift( $translations );
 		self::$model->post->save_translations( $post_id, $translations );
 
-		self::$model->post->update_language( $post_id, self::$model->get_language( $to ) );
+		self::$model->post->set_language( $post_id, self::$model->get_language( $to ) );
 
 		$updated_language_translations_group = array_keys( self::$model->post->get_translations( $post_id ) );
 		$updated_language_old_translations_group = array_keys( self::$model->post->get_translations( array_values( $translations )[0] ) );


### PR DESCRIPTION
See https://github.com/polylang/polylang-wc/issues/502

Removal of `update_language()`. 
`PLL_Translated_Object::set_language()` handles translation groups.

It looks like that the handling of terms that must always have a translation group is already handled [here](https://github.com/polylang/polylang/blob/3.4-dev/include/translated-term.php#L106-L113).