### PR TITLE
Avoid creating PLL_Language object to get flags.

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -703,4 +703,18 @@ class PLL_Language {
 	public function get_object_vars() {
 		return get_object_vars( $this );
 	}
+
+	/**
+	 * Returns a predefined HTML flag.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $flag_code Flag code to render.
+	 * @return string HTML code for the flag.
+	 */
+	public static function get_predefined_flag( $flag_code ) {
+		$flag = self::get_flag_informations( $flag_code );
+
+		return self::get_flag_html( $flag );
+	}
 }

--- a/modules/wizard/view-wizard-step-languages.php
+++ b/modules/wizard/view-wizard-step-languages.php
@@ -11,9 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
-$existing_languages = $this->model->get_languages_list();
-$default_language = count( $existing_languages ) > 0 ? $this->options['default_lang'] : null;
-
+$existing_languages  = $this->model->get_languages_list();
+$default_language    = count( $existing_languages ) > 0 ? $this->options['default_lang'] : null;
 $languages_list = array_diff_key(
 	PLL_Settings::get_predefined_languages(),
 	wp_list_pluck( $existing_languages, 'locale', 'locale' )
@@ -35,16 +34,12 @@ $languages_list = array_diff_key(
 		<select name="lang_list" id="lang_list">
 			<option value=""></option>
 			<?php
-			foreach ( $languages_list as $lg ) {
-				// To set flag base64 encoded for predefined languages as user defined languages.
-				$lg['flag_code'] = $lg['flag'];
-				$language = new PLL_Language( $lg );
-				$language->set_flag();
+			foreach ( $languages_list as $language ) {
 				printf(
 					'<option value="%1$s" data-flag-html="%3$s" data-language-name="%2$s" >%2$s - %1$s</option>' . "\n",
-					esc_attr( $language->locale ),
-					esc_html( $language->name ),
-					esc_html( $language->flag )
+					esc_attr( $language['locale'] ),
+					esc_attr( $language['name'] ),
+					esc_attr( PLL_Language::get_predefined_flag( $language['flag'] ) )
 				);
 			}
 			?>

--- a/modules/wizard/view-wizard-step-languages.php
+++ b/modules/wizard/view-wizard-step-languages.php
@@ -11,8 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
-$existing_languages  = $this->model->get_languages_list();
-$default_language    = count( $existing_languages ) > 0 ? $this->options['default_lang'] : null;
+$existing_languages = $this->model->get_languages_list();
+$default_language   = count( $existing_languages ) > 0 ? $this->options['default_lang'] : null;
 $languages_list = array_diff_key(
 	PLL_Settings::get_predefined_languages(),
 	wp_list_pluck( $existing_languages, 'locale', 'locale' )

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -54,18 +54,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<select name="lang_list" id="lang_list">
 							<option value=""></option>
 							<?php
-							foreach ( $this->get_predefined_languages() as $lg ) {
-								$lg['flag_code'] = $lg['flag'];
-								$language = new PLL_Language( $lg );
-								$language->set_flag();
+							foreach ( PLL_Settings::get_predefined_languages() as $language ) {
 								printf(
 									'<option value="%1$s:%2$s:%3$s:%4$s" data-flag-html="%6$s">%5$s - %2$s</option>' . "\n",
-									esc_attr( $lg['code'] ),
-									esc_attr( $lg['locale'] ),
-									'rtl' == $lg['dir'] ? '1' : '0',
-									esc_attr( $lg['flag'] ),
-									esc_html( $lg['name'] ),
-									esc_html( $language->flag )
+									esc_attr( $language['code'] ),
+									esc_attr( $language['locale'] ),
+									'rtl' == $language['dir'] ? '1' : '0',
+									esc_attr( $language['flag'] ),
+									esc_html( $language['name'] ),
+									esc_attr( PLL_Language::get_predefined_flag( $language['flag'] ) )
 								);
 							}
 							?>


### PR DESCRIPTION
The purpose is to avoid this error:
```
Settings_Test::test_edit_language
Undefined index: language

/Users/hugodrelon/WPSyntex/polylang/include/language.php:284
/Users/hugodrelon/WPSyntex/polylang/settings/view-tab-lang.php:59
/Users/hugodrelon/WPSyntex/polylang/settings/view-languages.php:21
/Users/hugodrelon/WPSyntex/polylang/settings/settings.php:321
/Users/hugodrelon/WPSyntex/polylang/tests/phpunit/tests/test-settings.php:49
phpvfscomposer:///Users/hugodrelon/WPSyntex/polylang/vendor/phpunit/phpunit/phpunit:97
```

Indeed, in view-wizard-step-languages.php and view-tab-lang.php we are creating `PLL_Language` objects to get predefined flags. This PR propose to add a new static method to `PLL_Language` named `get_predefined_flag()`.