### PR TITLE
Fix term import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # TravisCI configuration for polylang/polylang
 
-if: "branch = master"
+if: "branch = fix-phpunit-please"
 
 language: "php"
 os:
@@ -29,9 +29,20 @@ jobs:
       script:
         - "vendor/bin/phpunit --verbose"
 
+    - name: "WP 5.7 - PHP 5.6"
+      php: "5.6"
+      env: "WP_VERSION=5.7 WP_MULTISITE=0"
+      script:
+        - "vendor/bin/phpunit --verbose"
+
     - name: "WP 6.1 - PHP 5.6"
       dist: "xenial"
       php: "5.6"
+      env: "WP_VERSION=6.1 WP_MULTISITE=0"
+
+    - name: "WP 6.1 - PHP 7.4"
+      dist: "xenial"
+      php: "7.4"
       env: "WP_VERSION=6.1 WP_MULTISITE=0"
 
     - name: "WP 6.1 - PHP 8.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # TravisCI configuration for polylang/polylang
 
-if: "branch = fix-phpunit-please"
+if: "branch = master"
 
 language: "php"
 os:
@@ -29,19 +29,9 @@ jobs:
       script:
         - "vendor/bin/phpunit --verbose"
 
-    - name: "WP 5.7 - PHP 5.6"
-      dist: "xenial"
-      php: "5.6"
-      env: "WP_VERSION=5.7 WP_MULTISITE=0"
-
     - name: "WP 6.1 - PHP 5.6"
       dist: "xenial"
       php: "5.6"
-      env: "WP_VERSION=6.1 WP_MULTISITE=0"
-
-    - name: "WP 6.1 - PHP 7.4"
-      dist: "xenial"
-      php: "7.4"
       env: "WP_VERSION=6.1 WP_MULTISITE=0"
 
     - name: "WP 6.1 - PHP 8.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,9 @@ jobs:
         - "vendor/bin/phpunit --verbose"
 
     - name: "WP 5.7 - PHP 5.6"
+      dist: "xenial"
       php: "5.6"
       env: "WP_VERSION=5.7 WP_MULTISITE=0"
-      script:
-        - "vendor/bin/phpunit --verbose"
 
     - name: "WP 6.1 - PHP 5.6"
       dist: "xenial"

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -47,6 +47,8 @@ class PLL_WP_Import extends WP_Import {
 			update_option( 'polylang', PLL()->options );
 		}
 
+		PLL()->model->clean_languages_cache();
+
 		$this->remap_terms_relations( $term_translations );
 		$this->remap_translations( $term_translations, $this->processed_terms );
 	}

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -47,6 +47,7 @@ class PLL_WP_Import extends WP_Import {
 			update_option( 'polylang', PLL()->options );
 		}
 
+		// Clean languages case in case some of them were created.
 		PLL()->model->clean_languages_cache();
 
 		$this->remap_terms_relations( $term_translations );

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -47,7 +47,7 @@ class PLL_WP_Import extends WP_Import {
 			update_option( 'polylang', PLL()->options );
 		}
 
-		// Clean languages cache in case some of them were created.
+		// Clean languages cache in case some of them were created during import.
 		PLL()->model->clean_languages_cache();
 
 		$this->remap_terms_relations( $term_translations );

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -47,7 +47,7 @@ class PLL_WP_Import extends WP_Import {
 			update_option( 'polylang', PLL()->options );
 		}
 
-		// Clean languages case in case some of them were created.
+		// Clean languages cache in case some of them were created.
 		PLL()->model->clean_languages_cache();
 
 		$this->remap_terms_relations( $term_translations );


### PR DESCRIPTION
Term import with the WordPress importer is broken since the refactor. The language is not assigned to the imported terms even though the languages are well created. This is due to the call to `get_language()` returning `false` [here](https://github.com/polylang/polylang/blob/05d7399833215c32397d0c4f68187d45c4b42bbd/integrations/wp-importer/wp-import.php#L128).

To prevent it, it appears that flushing the language cache after terms are processed fix the issue.

This also fixes the remaining failing test `WP_Importer_Test::test_simple_import()`.