### PR TITLE
Update get_calendar() to match WP 6.2 changes

### DIFF
--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -58,10 +58,10 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 	 * @since 0.5
 	 *
 	 * @param bool $initial Optional, default is true. Use initial calendar names.
-	 * @param bool $echo    Optional, default is true. Set to false for return.
-	 * @return void|string Void if `$echo` argument is true, calendar HTML if `$echo` is false.
+	 * @param bool $display Optional, default is true. Set to false for return.
+	 * @return void|string Void if `$display` argument is true, calendar HTML if `$display` is false.
  	 */
-	static public function get_calendar( $initial = true, $echo = true ) {
+	static public function get_calendar( $initial = true, $display = true ) {
 		global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 
 		$join_clause  = PLL()->model->post->join_clause(); #added#
@@ -74,7 +74,7 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 			/** This filter is documented in wp-includes/general-template.php */
 			$output = apply_filters( 'get_calendar', $cache[ $key ] );
 
-			if ( $echo ) {
+			if ( $display ) {
 				echo $output;
 				return;
 			}
@@ -271,7 +271,7 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		$cache[ $key ] = $calendar_output;
 		wp_cache_set( 'get_calendar', $cache, 'calendar' );
 
-		if ( $echo ) {
+		if ( $display ) {
 			/** This filter is documented in wp-includes/general-template.php */
 			echo apply_filters( 'get_calendar', $calendar_output );
 			return;

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -8,7 +8,7 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_calendar() {
-		$this->check_method( '218e132e305bb498f975d340a4503e15', '5.6', 'get_calendar' );
+		$this->check_method( '91861c7d8b70cb3e4d2b6d0b9deae2fe', '6.2', 'get_calendar' );
 	}
 
 	public function test_wp_admin_bar() {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/56788#comment:9 for the context (related to named parameters in PHP 8).
This fixes a copied function test failing for WP nightly.