### PR TITLE
Fix forgotten key change

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -182,7 +182,7 @@ class PLL_Admin_Classic_Editor {
 			wp_die( 'You are not allowed to edit this post.' );
 		}
 
-		$this->model->post->update_language( $post_ID, $lang );
+		$this->model->post->set_language( $post_ID, $lang );
 
 		ob_start();
 		if ( 'attachment' === $post_type ) {

--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -116,7 +116,7 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 		// Language is filled in attachment by the function applying the filter 'attachment_fields_to_save'
 		// All security checks have been done by functions applying this filter
 		if ( ! empty( $attachment['language'] ) && current_user_can( 'edit_post', $post['ID'] ) ) {
-			$this->model->post->update_language( $post['ID'], $this->model->get_language( $attachment['language'] ) );
+			$this->model->post->set_language( $post['ID'], $this->model->get_language( $attachment['language'] ) );
 		}
 
 		return $post;

--- a/admin/admin-filters-post.php
+++ b/admin/admin-filters-post.php
@@ -169,7 +169,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 				$post_ids = array_map( 'intval', (array) $_REQUEST['post'] );
 				foreach ( $post_ids as $post_id ) {
 					if ( current_user_can( 'edit_post', $post_id ) ) {
-						$this->model->post->update_language( $post_id, $lang );
+						$this->model->post->set_language( $post_id, $lang );
 					}
 				}
 			}
@@ -190,7 +190,7 @@ class PLL_Admin_Filters_Post extends PLL_Admin_Filters_Post_Base {
 			$post_id = (int) $_POST['post_ID'];
 			$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) );
 			if ( $post_id && $lang && current_user_can( 'edit_post', $post_id ) ) {
-				$this->model->post->update_language( $post_id, $lang );
+				$this->model->post->set_language( $post_id, $lang );
 			}
 		}
 	}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -342,7 +342,7 @@ class PLL_Admin_Filters_Term {
 			);
 
 			$lang = $this->model->get_language( sanitize_key( $_POST['inline_lang_choice'] ) );
