### PR TITLE
Simplify languages list creation

### DIFF
--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -41,7 +41,7 @@ class PLL_Language_Factory {
 	 *
 	 * @since 3.4
 	 *
-	 * @param WP_Term[] $terms List of language terms, with the language taxonomies language as array keys.
+	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
 	 *                         `language` and `term_language` are mandatory keys.
 	 * @return PLL_Language
 	 *

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -45,7 +45,7 @@ class PLL_Language_Factory {
 	 *                         `language` and `term_language` are mandatory keys.
 	 * @return PLL_Language
 	 *
-	 * @phpstan-param array{post:WP_Term, term:WP_Term}&array<string, WP_Term> $terms
+	 * @phpstan-param array{language:WP_Term, term_language:WP_Term}&array<string, WP_Term> $terms
 	 */
 	public static function get_from_terms( array $terms ) {
 		$languages = self::get_languages();

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -41,8 +41,8 @@ class PLL_Language_Factory {
 	 *
 	 * @since 3.4
 	 *
-	 * @param WP_Term[] $terms List of language terms, with the type as array keys.
-	 *                         `post` and `term` are mandatory keys.
+	 * @param WP_Term[] $terms List of language terms, with the language taxonomies language as array keys.
+	 *                         `language` and `term_language` are mandatory keys.
 	 * @return PLL_Language
 	 *
 	 * @phpstan-param array{post:WP_Term, term:WP_Term}&array<string, WP_Term> $terms
@@ -50,9 +50,9 @@ class PLL_Language_Factory {
 	public static function get_from_terms( array $terms ) {
 		$languages = self::get_languages();
 		$data      = array(
-			'name'       => $terms['post']->name,
-			'slug'       => $terms['post']->slug,
-			'term_group' => $terms['post']->term_group,
+			'name'       => $terms['language']->name,
+			'slug'       => $terms['language']->slug,
+			'term_group' => $terms['language']->term_group,
 			'term_props' => array(),
 			'mo_id'      => PLL_MO::get_id_from_term_id( $terms['post']->term_id ),
 		);
@@ -66,7 +66,7 @@ class PLL_Language_Factory {
 		}
 
 		// The description field can contain any property.
-		$description = maybe_unserialize( $terms['post']->description );
+		$description = maybe_unserialize( $terms['language']->description );
 
 		if ( is_array( $description ) ) {
 			$description = array_intersect_key(

--- a/include/model.php
+++ b/include/model.php
@@ -703,12 +703,6 @@ class PLL_Model {
 	 */
 	protected function get_languages_from_taxonomies() {
 
-		$taxonomies = array();
-
-		foreach ( $this->translatable_objects as $type => $sub_model ) {
-			$taxonomies[ $sub_model->get_tax_language() ] = $type;
-		}
-
 		// To get language taxonomies first.
 		$reversed_terms = array_reverse( $this->get_language_terms() );
 
@@ -717,7 +711,7 @@ class PLL_Model {
 		foreach ( $reversed_terms as $term ) {
 			if ( $term instanceof WP_Term ) {
 				$key = 'language' === $term->taxonomy ? $term->slug : substr( $term->slug, 4 );
-				$terms_by_slug[ $key ][ $taxonomies[ $term->taxonomy ] ] = $term;
+				$terms_by_slug[ $key ][ $term->taxonomy ] = $term;
 			}
 		}
 

--- a/include/model.php
+++ b/include/model.php
@@ -710,6 +710,7 @@ class PLL_Model {
 
 		foreach ( $reversed_terms as $term ) {
 			if ( $term instanceof WP_Term ) {
+				// Except for language taxonomy term slugs, remove 'pll_' prefix from the other language taxonomy term slugs.
 				$key = 'language' === $term->taxonomy ? $term->slug : substr( $term->slug, 4 );
 				$terms_by_slug[ $key ][ $term->taxonomy ] = $term;
 			}

--- a/include/model.php
+++ b/include/model.php
@@ -703,7 +703,11 @@ class PLL_Model {
 	 */
 	protected function get_languages_from_taxonomies() {
 
-		// To get language taxonomies first.
+		/*
+		 * Only terms of the taxonomy 'language' include a 'term_group' for the order.
+		 * `array_reverse()` allows to make sure that the next loop fills the array
+		 *  with these terms first, allowing to keep the languages order.
+		 */
 		$reversed_terms = array_reverse( $this->get_language_terms() );
 
 		$terms_by_slug = array();
@@ -716,21 +720,13 @@ class PLL_Model {
 			}
 		}
 
-		// To put the language in the right order.
+		// Restore the right order after the first `array_reverse()`.
 		$terms_by_slug = array_reverse( $terms_by_slug );
 
 		$languages = array();
 
 		foreach ( $terms_by_slug as $lang_terms ) {
-
-			$language = PLL_Language_Factory::get_from_terms( $lang_terms );
-
-			if ( empty( $language ) ) {
-				continue;
-			}
-
-			$languages[] = $language;
-
+			$languages[] = PLL_Language_Factory::get_from_terms( $lang_terms );
 		}
 
 		// We will need the languages list to allow its access in the filter below.
@@ -775,15 +771,15 @@ class PLL_Model {
 	 */
 	protected function get_language_terms() {
 		add_filter( 'get_terms_orderby', array( $this, 'filter_language_terms_orderby' ), 10, 3 );
-		$post_languages = get_terms(
+		$terms = get_terms(
 			array(
 				'taxonomy'   => $this->translatable_objects->get_taxonomy_names( array( 'language' ) ),
-				'orderby' => 'term_group',
+				'orderby'    => 'term_group',
 				'hide_empty' => false,
 			)
 		);
 		remove_filter( 'get_terms_orderby', array( $this, 'filter_language_terms_orderby' ) );
 
-		return empty( $post_languages ) || is_wp_error( $post_languages ) ? array() : $post_languages;
+		return empty( $terms ) || is_wp_error( $terms ) ? array() : $terms;
 	}
 }

--- a/include/model.php
+++ b/include/model.php
@@ -702,34 +702,31 @@ class PLL_Model {
 	 * @phpstan-return list<PLL_Language>
 	 */
 	protected function get_languages_from_taxonomies() {
-		$terms_by_type = $this->get_language_terms_by_type();
 
-		if ( empty( $terms_by_type['post'] ) || empty( $terms_by_type['term'] ) ) {
-			// `post` and `term` languages are mandatory.
-			return array();
+		$taxonomies = array();
+
+		foreach ( $this->translatable_objects as $type => $sub_model ) {
+			$taxonomies[ $sub_model->get_tax_language() ] = $type;
 		}
+
+		// To get language taxonomies first.
+		$reversed_terms = array_reverse( $this->get_language_terms() );
+
+		$terms_by_slug = array();
+
+		foreach ( $reversed_terms as $term ) {
+			if ( $term instanceof WP_Term ) {
+				$key = 'language' === $term->taxonomy ? $term->slug : substr( $term->slug, 4 );
+				$terms_by_slug[ $key ][ $taxonomies[ $term->taxonomy ] ] = $term;
+			}
+		}
+
+		// To put the language in the right order.
+		$terms_by_slug = array_reverse( $terms_by_slug );
 
 		$languages = array();
 
-		foreach ( $terms_by_type['post'] as $term_slug => $lang_term ) {
-			if ( ! isset( $terms_by_type['term'][ "pll_{$term_slug}" ] ) ) {
-				// A corresponding `term` language is mandatory.
-				continue;
-			}
-
-			$lang_terms = array();
-
-			foreach ( $terms_by_type as $type => $terms ) {
-				$key = 'post' === $type ? $term_slug : "pll_{$term_slug}";
-
-				if ( isset( $terms[ $key ] ) ) {
-					$lang_terms[ $type ] = $terms[ $key ];
-				}
-			}
-
-			if ( ! isset( $lang_terms['post'], $lang_terms['term'] ) ) {
-				continue;
-			}
+		foreach ( $terms_by_slug as $lang_terms ) {
 
 			$language = PLL_Language_Factory::get_from_terms( $lang_terms );
 
@@ -738,6 +735,7 @@ class PLL_Model {
 			}
 
 			$languages[] = $language;
+
 		}
 
 		// We will need the languages list to allow its access in the filter below.
@@ -772,51 +770,6 @@ class PLL_Model {
 	}
 
 	/**
-	 * Returns the list of all language terms, by type (post, term, etc).
-	 *
-	 * @since 3.4
-	 *
-	 * @return array[] An array (type as array keys) of arrays (term slug as array keys) of terms.
-	 *
-	 * @phpstan-return array<non-empty-string, non-empty-array<non-empty-string, WP_Term>>
-	 */
-	protected function get_language_terms_by_type() {
-		$terms = $this->get_language_terms();
-
-		if ( empty( $terms ) ) {
-			return array();
-		}
-
-		$terms_by_type = array();
-
-		foreach ( $terms as $term ) {
-			$terms_by_type['post'][ $term->slug ] = $term;
-		}
-
-		foreach ( $this->translatable_objects->get_secondary_translatable_objects() as $type => $sub_model ) {
-			$terms = get_terms(
-				array(
-					'taxonomy'   => $sub_model->get_tax_language(),
-					'hide_empty' => false,
-				)
-			);
-
-			if ( empty( $terms ) || ! is_array( $terms ) ) {
-				continue;
-			}
-
-			foreach ( $terms as $term ) {
-				if ( $term instanceof WP_Term ) {
-					$terms_by_type[ $type ][ $term->slug ] = $term;
-				}
-			}
-		}
-
-		/** @var array<non-empty-string, non-empty-array<non-empty-string, WP_Term>> */
-		return $terms_by_type;
-	}
-
-	/**
 	 * Returns the list of existing language terms.
 	 * - Returns all terms, that are or not assigned to posts.
 	 * - Terms are ordered by `term_group` and `term_id` (see `PLL_Model->filter_language_terms_orderby()`).
@@ -827,7 +780,13 @@ class PLL_Model {
 	 */
 	protected function get_language_terms() {
 		add_filter( 'get_terms_orderby', array( $this, 'filter_language_terms_orderby' ), 10, 3 );
-		$post_languages = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false, 'orderby' => 'term_group' ) );
+		$post_languages = get_terms(
+			array(
+				'taxonomy'   => $this->translatable_objects->get_taxonomy_names( array( 'language' ) ),
+				'orderby' => 'term_group',
+				'hide_empty' => false,
+			)
+		);
 		remove_filter( 'get_terms_orderby', array( $this, 'filter_language_terms_orderby' ) );
 
 		return empty( $post_languages ) || is_wp_error( $post_languages ) ? array() : $post_languages;


### PR DESCRIPTION
After merging #1160 it remained to simplify how the languages list is created.

It is the goal of this PR

## Changes
- Modify the terms request in `PLL_Model::get_language_terms()` to request all taxonomies in one time. Also introduce `'orderby' => 'term_group'` to take in account the language display order.
- Remove `PLL_Model::get_terms_by_type` method become useless
- Simplify `PLL_Model::get_languages_from_taxonomies()` to prepare data to send to `PLL_Language_Factory::get_from_terms()` method
- Remove reference to content type in the parameter of `PLL_Language_Factory::get_from_terms()` method and use language taxonomies instead.
