### PR TITLE
Fix languages list order.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # TravisCI configuration for polylang/polylang
 
-if: "branch = master"
+if: "branch = test-languages-list-order"
 
 language: "php"
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # TravisCI configuration for polylang/polylang
 
-if: "branch = test-languages-list-order"
+if: "branch = master"
 
 language: "php"
 os:

--- a/include/model.php
+++ b/include/model.php
@@ -695,11 +695,9 @@ class PLL_Model {
 	 * @return string
 	 */
 	public function filter_language_terms_orderby( $orderby, $args, $taxonomies ) {
-		if ( ! is_array( $taxonomies ) || count( $taxonomies ) > 1 ) {
-			return $orderby;
-		}
+		$allowed_taxonomies = $this->translatable_objects->get_taxonomy_names( array( 'language' ) );
 
-		if ( 'language' !== reset( $taxonomies ) ) {
+		if ( ! is_array( $taxonomies ) || ! empty( array_diff( $taxonomies, $allowed_taxonomies ) ) ) {
 			return $orderby;
 		}
 

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -41,7 +41,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 * @phpstan-param -1|positive-int $limit
 	 * @phpstan-param array<string> $args
 	 */
-	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array()  ) {
+	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array() ) {
 		if ( empty( $args ) ) {
 			return '';
 		}

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -230,4 +230,20 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		);
 		$this->assertTrue( self::$model->add_language( $args ) );
 	}
+
+	public function test_default_language_order() {
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+		self::create_language( 'de_DE' );
+		self::create_language( 'es_ES' );
+
+		$expected = array(
+			'en',
+			'fr',
+			'de',
+			'es',
+		);
+
+		$this->assertSameSetsWithIndex( $expected, self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
+	}
 }


### PR DESCRIPTION
Some errors occurs in Travis as well in some of our local environment. @Chouby managed to narrow the problem the languages order returned in `PLL_Model::get_languages_list()` being not consistent.

After some investigation, it appears that our callback `PLL_Model::filter_language_terms_orderby()` hooked on `get_terms_orderby` doesn't work as expected anymore. 
Indeed, we are bailing out early on every query [here](https://github.com/polylang/polylang/blob/5a67c8b4310884b5779d3b3d6bf8e159741739fd/include/model.php#L698-L700) because we try to retrieve *all* language taxonomies [here](https://github.com/polylang/polylang/blob/5a67c8b4310884b5779d3b3d6bf8e159741739fd/include/model.php#L798) and not only `language` ...

I propose to check against all registered language taxonomies before returning. I also added a test.