-			$this->model->term->update_language( $term_id, $lang );
+			$this->model->term->set_language( $term_id, $lang );
 		}
 
 		// Edit post

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -29,7 +29,7 @@ class PLL_Admin_Model extends PLL_Model {
 	 */
 	public function add_language( $args ) {
 		$errors = $this->validate_lang( $args );
-		if ( $errors->get_error_code() ) { // Using has_errors() would be more meaningful but is available only since WP 5.0
+		if ( $errors->has_errors() ) {
 			return $errors;
 		}
 

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -68,9 +68,24 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 		else {
 			foreach ( $this->model->get_translated_taxonomies() as $taxonomy ) {
 				$tax_object = get_taxonomy( $taxonomy );
-				if ( ! empty( $tax_object ) && $var = get_query_var( $tax_object->query_var ) ) {
-					$lang = $this->model->term->get_language( $var, $taxonomy );
+
+				if ( empty( $tax_object ) ) {
+					continue;
 				}
+
+				$var = get_query_var( $tax_object->query_var );
+
+				if ( ! is_string( $var ) || empty( $var ) ) {
+					continue;
+				}
+
+				$term = get_term_by( 'slug', $var, $taxonomy );
+
+				if ( ! $term instanceof WP_Term ) {
+					continue;
+				}
+
+				$lang = $this->model->term->get_language( $term->term_id );
 			}
 		}
 

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -44,6 +44,8 @@ class PLL_Frontend_Auto_Translate {
 	 *
 	 * @param int $post_id
 	 * @return int
+	 *
+	 * @phpstan-return int<0, max>
 	 */
 	protected function get_post( $post_id ) {
 		return $this->model->post->get( $post_id, $this->curlang );
@@ -56,6 +58,8 @@ class PLL_Frontend_Auto_Translate {
 	 *
 	 * @param int $term_id
 	 * @return int
+	 *
+	 * @phpstan-return int<0, max>
 	 */
 	protected function get_term( $term_id ) {
 		return $this->model->term->get( $term_id, $this->curlang );

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -75,11 +75,15 @@ class PLL_Frontend_Filters extends PLL_Filters {
 		if ( ! defined( 'REST_REQUEST' ) && ! empty( $this->curlang ) && ! empty( $posts ) ) {
 			$_posts = wp_cache_get( 'sticky_posts', 'options' ); // This option is usually cached in 'all_options' by WP
 
-			if ( empty( $_posts ) || ! is_array( $_posts[ $this->curlang->term_taxonomy_id ] ) ) {
+			if ( empty( $_posts ) || ! is_array( $_posts[ $this->curlang->get_tax_prop( 'language', 'term_taxonomy_id' ) ] ) ) {
 				$posts = array_map( 'intval', $posts );
 				$posts = implode( ',', $posts );
 
-				$languages = $this->model->get_languages_list( array( 'fields' => 'term_taxonomy_id' ) );
+				$languages = array();
+				foreach ( $this->model->get_languages_list() as $language ) {
+					$languages[] = $language->get_tax_prop( 'language', 'term_taxonomy_id' );
+				}
+
 				$_posts = array_fill_keys( $languages, array() ); // Init with empty arrays
 				$languages = implode( ',', $languages );
 
@@ -92,7 +96,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 				wp_cache_add( 'sticky_posts', $_posts, 'options' );
 			}
 
-			$posts = $_posts[ $this->curlang->term_taxonomy_id ];
+			$posts = $_posts[ $this->curlang->get_tax_prop( 'language', 'term_taxonomy_id' ) ];
 		}
 
 		return $posts;

--- a/include/api.php
+++ b/include/api.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * The Polylang public API.
+ *
  * @package Polylang
  */
 
@@ -29,6 +31,10 @@
  * @return string|array Either the html markup of the switcher or the raw elements to build a custom language switcher.
  */
 function pll_the_languages( $args = array() ) {
+	if ( empty( PLL()->links ) ) {
+		return empty( $args['raw'] ) ? '' : array();
+	}
+
 	$switcher = new PLL_Switcher();
 	return $switcher->the_languages( PLL()->links, $args );
 }
@@ -41,12 +47,17 @@ function pll_the_languages( $args = array() ) {
  * @since 0.8.1
  *
  * @param string $field Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|PLL_Language|false The requested field for the current language.
+ * @return string|PLL_Language|false The requested field or object for the current language, false if field isn't set or if current language doesn't exist yet.
  */
 function pll_current_language( $field = 'slug' ) {
+	if ( empty( PLL()->curlang ) ) {
+		return false;
+	}
+
 	if ( OBJECT === $field ) {
 		return PLL()->curlang;
 	}
+
 	return isset( PLL()->curlang->$field ) ? PLL()->curlang->$field : false;
 }
 
@@ -57,47 +68,72 @@ function pll_current_language( $field = 'slug' ) {
  * @since 1.0
  *
  * @param string $field Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|PLL_Language|false The requested field for the default language.
+ * @return string|PLL_Language|false The requested field or object for the default language. False if none.
  */
 function pll_default_language( $field = 'slug' ) {
-	if ( isset( PLL()->options['default_lang'] ) ) {
-		$lang = PLL()->model->get_language( PLL()->options['default_lang'] );
-		if ( $lang ) {
-			if ( OBJECT === $field ) {
-				return $lang;
-			}
-			return isset( $lang->$field ) ? $lang->$field : false;
-		}
+	if ( empty( PLL()->options['default_lang'] ) ) {
+		return false;
 	}
-	return false;
+
+	$lang = PLL()->model->get_language( PLL()->options['default_lang'] );
+
+	if ( empty( $lang ) ) {
+		return false;
+	}
+
+	if ( OBJECT === $field ) {
+		return $lang;
+	}
+
+	return isset( $lang->$field ) ? $lang->$field : false;
 }
 
 /**
- * Among the post and its translations, returns the id of the post which is in the language represented by $lang.
+ * Among the post and its translations, returns the ID of the post which is in the language represented by $lang.
  *
  * @api
  * @since 0.5
+ * @since 3.4 Returns 0 instead of false.
+ * @since 3.4 $lang accepts PLL_Language or string.
  *
- * @param int    $post_id Post id.
- * @param string $lang    Optional language code, defaults to the current language.
- * @return int|false|null Post id of the translation if it exists, false otherwise, null if the current language is not defined yet.
+ * @param int                 $post_id Post ID.
+ * @param PLL_Language|string $lang    Optional language (object or slug), defaults to the current language.
+ * @return int|false The translation post ID if exists, otherwise the passed ID. False if the passed object has no language or if the language doesn't exist.
+ *
+ * @phpstan-return int<0, max>|false
  */
 function pll_get_post( $post_id, $lang = '' ) {
-	return ( $lang = $lang ? $lang : pll_current_language() ) ? PLL()->model->post->get( $post_id, $lang ) : null;
+	$lang = $lang ? $lang : pll_current_language();
+
+	if ( empty( $lang ) ) {
+		return false;
+	}
+
+	return PLL()->model->post->get( $post_id, $lang );
 }
 
 /**
- * Among the term and its translations, returns the id of the term which is in the language represented by $lang.
+ * Among the term and its translations, returns the ID of the term which is in the language represented by $lang.
  *
  * @api
  * @since 0.5
+ * @since 3.4 Returns 0 instead of false.
+ * @since 3.4 $lang accepts PLL_Language or string.
  *
- * @param int    $term_id Term id.
- * @param string $lang    Optional language code, defaults to the current language.
- * @return int|false|null Term id of the translation if it exists, false otherwise, null if the current language is not defined yet.
+ * @param int                 $term_id Term ID.
+ * @param PLL_Language|string $lang    Optional language (object or slug), defaults to the current language.
+ * @return int|false The translation term ID if exists, otherwise the passed ID. False if the passed object has no language or if the language doesn't exist.
+ *
+ * @phpstan-return int<0, max>|false
  */
-function pll_get_term( $term_id, $lang = '' ) {
-	return ( $lang = $lang ? $lang : pll_current_language() ) ? PLL()->model->term->get( $term_id, $lang ) : null;
+function pll_get_term( $term_id, $lang = null ) {
+	$lang = $lang ? $lang : pll_current_language();
+
+	if ( empty( $lang ) ) {
+		return false;
+	}
+
+	return PLL()->model->term->get( $term_id, $lang );
 }
 
 /**
@@ -114,7 +150,11 @@ function pll_home_url( $lang = '' ) {
 		$lang = pll_current_language();
 	}
 
-	return empty( $lang ) ? home_url( '/' ) : PLL()->links->get_home_url( $lang );
+	if ( empty( $lang ) || empty( PLL()->links ) ) {
+		return home_url( '/' );
+	}
+
+	return PLL()->links->get_home_url( $lang );
 }
 
 /**
@@ -230,11 +270,17 @@ function pll_esc_attr_e( $string ) {
  * @return string The string translated in the requested language.
  */
 function pll_translate_string( $string, $lang ) {
-	if ( PLL() instanceof PLL_Frontend && pll_current_language() == $lang ) {
+	if ( PLL() instanceof PLL_Frontend && pll_current_language() === $lang ) {
 		return pll__( $string );
 	}
 
 	if ( ! is_scalar( $string ) || '' === $string ) {
+		return $string;
+	}
+
+	$lang = PLL()->model->get_language( $lang );
+
+	if ( empty( $lang ) ) {
 		return $string;
 	}
 
@@ -244,9 +290,11 @@ function pll_translate_string( $string, $lang ) {
 		$cache = new PLL_Cache();
 	}
 
-	if ( false === $mo = $cache->get( $lang ) ) {
+	$mo = $cache->get( $lang );
+
+	if ( ! $mo instanceof PLL_MO ) {
 		$mo = new PLL_MO();
-		$mo->import_from_db( PLL()->model->get_language( $lang ) );
+		$mo->import_from_db( $lang );
 		$cache->set( $lang, $mo );
 	}
 
@@ -303,13 +351,16 @@ function pll_languages_list( $args = array() ) {
  *
  * @api
  * @since 1.5
+ * @since 3.4 $lang accepts PLL_Language or string.
+ * @since 3.4 Returns a boolean.
  *
- * @param int    $id   Post id.
- * @param string $lang Language code.
- * @return void
+ * @param int                 $id   Post ID.
+ * @param PLL_Language|string $lang Language (object or slug).
+ * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+ *              the post).
  */
 function pll_set_post_language( $id, $lang ) {
-	PLL()->model->post->set_language( $id, $lang );
+	return PLL()->model->post->set_language( $id, $lang );
 }
 
 /**
@@ -317,13 +368,16 @@ function pll_set_post_language( $id, $lang ) {
  *
  * @api
  * @since 1.5
+ * @since 3.4 $lang accepts PLL_Language or string.
+ * @since 3.4 Returns a boolean.
  *
- * @param int    $id   Term id.
- * @param string $lang Language code.
- * @return void
+ * @param int                 $id   Term ID.
+ * @param PLL_Language|string $lang Language (object or slug).
+ * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+ *              the term).
  */
 function pll_set_term_language( $id, $lang ) {
-	PLL()->model->term->set_language( $id, $lang );
+	return PLL()->model->term->set_language( $id, $lang );
 }
 
 /**
@@ -331,12 +385,20 @@ function pll_set_term_language( $id, $lang ) {
  *
  * @api
  * @since 1.5
+ * @since 3.4 Returns an associative array of translations.
  *
- * @param int[] $arr An associative array of translations with language code as key and post id as value.
- * @return void
+ * @param int[] $arr An associative array of translations with language code as key and post ID as value.
+ * @return int[] An associative array with language codes as key and post IDs as values.
+ *
+ * @phpstan-return array<non-empty-string, positive-int>
  */
 function pll_save_post_translations( $arr ) {
-	PLL()->model->post->save_translations( reset( $arr ), $arr );
+	$id = reset( $arr );
+	if ( $id ) {
+		return PLL()->model->post->save_translations( $id, $arr );
+	}
+
+	return array();
 }
 
 /**
@@ -344,12 +406,20 @@ function pll_save_post_translations( $arr ) {
  *
  * @api
  * @since 1.5
+ * @since 3.4 Returns an associative array of translations.
  *
- * @param int[] $arr An associative array of translations with language code as key and term id as value.
- * @return void
+ * @param int[] $arr An associative array of translations with language code as key and term ID as value.
+ * @return int[] An associative array with language codes as key and term IDs as values.
+ *
+ * @phpstan-return array<non-empty-string, positive-int>
  */
 function pll_save_term_translations( $arr ) {
-	PLL()->model->term->save_translations( reset( $arr ), $arr );
+	$id = reset( $arr );
+	if ( $id ) {
+		return PLL()->model->term->save_translations( $id, $arr );
+	}
+
+	return array();
 }
 
 /**
@@ -358,12 +428,26 @@ function pll_save_term_translations( $arr ) {
  * @api
  * @since 1.5.4
  *
- * @param int    $post_id Post id.
+ * @param int    $post_id Post ID.
  * @param string $field   Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'.
  * @return string|false The requested field for the post language, false if no language is associated to that post.
  */
 function pll_get_post_language( $post_id, $field = 'slug' ) {
-	return ( $lang = PLL()->model->post->get_language( $post_id ) ) ? $lang->$field : false;
+	$lang = PLL()->model->post->get_language( $post_id );
+
+	if ( empty( $lang ) ) {
+		return false;
+	}
+
+	if ( OBJECT === $field ) {
+		return $lang;
+	}
+
+	if ( ! isset( $lang->$field ) ) {
+		return false;
+	}
+
+	return $lang->$field;
 }
 
 /**
@@ -372,12 +456,26 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  * @api
  * @since 1.5.4
  *
- * @param int    $term_id Term id.
+ * @param int    $term_id Term ID.
  * @param string $field   Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'.
  * @return string|false The requested field for the term language, false if no language is associated to that term.
  */
 function pll_get_term_language( $term_id, $field = 'slug' ) {
-	return ( $lang = PLL()->model->term->get_language( $term_id ) ) ? $lang->$field : false;
+	$lang = PLL()->model->term->get_language( $term_id );
+
+	if ( empty( $lang ) ) {
+		return false;
+	}
+
+	if ( OBJECT === $field ) {
+		return $lang;
+	}
+
+	if ( ! isset( $lang->$field ) ) {
+		return false;
+	}
+
+	return $lang->$field;
 }
 
 /**
@@ -386,8 +484,10 @@ function pll_get_term_language( $term_id, $field = 'slug' ) {
  * @api
  * @since 1.8
  *
- * @param int $post_id Post id.
- * @return int[] An associative array of translations with language code as key and translation post id as value.
+ * @param int $post_id Post ID.
+ * @return int[] An associative array of translations with language code as key and translation post ID as value.
+ *
+ * @phpstan-return array<non-empty-string, positive-int>
  */
 function pll_get_post_translations( $post_id ) {
 	return PLL()->model->post->get_translations( $post_id );
@@ -399,8 +499,10 @@ function pll_get_post_translations( $post_id ) {
  * @api
  * @since 1.8
  *
- * @param int $term_id Term id.
- * @return int[] An associative array of translations with language code as key and translation term id as value.
+ * @param int $term_id Term ID.
+ * @return int[] An associative array of translations with language code as key and translation term ID as value.
+ *
+ * @phpstan-return array<non-empty-string, positive-int>
  */
 function pll_get_term_translations( $term_id ) {
 	return PLL()->model->term->get_translations( $term_id );
@@ -414,8 +516,7 @@ function pll_get_term_translations( $term_id ) {
  *
  * @param string $lang Language code.
  * @param array  $args {
- *   Optional arguments.
- *   Accepted keys:
+ *   Optional array of arguments.
  *
  *   @type string $post_type   Post type.
  *   @type int    $m           YearMonth ( ex: 201307 ).
@@ -430,7 +531,13 @@ function pll_get_term_translations( $term_id ) {
  * @return int Posts count.
  */
 function pll_count_posts( $lang, $args = array() ) {
-	return PLL()->model->count_posts( PLL()->model->get_language( $lang ), $args );
+	$lang = PLL()->model->get_language( $lang );
+
+	if ( empty( $lang ) ) {
+		return 0;
+	}
+
+	return PLL()->model->count_posts( $lang, $args );
 }
 
 /**

--- a/include/api.php
+++ b/include/api.php
@@ -290,12 +290,12 @@ function pll_translate_string( $string, $lang ) {
 		$cache = new PLL_Cache();
 	}
 
-	$mo = $cache->get( $lang );
+	$mo = $cache->get( $lang->slug );
 
 	if ( ! $mo instanceof PLL_MO ) {
 		$mo = new PLL_MO();
 		$mo->import_from_db( $lang );
-		$cache->set( $lang, $mo );
+		$cache->set( $lang->slug, $mo );
 	}
 
 	return $mo->translate( $string );

--- a/include/filters.php
+++ b/include/filters.php
@@ -257,7 +257,7 @@ class PLL_Filters {
 				array(
 					'taxonomy' => 'language',
 					'field'    => 'term_taxonomy_id', // Since WP 3.5.
-					'terms'    => $language->term_taxonomy_id,
+					'terms'    => $language->get_tax_prop( 'language', 'term_taxonomy_id' ),
 					'operator' => $relation,
 				),
 			),

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -41,18 +41,18 @@ class PLL_Language_Factory {
 	 *
 	 * @since 3.4
 	 *
-	 * @param WP_Term[] $terms List of language terms, with the type as array keys.
-	 *                         `post` and `term` are mandatory keys.
+	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
+	 *                         `language` and `term_language` are mandatory keys.
 	 * @return PLL_Language
 	 *
-	 * @phpstan-param array{post:WP_Term, term:WP_Term}&array<string, WP_Term> $terms
+	 * @phpstan-param array{language:WP_Term, term_language:WP_Term}&array<string, WP_Term> $terms
 	 */
 	public static function get_from_terms( array $terms ) {
 		$languages = self::get_languages();
 		$data      = array(
-			'name'       => $terms['post']->name,
-			'slug'       => $terms['post']->slug,
-			'term_group' => $terms['post']->term_group,
+			'name'       => $terms['language']->name,
+			'slug'       => $terms['language']->slug,
+			'term_group' => $terms['language']->term_group,
 			'term_props' => array(),
 			'mo_id'      => PLL_MO::get_id_from_term_id( $terms['post']->term_id ),
 		);
@@ -66,7 +66,7 @@ class PLL_Language_Factory {
 		}
 
 		// The description field can contain any property.
-		$description = maybe_unserialize( $terms['post']->description );
+		$description = maybe_unserialize( $terms['language']->description );
 
 		if ( is_array( $description ) ) {
 			$description = array_intersect_key(

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -118,7 +118,7 @@ class PLL_Language_Factory {
 
 		$positive_fields = array( 'term_group', 'mo_id', 'page_on_front', 'page_for_posts' );
 
-		foreach( $positive_fields as $field ) {
+		foreach ( $positive_fields as $field ) {
 			$data[ $field ] = absint( $data[ $field ] );
 		}
 

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -116,10 +116,10 @@ class PLL_Language_Factory {
 
 		$data['is_rtl'] = ! empty( $data['is_rtl'] ) ? 1 : 0;
 
-		$positive_fields = array( 'term_group', 'mo_id', 'page_on_front', 'page_for_posts' );
+		$positive_fields = array( 'mo_id', 'term_group', 'page_on_front', 'page_for_posts' );
 
 		foreach ( $positive_fields as $field ) {
-			$data[ $field ] = absint( $data[ $field ] );
+			$data[ $field ] = ! empty( $data[ $field ] ) ? absint( $data[ $field ] ) : 0;
 		}
 
 		/**

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -54,7 +54,7 @@ class PLL_Language_Factory {
 			'slug'       => $terms['language']->slug,
 			'term_group' => $terms['language']->term_group,
 			'term_props' => array(),
-			'mo_id'      => PLL_MO::get_id_from_term_id( $terms['post']->term_id ),
+			'mo_id'      => PLL_MO::get_id_from_term_id( $terms['language']->term_id ),
 		);
 
 		foreach ( $terms as $term ) {

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * PLL_Language factory.
+ *
+ * @since 3.4
+ *
+ * @phpstan-import-type LanguageData from PLL_Language
+ */
+class PLL_Language_Factory {
+	/**
+	 * Predefined languages.
+	 *
+	 * @var array[]
+	 *
+	 * @phpstan-var array<string, array<string, string>>
+	 */
+	private static $languages;
+
+	/**
+	 * Returns a language object matching the given data, looking up in cached transient.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $language_data Language object properties stored as an array. See `PLL_Language::__construct()`
+	 *                             for information on accepted properties.
+	 *
+	 * @return PLL_Language|null A language object if given data pass sanitization, null otherwise.
+	 *
+	 * @phpstan-param LanguageData $language_data
+	 */
+	public static function get( $language_data ) {
+		return new PLL_Language( self::sanitize_data( $language_data ) );
+	}
+
+	/**
+	 * Returns a language object based on terms.
+	 *
+	 * @since 3.4
+	 *
+	 * @param WP_Term[] $terms List of language terms, with the type as array keys.
+	 *                         `post` and `term` are mandatory keys.
+	 * @return PLL_Language
+	 *
+	 * @phpstan-param array{post:WP_Term, term:WP_Term}&array<string, WP_Term> $terms
+	 */
+	public static function get_from_terms( array $terms ) {
+		$languages = self::get_languages();
+		$data      = array(
+			'name'       => $terms['post']->name,
+			'slug'       => $terms['post']->slug,
+			'term_group' => $terms['post']->term_group,
+			'term_props' => array(),
+			'mo_id'      => PLL_MO::get_id_from_term_id( $terms['post']->term_id ),
+		);
+
+		foreach ( $terms as $term ) {
+			$data['term_props'][ $term->taxonomy ] = array(
+				'term_id'          => $term->term_id,
+				'term_taxonomy_id' => $term->term_taxonomy_id,
+				'count'            => $term->count,
+			);
+		}
+
+		// The description field can contain any property.
+		$description = maybe_unserialize( $terms['post']->description );
+
+		if ( is_array( $description ) ) {
+			$description = array_intersect_key(
+				$description,
+				array( 'locale' => null, 'rtl' => null, 'flag_code' => null )
+			);
+
+			foreach ( $description as $prop => $value ) {
+				if ( 'rtl' === $prop ) {
+					$data['is_rtl'] = $value;
+				} else {
+					$data[ $prop ] = $value;
+				}
+			}
+		}
+
+		if ( ! empty( $data['locale'] ) ) {
+			if ( isset( $languages[ $data['locale'] ]['w3c'] ) ) {
+				$data['w3c'] = $languages[ $data['locale'] ]['w3c'];
+			} else {
+				$data['w3c'] = str_replace( '_', '-', $data['locale'] );
+			}
+
+			if ( isset( $languages[ $data['locale'] ]['facebook'] ) ) {
+				$data['facebook'] = $languages[ $data['locale'] ]['facebook'];
+			}
+		}
+
+		return new PLL_Language( self::sanitize_data( $data ) );
+	}
+
+	/**
+	 * Sanitizes data, to be ready to be used in the constructor.
+	 * This doesn't verify that the language terms exist.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $data Data to process. See `PLL_Language::__construct()` for information on accepted data.
+	 * @return array Sanitized Data.
+	 *
+	 * @phpstan-return LanguageData
+	 */
+	private static function sanitize_data( array $data ) {
+		foreach ( $data['term_props'] as $tax => $props ) {
+			$data['term_props'][ $tax ] = array_map( 'absint', $props );
+		}
+
+		$data['is_rtl'] = ! empty( $data['is_rtl'] ) ? 1 : 0;
+
+		$positive_fields = array( 'term_group', 'mo_id', 'page_on_front', 'page_for_posts' );
+
+		foreach( $positive_fields as $field ) {
+			$data[ $field ] = absint( $data[ $field ] );
+		}
+
+		/**
+		 * @var LanguageData
+		 */
+		return $data;
+	}
+
+	/**
+	 * Returns predefined languages data.
+	 *
+	 * @since 3.4
+	 *
+	 * @return array[]
+	 *
+	 * @phpstan-return array<string, array<string, string>>
+	 */
+	private static function get_languages() {
+		if ( empty( self::$languages ) ) {
+			self::$languages = include POLYLANG_DIR . '/settings/languages.php';
+		}
+
+		return self::$languages;
+	}
+}

--- a/include/language.php
+++ b/include/language.php
@@ -314,14 +314,12 @@ class PLL_Language {
 			/** This filter is documented in wordpress/wp-includes/functions.php */
 			if ( WP_DEBUG && apply_filters( 'deprecated_function_trigger_error', true ) ) {
 				trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-					esc_html(
-						sprintf(
-							"Class property %1\$s::\$%2\$s is deprecated, use %1\$s::get_tax_prop( '%3\$s', '%4\$s' ) instead.\nError handler",
-							get_class( $this ),
-							$property,
-							$term_prop_type,
-							$term_prop
-						)
+					sprintf(
+						"Class property %1\$s::\$%2\$s is deprecated, use %1\$s::get_tax_prop( '%3\$s', '%4\$s' ) instead.\nError handler",
+						esc_html( get_class( $this ) ),
+						esc_html( $property ),
+						esc_html( $term_prop_type ),
+						esc_html( $term_prop )
 					),
 					E_USER_DEPRECATED
 				);
@@ -351,7 +349,7 @@ class PLL_Language {
 		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			esc_html(
 				sprintf(
-					"Cannot access %s property %s::$%s in %s on line %d\nError handler",
+					"Cannot access %s property %s::$%s in %s on line %d.\nError handler",
 					$visibility,
 					get_class( $this ),
 					$property,

--- a/include/language.php
+++ b/include/language.php
@@ -8,27 +8,58 @@
  * Manipulating only one object per language instead of two terms should make things easier.
  *
  * @since 1.2
+ * @immutable
+ *
+ * @phpstan-type LanguageData array{
+ *     term_props: array{
+ *         language: array{
+ *             term_id: positive-int,
+ *             term_taxonomy_id: positive-int,
+ *             count: int<0, max>
+ *         },
+ *         term_language: array{
+ *             term_id: positive-int,
+ *             term_taxonomy_id: positive-int,
+ *             count: int<0, max>
+ *         }
+ *     },
+ *     name: non-empty-string,
+ *     slug: non-empty-string,
+ *     locale: non-empty-string,
+ *     w3c: non-empty-string,
+ *     flag_code: non-empty-string,
+ *     term_group: int,
+ *     is_rtl: int<0, 1>,
+ *     mo_id: positive-int,
+ *     facebook?: string,
+ *     home_url: non-empty-string,
+ *     search_url: non-empty-string,
+ *     host: non-empty-string,
+ *     flag_url: non-empty-string,
+ *     flag: non-empty-string,
+ *     custom_flag_url?: string,
+ *     custom_flag?: string,
+ *     page_on_front:positive-int,
+ *     page_for_posts:positive-int
+ * }
  */
 #[AllowDynamicProperties]
 class PLL_Language {
 	/**
-	 * Id of the term in 'language' taxonomy.
-	 *
-	 * @var int
-	 */
-	public $term_id;
-
-	/**
 	 * Language name. Ex: English.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $name;
 
 	/**
-	 * Language code used in url. Ex: en.
+	 * Language code used in URL. Ex: en.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $slug;
 
@@ -40,44 +71,22 @@ class PLL_Language {
 	public $term_group;
 
 	/**
-	 * Term taxonomy id in 'language' taxonomy.
+	 * ID of the term in 'language' taxonomy.
+	 * Duplicated from `$this->term_props['language']['term_id'],
+	 * but kept to facilitate the use of it.
 	 *
 	 * @var int
-	 */
-	public $term_taxonomy_id;
-
-	/**
-	 * Number of posts and pages in that language.
 	 *
-	 * @var int
+	 * @phpstan-var int<1, max>
 	 */
-	public $count;
-
-	/**
-	 * Id of the term in 'term_language' taxonomy.
-	 *
-	 * @var int
-	 */
-	public $tl_term_id;
-
-	/**
-	 * Term taxonomy id in 'term_language' taxonomy.
-	 *
-	 * @var int
-	 */
-	public $tl_term_taxonomy_id;
-
-	/**
-	 * Number of terms in that language.
-	 *
-	 * @var int
-	 */
-	public $tl_count;
+	public $term_id;
 
 	/**
 	 * WordPress language locale. Ex: en_US.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $locale;
 
@@ -85,6 +94,8 @@ class PLL_Language {
 	 * 1 if the language is rtl, 0 otherwise.
 	 *
 	 * @var int
+	 *
+	 * @phpstan-var int<0, 1>
 	 */
 	public $is_rtl;
 
@@ -92,55 +103,65 @@ class PLL_Language {
 	 * W3C locale.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $w3c;
 
 	/**
 	 * Facebook locale.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	public $facebook;
+	public $facebook = '';
 
 	/**
-	 * Home url in this language.
+	 * Home URL in this language.
 	 *
-	 * @var string|null
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $home_url;
 
 	/**
-	 * Home url to use in search forms.
+	 * Home URL to use in search forms.
 	 *
-	 * @var string|null
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $search_url;
 
 	/**
 	 * Host corresponding to this language.
 	 *
-	 * @var string|null
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $host;
 
 	/**
-	 * Id of the post storing strings translations.
+	 * ID of the post storing strings translations.
 	 *
 	 * @var int
+	 *
+	 * @phpstan-var positive-int
 	 */
 	public $mo_id;
 
 	/**
-	 * Id of the page on front in this language ( set from pll_languages_list filter ).
+	 * ID of the page on front in this language (set from pll_languages_list filter).
 	 *
-	 * @var int|null
+	 * @var int
 	 */
 	public $page_on_front;
 
 	/**
-	 * Id of the page for posts in this language ( set from pll_languages_list filter ).
+	 * ID of the page for posts in this language (set from pll_languages_list filter).
 	 *
-	 * @var int|null
+	 * @var int
 	 */
 	public $page_for_posts;
 
@@ -148,78 +169,268 @@ class PLL_Language {
 	 * Code of the flag.
 	 *
 	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $flag_code;
 
 	/**
-	 * Url of the flag.
+	 * URL of the flag.
 	 *
-	 * @var string|null
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $flag_url;
 
 	/**
-	 * Html markup of the flag.
+	 * HTML markup of the flag.
 	 *
-	 * @var string|null
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
 	 */
 	public $flag;
 
 	/**
-	 * Url of the custom flag if it exists.
+	 * URL of the custom flag if it exists.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	public $custom_flag_url;
+	public $custom_flag_url = '';
 
 	/**
-	 * Html markup of the custom flag if it exists.
+	 * HTML markup of the custom flag if it exists.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	public $custom_flag;
+	public $custom_flag = '';
 
 	/**
-	 * Constructor: builds a language object given its two corresponding terms in 'language' and 'term_language' taxonomies.
+	 * Stores language term properties (like term IDs and counts) for each language taxonomy (`language`,
+	 * `term_language`, etc).
+	 * This stores the values of the properties `$term_id` + `$term_taxonomy_id` + `$count` (`language`), `$tl_term_id`
+	 * + `$tl_term_taxonomy_id` + `$tl_count` (`term_language`), and the `term_id` + `term_taxonomy_id` + `count` for
+	 * other language taxonomies.
+	 *
+	 * @var array[] Array keys are language term names.
+	 *
+	 * @exemple array(
+	 *     'language'       => array(
+	 *         'term_id'          => 7,
+	 *         'term_taxonomy_id' => 8,
+	 *         'count'            => 11,
+	 *     ),
+	 *     'term_language' => array(
+	 *         'term_id'          => 11,
+	 *         'term_taxonomy_id' => 12,
+	 *         'count'            => 6,
+	 *     ),
+	 *     'foo_language'  => array(
+	 *         'term_id'          => 33,
+	 *         'term_taxonomy_id' => 34,
+	 *         'count'            => 0,
+	 *     ),
+	 * )
+	 *
+	 * @phpstan-var array<
+	 *     non-empty-string,
+	 *     array{
+	 *         term_id: positive-int,
+	 *         term_taxonomy_id: positive-int,
+	 *         count: int<0, max>
+	 *     }
+	 * >
+	 */
+	protected $term_props = array();
+
+	/**
+	 * Constructor: builds a language object given the corresponding data.
 	 *
 	 * @since 1.2
+	 * @since 3.4 Only accepts one argument.
 	 *
-	 * @param WP_Term|array $language      Term in 'language' taxonomy or language object properties stored as an array.
-	 * @param WP_Term       $term_language Corresponding 'term_language' term.
+	 * @param array $language_data {
+	 *     Language object properties stored as an array.
+	 *
+	 *     @type array[] $term_props      An array of language term properties. Array keys are language taxonomy names
+	 *                                    (`language` and `term_language` are mandatory), array values are arrays of
+	 *                                    language term properties (`term_id`, `term_taxonomy_id`, and `count`).
+	 *     @type string  $name            Language name. Ex: English.
+	 *     @type string  $slug            Language code used in URL. Ex: en.
+	 *     @type string  $locale          WordPress language locale. Ex: en_US.
+	 *     @type string  $w3c             W3C locale.
+	 *     @type string  $flag_code       Code of the flag.
+	 *     @type int     $term_group      Order of the language when displayed in a list of languages.
+	 *     @type int     $is_rtl          `1` if the language is rtl, `0` otherwise.
+	 *     @type int     $mo_id           ID of the post storing strings translations.
+	 *     @type string  $facebook        Optional. Facebook locale.
+	 *     @type string  $home_url        Home URL in this language.
+	 *     @type string  $search_url      Home URL to use in search forms.
+	 *     @type string  $host            Host corresponding to this language.
+	 *     @type string  $flag_url        URL of the flag.
+	 *     @type string  $flag            HTML markup of the flag.
+	 *     @type string  $custom_flag_url Optional. URL of the custom flag if it exists.
+	 *     @type string  $custom_flag     Optional. HTML markup of the custom flag if it exists.
+	 *     @type int     $page_on_front   ID of the page on front in this language.
+	 *     @type int     $page_for_posts  ID of the page for posts in this language.
+	 * }
+	 *
+	 * @phpstan-param LanguageData $language_data
 	 */
-	public function __construct( $language, $term_language = null ) {
-		if ( empty( $term_language ) ) {
-			// Build the object from all properties stored as an array.
-			foreach ( $language as $prop => $value ) {
-				$this->$prop = $value;
-			}
-		} else {
-			// Build the object from taxonomy terms.
-			$this->term_id = (int) $language->term_id;
-			$this->name = $language->name;
-			$this->slug = $language->slug;
-			$this->term_group = (int) $language->term_group;
-			$this->term_taxonomy_id = (int) $language->term_taxonomy_id;
-			$this->count = (int) $language->count;
-
-			$this->tl_term_id = (int) $term_language->term_id;
-			$this->tl_term_taxonomy_id = (int) $term_language->term_taxonomy_id;
-			$this->tl_count = (int) $term_language->count;
-
-			// The description field can contain any property.
-			$description = maybe_unserialize( $language->description );
-			foreach ( $description as $prop => $value ) {
-				'rtl' == $prop ? $this->is_rtl = $value : $this->$prop = $value;
-			}
-
-			$this->mo_id = PLL_MO::get_id( $this );
-
-			$languages = include POLYLANG_DIR . '/settings/languages.php';
-			$this->w3c = isset( $languages[ $this->locale ]['w3c'] ) ? $languages[ $this->locale ]['w3c'] : str_replace( '_', '-', $this->locale );
-			if ( isset( $languages[ $this->locale ]['facebook'] ) ) {
-				$this->facebook = $languages[ $this->locale ]['facebook'];
-			}
+	public function __construct( array $language_data ) {
+		foreach ( $language_data as $prop => $value ) {
+			$this->$prop = $value;
 		}
+
+		$this->term_id = $this->term_props['language']['term_id'];
+	}
+
+	/**
+	 * Throws a depreciation notice if someone tries to get one of the following properties:
+	 * `term_taxonomy_id`, `count`, `tl_term_id`, `tl_term_taxonomy_id` or `tl_count`.
+	 *
+	 * Backward compatibility with Polylang < 3.4.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $property Property to get.
+	 * @return mixed Required property value.
+	 */
+	public function __get( $property ) {
+		$deprecated_properties = array(
+			'term_taxonomy_id'    => array( 'language', 'term_taxonomy_id' ),
+			'count'               => array( 'language', 'count' ),
+			'tl_term_id'          => array( 'term_language', 'term_id' ),
+			'tl_term_taxonomy_id' => array( 'term_language', 'term_taxonomy_id' ),
+			'tl_count'            => array( 'term_language', 'count' ),
+		);
+
+		// Deprecated property.
+		if ( array_key_exists( $property, $deprecated_properties ) ) {
+			$term_prop_type = $deprecated_properties[ $property ][0];
+			$term_prop      = $deprecated_properties[ $property ][1];
+
+			/** This filter is documented in wordpress/wp-includes/functions.php */
+			if ( WP_DEBUG && apply_filters( 'deprecated_function_trigger_error', true ) ) {
+				trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+					esc_html(
+						sprintf(
+							"Class property %1\$s::\$%2\$s is deprecated, use %1\$s::get_tax_prop( '%3\$s', '%4\$s' ) instead.\nError handler",
+							get_class( $this ),
+							$property,
+							$term_prop_type,
+							$term_prop
+						)
+					),
+					E_USER_DEPRECATED
+				);
+			}
+
+			return $this->term_props[ $term_prop_type ][ $term_prop ];
+		}
+
+		// Undefined property.
+		if ( ! property_exists( $this, $property ) ) {
+			return null;
+		}
+
+		// The property is defined.
+		$ref = new ReflectionProperty( $this, $property );
+
+		// Public property.
+		if ( $ref->isPublic() ) {
+			return $this->{$property};
+		}
+
+		// Protected or private property.
+		$visibility = $ref->isPrivate() ? 'private' : 'protected';
+		$trace      = debug_backtrace(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection, WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$file       = isset( $trace[0]['file'] ) ? $trace[0]['file'] : '';
+		$line       = isset( $trace[0]['line'] ) ? $trace[0]['line'] : 0;
+		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			esc_html(
+				sprintf(
+					"Cannot access %s property %s::$%s in %s on line %d\nError handler",
+					$visibility,
+					get_class( $this ),
+					$property,
+					$file,
+					$line
+				)
+			),
+			E_USER_ERROR
+		);
+	}
+
+	/**
+	 * Checks for a deprecated property.
+	 * Is triggered by calling `isset()` or `empty()` on inaccessible (protected or private) or non-existing properties.
+	 *
+	 * Backward compatibility with Polylang < 3.4.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $property A property name.
+	 * @return bool
+	 */
+	public function __isset( $property ) {
+		$deprecated_properties = array( 'term_taxonomy_id', 'count', 'tl_term_id', 'tl_term_taxonomy_id', 'tl_count' );
+		return in_array( $property, $deprecated_properties, true );
+	}
+
+	/**
+	 * Returns a language term property value (term ID, term taxonomy ID, or count).
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $taxonomy_name Name of the taxonomy.
+	 * @param string $prop_name     Name of the property: 'term_taxonomy_id', 'term_id', 'count'.
+	 * @return int
+	 *
+	 * @phpstan-param non-empty-string $taxonomy_name
+	 * @phpstan-param 'term_taxonomy_id'|'term_id'|'count' $prop_name
+	 * @phpstan-return int<0, max>
+	 */
+	public function get_tax_prop( $taxonomy_name, $prop_name ) {
+		return isset( $this->term_props[ $taxonomy_name ][ $prop_name ] ) ? $this->term_props[ $taxonomy_name ][ $prop_name ] : 0;
+	}
+
+	/**
+	 * Returns the language term props for all content types.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|null $field Name of the field to return. `null` to return them all.
+	 * @return (int[]|int)[] Array keys are taxonomy names, array values depend of `$field`.
+	 *
+	 * @phpstan-param 'term_taxonomy_id'|'term_id'|'count'|null $field
+	 * @phpstan-return array<non-empty-string, (
+	 *     $field is non-empty-string ?
+	 *     (
+	 *         $field is 'count' ?
+	 *         int<0, max> :
+	 *         positive-int
+	 *     ) :
+	 *     array{
+	 *         term_id: positive-int,
+	 *         term_taxonomy_id: positive-int,
+	 *         count: int<0, max>
+	 *     }
+	 * )>
+	 */
+	public function get_tax_props( $field = '' ) {
+		if ( empty( $field ) ) {
+			return $this->term_props;
+		}
+
+		$term_props = array();
+
+		foreach ( $this->term_props as $taxonomy_name => $props ) {
+			$term_props[ $taxonomy_name ] = $props[ $field ];
+		}
+
+		return $term_props;
 	}
 
 	/**
@@ -432,8 +643,9 @@ class PLL_Language {
 	 * @return void
 	 */
 	public function update_count() {
-		wp_update_term_count( $this->term_taxonomy_id, 'language' ); // Posts count.
-		wp_update_term_count( $this->tl_term_taxonomy_id, 'term_language' ); // Terms count.
+		foreach ( $this->term_props as $taxonomy => $props ) {
+			wp_update_term_count( $props['term_taxonomy_id'], $taxonomy );
+		}
 	}
 
 	/**
@@ -444,10 +656,13 @@ class PLL_Language {
 	 * @param string $search_url Home url to use in search forms.
 	 * @param string $home_url   Home url.
 	 * @return void
+	 *
+	 * @phpstan-param non-empty-string $search_url
+	 * @phpstan-param non-empty-string $home_url
 	 */
 	public function set_home_url( $search_url, $home_url ) {
 		$this->search_url = $search_url;
-		$this->home_url = $home_url;
+		$this->home_url   = $home_url;
 	}
 
 	/**
@@ -460,21 +675,12 @@ class PLL_Language {
 	 * @return void
 	 */
 	public function set_url_scheme() {
-		if ( ! empty( $this->home_url ) ) {
-			$this->home_url = set_url_scheme( $this->home_url );
-		}
+		$props = array( 'home_url', 'search_url', 'flag_url', 'custom_flag_url' );
 
-		if ( ! empty( $this->search_url ) ) {
-			$this->search_url = set_url_scheme( $this->search_url );
-		}
-
-		// Set url scheme, also for the flags.
-		if ( ! empty( $this->flag_url ) ) {
-			$this->flag_url = set_url_scheme( $this->flag_url );
-		}
-
-		if ( ! empty( $this->custom_flag_url ) ) {
-			$this->custom_flag_url = set_url_scheme( $this->custom_flag_url );
+		foreach ( $props as $prop ) {
+			if ( ! empty( $this->$prop ) ) {
+				$this->$prop = set_url_scheme( $this->$prop );
+			}
 		}
 	}
 
@@ -489,5 +695,16 @@ class PLL_Language {
 	 */
 	public function get_locale( $filter = 'raw' ) {
 		return 'display' === $filter ? $this->w3c : $this->locale;
+	}
+
+	/**
+	 * Returns the values of this instance's properties.
+	 *
+	 * @since 3.4
+	 *
+	 * @return array
+	 */
+	public function get_object_vars() {
+		return get_object_vars( $this );
 	}
 }

--- a/include/language.php
+++ b/include/language.php
@@ -30,7 +30,7 @@
  *     flag_code: non-empty-string,
  *     term_group: int,
  *     is_rtl: int<0, 1>,
- *     mo_id: positive-int,
+ *     mo_id: int,
  *     facebook?: string,
  *     home_url: non-empty-string,
  *     search_url: non-empty-string,
@@ -146,8 +146,6 @@ class PLL_Language {
 	 * ID of the post storing strings translations.
 	 *
 	 * @var int
-	 *
-	 * @phpstan-var positive-int
 	 */
 	public $mo_id;
 

--- a/include/mo.php
+++ b/include/mo.php
@@ -78,14 +78,30 @@ class PLL_MO extends MO {
 	}
 
 	/**
-	 * Returns the post id of the post storing the strings translations.
+	 * Returns the post ID of the post storing the strings translations.
 	 *
 	 * @since 1.4
 	 *
 	 * @param PLL_Language $lang The language object.
-	 * @return int
+	 * @return int|null
+	 *
+	 * @phpstan-return positive-int|null
 	 */
 	public static function get_id( $lang ) {
+		return self::get_id_from_term_id( $lang->term_id );
+	}
+
+	/**
+	 * Returns the post ID of the post storing the strings translations.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int $term_id The language term ID.
+	 * @return int|null
+	 *
+	 * @phpstan-return positive-int|null
+	 */
+	public static function get_id_from_term_id( $term_id ) {
 		global $wpdb;
 
 		$ids = wp_cache_get( 'polylang_mo_ids' );
@@ -95,8 +111,8 @@ class PLL_MO extends MO {
 			wp_cache_add( 'polylang_mo_ids', $ids );
 		}
 
-		// The mo id for a language can be transiently empty
-		return isset( $ids[ 'polylang_mo_' . $lang->term_id ] ) ? $ids[ 'polylang_mo_' . $lang->term_id ]->ID : null;
+		// The mo id for a language can be transiently empty.
+		return isset( $ids[ 'polylang_mo_' . $term_id ] ) ? $ids[ 'polylang_mo_' . $term_id ]->ID : null;
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -731,7 +731,7 @@ class PLL_Model {
 				continue;
 			}
 
-			$language = PLL_Language_Factory::create_from_terms( $lang_terms );
+			$language = PLL_Language_Factory::get_from_terms( $lang_terms );
 
 			if ( empty( $language ) ) {
 				continue;

--- a/include/model.php
+++ b/include/model.php
@@ -145,7 +145,11 @@ class PLL_Model {
 
 		// Remove empty languages if requested.
 		if ( ! empty( $args['hide_empty'] ) ) {
-			$languages = wp_list_filter( $languages, array( 'count' => 0 ), 'NOT' );
+			foreach ( $languages as $key => $language ) {
+				if ( empty( $language->get_tax_prop( 'language', 'count' ) ) ) {
+					unset( $languages[ $key ] );
+				}
+			}
 		}
 
 		return empty( $args['fields'] ) ? $languages : wp_list_pluck( $languages, $args['fields'] );

--- a/include/query.php
+++ b/include/query.php
@@ -109,7 +109,11 @@ class PLL_Query {
 		if ( ! is_array( $languages ) ) {
 			$languages = array( $languages );
 		}
-		$tt_ids = wp_list_pluck( $languages, 'term_taxonomy_id' );
+
+		$tt_ids = array();
+		foreach ( $languages as $language ) {
+			$tt_ids[] = $language->get_tax_prop( 'language', 'term_taxonomy_id' );
+		}
 
 		// Defining directly the tax_query (rather than setting 'lang' avoids transforming the query by WP).
 		$lang_query = array(

--- a/include/translatable-object-with-types-interface.php
+++ b/include/translatable-object-with-types-interface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface to use for objects that can have one or more types.
+ *
+ * @since 3.4
+ */
+interface PLL_Translatable_Object_With_Types_Interface {
+
+	/**
+	 * Returns object types that need to be translated.
+	 *
+	 * @since 3.4
+	 *
+	 * @param bool $filter True if we should return only valid registered object types.
+	 * @return string[] Object type names for which Polylang manages languages.
+	 *
+	 * @phpstan-return array<non-empty-string, non-empty-string>
+	 */
+	public function get_translated_object_types( $filter = true );
+
+	/**
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	public function is_translated_object_type( $object_type );
+}

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -58,4 +58,19 @@ trait PLL_Translatable_Object_With_Types_Trait {
 			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
 		);
 	}
+
+	/**
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type (taxonomy name) name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	public function is_translated_object_type( $object_type ) {
+		$object_types = $this->get_translated_object_types( false );
+		return ! empty( array_intersect( (array) $object_type, $object_types ) );
+	}
 }

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait to use for objects that can have one or more types.
+ * This must be used with {@see PLL_Translatable_Object_With_Types_Interface}.
+ *
+ * @since 3.4
+ *
+ * @property string[] $db {
+ *     @type string $table         Name of the table.
+ *     @type string $id_column     Name of the column containing the object's ID.
+ *     @type string $type_column   Name of the column containing the object's type.
+ *     @type string $default_alias Default alias corresponding to the object's table.
+ * }
+ *
+ * @phpstan-property array{
+ *     table: non-empty-string,
+ *     id_column: non-empty-string,
+ *     type_column: non-empty-string,
+ *     default_alias: non-empty-string
+ * } $db
+ */
+trait PLL_Translatable_Object_With_Types_Trait {
+
+	/**
+	 * Returns SQL query that fetches the IDs of the objects without language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int[] $language_ids List of language `term_taxonomy_id`.
+	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @return string
+	 *
+	 * @phpstan-param array<positive-int> $language_ids
+	 * @phpstan-param -1|positive-int $limit
+	 */
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit ) {
+		$object_types = $this->get_translated_object_types();
+
+		if ( empty( $object_types ) ) {
+			return '';
+		}
+
+		return sprintf(
+			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
+			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (
+				SELECT object_id FROM {$GLOBALS['wpdb']->term_relationships} WHERE term_taxonomy_id IN (%s)
+			)
+			AND {$this->db['type_column']} IN (%s)
+			%s",
+			PLL_Db_Tools::prepare_values_list( $language_ids ),
+			PLL_Db_Tools::prepare_values_list( $object_types ),
+			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
+		);
+	}
+}

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Abstract class to use for object types that support at least one language.
+ *
+ * @since 3.4
+ */
+abstract class PLL_Translatable_Object {
+
+	/**
+	 * @var PLL_Model
+	 */
+	public $model;
+
+	/**
+	 * List of taxonomies to cache.
+	 *
+	 * @var string[]
+	 * @see PLL_Translatable_Object::get_object_term()
+	 *
+	 * @phpstan-var list<non-empty-string>
+	 */
+	protected $tax_to_cache = array();
+
+	/**
+	 * Taxonomy name for the languages.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $tax_language;
+
+	/**
+	 * Identifier that must be unique for each type of content.
+	 * Also used when checking capabilities.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $type;
+
+	/**
+	 * Object type to use when registering the taxonomy.
+	 * Left empty for posts.
+	 *
+	 * @var string|null
+	 *
+	 * @phpstan-var non-empty-string|null
+	 */
+	protected $object_type = null;
+
+	/**
+	 * Contains database-related informations that can be used in some of this class methods.
+	 * These are specific to the table containing the objects.
+	 *
+	 * @var string[] {
+	 *     @type string $table         Name of the table.
+	 *     @type string $id_column     Name of the column containing the object's ID.
+	 *     @type string $default_alias Default alias corresponding to the object's table.
+	 * }
+	 * @see PLL_Translatable_Object::join_clause()
+	 * @see PLL_Translatable_Object::get_objects_with_no_lang_sql()
+	 *
+	 * @phpstan-var array{
+	 *     table: non-empty-string,
+	 *     id_column: non-empty-string,
+	 *     default_alias: non-empty-string
+	 * }
+	 */
+	protected $db;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.4
+	 *
+	 * @param PLL_Model $model Instance of `PLL_Model`, passed by reference.
+	 */
+	public function __construct( PLL_Model &$model ) {
+		$this->model          = $model;
+		$this->tax_to_cache[] = $this->tax_language;
+
+		/*
+		 * Register our taxonomy as soon as possible.
+		 * This is early registration, not ready for rewrite rules as $wp_rewrite will be setup later.
+		 */
+		register_taxonomy(
+			$this->tax_language,
+			(array) $this->object_type,
+			array(
+				'label'     => false,
+				'public'    => false,
+				'query_var' => false,
+				'rewrite'   => false,
+				'_pll'      => true,
+			)
+		);
+	}
+
+	/**
+	 * Returns the language taxonomy name.
+	 *
+	 * @since 3.4
+	 *
+	 * @return string
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_tax_language() {
+		return $this->tax_language;
+	}
+
+	/**
+	 * Returns the type of object.
+	 *
+	 * @since 3.4
+	 *
+	 * @return string
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_type() {
+		return $this->type;
+	}
+
+	/**
+	 * Adds hooks.
+	 *
+	 * @since 3.4
+	 *
+	 * @return static
+	 */
+	public function init() {
+		return $this;
+	}
+
+	/**
+	 * Stores the object's language into the database.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int                     $id   Object ID.
+	 * @param PLL_Language|string|int $lang Language (object, slug, or term ID).
+	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+	 *              the object).
+	 */
+	public function set_language( $id, $lang ) {
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		$old_lang = $this->get_language( $id );
+		$old_lang = $old_lang ? $old_lang->get_tax_prop( $this->tax_language, 'term_id' ) : 0;
+
+		$lang = $this->model->get_language( $lang );
+		$lang = $lang ? $lang->get_tax_prop( $this->tax_language, 'term_id' ) : 0;
+
+		if ( $old_lang === $lang ) {
+			return false;
+		}
+
+		return is_array( wp_set_object_terms( $id, $lang, $this->tax_language ) );
+	}
+
+	/**
+	 * Assigns a new language to an object.
+	 *
+	 * @since 3.1
+	 *
+	 * @param int          $id   Object ID.
+	 * @param PLL_Language $lang New language to assign to the object.
+	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
+	 *              the object).
+	 */
+	public function update_language( $id, PLL_Language $lang ) {
+		return $this->set_language( $id, $lang );
+	}
+
+	/**
+	 * Returns the language of an object.
+	 *
+	 * @since 0.1
+	 * @since 3.4 Renamed the parameter $post_id into $id.
+	 *
+	 * @param int $id Object ID.
+	 * @return PLL_Language|false A `PLL_Language` object. `false` if no language is associated to that object or if the
+	 *                            ID is invalid.
+	 */
+	public function get_language( $id ) {
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		// Get the language and make sure it is a PLL_Language object.
+		$lang = $this->get_object_term( $id, $this->tax_language );
+
+		if ( empty( $lang ) ) {
+			return false;
+		}
+
+		return $this->model->get_language( $lang->term_id );
+	}
+
+	/**
+	 * Removes the term language from the database.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int $id Term ID.
+	 * @return void
+	 */
+	public function delete_language( $id ) {
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return;
+		}
+
+		wp_delete_object_term_relationships( $id, $this->tax_language );
+	}
+
+	/**
+	 * Wraps `wp_get_object_terms()` to cache it and return only one object.
+	 * Inspired by the WordPress function `get_the_terms()`.
+	 *
+	 * @since 1.2
+	 *
+	 * @param int    $id       Object ID.
+	 * @param string $taxonomy Polylang taxonomy depending if we are looking for a post (or term, or else) language.
+	 * @return WP_Term|false The term associated to the object in the requested taxonomy if it exists, `false` otherwise.
+	 */
+	public function get_object_term( $id, $taxonomy ) {
+		global $wp_version;
+
+		$id = $this->sanitize_int_id( $id );
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		$term = get_object_term_cache( $id, $taxonomy );
+
+		if ( is_array( $term ) ) {
+			return ! empty( $term ) ? reset( $term ) : false;
+		}
+
+		// Query terms.
+		$terms        = array();
+		$term         = false;
+		$object_terms = wp_get_object_terms( $id, $this->tax_to_cache, array( 'update_term_meta_cache' => false ) );
+
+		if ( is_array( $object_terms ) ) {
+			foreach ( $object_terms as $t ) {
+				$terms[ $t->taxonomy ] = $t;
+				if ( $t->taxonomy === $taxonomy ) {
+					$term = $t;
+				}
+			}
+		}
+
+		// Stores it the way WP expects it. Set an empty cache if no term was found in the taxonomy.
+		$store_only_term_ids = version_compare( $wp_version, '6.0', '>=' );
+
+		foreach ( $this->tax_to_cache as $tax ) {
+			if ( empty( $terms[ $tax ] ) ) {
+				$to_cache = array();
+			} elseif ( $store_only_term_ids ) {
+				$to_cache = array( $terms[ $tax ]->term_id );
+			} else {
+				// Backward compatibility with WP < 6.0.
+				$to_cache = array( $terms[ $tax ] );
+			}
+
+			wp_cache_add( $id, $to_cache, "{$tax}_relationships" );
+		}
+
+		return $term;
+	}
+
+	/**
+	 * A JOIN clause to add to sql queries when filtering by language is needed directly in query.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $alias Optional alias for object table.
+	 * @return string The JOIN clause.
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	public function join_clause( $alias = '' ) {
+		global $wpdb;
+
+		if ( empty( $alias ) ) {
+			$alias = $this->db['default_alias'];
+		}
+
+		return " INNER JOIN {$wpdb->term_relationships} AS pll_tr ON pll_tr.object_id = {$alias}.{$this->db['id_column']}";
+	}
+
+	/**
+	 * A WHERE clause to add to sql queries when filtering by language is needed directly in query.
+	 *
+	 * @since 1.2
+	 *
+	 * @param PLL_Language|PLL_Language[]|string|string[] $lang A `PLL_Language` object, or a comma separated list of language slugs, or an array of language slugs or objects.
+	 * @return string The WHERE clause.
+	 *
+	 * @phpstan-param PLL_Language|PLL_Language[]|non-empty-string|non-empty-string[] $lang
+	 */
+	public function where_clause( $lang ) {
+		/*
+		 * $lang is an object.
+		 * This is generally the case if the query is coming from Polylang.
+		 */
+		if ( $lang instanceof PLL_Language ) {
+			return ' AND pll_tr.term_taxonomy_id = ' . absint( $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ) );
+		}
+
+		/*
+		 * $lang is an array of objects, an array of slugs, or a comma separated list of slugs.
+		 * The comma separated list of slugs can happen if the query is coming from outside with a 'lang' parameter.
+		 */
+		$languages        = is_array( $lang ) ? $lang : explode( ',', $lang );
+		$languages_tt_ids = array();
+
+		foreach ( $languages as $language ) {
+			$language = $this->model->get_language( $language );
+
+			if ( ! empty( $language ) ) {
+				$languages_tt_ids[] = absint( $language->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ) );
+			}
+		}
+
+		if ( empty( $languages_tt_ids ) ) {
+			return '';
+		}
+
+		return ' AND pll_tr.term_taxonomy_id IN ( ' . implode( ',', $languages_tt_ids ) . ' )';
+	}
+
+	/**
+	 * Returns the IDs of the objects without language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int $limit Max number of objects to return. `-1` to return all of them.
+	 * @return int[] Array of object IDs.
+	 *
+	 * @phpstan-param -1|positive-int $limit
+	 * @phpstan-return list<positive-int>
+	 */
+	public function get_objects_with_no_lang( $limit ) {
+		$language_ids = $this->model->get_languages_list();
+
+		foreach ( $language_ids as $i => $language ) {
+			$language_ids[ $i ] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
+		}
+
+		$language_ids = array_filter( $language_ids );
+
+		if ( empty( $language_ids ) ) {
+			return array();
+		}
+
+		$sql = $this->get_objects_with_no_lang_sql( $language_ids, $limit );
+
+		if ( empty( $sql ) ) {
+			return array();
+		}
+
+		$key          = md5( $sql );
+		$cache_type   = "{$this->type}s";
+		$last_changed = wp_cache_get_last_changed( $cache_type );
+		$cache_key    = "{$cache_type}_no_lang:{$key}:{$last_changed}";
+		$object_ids   = wp_cache_get( $cache_key, $cache_type );
+
+		if ( ! is_array( $object_ids ) ) {
+			$object_ids = $GLOBALS['wpdb']->get_col( $sql ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+			wp_cache_set( $cache_key, $object_ids, $cache_type );
+		}
+
+		return array_values( $this->sanitize_int_ids_list( $object_ids ) );
+	}
+
+	/**
+	 * Sanitizes an ID as positive integer.
+	 * Kind of similar to `absint()`, but rejects negetive integers instead of making them positive.
+	 *
+	 * @since 3.2
+	 *
+	 * @param mixed $id A supposedly numeric ID.
+	 * @return int A positive integer. `0` for non numeric values and negative integers.
+	 *
+	 * @phpstan-return int<0,max>
+	 */
+	public function sanitize_int_id( $id ) {
+		return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
+	}
+
+	/**
+	 * Sanitizes an array of IDs as positive integers.
+	 * `0` values are removed.
+	 *
+	 * @since 3.2
+	 *
+	 * @param mixed $ids An array of numeric IDs.
+	 * @return int[]
+	 *
+	 * @phpstan-return array<positive-int>
+	 */
+	public function sanitize_int_ids_list( $ids ) {
+		if ( empty( $ids ) || ! is_array( $ids ) ) {
+			return array();
+		}
+
+		$ids = array_map( array( $this, 'sanitize_int_id' ), $ids );
+
+		return array_filter( $ids );
+	}
+
+	/**
+	 * Returns SQL query that fetches the IDs of the objects without language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int[] $language_ids List of language `term_taxonomy_id`.
+	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @return string
+	 *
+	 * @phpstan-param array<positive-int> $language_ids
+	 * @phpstan-param -1|positive-int $limit
+	 */
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit ) {
+		return sprintf(
+			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
+			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (
+				SELECT object_id FROM {$GLOBALS['wpdb']->term_relationships} WHERE term_taxonomy_id IN (%s)
+			)
+			%s",
+			PLL_Db_Tools::prepare_values_list( $language_ids ),
+			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
+		);
+	}
+}

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -172,20 +172,6 @@ abstract class PLL_Translatable_Object {
 	}
 
 	/**
-	 * Assigns a new language to an object.
-	 *
-	 * @since 3.1
-	 *
-	 * @param int          $id   Object ID.
-	 * @param PLL_Language $lang New language to assign to the object.
-	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
-	 *              the object).
-	 */
-	public function update_language( $id, PLL_Language $lang ) {
-		return $this->set_language( $id, $lang );
-	}
-
-	/**
 	 * Returns the language of an object.
 	 *
 	 * @since 0.1

--- a/include/translatable-objects.php
+++ b/include/translatable-objects.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Registry for all translatable objects.
+ *
+ * @since 3.4
+ *
+ * @phpstan-implements IteratorAggregate<non-empty-string, PLL_Translatable_Object>
+ */
+class PLL_Translatable_Objects implements IteratorAggregate {
+
+	/**
+	 * Type of the main translatable object.
+	 *
+	 * @var string
+	 */
+	private $main_type = '';
+
+	/**
+	 * List of registered objects.
+	 *
+	 * @var PLL_Translatable_Object[] Array keys are the type of translated content (post, term, etc).
+	 *
+	 * @phpstan-var array<non-empty-string, PLL_Translatable_Object>
+	 */
+	private $objects = array();
+
+	/**
+	 * Registers a translatable object.
+	 *
+	 * @since 3.4
+	 *
+	 * @param PLL_Translatable_Object $object The translatable object to register.
+	 * @return PLL_Translatable_Object
+	 */
+	public function register( PLL_Translatable_Object $object ) {
+		if ( empty( $this->main_type ) ) {
+			$this->main_type = $object->get_type();
+		}
+
+		if ( ! isset( $this->objects[ $object->get_type() ] ) ) {
+			$this->objects[ $object->get_type() ] = $object;
+		}
+
+		return $this->objects[ $object->get_type() ];
+	}
+
+	/**
+	 * Returns all registered translatable objects.
+	 *
+	 * @since 3.4
+	 *
+	 * @return ArrayIterator Iterator on $objects array property. Keys are the type of translated content (post, term, etc).
+	 *
+	 * @phpstan-return ArrayIterator<string, PLL_Translatable_Object>
+	 */
+	public function getIterator() {
+		return new ArrayIterator( $this->objects );
+	}
+
+	/**
+	 * Returns a translatable object, given an object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $object_type The object type.
+	 * @return PLL_Translatable_Object|null
+	 */
+	public function get( $object_type ) {
+		if ( ! isset( $this->objects[ $object_type ] ) ) {
+			return null;
+		}
+
+		return $this->objects[ $object_type ];
+	}
+
+	/**
+	 * Returns all translatable objects except post one.
+	 *
+	 * @since 3.4
+	 *
+	 * @return PLL_Translatable_Object[] An array of secondary translatable objects. Array keys are the type of translated content (post, term, etc).
+	 *
+	 * @phpstan-return array<non-empty-string, PLL_Translatable_Object>
+	 */
+	public function get_secondary_translatable_objects() {
+		return array_diff_key( $this->objects, array( $this->main_type => null ) );
+	}
+
+	/**
+	 * Returns taxonomy names to manage language and translations.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string[] $filter An array on value to filter taxonomy names to return.
+	 * @return string[] Taxonomy names.
+	 *
+	 * @phpstan-param array<'language'|'translations'> $filter
+	 * @phpstan-return list<non-empty-string>
+	 */
+	public function get_taxonomy_names( $filter = array( 'language', 'translations' ) ) {
+		$taxonomies = array();
+
+		foreach ( $this->objects as $object ) {
+			if ( in_array( 'language', $filter, true ) ) {
+				$taxonomies[] = $object->get_tax_language();
+			}
+
+			if ( in_array( 'translations', $filter, true ) && $object instanceof PLL_Translated_Object ) {
+				$taxonomies[] = $object->get_tax_translations();
+			}
+		}
+
+		return $taxonomies;
+	}
+}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -64,17 +64,17 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	}
 
 	/**
-	 * Assigns a new language to an object, taking care of the translations group.
+	 * Assigns a language to an object, taking care of the translations group.
 	 *
-	 * @since 3.1
+	 * @since 3.4
 	 *
-	 * @param int          $id   Object ID.
-	 * @param PLL_Language $lang New language to assign to the object.
+	 * @param int                     $id   Object ID.
+	 * @param PLL_Language|string|int $lang Language to assign to the object.
 	 * @return bool True when successfully assigned. False otherwise (or if the given language is already assigned to
 	 *              the object).
 	 */
-	public function update_language( $id, PLL_Language $lang ) {
-		if ( ! $this->set_language( $id, $lang ) ) {
+	public function set_language( $id, $lang ) {
+		if ( ! parent::set_language( $id, $lang ) ) {
 			return false;
 		}
 

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -498,7 +498,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 		// Prepare terms taxonomy relationship
 		foreach ( $terms as $term ) {
 			$term_ids[] = $term->term_id;
-			$tts[] = $wpdb->prepare( '( %d, %s, %s, %d )', $term->term_id, $$this->tax_translations, $description[ $term->slug ], $count[ $term->slug ] );
+			$tts[] = $wpdb->prepare( '( %d, %s, %s, %d )', $term->term_id, $this->tax_translations, $description[ $term->slug ], $count[ $term->slug ] );
 		}
 
 		// Insert term_taxonomy

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -3,92 +3,91 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
- * Setups the posts languages and translations model
+ * Sets the posts languages and translations model up.
  *
  * @since 1.8
  */
-class PLL_Translated_Post extends PLL_Translated_Object {
+class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
+
+	use PLL_Translatable_Object_With_Types_Trait;
+
+	/**
+	 * Taxonomy name for the languages.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $tax_language = 'language';
+
+	/**
+	 * Identifier that must be unique for each type of content.
+	 * Also used when checking capabilities.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $type = 'post';
+
+	/**
+	 * Taxonomy name for the translation groups.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	protected $tax_translations = 'post_translations';
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Model $model PLL_Model instance.
+	 * @param PLL_Model $model Instance of `PLL_Model`.
 	 */
-	public function __construct( &$model ) {
-		// init properties
-		$this->object_type = null; // For taxonomies
-		$this->type = 'post'; // For capabilities
-		$this->tax_language = 'language';
-		$this->tax_translations = 'post_translations';
-		$this->tax_tt = 'term_taxonomy_id';
+	public function __construct( PLL_Model &$model ) {
+		$this->db = array(
+			'table'         => $GLOBALS['wpdb']->posts,
+			'id_column'     => 'ID',
+			'type_column'   => 'post_type',
+			'default_alias' => $GLOBALS['wpdb']->posts,
+		);
 
 		parent::__construct( $model );
 
-		// registers completely the language taxonomy
+		// Keep hooks in constructor for backward compatibility.
+		$this->init();
+	}
+
+	/**
+	 * Adds hooks.
+	 *
+	 * @since 3.4
+	 *
+	 * @return static
+	 */
+	public function init() {
+		// Registers completely the language taxonomy.
 		add_action( 'setup_theme', array( $this, 'register_taxonomy' ), 1 );
 
-		// setups post types to translate
+		// Setups post types to translate.
 		add_action( 'registered_post_type', array( $this, 'registered_post_type' ) );
 
-		// forces updating posts cache
+		// Forces updating posts cache.
 		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
+		return parent::init();
 	}
 
 	/**
-	 * Store the post language in the database.
-	 *
-	 * @since 0.6
-	 *
-	 * @param int                     $post_id Post id.
-	 * @param int|string|PLL_Language $lang    Language (term_id or slug or object).
-	 * @return void
-	 */
-	public function set_language( $post_id, $lang ) {
-		$post_id = $this->sanitize_int_id( $post_id );
-
-		if ( empty( $post_id ) ) {
-			return;
-		}
-
-		$old_lang = $this->get_language( $post_id );
-		$old_lang = $old_lang ? $old_lang->slug : '';
-
-		$lang = $this->model->get_language( $lang );
-		$lang = $lang ? $lang->slug : '';
-
-		if ( $old_lang !== $lang ) {
-			wp_set_post_terms( $post_id, $lang, $this->tax_language );
-		}
-	}
-
-	/**
-	 * Returns the language of a post
-	 *
-	 * @since 0.1
-	 *
-	 * @param int $post_id post id
-	 * @return PLL_Language|false PLL_Language object, false if no language is associated to that post
-	 */
-	public function get_language( $post_id ) {
-		$post_id = $this->sanitize_int_id( $post_id );
-
-		if ( empty( $post_id ) ) {
-			return false;
-		}
-
-		$lang = $this->get_object_term( $post_id, $this->tax_language );
-		return ! empty( $lang ) ? $this->model->get_language( $lang ) : false;
-	}
-
-	/**
-	 * Deletes a translation.
+	 * Deletes a translation of a post.
 	 *
 	 * @since 0.5
 	 *
-	 * @param int $id Post id.
+	 * @param int $id Post ID.
 	 * @return void
 	 */
 	public function delete_translation( $id ) {
@@ -103,23 +102,73 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	}
 
 	/**
-	 * A join clause to add to sql queries when filtering by language is needed directly in query
+	 * Returns object types (post types) that need to be translated.
+	 * The post types list is cached for better better performance.
+	 * The method waits for 'after_setup_theme' to apply the cache to allow themes adding the filter in functions.php.
 	 *
-	 * @since 1.2
+	 * @since 3.4
 	 *
-	 * @param string $alias Alias for $wpdb->posts table
-	 * @return string join clause
+	 * @param bool $filter True if we should return only valid registered object types.
+	 * @return string[] Object type names for which Polylang manages languages.
+	 *
+	 * @phpstan-return array<non-empty-string, non-empty-string>
 	 */
-	public function join_clause( $alias = '' ) {
-		global $wpdb;
-		if ( empty( $alias ) ) {
-			$alias = $wpdb->posts;
+	public function get_translated_object_types( $filter = true ) {
+		$post_types = $this->model->cache->get( 'post_types' );
+
+		if ( false === $post_types ) {
+			$post_types = array( 'post' => 'post', 'page' => 'page', 'wp_block' => 'wp_block' );
+
+			if ( ! empty( $this->model->options['post_types'] ) && is_array( $this->model->options['post_types'] ) ) {
+				$post_types = array_merge( $post_types, array_combine( $this->model->options['post_types'], $this->model->options['post_types'] ) );
+			}
+
+			if ( empty( $this->model->options['media_support'] ) ) {
+				// In case the post type attachment is stored in the option.
+				unset( $post_types['attachment'] );
+			} else {
+				$post_types['attachment'] = 'attachment';
+			}
+
+			/**
+			 * Filters the list of post types available for translation.
+			 * The default are post types which have the parameter ‘public’ set to true.
+			 * The filter must be added soon in the WordPress loading process:
+			 * in a function hooked to ‘plugins_loaded’ or directly in functions.php for themes.
+			 *
+			 * @since 0.8
+			 *
+			 * @param string[] $post_types  List of post type names (as array keys and values).
+			 * @param bool     $is_settings True when displaying the list of custom post types in Polylang settings.
+			 */
+			$post_types = apply_filters( 'pll_get_post_types', $post_types, false );
+
+			if ( did_action( 'after_setup_theme' ) ) {
+				$this->model->cache->set( 'post_types', $post_types );
+			}
 		}
-		return " INNER JOIN $wpdb->term_relationships AS pll_tr ON pll_tr.object_id = $alias.ID";
+
+		/** @var array<non-empty-string, non-empty-string> $post_types */
+		return $filter ? array_intersect( $post_types, get_post_types() ) : $post_types;
 	}
 
 	/**
-	 * Register the language taxonomy
+	 * Returns true if Polylang manages languages for this object type.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string|string[] $object_type Object type (post type) name or array of object type names.
+	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
+	 */
+	public function is_translated_object_type( $object_type ) {
+		$post_types = $this->get_translated_object_types( false );
+		return ( is_array( $object_type ) && array_intersect( $object_type, $post_types ) || in_array( $object_type, $post_types ) || 'any' === $object_type && ! empty( $post_types ) );
+	}
+
+	/**
+	 * Registers the language taxonomy.
 	 *
 	 * @since 1.2
 	 *
@@ -136,23 +185,25 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 					'all_items'     => __( 'All languages', 'polylang' ),
 				),
 				'public'             => false,
-				'show_ui'            => false, // hide the taxonomy on admin side, needed for WP 4.4.x
-				'show_in_nav_menus'  => false, // no metabox for nav menus, needed for WP 4.4.x
-				'publicly_queryable' => true, // since WP 4.5
+				'show_ui'            => false, // Hide the taxonomy on admin side, needed for WP 4.4.x.
+				'show_in_nav_menus'  => false, // No metabox for nav menus, needed for WP 4.4.x.
+				'publicly_queryable' => true, // Since WP 4.5.
 				'query_var'          => 'lang',
-				'rewrite'            => $this->model->options['force_lang'] < 2, // no rewrite for domains and sub-domains
-				'_pll'               => true, // polylang taxonomy
+				'rewrite'            => $this->model->options['force_lang'] < 2, // No rewrite for domains and sub-domains.
+				'_pll'               => true, // Polylang taxonomy.
 			)
 		);
 	}
 
 	/**
-	 * Check if registered post type must be translated
+	 * Checks if registered post type must be translated.
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $post_type post type name
+	 * @param string $post_type Post type name.
 	 * @return void
+	 *
+	 * @phpstan-param non-empty-string $post_type
 	 */
 	public function registered_post_type( $post_type ) {
 		if ( $this->model->is_translated_post_type( $post_type ) ) {
@@ -178,22 +229,25 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	}
 
 	/**
-	 * Checks if the current user can read the post
+	 * Checks if the current user can read the post.
 	 *
 	 * @since 1.5
+	 * @since 3.4 Renamed the parameter $post_id into $id.
 	 *
-	 * @param int    $post_id Post ID
-	 * @param string $context Optional, 'edit' or 'view', defaults to 'view'.
+	 * @param int    $id Post ID
+	 * @param string $context Optional, 'edit' or 'view'. Defaults to 'view'.
 	 * @return bool
+	 *
+	 * @phpstan-param non-empty-string $context
 	 */
-	public function current_user_can_read( $post_id, $context = 'view' ) {
-		$post_id = $this->sanitize_int_id( $post_id );
+	public function current_user_can_read( $id, $context = 'view' ) {
+		$id = $this->sanitize_int_id( $id );
 
-		if ( empty( $post_id ) ) {
+		if ( empty( $id ) ) {
 			return false;
 		}
 
-		$post = get_post( $post_id );
+		$post = get_post( $id );
 
 		if ( empty( $post ) ) {
 			return false;
@@ -239,7 +293,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 
 			if ( in_array( $post->post_status, $states ) ) {
 				$user = wp_get_current_user();
-				return is_user_logged_in() && ( current_user_can( 'edit_posts' ) || $user->ID == $post->post_author ); // Comparison must not be strict!
+				return is_user_logged_in() && ( current_user_can( 'edit_posts' ) || (int) $user->ID === (int) $post->post_author );
 			}
 		}
 
@@ -247,8 +301,7 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	}
 
 	/**
-	 * Returns a list of posts in a language ( $lang )
-	 * not translated in another language ( $untranslated_in ).
+	 * Returns a list of posts in a language ($lang) not translated in another language ($untranslated_in).
 	 *
 	 * @since 2.6
 	 *
@@ -258,29 +311,29 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 	 * @param string       $search          Limit the results to the posts matching this string.
 	 * @return WP_Post[] Array of posts.
 	 */
-	public function get_untranslated( $type, $untranslated_in, $lang, $search = '' ) {
+	public function get_untranslated( $type, PLL_Language $untranslated_in, PLL_Language $lang, $search = '' ) {
 		$return = array();
 
-		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough
+		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough.
 		$args = array(
 			's'                => $search,
-			'suppress_filters' => 0, // To make the post_fields filter work
-			'lang'             => 0, // Avoid admin language filter
-			'numberposts'      => 20, // Limit to 20 posts
+			'suppress_filters' => 0, // To make the post_fields filter work.
+			'lang'             => 0, // Avoid admin language filter.
+			'numberposts'      => 20, // Limit to 20 posts.
 			'post_status'      => 'any',
 			'post_type'        => $type,
 			'tax_query'        => array(
 				array(
 					'taxonomy' => $this->tax_language,
-					'field'    => 'term_taxonomy_id', // WP 3.5+
-					'terms'    => $lang->term_taxonomy_id,
+					'field'    => 'term_taxonomy_id', // WP 3.5+.
+					'terms'    => $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
 				),
 			),
 		);
 
 		/**
-		 * Filter the query args when auto suggesting untranslated posts in the Languages metabox
-		 * This should help plugins to fix some edge cases
+		 * Filter the query args when auto suggesting untranslated posts in the Languages metabox.
+		 * This should help plugins to fix some edge cases.
 		 *
 		 * @see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough
 		 *
@@ -299,5 +352,4 @@ class PLL_Translated_Post extends PLL_Translated_Object {
 
 		return $return;
 	}
-
 }

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -220,21 +220,6 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
-	 * Returns true if Polylang manages languages for this object type.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string|string[] $object_type Object type (taxonomy name) name or array of object type names.
-	 * @return bool
-	 *
-	 * @phpstan-param non-empty-string|non-empty-string[] $object_type
-	 */
-	public function is_translated_object_type( $object_type ) {
-		$taxonomies = $this->get_translated_object_types( false );
-		return ( is_array( $object_type ) && array_intersect( $object_type, $taxonomies ) || in_array( $object_type, $taxonomies ) );
-	}
-
-	/**
 	 * Caches the language and translations when terms are queried by get_terms().
 	 *
 	 * @since 1.2

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -299,4 +299,28 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		$term = $this->get_object_term( $id, $this->tax_translations );
 		return empty( $term ) || ! empty( array_diff_assoc( $translations, $old_translations ) );
 	}
+
+	/**
+	 * Assigns a language to terms in mass.
+	 *
+	 * @since 1.2
+	 * @since 3.4 Moved from PLL_Admin_Model class.
+	 *
+	 * @param int[]        $ids  Array of post ids or term ids.
+	 * @param PLL_Language $lang Language to assign to the posts or terms.
+	 * @return void
+	 */
+	public function set_language_in_mass( $ids, $lang ) {
+		parent::set_language_in_mass( $ids, $lang );
+
+		$translations = array();
+
+		foreach ( $ids as $id ) {
+			$translations[] = array( $lang->slug => $id );
+		}
+
+		if ( ! empty( $translations ) ) {
+			$this->set_translation_in_mass( $translations );
+		}
+	}
 }

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -103,12 +103,12 @@ class PLL_Upgrade {
 	 * @return void
 	 */
 	public function _upgrade() {
-		foreach ( array( '2.0.8', '2.1', '2.7', '2.8.1' ) as $version ) {
+		foreach ( array( '2.0.8', '2.1', '2.7', '3.4' ) as $version ) {
 			if ( version_compare( $this->options['version'], $version, '<' ) ) {
 				$method_to_call = array( $this, 'upgrade_' . str_replace( '.', '_', $version ) );
 				if ( is_callable( $method_to_call ) ) {
 					call_user_func( $method_to_call );
-				}               
+				}
 			}
 		}
 
@@ -190,19 +190,20 @@ class PLL_Upgrade {
 	}
 
 	/**
-	 * Upgrades if the previous version is < 2.8.1
+	 * Upgrades if the previous version is < 3.4.0.
 	 *
 	 * Deletes language cache due to:
-	 * - 'redirect_lang' option removed for subdomains and multiple domains in 2.2
-	 * - W3C and Facebook locales added to PLL_Language objects in 2.3
-	 * - flags moved to a different directory in Polylang Pro 2.8
-	 * - bug of flags url returning html fixed in 2.8.1
+	 * - 'redirect_lang' option removed for subdomains and multiple domains in 2.2,
+	 * - W3C and Facebook locales added to PLL_Language objects in 2.3,
+	 * - flags moved to a different directory in Polylang Pro 2.8,
+	 * - bug of flags url returning html fixed in 2.8.1,
+	 * - important changes in `PLL_Model` and `PLL_Language` in 3.4.
 	 *
-	 * @since 2.8.1
+	 * @since 3.4
 	 *
 	 * @return void
 	 */
-	protected function upgrade_2_8_1() {
+	protected function upgrade_3_4() {
 		delete_transient( 'pll_languages_list' );
 	}
 }

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -127,7 +127,7 @@ class PLL_WP_Import extends WP_Import {
 			foreach ( $translations as $slug => $old_id ) {
 				if ( $old_id && ! empty( $this->processed_terms[ $old_id ] ) && $lang = PLL()->model->get_language( $slug ) ) {
 					// Language relationship
-					$trs[] = $wpdb->prepare( '( %d, %d )', $this->processed_terms[ $old_id ], $lang->tl_term_taxonomy_id );
+					$trs[] = $wpdb->prepare( '( %d, %d )', $this->processed_terms[ $old_id ], $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' ) );
 
 					// Translation relationship
 					$trs[] = $wpdb->prepare( '( %d, %d )', $this->processed_terms[ $old_id ], get_term( $this->processed_terms[ $term['term_id'] ], 'term_translations' )->term_taxonomy_id );

--- a/integrations/wp-sweep/wp-sweep.php
+++ b/integrations/wp-sweep/wp-sweep.php
@@ -50,11 +50,12 @@ class PLL_WP_Sweep {
 		$excluded_term_ids = array_merge( $excluded_term_ids, $_term_ids );
 
 		// Add the terms of our languages.
-		$excluded_term_ids = array_merge(
-			$excluded_term_ids,
-			pll_languages_list( array( 'fields' => 'term_id' ) ),
-			pll_languages_list( array( 'fields' => 'tl_term_id' ) )
-		);
+		foreach ( PLL()->model->get_languages_list() as $language ) {
+			$excluded_term_ids = array_merge(
+				$excluded_term_ids,
+				array_values( $language->get_tax_props( 'term_id' ) )
+			);
+		}
 
 		return array_unique( $excluded_term_ids );
 	}

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -105,7 +105,7 @@ class PLL_Sync_Tax {
 				 * @param int    $term    Source term id
 				 * @param string $lang    Language slug
 				 */
-				if ( $term_id = apply_filters( 'pll_maybe_translate_term', $this->model->term->get_translation( $term, $lang ), $term, $lang ) ) {
+				if ( $term_id = apply_filters( 'pll_maybe_translate_term', (int) $this->model->term->get_translation( $term, $lang ), $term, $lang ) ) {
 					$newterms[] = (int) $term_id; // Cast is important otherwise we get 'numeric' tags
 				}
 			}

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -208,7 +208,7 @@ class PLL_Sync {
 				$translations = $this->model->term->get_translations( $term_id );
 
 				foreach ( $translations as $lang => $tr_id ) {
-					if ( ! empty( $tr_id ) && $tr_id !== $term_id ) {
+					if ( $tr_id !== $term_id ) {
 						$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
 						$tr_term   = get_term( (int) $tr_id, $taxonomy );
 

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -704,10 +704,10 @@ class PLL_Wizard {
 
 		while ( $nolang = $this->model->get_objects_with_no_lang( 1000 ) ) {
 			if ( ! empty( $nolang['posts'] ) ) {
-				$this->model->set_language_in_mass( 'post', $nolang['posts'], $language->slug );
+				$this->model->post->set_language_in_mass( $nolang['posts'], $language );
 			}
 			if ( ! empty( $nolang['terms'] ) ) {
-				$this->model->set_language_in_mass( 'term', $nolang['terms'], $language->slug );
+				$this->model->term->set_language_in_mass( $nolang['terms'], $language );
 			}
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -821,72 +821,12 @@ parameters:
 			path: include/language.php
 
 		-
-			message: "#^Argument of an invalid type array\\|WP_Term supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$count on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$description on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$name on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$slug on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$term_group on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$term_id on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Cannot access property \\$term_taxonomy_id on array\\|WP_Term\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
 			message: "#^Cannot use array destructuring on array\\|false\\.$#"
 			count: 1
 			path: include/language.php
 
 		-
-			message: "#^Method PLL_Language\\:\\:get_display_flag\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Method PLL_Language\\:\\:get_display_flag_url\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
 			message: "#^Parameter \\#1 \\$.+ of function base64_encode expects string, string\\|false given\\.$#"
-			count: 1
-			path: include/language.php
-
-		-
-			message: "#^Property PLL_Language\\:\\:\\$is_rtl \\(int\\) does not accept mixed\\.$#"
 			count: 1
 			path: include/language.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1251,11 +1251,6 @@ parameters:
 			path: include/translated-object.php
 
 		-
-			message: "#^Parameter \\#2 \\$object_type of function register_taxonomy expects array\\|string, string\\|null given\\.$#"
-			count: 2
-			path: include/translated-object.php
-
-		-
 			message: "#^Parameter \\#3 \\$args of function wp_insert_term expects array\\{alias_of\\?\\: string, description\\?\\: string, parent\\?\\: int, slug\\?\\: string\\}, array\\{description\\: mixed\\} given\\.$#"
 			count: 1
 			path: include/translated-object.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -701,36 +701,6 @@ parameters:
 			path: frontend/frontend.php
 
 		-
-			message: "#^Cannot call method get_home_url\\(\\) on PLL_Admin_Links\\|PLL_Frontend_Links\\|null\\.$#"
-			count: 1
-			path: include/api.php
-
-		-
-			message: "#^Function pll_current_language\\(\\) should return PLL_Language\\|string\\|false but returns PLL_Language\\|false\\|null\\.$#"
-			count: 1
-			path: include/api.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of method PLL_Translated_Object\\:\\:save_translations\\(\\) expects int, int\\|false given\\.$#"
-			count: 2
-			path: include/api.php
-
-		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_MO\\:\\:import_from_db\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
-			count: 1
-			path: include/api.php
-
-		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_Model\\:\\:count_posts\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
-			count: 1
-			path: include/api.php
-
-		-
-			message: "#^Parameter \\#1 \\$links of method PLL_Switcher\\:\\:the_languages\\(\\) expects PLL_Links, PLL_Admin_Links\\|PLL_Frontend_Links\\|null given\\.$#"
-			count: 1
-			path: include/api.php
-
-		-
 			message: "#^Parameter \\#2 .+ of function array_merge expects array, mixed given\\.$#"
 			count: 1
 			path: include/base.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,3 +49,15 @@ parameters:
 			message: "#^Action callback returns string\\|void but should not return anything\\.$#"
 			count: 1
 			path: frontend/frontend.php
+
+		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
+			count: 1
+			path: include/translated-post.php
+
+		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
+			count: 1
+			path: include/translated-term.php

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -241,11 +241,12 @@ class PLL_Settings extends PLL_Admin_Base {
 				check_admin_referer( 'content-default-lang' );
 
 				if ( $nolang = $this->model->get_objects_with_no_lang() ) {
+					$lang = $this->model->get_language( $this->options['default_lang'] );
 					if ( ! empty( $nolang['posts'] ) ) {
-						$this->model->set_language_in_mass( 'post', $nolang['posts'], $this->options['default_lang'] );
+						$this->model->post->set_language_in_mass( $nolang['posts'], $lang );
 					}
 					if ( ! empty( $nolang['terms'] ) ) {
-						$this->model->set_language_in_mass( 'term', $nolang['terms'], $this->options['default_lang'] );
+						$this->model->term->set_language_in_mass( $nolang['terms'], $lang );
 					}
 				}
 

--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -68,8 +68,10 @@ class PLL_Table_Languages extends WP_List_Table {
 				return esc_html( $item->$column_name );
 
 			case 'term_group':
-			case 'count':
 				return (int) $item->$column_name;
+
+			case 'count':
+				return $item->get_tax_prop( 'language', $column_name );
 
 			default:
 				return $item->$column_name; // Flag.

--- a/tests/phpunit/tests/plugins/test-duplicate-post.php
+++ b/tests/phpunit/tests/plugins/test-duplicate-post.php
@@ -39,8 +39,8 @@ if ( file_exists( DIR_TESTROOT . '/../duplicate-post/' ) ) {
 			$this->assertContains( 'post_translations', get_option( 'duplicate_post_taxonomies_blacklist' ) );
 
 			// Check the integration.
-			$this->assertEquals( $fr, self::$model->post->get( $en, 'fr' ) );
-			$this->assertFalse( self::$model->post->get( $new_id, 'fr' ) );
+			$this->assertSame( $fr, self::$model->post->get( $en, 'fr' ) );
+			$this->assertSame( 0, self::$model->post->get( $new_id, 'fr' ) );
 		}
 	}
 }

--- a/tests/phpunit/tests/test-accept-languages-collection.php
+++ b/tests/phpunit/tests/test-accept-languages-collection.php
@@ -1,32 +1,6 @@
 <?php
 
-class Accept_Languages_Collection_Test extends WP_UnitTestCase {
-	/**
-	 * Polylang pre-registered languages.
-	 *
-	 * @see settings/languages.php
-	 * @var array
-	 */
-	protected static $known_languages;
-
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-		self::$known_languages = include POLYLANG_DIR . '/settings/languages.php';
-	}
-
-	/**
-	 * Returns a pre-registered language.
-	 *
-	 * @param string $locale
-	 * @return PLL_Language
-	 */
-	protected function get_known_language( $locale ) {
-		$language = self::$known_languages[ $locale ];
-		$language['slug'] = $language['code'];
-		$language['w3c']  = isset( $language['w3c'] ) ? $language['w3c'] : str_replace( '_', '-', $language['locale'] );
-		return new PLL_Language( $language );
-	}
-
+class Accept_Languages_Collection_Test extends PLL_UnitTestCase {
 	/**
 	 * Use reflection to access PLL_Accept_Language values from PLL_Accept_Languages_Collection.
 	 *
@@ -44,7 +18,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 3, count( $this->get_accept_languages_array( $accept_languages ) ) );
+		$this->assertCount( 3, $this->get_accept_languages_array( $accept_languages ) );
 	}
 
 	public function test_parse_simple_language_subtag() {
@@ -52,7 +26,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 'en', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'language' ) );
+		$this->assertSame( 'en', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'language' ) );
 	}
 
 	public function test_parse_language_subtag_when_region_provided() {
@@ -60,7 +34,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 'en', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'language' ) );
+		$this->assertSame( 'en', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'language' ) );
 	}
 
 	public function test_parse_region_subtag() {
@@ -68,7 +42,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 'HK', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'region' ) );
+		$this->assertSame( 'HK', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'region' ) );
 	}
 
 	public function test_parse_region_subtag_when_script_provided() {
@@ -76,7 +50,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 'HK', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'region' ) );
+		$this->assertSame( 'HK', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'region' ) );
 	}
 
 	public function test_parse_variant_subtag() {
@@ -84,7 +58,7 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 'formal', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'variant' ) );
+		$this->assertSame( 'formal', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'variant' ) );
 	}
 
 	public function test_parse_variant_subtag_when_region_provided() {
@@ -92,55 +66,52 @@ class Accept_Languages_Collection_Test extends WP_UnitTestCase {
 
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( $http_header );
 
-		$this->assertEquals( 'formal', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'variant' ) );
+		$this->assertSame( 'formal', $this->get_accept_languages_array( $accept_languages )[0]->get_subtag( 'variant' ) );
 	}
 
 	public function test_pick_matching_language_with_different_region() {
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'en-US' );
-		$en = $this->get_known_language( 'en_GB' );
+		self::create_language( 'en_GB' );
+		$en = self::$model->get_language( 'en_GB' );
 		$languages = array( $en );
 
 		$best_match = $accept_languages->find_best_match( $languages );
 
-		$this->assertEquals( $en->slug, $best_match );
+		$this->assertSame( $en->slug, $best_match );
 	}
 
 	public function test_pick_matching_language_and_region_when_script_is_missing() {
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-Hant-HK' );
-		$zh_hk = $this->get_known_language( 'zh_HK' );
+		self::create_language( 'zh_HK' );
+		$zh_hk = self::$model->get_language( 'zh_HK' );
 		$languages = array( $zh_hk );
 
 		$best_match = $accept_languages->find_best_match( $languages );
 
-		$this->assertEquals( $zh_hk->slug, $best_match );
+		$this->assertSame( $zh_hk->slug, $best_match );
 	}
 
 	public function test_pick_matching_language_and_variant_when_region_is_missing() {
 		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'de-formal' );
-		$de_de_formal = $this->get_known_language( 'de_DE_formal' );
+		self::create_language( 'de_DE_formal' );
+		$de_de_formal = self::$model->get_language( 'de_DE_formal' );
 		$languages = array( $de_de_formal );
 
 		$best_match = $accept_languages->find_best_match( $languages );
 
-		$this->assertEquals( $de_de_formal->slug, $best_match );
+		$this->assertSame( $de_de_formal->slug, $best_match );
 	}
 
 	public function test_pick_matching_language_and_region_with_custom_slug() {
-		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-HK' );
-		$zh_cn = new PLL_Language(
-			array_merge(
-				self::$known_languages['zh_CN'],
-				array(
-					'slug' => 'zh-cn',
-					'w3c'  => 'zh-CN', // Is computed from locale when language is set from term. {@see PLL_Language::__construct()}.
-				)
-			)
-		);
+		$accept_languages    = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-HK' );
+		$zh_cn['slug']       = 'zh-cn'; // Custom slug.
+		self::create_language( 'zh_CN', $zh_cn );
+		$zh_cn = self::$model->get_language( 'zh_CN' );
 		$languages = array( $zh_cn );
 
 		$best_match = $accept_languages->find_best_match( $languages );
 
-		$this->assertEquals( $zh_cn->slug, $best_match );
+		$this->assertSame( $zh_cn->slug, $best_match );
 	}
 
 }

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -103,7 +103,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		}
 
 		$posts = self::factory()->post->create_many( 2 );
-		self::$model->set_language_in_mass( 'post', $posts, 'fr' );
+		self::$model->post->set_language_in_mass( $posts, self::$model->get_language( 'fr' ) );
 
 		$posts = get_posts( array( 'fields' => 'ids', 'posts_per_page' => -1 ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $posts ), 'slug' );
@@ -121,7 +121,7 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		}
 
 		$tags = self::factory()->tag->create_many( 2 );
-		self::$model->set_language_in_mass( 'term', $tags, 'fr' );
+		self::$model->term->set_language_in_mass( $tags, self::$model->get_language( 'fr' ) );
 
 		$terms = get_terms( array( 'taxonomy' => 'post_tag', 'hide_empty' => false, 'fields' => 'ids' ) );
 		$languages = wp_list_pluck( array_map( array( self::$model->term, 'get_language' ), $terms ), 'slug' );

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -147,10 +147,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'slug',
 			'term_group',
 			'term_taxonomy_id',
-			'count',
-			'tl_term_id',
-			'tl_term_taxonomy_id',
-			'tl_count',
+			'term_props',
 			'locale',
 			'is_rtl',
 			'w3c',
@@ -169,7 +166,18 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		);
 
 		$languages = get_transient( 'pll_languages_list' );
-		$this->assertEqualSets( $properties, array_keys( reset( $languages ) ) );
+		$language  = reset( $languages );
+		$this->assertEqualSets( $properties, array_keys( $language ) );
+
+		// Let's check PLL_Language::$term_props.
+		$this->assertArrayHasKey( 'language', $language['term_props'] );
+		$this->assertArrayHasKey( 'term_id', $language['term_props']['language'] );
+		$this->assertArrayHasKey( 'term_taxonomy_id', $language['term_props']['language'] );
+		$this->assertArrayHasKey( 'count', $language['term_props']['language'] );
+		$this->assertArrayHasKey( 'term_language', $language['term_props'] );
+		$this->assertArrayHasKey( 'term_id', $language['term_props']['term_language'] );
+		$this->assertArrayHasKey( 'term_taxonomy_id', $language['term_props']['term_language'] );
+		$this->assertArrayHasKey( 'count', $language['term_props']['term_language'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -104,8 +104,8 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_terms( array( 'taxonomy' => 'term_language' ) ) );
 
 		// No languages for posts and terms
-		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $english->term_taxonomy_id ) ) );
-		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $english->tl_term_taxonomy_id ) ) );
+		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $english->get_tax_prop( 'language', 'term_taxonomy_id' ) ) ) );
+		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $english->get_tax_prop( 'term_language', 'term_taxonomy_id' ) ) ) );
 
 		// No translations for posts and terms
 		$this->assertEmpty( get_terms( array( 'taxonomy' => 'post_translations' ) ) );

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -161,7 +161,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		$post_id = array_shift( $translations );
 		self::$model->post->save_translations( $post_id, $translations );
 
-		self::$model->post->update_language( $post_id, $to, 'post' );
+		self::$model->post->update_language( $post_id, self::$model->get_language( $to ) );
 
 		$updated_language_translations_group = array_keys( self::$model->post->get_translations( $post_id ) );
 		$updated_language_old_translations_group = array_keys( self::$model->post->get_translations( array_values( $translations )[0] ) );

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -161,7 +161,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 		$post_id = array_shift( $translations );
 		self::$model->post->save_translations( $post_id, $translations );
 
-		self::$model->post->update_language( $post_id, self::$model->get_language( $to ) );
+		self::$model->post->set_language( $post_id, self::$model->get_language( $to ) );
 
 		$updated_language_translations_group = array_keys( self::$model->post->get_translations( $post_id ) );
 		$updated_language_old_translations_group = array_keys( self::$model->post->get_translations( array_values( $translations )[0] ) );


### PR DESCRIPTION
This PR brought changes in accepted array of `PLL_Language_Factory::get_from_terms()`. A remaining deleted key is still in use. This PR use `language` all the way.