### PR TITLE
Fix PHPunit errors since language objects refactor.

### DIFF
--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -29,8 +29,7 @@ class PLL_Admin_Model extends PLL_Model {
 	 */
 	public function add_language( $args ) {
 		$errors = $this->validate_lang( $args );
-		// TODO: Remove this backward compatibility?
-		if ( $errors->get_error_code() ) { // Using has_errors() would be more meaningful but is available only since WP 5.0
+		if ( $errors->has_errors() ) {
 			return $errors;
 		}
 

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -29,6 +29,7 @@ class PLL_Admin_Model extends PLL_Model {
 	 */
 	public function add_language( $args ) {
 		$errors = $this->validate_lang( $args );
+		// TODO: Remove this backward compatibility?
 		if ( $errors->get_error_code() ) { // Using has_errors() would be more meaningful but is available only since WP 5.0
 			return $errors;
 		}

--- a/include/api.php
+++ b/include/api.php
@@ -290,12 +290,12 @@ function pll_translate_string( $string, $lang ) {
 		$cache = new PLL_Cache();
 	}
 
-	$mo = $cache->get( $lang );
+	$mo = $cache->get( $lang->slug );
 
 	if ( ! $mo instanceof PLL_MO ) {
 		$mo = new PLL_MO();
 		$mo->import_from_db( $lang );
-		$cache->set( $lang, $mo );
+		$cache->set( $lang->slug, $mo );
 	}
 
 	return $mo->translate( $string );

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -116,10 +116,12 @@ class PLL_Language_Factory {
 
 		$data['is_rtl'] = ! empty( $data['is_rtl'] ) ? 1 : 0;
 
-		$positive_fields = array( 'term_group', 'mo_id', 'page_on_front', 'page_for_posts' );
+		$data['mo_id'] = absint( $data['mo_id'] );
+
+		$positive_fields = array( 'term_group', 'page_on_front', 'page_for_posts' );
 
 		foreach ( $positive_fields as $field ) {
-			$data[ $field ] = absint( $data[ $field ] );
+			$data[ $field ] = ! empty( $data[ $field ] ) ? absint( $data[ $field ] ) : 0;
 		}
 
 		/**

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -116,9 +116,7 @@ class PLL_Language_Factory {
 
 		$data['is_rtl'] = ! empty( $data['is_rtl'] ) ? 1 : 0;
 
-		$data['mo_id'] = absint( $data['mo_id'] );
-
-		$positive_fields = array( 'term_group', 'page_on_front', 'page_for_posts' );
+		$positive_fields = array( 'mo_id', 'term_group', 'page_on_front', 'page_for_posts' );
 
 		foreach ( $positive_fields as $field ) {
 			$data[ $field ] = ! empty( $data[ $field ] ) ? absint( $data[ $field ] ) : 0;

--- a/include/language.php
+++ b/include/language.php
@@ -30,7 +30,7 @@
  *     flag_code: non-empty-string,
  *     term_group: int,
  *     is_rtl: int<0, 1>,
- *     mo_id: positive-int,
+ *     mo_id: int,
  *     facebook?: string,
  *     home_url: non-empty-string,
  *     search_url: non-empty-string,
@@ -146,8 +146,6 @@ class PLL_Language {
 	 * ID of the post storing strings translations.
 	 *
 	 * @var int
-	 *
-	 * @phpstan-var positive-int
 	 */
 	public $mo_id;
 

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -498,7 +498,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 		// Prepare terms taxonomy relationship
 		foreach ( $terms as $term ) {
 			$term_ids[] = $term->term_id;
-			$tts[] = $wpdb->prepare( '( %d, %s, %s, %d )', $term->term_id, $$this->tax_translations, $description[ $term->slug ], $count[ $term->slug ] );
+			$tts[] = $wpdb->prepare( '( %d, %s, %s, %d )', $term->term_id, $this->tax_translations, $description[ $term->slug ], $count[ $term->slug ] );
 		}
 
 		// Insert term_taxonomy

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -57,6 +57,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							foreach ( $this->get_predefined_languages() as $lg ) {
 								$lg['flag_code'] = $lg['flag'];
 								$language = new PLL_Language( $lg );
+								// TODO: Maybe we should find an other way to get the flag, not sure creating language objects is the right solution here.
 								$language->set_flag();
 								printf(
 									'<option value="%1$s:%2$s:%3$s:%4$s" data-flag-html="%6$s">%5$s - %2$s</option>' . "\n",

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -57,7 +57,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 							foreach ( $this->get_predefined_languages() as $lg ) {
 								$lg['flag_code'] = $lg['flag'];
 								$language = new PLL_Language( $lg );
-								// TODO: Maybe we should find an other way to get the flag, not sure creating language objects is the right solution here.
 								$language->set_flag();
 								printf(
 									'<option value="%1$s:%2$s:%3$s:%4$s" data-flag-html="%6$s">%5$s - %2$s</option>' . "\n",

--- a/tests/phpunit/tests/test-accept-languages-collection.php
+++ b/tests/phpunit/tests/test-accept-languages-collection.php
@@ -36,7 +36,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 		$language['locale']     = $locale;
 		$language['slug']       = $language['code'];
 		$language['w3c']        = isset( $language['w3c'] ) ? $language['w3c'] : str_replace( '_', '-', $language['locale'] );
-		$language['rtl']        = $language['dir'] === 'rtl' ? 1 : 0;
+		$language['rtl']        = 'rtl' === $language['dir'] ? 1 : 0;
 		$language['term_group'] = 0;
 		$result = self::$model->add_language( $language );
 
@@ -147,15 +147,15 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 	public function test_pick_matching_language_and_region_with_custom_slug() {
 		$accept_languages    = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-HK' );
-		$zh_cn               = self::$known_languages[ 'zh_CN' ];
+		$zh_cn               = self::$known_languages['zh_CN'];
 		$zh_cn['locale']     = 'zh_CN';
 		$zh_cn['slug']       = 'zh-cn'; // Custom slug.
 		$zh_cn['w3c']        = 'zh-CN';
-		$zh_cn['rtl']        = $zh_cn['dir'] === 'rtl' ? 1 : 0;
+		$zh_cn['rtl']        = 'rtl' === $zh_cn['dir'] ? 1 : 0;
 		$zh_cn['term_group'] = 0;
 		$result              = self::$model->add_language( $zh_cn );
 
-		$this->assertNotInstanceOf( WP_Error::class, $result, "zh_CN language is not created." );
+		$this->assertNotInstanceOf( WP_Error::class, $result, 'zh_CN language is not created.' );
 
 		self::$model->clean_languages_cache();
 

--- a/tests/phpunit/tests/test-accept-languages-collection.php
+++ b/tests/phpunit/tests/test-accept-languages-collection.php
@@ -1,52 +1,6 @@
 <?php
 
-class Accept_Languages_Collection_Test extends WP_UnitTestCase {
-	/**
-	 * Polylang pre-registered languages.
-	 *
-	 * @see settings/languages.php
-	 * @var array
-	 */
-	protected static $known_languages;
-
-	/**
-	 * Polylang Admin Model, used to handle languages.
-	 *
-	 * @var PLL_Admin_Model
-	 */
-	protected static $model;
-
-	/**
-	 * @param WP_UnitTest_Factory $factory
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$known_languages = include POLYLANG_DIR . '/settings/languages.php';
-		$options               = PLL_Install::get_default_options();
-		self::$model           = new PLL_Admin_Model( $options );
-	}
-
-	/**
-	 * Returns a pre-registered language.
-	 *
-	 * @param string $locale
-	 * @return PLL_Language
-	 */
-	protected function get_known_language( $locale ) {
-		$language               = self::$known_languages[ $locale ];
-		$language['locale']     = $locale;
-		$language['slug']       = $language['code'];
-		$language['w3c']        = isset( $language['w3c'] ) ? $language['w3c'] : str_replace( '_', '-', $language['locale'] );
-		$language['rtl']        = 'rtl' === $language['dir'] ? 1 : 0;
-		$language['term_group'] = 0;
-		$result = self::$model->add_language( $language );
-
-		$this->assertNotInstanceOf( WP_Error::class, $result, "{$locale} language is not created." );
-
-		self::$model->clean_languages_cache();
-
-		return self::$model->get_language( $language['slug'] );
-	}
-
+class Accept_Languages_Collection_Test extends PLL_UnitTestCase {
 	/**
 	 * Use reflection to access PLL_Accept_Language values from PLL_Accept_Languages_Collection.
 	 *
@@ -117,7 +71,8 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 	public function test_pick_matching_language_with_different_region() {
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'en-US' );
-		$en = $this->get_known_language( 'en_GB' );
+		self::create_language( 'en_GB' );
+		$en = self::$model->get_language( 'en_GB' );
 		$languages = array( $en );
 
 		$best_match = $accept_languages->find_best_match( $languages );
@@ -127,7 +82,8 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 	public function test_pick_matching_language_and_region_when_script_is_missing() {
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-Hant-HK' );
-		$zh_hk = $this->get_known_language( 'zh_HK' );
+		self::create_language( 'zh_HK' );
+		$zh_hk = self::$model->get_language( 'zh_HK' );
 		$languages = array( $zh_hk );
 
 		$best_match = $accept_languages->find_best_match( $languages );
@@ -137,7 +93,8 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 	public function test_pick_matching_language_and_variant_when_region_is_missing() {
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'de-formal' );
-		$de_de_formal = $this->get_known_language( 'de_DE_formal' );
+		self::create_language( 'de_DE_formal' );
+		$de_de_formal = self::$model->get_language( 'de_DE_formal' );
 		$languages = array( $de_de_formal );
 
 		$best_match = $accept_languages->find_best_match( $languages );
@@ -147,21 +104,11 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 	public function test_pick_matching_language_and_region_with_custom_slug() {
 		$accept_languages    = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-HK' );
-		$zh_cn               = self::$known_languages['zh_CN'];
-		$zh_cn['locale']     = 'zh_CN';
 		$zh_cn['slug']       = 'zh-cn'; // Custom slug.
-		$zh_cn['w3c']        = 'zh-CN';
-		$zh_cn['rtl']        = 'rtl' === $zh_cn['dir'] ? 1 : 0;
-		$zh_cn['term_group'] = 0;
-		$result              = self::$model->add_language( $zh_cn );
-
-		$this->assertNotInstanceOf( WP_Error::class, $result, 'zh_CN language is not created.' );
-
-		self::$model->clean_languages_cache();
-
-		$zh_cn = self::$model->get_language( $zh_cn['slug'] );
-
+		self::create_language( 'zh_CN', $zh_cn );
+		$zh_cn = self::$model->get_language( 'zh_CN' );
 		$languages = array( $zh_cn );
+
 		$best_match = $accept_languages->find_best_match( $languages );
 
 		$this->assertSame( $zh_cn->slug, $best_match );

--- a/tests/phpunit/tests/test-accept-languages-collection.php
+++ b/tests/phpunit/tests/test-accept-languages-collection.php
@@ -64,7 +64,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertSame( 3, count( $this->get_accept_languages_array( $accept_languages ) ) );
+		$this->assertCount( 3, $this->get_accept_languages_array( $accept_languages ) );
 	}
 
 	public function test_parse_simple_language_subtag() {

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -103,7 +103,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		}
 
 		$posts = self::factory()->post->create_many( 2 );
-		self::$model->set_language_in_mass( 'post', $posts, 'fr' );
+		self::$model->post->set_language_in_mass( $posts, self::$model->get_language( 'fr' ) );
 
 		$posts = get_posts( array( 'fields' => 'ids', 'posts_per_page' => -1 ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $posts ), 'slug' );
@@ -121,7 +121,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		}
 
 		$tags = self::factory()->tag->create_many( 2 );
-		self::$model->set_language_in_mass( 'term', $tags, 'fr' );
+		self::$model->term->set_language_in_mass( $tags, self::$model->get_language( 'fr' ) );
 
 		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'hide_empty' => false, 'fields' => 'ids' ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->term, 'get_language' ), $terms ), 'slug' );


### PR DESCRIPTION
After all the work done to refactor language objects, several PHPUnit errors are raised (see: https://app.travis-ci.com/github/polylang/polylang/jobs/591309741).
This PR only takes care of the errors. I suggest to handle failures in another PR.

There is a remaining error in `Settings_Test::test_edit_language`, this will be handled in another PR to make review easier. 