### PR TITLE
Move is_translated_object_type() to the trait

### DIFF
--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -58,4 +58,19 @@ trait PLL_Translatable_Object_With_Types_Trait {
 			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
 		);
 	}
+
+	/**
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type (taxonomy name) name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	public function is_translated_object_type( $object_type ) {
+		$order_types = $this->get_translated_object_types( false );
+		return ! empty( array_intersect( (array) $object_type, $order_types ) );
+	}
 }

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -70,7 +70,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
 	 */
 	public function is_translated_object_type( $object_type ) {
-		$order_types = $this->get_translated_object_types( false );
-		return ! empty( array_intersect( (array) $object_type, $order_types ) );
+		$object_types = $this->get_translated_object_types( false );
+		return ! empty( array_intersect( (array) $object_type, $object_types ) );
 	}
 }

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -220,21 +220,6 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
-	 * Returns true if Polylang manages languages for this object type.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string|string[] $object_type Object type (taxonomy name) name or array of object type names.
-	 * @return bool
-	 *
-	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
-	 */
-	public function is_translated_object_type( $object_type ) {
-		$taxonomies = $this->get_translated_object_types( false );
-		return ( is_array( $object_type ) && array_intersect( $object_type, $taxonomies ) || in_array( $object_type, $taxonomies ) );
-	}
-
-	/**
 	 * Caches the language and translations when terms are queried by get_terms().
 	 *
 	 * @since 1.2


### PR DESCRIPTION
This PR moves `PLL_Translated_Term::is_translated_object_type()` to the trait `PLL_Translatable_Object_With_Types_Trait`.
This allows it to be reused for other types like WC orders.
`PLL_Translated_Post` still has its own version allowing the `any` value.
[Source](https://github.com/polylang/polylang-wc/pull/521#discussion_r1046883038).