### PR TITLE
Fix has_languages return

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -77,7 +77,7 @@ class PLL_Model {
 			return true;
 		}
 
-		if ( false !== get_transient( 'pll_languages_list' ) ) {
+		if ( ! empty( get_transient( 'pll_languages_list' ) ) ) {
 			return true;
 		}
 

--- a/include/model.php
+++ b/include/model.php
@@ -73,7 +73,7 @@ class PLL_Model {
 	 * @return bool True if there are, false otherwise.
 	 */
 	public function has_languages() {
-		if ( false !== $this->cache->get( 'languages' ) ) {
+		if ( ! empty( $this->cache->get( 'languages' ) ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
`has_languages` could return `true` in cases without languages.

Check `! empty()` instead of `!== false` for `$this->cache->get( 'languages' )` since the return can be `mixed`.

I guess the same thing should be done for the transient.
