### PR TITLE
Adds an object type parameter to get_objects_with_no_lang()

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -614,7 +614,7 @@ class PLL_Model {
 		foreach ( $this->translatable_objects as $type => $object ) {
 			// The trailing 's' in the array key is for backward compatibility.
 			if ( $object instanceof PLL_Translatable_Object_With_Types_Interface ) {
-				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, array( 'type' => $object->get_translated_object_types() ) );
+				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, array( 'types' => $object->get_translated_object_types() ) );
 			} else {
 				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
 			}
@@ -646,7 +646,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, array( 'type' => $post_types ) );
+		return $object->get_objects_with_no_lang( $limit, array( 'types' => $post_types ) );
 	}
 
 	/**
@@ -665,7 +665,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, array( 'type' => $taxonomies ) );
+		return $object->get_objects_with_no_lang( $limit, array( 'types' => $taxonomies ) );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -614,7 +614,7 @@ class PLL_Model {
 		foreach ( $this->translatable_objects as $type => $object ) {
 			// The trailing 's' in the array key is for backward compatibility.
 			if ( $object instanceof PLL_Translatable_Object_With_Types_Interface ) {
-				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, array( 'types' => $object->get_translated_object_types() ) );
+				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, $object->get_translated_object_types() );
 			} else {
 				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
 			}
@@ -646,7 +646,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, array( 'types' => $post_types ) );
+		return $object->get_objects_with_no_lang( $limit, is_array( $post_types ) ? $post_types : array( $post_types ) );
 	}
 
 	/**
@@ -665,7 +665,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, array( 'types' => $taxonomies ) );
+		return $object->get_objects_with_no_lang( $limit, is_array( $taxonomies ) ? $taxonomies : array( $taxonomies ) );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -642,7 +642,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $object->get_translated_object_types(), $limit );
+		return $object->get_objects_with_no_lang( $post_types, $limit );
 	}
 
 	/**
@@ -661,7 +661,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $object->get_translated_object_types(), $limit );
+		return $object->get_objects_with_no_lang( $taxonomies, $limit );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -665,7 +665,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, $taxonomies );
+		return $object->get_objects_with_no_lang( $limit, array( 'type' => $taxonomies ) );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -613,7 +613,9 @@ class PLL_Model {
 
 		foreach ( $this->translatable_objects as $type => $object ) {
 			// The trailing 's' in the array key is for backward compatibility.
-			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $object->get_translated_object_types(), $limit );
+			if ( $object instanceof PLL_Translatable_Object_With_Types_Interface ) {
+				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, array( 'type' => $object->get_translated_object_types() ) );
+			}
 		}
 
 		/**
@@ -642,7 +644,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $post_types, $limit );
+		return $object->get_objects_with_no_lang( $limit, $post_types );
 	}
 
 	/**
@@ -661,7 +663,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $taxonomies, $limit );
+		return $object->get_objects_with_no_lang( $limit, $taxonomies );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -642,7 +642,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $post_types, $limit );
+		return $object->get_objects_with_no_lang( $object->get_translated_object_types(), $limit );
 	}
 
 	/**
@@ -661,7 +661,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $taxonomies, $limit );
+		return $object->get_objects_with_no_lang( $object->get_translated_object_types(), $limit );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -646,7 +646,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, $post_types );
+		return $object->get_objects_with_no_lang( $limit, array( 'type' => $post_types ) );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -615,6 +615,8 @@ class PLL_Model {
 			// The trailing 's' in the array key is for backward compatibility.
 			if ( $object instanceof PLL_Translatable_Object_With_Types_Interface ) {
 				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, array( 'type' => $object->get_translated_object_types() ) );
+			} else {
+				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
 			}
 		}
 

--- a/include/model.php
+++ b/include/model.php
@@ -646,7 +646,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, is_array( $post_types ) ? $post_types : array( $post_types ) );
+		return $object->get_objects_with_no_lang( $limit, (array) $post_types );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -642,7 +642,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit );
+		return $object->get_objects_with_no_lang( $post_types, $limit );
 	}
 
 	/**
@@ -661,7 +661,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit );
+		return $object->get_objects_with_no_lang( $taxonomies, $limit );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -665,7 +665,7 @@ class PLL_Model {
 			return array();
 		}
 
-		return $object->get_objects_with_no_lang( $limit, is_array( $taxonomies ) ? $taxonomies : array( $taxonomies ) );
+		return $object->get_objects_with_no_lang( $limit, (array) $taxonomies );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -613,7 +613,7 @@ class PLL_Model {
 
 		foreach ( $this->translatable_objects as $type => $object ) {
 			// The trailing 's' in the array key is for backward compatibility.
-			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
+			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $type, $limit );
 		}
 
 		/**

--- a/include/model.php
+++ b/include/model.php
@@ -613,7 +613,7 @@ class PLL_Model {
 
 		foreach ( $this->translatable_objects as $type => $object ) {
 			// The trailing 's' in the array key is for backward compatibility.
-			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $type, $limit );
+			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $object->get_translated_object_types(), $limit );
 		}
 
 		/**

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -37,7 +37,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 * @param array $args {
 	 * 		The object args.
 	 *
-	 * 		@type string|string[] $object_types A translated object type or an array of translated object types.
+	 * 		@type string|string[] $type A translated object type or an array of translated object types.
 	 * }
 	 * @return string
 	 *
@@ -45,8 +45,8 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 * @phpstan-param -1|positive-int $limit
 	 * @phpstan-param array<array<string, string>> $args
 	 */
