### PR TITLE
Use custom query to search for untranslated posts.

### DIFF
--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -342,8 +342,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 				OR ({$wpdb->posts}.post_excerpt LIKE %s)
 				OR ({$wpdb->posts}.post_content LIKE %s))
 			AND {$wpdb->posts}.post_type = %s
-			AND (({$wpdb->posts}.post_status <> 'trash'
-			AND {$wpdb->posts}.post_status <> 'auto-draft'))",
+			AND {$wpdb->posts}.post_status NOT IN ('trash', 'auto-draft')",
 			$lang->term_taxonomy_id,
 			$search_like,
 			$search_like,

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -351,55 +351,39 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 		 *
 		 * @param array $args WP_Query arguments
 		 */
-		$args  = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
-		$limit = $args['numberposts'];
+		$args = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
 
-		$search_like = '%' . $wpdb->esc_like( $search ) . '%';
-
-		$search_query = $wpdb->prepare(
-			"INNER JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)
-			AND tr1.term_taxonomy_id IN (%d)
-			AND (({$wpdb->posts}.post_title LIKE %s)
-				OR ({$wpdb->posts}.post_excerpt LIKE %s)
-				OR ({$wpdb->posts}.post_content LIKE %s))
-			AND {$wpdb->posts}.post_type = %s
-			AND {$wpdb->posts}.post_status NOT IN ('trash', 'auto-draft')",
-			$lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
-			$search_like,
-			$search_like,
-			$search_like,
-			$type
-		);
-
+		$limit             = $args['numberposts'];
+		$search_like       = '%' . $wpdb->esc_like( $search ) . '%';
 		$untranslated_like = '%' . $wpdb->esc_like( $untranslated_in->slug ) . '%';
-
-		$not_translated_query = $wpdb->prepare(
-			"WHERE {$wpdb->posts}.ID NOT IN (
-				SELECT {$wpdb->posts}.ID FROM {$wpdb->posts}
-					LEFT JOIN {$wpdb->term_relationships} AS tr2 ON ({$wpdb->posts}.ID = tr2.object_id)
-					INNER JOIN {$wpdb->term_taxonomy} AS tt ON (tt.term_taxonomy_id = tr2.term_taxonomy_id)
-						AND (tt.taxonomy = 'post_translations')
-						AND tt.description LIKE %s
-			)",
-			$untranslated_like
+		$posts             = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->posts}
+				INNER JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)
+				AND tr1.term_taxonomy_id IN (%d)
+				AND (({$wpdb->posts}.post_title LIKE %s)
+					OR ({$wpdb->posts}.post_excerpt LIKE %s)
+					OR ({$wpdb->posts}.post_content LIKE %s)
+				)
+				AND {$wpdb->posts}.post_type = %s
+				AND {$wpdb->posts}.post_status NOT IN ('trash', 'auto-draft')
+				WHERE {$wpdb->posts}.ID NOT IN (
+					SELECT {$wpdb->posts}.ID FROM {$wpdb->posts}
+						LEFT JOIN {$wpdb->term_relationships} AS tr2 ON ({$wpdb->posts}.ID = tr2.object_id)
+						INNER JOIN {$wpdb->term_taxonomy} AS tt ON (tt.term_taxonomy_id = tr2.term_taxonomy_id)
+							AND (tt.taxonomy = 'post_translations')
+							AND tt.description LIKE %s
+				)
+				LIMIT 0, %d",
+				$lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
+				$search_like,
+				$search_like,
+				$search_like,
+				$type,
+				$untranslated_like,
+				$limit
+			)
 		);
