### PR TITLE
Add "active" language property.

### DIFF
--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -122,6 +122,8 @@ class PLL_Language_Factory {
 			$data[ $field ] = ! empty( $data[ $field ] ) ? absint( $data[ $field ] ) : 0;
 		}
 
+		$data['active'] = isset( $data['active'] ) ? $data['active'] : true;
+
 		/**
 		 * @var LanguageData
 		 */

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -71,7 +71,7 @@ class PLL_Language_Factory {
 		if ( is_array( $description ) ) {
 			$description = array_intersect_key(
 				$description,
-				array( 'locale' => null, 'rtl' => null, 'flag_code' => null )
+				array( 'locale' => null, 'rtl' => null, 'flag_code' => null, 'active' => null )
 			);
 
 			foreach ( $description as $prop => $value ) {

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -122,7 +122,7 @@ class PLL_Language_Factory {
 			$data[ $field ] = ! empty( $data[ $field ] ) ? absint( $data[ $field ] ) : 0;
 		}
 
-		$data['active'] = isset( $data['active'] ) ? $data['active'] : true;
+		$data['active'] = isset( $data['active'] ) ? (bool) $data['active'] : true;
 
 		/**
 		 * @var LanguageData

--- a/include/language.php
+++ b/include/language.php
@@ -40,7 +40,8 @@
  *     custom_flag_url?: string,
  *     custom_flag?: string,
  *     page_on_front:positive-int,
- *     page_for_posts:positive-int
+ *     page_for_posts:positive-int,
+ *     active?: bool
  * }
  */
 #[AllowDynamicProperties]
@@ -205,6 +206,13 @@ class PLL_Language {
 	public $custom_flag = '';
 
 	/**
+	 * Whether or not the language is active. Default `true`.
+	 *
+	 * @var boolean
+	 */
+	public $active = true;
+
+	/**
 	 * Stores language term properties (like term IDs and counts) for each language taxonomy (`language`,
 	 * `term_language`, etc).
 	 * This stores the values of the properties `$term_id` + `$term_taxonomy_id` + `$count` (`language`), `$tl_term_id`
@@ -272,6 +280,7 @@ class PLL_Language {
 	 *     @type string  $custom_flag     Optional. HTML markup of the custom flag if it exists.
 	 *     @type int     $page_on_front   ID of the page on front in this language.
 	 *     @type int     $page_for_posts  ID of the page for posts in this language.
+	 *     @type bool    $active          Whether or not the language is active. Default `true`.
 	 * }
 	 *
 	 * @phpstan-param LanguageData $language_data

--- a/include/language.php
+++ b/include/language.php
@@ -280,7 +280,7 @@ class PLL_Language {
 	 *     @type string  $custom_flag     Optional. HTML markup of the custom flag if it exists.
 	 *     @type int     $page_on_front   ID of the page on front in this language.
 	 *     @type int     $page_for_posts  ID of the page for posts in this language.
-	 *     @type bool    $active          Whether or not the language is active. Default `true`.
+	 *     @type bool    $active          Optional. Whether or not the language is active. Default `true`.
 	 * }
 	 *
 	 * @phpstan-param LanguageData $language_data

--- a/include/language.php
+++ b/include/language.php
@@ -41,7 +41,7 @@
  *     custom_flag?: string,
  *     page_on_front:positive-int,
  *     page_for_posts:positive-int,
- *     active?: bool
+ *     active: bool
  * }
  */
 #[AllowDynamicProperties]
@@ -280,7 +280,7 @@ class PLL_Language {
 	 *     @type string  $custom_flag     Optional. HTML markup of the custom flag if it exists.
 	 *     @type int     $page_on_front   ID of the page on front in this language.
 	 *     @type int     $page_for_posts  ID of the page for posts in this language.
-	 *     @type bool    $active          Optional. Whether or not the language is active. Default `true`.
+	 *     @type bool    $active          Whether or not the language is active. Default `true`.
 	 * }
 	 *
 	 * @phpstan-param LanguageData $language_data

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -162,6 +162,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'flag',
 			'custom_flag_url',
 			'custom_flag',
+			'active'
 		);
 
 		$languages = get_transient( 'pll_languages_list' );

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -162,7 +162,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'flag',
 			'custom_flag_url',
 			'custom_flag',
-			'active'
+			'active',
 		);
 
 		$languages = get_transient( 'pll_languages_list' );


### PR DESCRIPTION
In order to ease the "Activated Language" feature in Polylang Pro, we chose to set this property in `PLL_Language`.
`PLL_Language::$active` default value is `true`.