-	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $args = array() ) {
-		if ( empty( $args ) || ! isset( $args['type'] ) ) {
+	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array()  ) {
+		if ( empty( $args['type'] ) ) {
 			return '';
 		}
 

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -34,21 +34,15 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 *
 	 * @param int[] $language_ids List of language `term_taxonomy_id`.
 	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
-	 * @param array $args {
-	 * 		The object args.
-	 *
-	 * 		@type string|string[] $types A translated object type or an array of translated object types.
-	 * }
+	 * @param array $args         An array of translated object types.
 	 * @return string
 	 *
 	 * @phpstan-param array<positive-int> $language_ids
 	 * @phpstan-param -1|positive-int $limit
-	 * @phpstan-param array{
-	 *     types?: string|array<string>
-	 * } $args
+	 * @phpstan-param array<string> $args
 	 */
 	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array()  ) {
-		if ( empty( $args['types'] ) ) {
+		if ( empty( $args ) ) {
 			return '';
 		}
 
@@ -60,7 +54,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 			AND {$this->db['type_column']} IN (%s)
 			%s",
 			PLL_Db_Tools::prepare_values_list( $language_ids ),
-			PLL_Db_Tools::prepare_values_list( $args['types'] ),
+			PLL_Db_Tools::prepare_values_list( $args ),
 			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
 		);
 	}

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -37,7 +37,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 * @param array $args {
 	 * 		The object args.
 	 *
-	 * 		@type string|string[] $type A translated object type or an array of translated object types.
+	 * 		@type string|string[] $types A translated object type or an array of translated object types.
 	 * }
 	 * @return string
 	 *
@@ -46,7 +46,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 * @phpstan-param array<array<string, string>> $args
 	 */
 	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array()  ) {
-		if ( empty( $args['type'] ) ) {
+		if ( empty( $args['types'] ) ) {
 			return '';
 		}
 
@@ -58,7 +58,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 			AND {$this->db['type_column']} IN (%s)
 			%s",
 			PLL_Db_Tools::prepare_values_list( $language_ids ),
-			PLL_Db_Tools::prepare_values_list( $args['type'] ),
+			PLL_Db_Tools::prepare_values_list( $args['types'] ),
 			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
 		);
 	}

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -43,7 +43,9 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 *
 	 * @phpstan-param array<positive-int> $language_ids
 	 * @phpstan-param -1|positive-int $limit