-
-		$limit_query = $wpdb->prepare(
-			'LIMIT 0, %d',
-			$limit
-		);
-
-		$sql = "SELECT * FROM {$wpdb->posts}
-				{$search_query}
-                {$not_translated_query}
-                GROUP BY {$wpdb->posts}.ID
-                ORDER BY {$wpdb->posts}.post_date DESC
-                {$limit_query}";
-
-		/**
-		 * Already prepared above.
-		 */
-		$posts = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		foreach ( $posts as $i => $post ) {
 			if ( ! $this->current_user_can_read( $post->ID, 'edit' ) ) {

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -340,14 +340,11 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 			),
 		);
 		/**
-		 * Filter the query args when auto suggesting untranslated posts in the Languages metabox
-		 * This should help plugins to fix some edge cases
-		 *
-		 * @see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough
+		 * Filters the query args when auto suggesting untranslated posts in the Languages metabox.
 		 *
 		 * @since 1.7
 		 * @since 3.4 Handled arguments restricted to `numberposts` to limit queried posts.
-		 * @since 3.4 No `WP_Query` is made anymore, a custom one is used instead.
+		 *            No `WP_Query` is made anymore, a custom one is used instead.
 		 *
 		 * @param array $args WP_Query arguments
 		 */

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -323,22 +323,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	public function get_untranslated( $type, PLL_Language $untranslated_in, PLL_Language $lang, $search = '' ) {
 		global $wpdb;
 
-		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough.
-		$args = array(
-			's'                => $search,
-			'suppress_filters' => 0, // To make the post_fields filter work.
-			'lang'             => 0, // Avoid admin language filter.
-			'numberposts'      => 20, // Limit to 20 posts.
-			'post_status'      => 'any',
-			'post_type'        => $type,
-			'tax_query'        => array(
-				array(
-					'taxonomy' => $this->tax_language,
-					'field'    => 'term_taxonomy_id', // WP 3.5+.
-					'terms'    => $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
-				),
-			),
-		);
+		$args = array( 'numberposts' => 20 ); // Limit to 20 posts by default.
 		/**
 		 * Filters the query args when auto suggesting untranslated posts in the Languages metabox.
 		 *

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -321,44 +321,65 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @return WP_Post[] Array of posts.
 	 */
 	public function get_untranslated( $type, PLL_Language $untranslated_in, PLL_Language $lang, $search = '' ) {
-		$return = array();
-
-		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough.
-		$args = array(
-			's'                => $search,
-			'suppress_filters' => 0, // To make the post_fields filter work.
-			'lang'             => 0, // Avoid admin language filter.
-			'numberposts'      => 20, // Limit to 20 posts.
-			'post_status'      => 'any',
-			'post_type'        => $type,
-			'tax_query'        => array(
-				array(
-					'taxonomy' => $this->tax_language,
-					'field'    => 'term_taxonomy_id', // WP 3.5+.
-					'terms'    => $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
-				),
-			),
-		);
+		global $wpdb;
 
 		/**
 		 * Filter the query args when auto suggesting untranslated posts in the Languages metabox.
 		 * This should help plugins to fix some edge cases.
 		 *
-		 * @see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough
+		 * @since 3.4
 		 *
-		 * @since 1.7
-		 *
-		 * @param array $args WP_Query arguments
+		 * @param int $limit Limit to searched posts, default 20.
 		 */
-		$args  = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
-		$posts = get_posts( $args );
+		$limit = apply_filters( 'pll_ajax_posts_not_translated_limit', 20 );
 
-		foreach ( $posts as $post ) {
-			if ( $post instanceof WP_Post && ! $this->get_translation( $post->ID, $untranslated_in ) && $this->current_user_can_read( $post->ID, 'edit' ) ) {
-				$return[] = $post;
-			}
-		}
+		$not_translated_query = $wpdb->prepare(
+			"LEFT JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)
+			INNER JOIN {$wpdb->term_taxonomy} AS tt ON (tt.term_taxonomy_id = tr1.term_taxonomy_id)
+				AND (tt.taxonomy = 'post_translations')
+				AND tt.description NOT LIKE '%%%s%%'",
+			$untranslated_in->slug
+		);
 
-		return $return;
+		$search_query = $wpdb->prepare(
+			"INNER JOIN {$wpdb->term_relationships} AS tr2 ON ({$wpdb->posts}.ID = tr2.object_id)
+			AND tr2.term_taxonomy_id IN (%d)
+			AND (({$wpdb->posts}.post_title LIKE '%%%s%%')
+				OR ({$wpdb->posts}.post_excerpt LIKE '%%%s%%')
+				OR ({$wpdb->posts}.post_content LIKE '%%%s%%'))
+			AND {$wpdb->posts}.post_type = %s
+			AND (({$wpdb->posts}.post_status <> 'trash'
+			AND {$wpdb->posts}.post_status <> 'auto-draft'))",
+			$lang->term_taxonomy_id,
+			$search,
+			$search,
+			$search,
+			$type
+		);
+
+		$limit_query = $wpdb->prepare(
+			"LIMIT 0, %d",
+			$limit
+		);
+
+        $sql = "SELECT * FROM {$wpdb->posts}
+                {$not_translated_query}
+				{$search_query}
+                GROUP BY {$wpdb->posts}.ID
+                ORDER BY {$wpdb->posts}.post_date DESC
+                {$limit_query}";
+
+        $posts = $wpdb->get_results( $sql );
+
+        foreach ( $posts as $i => $post ) {
+            if ( ! $this->current_user_can_read( $post->ID, 'edit' ) ) {
+                unset( $posts[ $i ] );
+                continue;
+            }
+
+            $posts[ $i ] = new WP_Post( $post );
+        }
+
+        return $posts;
 	}
 }

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -323,18 +323,18 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	public function get_untranslated( $type, PLL_Language $untranslated_in, PLL_Language $lang, $search = '' ) {
 		global $wpdb;
 
-		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough
+		// Don't order by title: see https://wordpress.org/support/topic/find-translated-post-when-10-is-not-enough.
 		$args = array(
 			's'                => $search,
-			'suppress_filters' => 0, // To make the post_fields filter work
-			'lang'             => 0, // Avoid admin language filter
-			'numberposts'      => 20, // Limit to 20 posts
+			'suppress_filters' => 0, // To make the post_fields filter work.
+			'lang'             => 0, // Avoid admin language filter.
+			'numberposts'      => 20, // Limit to 20 posts.
 			'post_status'      => 'any',
 			'post_type'        => $type,
 			'tax_query'        => array(
 				array(
 					'taxonomy' => $this->tax_language,
-					'field'    => 'term_taxonomy_id', // WP 3.5+
+					'field'    => 'term_taxonomy_id', // WP 3.5+.
 					'terms'    => $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
 				),
 			),

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -165,7 +165,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
-		} catch ( WPAjaxDieContinueException $e ) {
+		} catch ( WPAjaxDieStopException $e ) {
 			$response = json_decode( $e->getMessage(), true );
 			unset( $e );
 		}
@@ -182,7 +182,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		// the search must contain the current translation
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
-		} catch ( WPAjaxDieContinueException $e ) {
+		} catch ( WPAjaxDieStopException $e ) {
 			$response = json_decode( $e->getMessage(), true );
 			unset( $e );
 		}
