### PR TITLE
Fix translate option performance

### DIFF
--- a/include/mo.php
+++ b/include/mo.php
@@ -67,13 +67,19 @@ class PLL_MO extends MO {
 	 * @return void
 	 */
 	public function import_from_db( $lang ) {
-		if ( ! empty( $lang->mo_id ) ) {
-			$strings = get_post_meta( $lang->mo_id, '_pll_strings_translations', true );
-			if ( is_array( $strings ) ) {
-				foreach ( $strings as $msg ) {
-					$this->add_entry( $this->make_entry( $msg[0], $msg[1] ) );
-				}
-			}
+		if ( empty( $lang->mo_id ) ) {
+			return;
+		}
+
+		$this->set_header( 'Language', $lang->slug );
+
+		$strings = get_post_meta( $lang->mo_id, '_pll_strings_translations', true );
+		if ( ! is_array( $strings ) ) {
+			return;
+		}
+
+		foreach ( $strings as $msg ) {
+			$this->add_entry( $this->make_entry( $msg[0], $msg[1] ) );
 		}
 	}
 

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -291,6 +291,8 @@ class PLL_Translate_Option {
 				$mo->export_to_db( $language );
 			}
 		}
+
+		unset( $this->translated_values );
 	}
 
 	/**

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -38,11 +38,11 @@ class PLL_Translate_Option {
 	private $translations;
 
 	/**
-	 * Cache for the translated value.
+	 * Cache for the translated values.
 	 *
-	 * @var mixed
+	 * @var array
 	 */
-	private $translated_value;
+	private $translated_values;
 
 	/**
 	 * Constructor
@@ -77,12 +77,6 @@ class PLL_Translate_Option {
 		$this->keys = $keys;
 		add_filter( 'option_' . $name, array( $this, 'translate' ) ); // Make sure to add this filter after options are registered.
 
-		// Resets the cache on the same actions we load the strings translations.
-		add_action( 'pll_language_defined', array( $this, 'reset_translated_value' ), 5 );
-		add_action( 'change_locale', array( $this, 'reset_translated_value' ) ); // Since WP 4.7
-		add_action( 'personal_options_update', array( $this, 'reset_translated_value' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
-		add_action( 'lostpassword_post', array( $this, 'reset_translated_value' ), 10, 0 ); // Password reset email.
-
 		// Filters updated values.
 		add_filter( 'pre_update_option_' . $name, array( $this, 'pre_update_option' ), 10, 3 );
 		add_action( 'update_option_' . $name, array( $this, 'update_option' ) );
@@ -108,20 +102,17 @@ class PLL_Translate_Option {
 			return $value;
 		}
 
-		if ( ! isset( $this->translated_value ) ) {
-			$this->translated_value = $this->translate_string_recursive( $value, $this->keys );
+		$lang = pll_current_language();
+
+		if ( empty( $lang ) ) {
+			return $value;
 		}
 
-		return $this->translated_value;
-	}
+		if ( ! isset( $this->translated_values[ $lang ] ) ) {
+			$this->translated_values[ $lang ] = $this->translate_string_recursive( $value, $this->keys );
+		}
 
-	/**
-	 * Resets the translated value cache.
-	 *
-	 * @since 3.4
-	 */
-	public function reset_translated_value() {
-		unset( $this->translated_value );
+		return $this->translated_values[ $lang ];
 	}
 
 	/**

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -102,11 +102,11 @@ class PLL_Translate_Option {
 			return $value;
 		}
 
-		$lang = pll_current_language();
-
-		if ( empty( $lang ) ) {
+		if ( empty( $GLOBALS['l10n']['pll_string'] ) || ! $GLOBALS['l10n']['pll_string'] instanceof PLL_MO ) {
 			return $value;
 		}
+
+		$lang = $GLOBALS['l10n']['pll_string']->get_header( 'Language' );
 
 		if ( ! isset( $this->translated_values[ $lang ] ) ) {
 			$this->translated_values[ $lang ] = $this->translate_string_recursive( $value, $this->keys );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1575

The Issue may occur if a theme or a plugin reads a translatable option with lot of values hundreds of times. In that case, our filter uselessly recursively translates all the values as many times as `get_option()` is called, while the them or plugin developper expects the option to be cached, forgetting that the cached vlue is filtered with `option_{$option_name}` anyway. As the translation process is known to be slow, this may become visible.

This PR introduces a property to cache the translated value.
To account for the current language to be modified, there is one cache per language.
This cache is flushed at option update.

The initial version used the current language (`pll_current_language()`) as cache key. This is however not valid as there are cases where translations in a different language are loaded without changing the current language itself. This is the case in tests but also in Polylang itself (ex: https://github.com/polylang/polylang/blob/3.3.1/include/base.php#L65-L66)

Thus the PR introduces a `Language` header in `PLL_MO` to store the language of .the current translations object. This header is then used as cache key. 