-	 * @phpstan-param array<array<string, string>> $args
+	 * @phpstan-param array{
+	 *     types?: string|array<string>
+	 * } $args
 	 */
 	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array()  ) {
 		if ( empty( $args['types'] ) ) {

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -32,16 +32,21 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 *
 	 * @since 3.4
 	 *
-	 * @param int[]           $language_ids List of language `term_taxonomy_id`.
-	 * @param int             $limit        Max number of objects to return. `-1` to return all of them.
-	 * @param string|string[] $object_types A translated object type or an array of translated object types.
+	 * @param int[] $language_ids List of language `term_taxonomy_id`.
+	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param array $args {
+	 * 		The object args.
+	 *
+	 * 		@type string|string[] $object_types A translated object type or an array of translated object types.
+	 * }
 	 * @return string
 	 *
 	 * @phpstan-param array<positive-int> $language_ids
 	 * @phpstan-param -1|positive-int $limit
+	 * @phpstan-param array<array<string, string>> $args
 	 */
-	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $object_types ) {
-		if ( empty( $object_types ) ) {
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $args = array() ) {
+		if ( empty( $args ) || ! isset( $args['type'] ) ) {
 			return '';
 		}
 
@@ -53,7 +58,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 			AND {$this->db['type_column']} IN (%s)
 			%s",
 			PLL_Db_Tools::prepare_values_list( $language_ids ),
-			PLL_Db_Tools::prepare_values_list( $object_types ),
+			PLL_Db_Tools::prepare_values_list( $args['type'] ),
 			$limit >= 1 ? sprintf( 'LIMIT %d', $limit ) : ''
 		);
 	}

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -32,16 +32,15 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 *
 	 * @since 3.4
 	 *
-	 * @param int[] $language_ids List of language `term_taxonomy_id`.
-	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param int[]           $language_ids List of language `term_taxonomy_id`.
+	 * @param int             $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param string|string[] $object_types A translated object type or an array of translated object types.
 	 * @return string
 	 *
 	 * @phpstan-param array<positive-int> $language_ids
 	 * @phpstan-param -1|positive-int $limit
 	 */
-	protected function get_objects_with_no_lang_sql( $language_ids, $limit ) {
-		$object_types = $this->get_translated_object_types();
-
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $object_types ) {
 		if ( empty( $object_types ) ) {
 			return '';
 		}

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -345,7 +345,7 @@ abstract class PLL_Translatable_Object {
 	 * @since 3.4
 	 *
 	 * @param int   $limit  Max number of objects to return. `-1` to return all of them.
-	 * @param array $args The object args.
+	 * @param array $args   The object args.
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -340,16 +340,18 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param int $limit Max number of objects to return. `-1` to return all of them.
+	 * @param string|string[] $object_types A translated object type or an array of translated object types.
+	 * @param int             $limit      Max number of objects to return. `-1` to return all of them.
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit
 	 * @phpstan-return list<positive-int>
 	 */
-	public function get_objects_with_no_lang( $limit ) {
-		$language_ids = $this->model->get_languages_list();
+	public function get_objects_with_no_lang( $object_types, $limit ) {
+		$languages = $this->model->get_languages_list();
 
-		foreach ( $language_ids as $i => $language ) {
+		$language_ids = array();
+		foreach ( $languages as $i => $language ) {
 			$language_ids[ $i ] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
 		}
 
@@ -359,7 +361,7 @@ abstract class PLL_Translatable_Object {
 			return array();
 		}
 
-		$sql = $this->get_objects_with_no_lang_sql( $language_ids, $limit );
+		$sql = $this->get_objects_with_no_lang_sql( $language_ids, $limit, $object_types );
 
 		if ( empty( $sql ) ) {
 			return array();
@@ -420,14 +422,15 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param int[] $language_ids List of language `term_taxonomy_id`.
-	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param int[]           $language_ids List of language `term_taxonomy_id`.
+	 * @param int             $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param string|string[] $object_types A translated object type or an array of translated object types.
 	 * @return string
 	 *
 	 * @phpstan-param array<positive-int> $language_ids
 	 * @phpstan-param -1|positive-int $limit
 	 */
-	protected function get_objects_with_no_lang_sql( $language_ids, $limit ) {
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $object_types ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return sprintf(
 			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
 			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -476,4 +476,16 @@ abstract class PLL_Translatable_Object {
 
 		clean_term_cache( $ids, $this->tax_language );
 	}
+
+	/**
+	 * Returns object types that need to be translated.
+	 *
+	 * @since 3.4
+	 *
+	 * @param bool $filter True if we should return only valid registered object types.
+	 * @return string[] Object type names for which Polylang manages languages.
+	 *
+	 * @phpstan-return array<non-empty-string, non-empty-string>
+	 */
+	abstract public function get_translated_object_types( $filter = true );
 }

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -431,7 +431,7 @@ abstract class PLL_Translatable_Object {
 	 * @phpstan-param -1|positive-int $limit
 	 * @phpstan-param array<empty> $args
 	 */
-	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $args = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return sprintf(
 			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
 			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -341,17 +341,10 @@ abstract class PLL_Translatable_Object {
 	 * @since 3.4
 	 *
 	 * @param int   $limit  Max number of objects to return. `-1` to return all of them.
-	 * @param array $args {
-	 * 		The object args.
-	 *
-	 * 		@type string|string[] $types A translated object type or an array of translated object types.
-	 * }
+	 * @param array $args The object args.
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit
-	 * @phpstan-param array{
-	 *     types?: string|array<string>
-	 * } $args
 	 * @phpstan-return list<positive-int>
 	 */
 	public function get_objects_with_no_lang( $limit, array $args = array() ) {

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -341,7 +341,7 @@ abstract class PLL_Translatable_Object {
 	 * @since 3.4
 	 *
 	 * @param string|string[] $object_types A translated object type or an array of translated object types.
-	 * @param int             $limit      Max number of objects to return. `-1` to return all of them.
+	 * @param int             $limit        Max number of objects to return. `-1` to return all of them.
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -344,19 +344,21 @@ abstract class PLL_Translatable_Object {
 	 * @param array $args {
 	 * 		The object args.
 	 *
-	 * 		@type string|string[] $object_types A translated object type or an array of translated object types.
+	 * 		@type string|string[] $type A translated object type or an array of translated object types.
 	 * }
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit
-	 * @phpstan-param array<array<string, string>> $args
+	 * @phpstan-param array{
+	 *     type?: string|array<string>
+	 * } $args
 	 * @phpstan-return list<positive-int>
 	 */
-	public function get_objects_with_no_lang( $limit, $args = array() ) {
+	public function get_objects_with_no_lang( $limit, array $args = array() ) {
 		$languages = $this->model->get_languages_list();
 
 		$language_ids = array();
-		foreach ( $languages as  $language ) {
+		foreach ( $languages as $language ) {
 			$language_ids[] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
 		}
 

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -340,19 +340,24 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param string|string[] $object_types A translated object type or an array of translated object types.
-	 * @param int             $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param int   $limit  Max number of objects to return. `-1` to return all of them.
+	 * @param array $args {
+	 * 		The object args.
+	 *
+	 * 		@type string|string[] $object_types A translated object type or an array of translated object types.
+	 * }
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit
+	 * @phpstan-param array<array<string, string>> $args
 	 * @phpstan-return list<positive-int>
 	 */
-	public function get_objects_with_no_lang( $object_types, $limit ) {
+	public function get_objects_with_no_lang( $limit, $args = array() ) {
 		$languages = $this->model->get_languages_list();
 
 		$language_ids = array();
-		foreach ( $languages as $i => $language ) {
-			$language_ids[ $i ] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
+		foreach ( $languages as  $language ) {
+			$language_ids[] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
 		}
 
 		$language_ids = array_filter( $language_ids );
@@ -361,7 +366,7 @@ abstract class PLL_Translatable_Object {
 			return array();
 		}
 
-		$sql = $this->get_objects_with_no_lang_sql( $language_ids, $limit, $object_types );
+		$sql = $this->get_objects_with_no_lang_sql( $language_ids, $limit, $args );
 
 		if ( empty( $sql ) ) {
 			return array();
@@ -422,15 +427,16 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param int[]           $language_ids List of language `term_taxonomy_id`.
-	 * @param int             $limit        Max number of objects to return. `-1` to return all of them.
-	 * @param string|string[] $object_types A translated object type or an array of translated object types.
+	 * @param int[] $language_ids List of language `term_taxonomy_id`.
+	 * @param int   $limit        Max number of objects to return. `-1` to return all of them.
+	 * @param array $args         The object args.
 	 * @return string
 	 *
 	 * @phpstan-param array<positive-int> $language_ids
 	 * @phpstan-param -1|positive-int $limit
+	 * @phpstan-param array<empty> $args
 	 */
-	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $object_types ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected function get_objects_with_no_lang_sql( $language_ids, $limit, $args = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return sprintf(
 			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
 			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (
@@ -476,16 +482,4 @@ abstract class PLL_Translatable_Object {
 
 		clean_term_cache( $ids, $this->tax_language );
 	}
-
-	/**
-	 * Returns object types that need to be translated.
-	 *
-	 * @since 3.4
-	 *
-	 * @param bool $filter True if we should return only valid registered object types.
-	 * @return string[] Object type names for which Polylang manages languages.
-	 *
-	 * @phpstan-return array<non-empty-string, non-empty-string>
-	 */
-	abstract public function get_translated_object_types( $filter = true );
 }

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -168,7 +168,11 @@ abstract class PLL_Translatable_Object {
 			return false;
 		}
 
-		return is_array( wp_set_object_terms( $id, $lang, $this->tax_language ) );
+		$term_taxonomy_ids = wp_set_object_terms( $id, $lang, $this->tax_language );
+
+		wp_cache_set( 'last_changed', microtime(), "{$this->type}s" );
+
+		return is_array( $term_taxonomy_ids );
 	}
 
 	/**

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -344,13 +344,13 @@ abstract class PLL_Translatable_Object {
 	 * @param array $args {
 	 * 		The object args.
 	 *
-	 * 		@type string|string[] $type A translated object type or an array of translated object types.
+	 * 		@type string|string[] $types A translated object type or an array of translated object types.
 	 * }
 	 * @return int[] Array of object IDs.
 	 *
 	 * @phpstan-param -1|positive-int $limit
 	 * @phpstan-param array{
-	 *     type?: string|array<string>
+	 *     types?: string|array<string>
 	 * } $args
 	 * @phpstan-return list<positive-int>
 	 */

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -103,7 +103,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 
 	/**
 	 * Returns object types (post types) that need to be translated.
-	 * The post types list is cached for better better performance.
+	 * The post types list is cached for better performance.
 	 * The method waits for 'after_setup_theme' to apply the cache to allow themes adding the filter in functions.php.
 	 *
 	 * @since 3.4

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -177,7 +177,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 
 	/**
 	 * Returns object types (taxonomy names) that need to be translated.
-	 * The taxonomies list is cached for better better performance.
+	 * The taxonomies list is cached for better performance.
 	 * The method waits for 'after_setup_theme' to apply the cache to allow themes adding the filter in functions.php.
 	 *
 	 * @since 3.4

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -86,6 +86,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $out );
 
 		wp_cache_flush();
+
 		ob_start();
 		self::$model->post->set_language( $id, 'en' );
 		do_action( 'admin_notices' );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -86,7 +86,6 @@ class Settings_Test extends PLL_UnitTestCase {
 		$this->assertNotEmpty( $out );
 
 		wp_cache_flush();
-
 		ob_start();
 		self::$model->post->set_language( $id, 'en' );
 		do_action( 'admin_notices' );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -85,6 +85,7 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		$this->assertNotEmpty( $out );
 
+		wp_cache_flush();
 		ob_start();
 		self::$model->post->set_language( $id, 'en' );
 		do_action( 'admin_notices' );
@@ -92,6 +93,7 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		$this->assertEmpty( $out );
 
+		wp_cache_flush();
 		ob_start();
 		$id = self::factory()->term->create();
 		do_action( 'admin_notices' );
@@ -99,6 +101,7 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		$this->assertNotEmpty( $out );
 
+		wp_cache_flush();
 		ob_start();
 		self::$model->term->set_language( $id, 'en' );
 		do_action( 'admin_notices' );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -85,7 +85,6 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		$this->assertNotEmpty( $out );
 
-		wp_cache_flush();
 		ob_start();
 		self::$model->post->set_language( $id, 'en' );
 		do_action( 'admin_notices' );
@@ -93,7 +92,6 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		$this->assertEmpty( $out );
 
-		wp_cache_flush();
 		ob_start();
 		$id = self::factory()->term->create();
 		do_action( 'admin_notices' );
@@ -101,7 +99,6 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		$this->assertNotEmpty( $out );
 
-		wp_cache_flush();
 		ob_start();
 		self::$model->term->set_language( $id, 'en' );
 		do_action( 'admin_notices' );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1554

- Adds an object type parameter to `PLL_Translatable_Object::get_objects_with_no_lang()`.

- Adds this same parameter to `PLL_Translatable_Object::get_objects_with_no_lang_sql()`. This one won't be used, see the PHPStan exclusion.

- Adds this same parameter to `PLL_Translatable_Object_With_Types_Trait::get_objects_with_no_lang_sql()`. 