@@ -223,9 +223,10 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		self::$model->post->set_language( $fr, 'fr' );
 
 		add_filter(
-			'pll_ajax_posts_not_translated_limit',
-			function( $limit ) {
-				return 4;
+			'pll_ajax_posts_not_translated_args',
+			function( $args ) {
+				$args['numberposts'] = 4;
+				return $args;
 			}
 		);
 
@@ -243,7 +244,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
-		} catch ( WPAjaxDieContinueException $e ) {
+		} catch ( WPAjaxDieStopException $e ) {
 			$response = json_decode( $e->getMessage(), true );
 			unset( $e );
 		}

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -165,7 +165,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
-		} catch ( WPAjaxDieStopException $e ) {
+		} catch ( WPAjaxDieContinueException $e ) {
 			$response = json_decode( $e->getMessage(), true );
 			unset( $e );
 		}
@@ -182,7 +182,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		// the search must contain the current translation
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
-		} catch ( WPAjaxDieStopException $e ) {
+		} catch ( WPAjaxDieContinueException $e ) {
 			$response = json_decode( $e->getMessage(), true );
 			unset( $e );
 		}
@@ -243,7 +243,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		try {
 			$this->_handleAjax( 'pll_posts_not_translated' );
-		} catch ( WPAjaxDieStopException $e ) {
+		} catch ( WPAjaxDieContinueException $e ) {
 			$response = json_decode( $e->getMessage(), true );
 			unset( $e );
 		}

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -191,6 +191,67 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertEqualSets( array( $searched, $en ), wp_list_pluck( $response, 'id' ) );
 	}
 
+	public function test_tricky_posts_not_translated() {
+		for ( $i = 0; $i < 5; $i++ ) {
+			$en = self::factory()->post->create( array( 'post_title' => "test {$i} english" ) );
+			self::$model->post->set_language( $en, 'en' );
+
+			$fr = self::factory()->post->create( array( 'post_title' => "test {$i} français" ) );
+			self::$model->post->set_language( $fr, 'fr' );
+
+			$es = self::factory()->post->create( array( 'post_title' => "test {$i} espagnol" ) );
+			self::$model->post->set_language( $es, 'es' );
+
+			self::$model->post->save_translations( $en, compact( 'en', 'fr', 'es' ) );
+		}
+
+		$searched_en = self::factory()->post->create( array( 'post_title' => 'test searched en' ) );
+		self::$model->post->set_language( $searched_en, 'en' );
+
+		$searched_es = self::factory()->post->create( array( 'post_title' => 'test searched es' ) );
+		self::$model->post->set_language( $searched_es, 'es' );
+
+		self::$model->post->save_translations(
+			$searched_en,
+			array(
+				'en' => $searched_en,
+				'es' => $searched_es,
+			)
+		);
+
+		$fr = self::factory()->post->create();
+		self::$model->post->set_language( $fr, 'fr' );
+
+		add_filter(
+			'pll_ajax_posts_not_translated_limit',
+			function( $limit ) {
+				return 4;
+			}
+		);
+
+		$_GET = array(
+			'action'               => 'pll_posts_not_translated',
+			'_pll_nonce'           => wp_create_nonce( 'pll_language' ),
+			'term'                 => 'tes',
+			'post_language'        => 'fr',
+			'translation_language' => 'en',
+			'post_type'            => 'post',
+			'pll_post_id'          => $fr,
+		);
+
+		$this->pll_admin->set_current_language();
+
+		try {
+			$this->_handleAjax( 'pll_posts_not_translated' );
+		} catch ( WPAjaxDieStopException $e ) {
+			$response = json_decode( $e->getMessage(), true );
+			unset( $e );
+		}
+
+		$this->assertCount( 1, $response );
+		$this->assertEquals( $searched_en, $response[0]['id'] );
+	}
+
 	public function test_save_post_from_quick_edit() {
 		$post_id = $en = self::factory()->post->create();
 		self::$model->post->set_language( $post_id, 'en' );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1551

## Issue
In some case, the desired posts doesn't show up in search. Especially when there is a lot of already translated posts (more than the limit queried, which is set to 20 by default) and the desired posts is returned at the end of the list.

## Description
To be sure to return the correct post, I propose to use a custom query. It's partially taken from the WordPress search query, with a join on `post_translations` taxonomy to look into the description (i.e. the translation table) and reject translated posts.