### PR TITLE
Add PHP 8.2 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ os:
   - "linux"
 dist: "bionic"
 
+addons:
+  apt:
+    update: true
+    packages:
+    - libonig-dev
+
 jobs:
   include:
     - name: "PHPCS + PHPStan - PHP 7.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ jobs:
       php: "8.0"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
-    - name: "WP nightly - PHP 8.1.0"
-      php: "8.1"
+    - name: "WP nightly - PHP 8.2.0"
+      php: "8.2"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
   allow_failures:
@@ -57,12 +57,18 @@ jobs:
     - php: "8.0"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
-    - php: "8.1"
+    - php: "8.2"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
 
 services:
   - "mysql"
+
+addons:
+  apt:
+    update: true
+    packages:
+    - libonig-dev
 
 cache:
   directories:


### PR DESCRIPTION
This PR replaces PHP 8.1 by PHP 8.2 in Travis CI.

The `addons` section is added per Travis support recommendation.

I keep PHP 8.0 for stable tests as PHP 8.1 still generates a deprecated notice in WordPress:
```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/travis/build/polylang/polylang/tmp/wordpress/wp-includes/taxonomy.php on line 2754
```
Reminder: PHP 8.0-8.2 are all in beta support in WordPress 6.1: https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/