### PR TITLE
Remove PLL_Language dynamic property in PLL_Walker_Dropdown

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -669,6 +669,17 @@ class PLL_Language {
 	}
 
 	/**
+	 * Converts current `PLL_language` into a stdClass object. Mostly used to allow dynamic properties.
+	 *
+	 * @since 3.4
+	 *
+	 * @return stdClass Converted `PLL_Language` object.
+	 */
+	public function to_standard_class() {
+		return (object) $this->get_object_vars();
+	}
+
+	/**
 	 * Returns a predefined HTML flag.
 	 *
 	 * @since 3.4

--- a/include/language.php
+++ b/include/language.php
@@ -656,7 +656,7 @@ class PLL_Language {
 	 *
 	 * @phpstan-return LanguageData
 	 */
-	public function get_object_vars( $context = 'display' ) {
+	public function to_array( $context = 'display' ) {
 		$language = get_object_vars( $this );
 
 		if ( 'db' !== $context ) {
@@ -669,14 +669,14 @@ class PLL_Language {
 	}
 
 	/**
-	 * Converts current `PLL_language` into a stdClass object. Mostly used to allow dynamic properties.
+	 * Converts current `PLL_language` into a `stdClass` object. Mostly used to allow dynamic properties.
 	 *
 	 * @since 3.4
 	 *
 	 * @return stdClass Converted `PLL_Language` object.
 	 */
-	public function to_standard_class() {
-		return (object) $this->get_object_vars();
+	public function to_std_class() {
+		return (object) $this->to_array();
 	}
 
 	/**

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -101,7 +101,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 	 */
 	public function front_page_url( $language ) {
 		if ( $language instanceof PLL_Language ) {
-			$language = $language->get_object_vars();
+			$language = $language->to_array();
 		}
 
 		if ( $this->options['hide_default'] && $language['slug'] == $this->options['default_lang'] ) {

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -132,7 +132,7 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	 */
 	public function front_page_url( $language ) {
 		if ( $language instanceof PLL_Language ) {
-			$language = $language->get_object_vars();
+			$language = $language->to_array();
 		}
 
 		if ( $this->options['hide_default'] && $language['slug'] === $this->options['default_lang'] ) {

--- a/include/model.php
+++ b/include/model.php
@@ -818,7 +818,7 @@ class PLL_Model {
 		 */
 		$languages_data = array_map(
 			function ( $language ) {
-				return $language->get_object_vars( 'db' );
+				return $language->to_array( 'db' );
 			},
 			$languages
 		);

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -241,6 +241,11 @@ class PLL_Switcher {
 			return $elements;
 		}
 
+		// Cast each elements to stdClass.
+		foreach ( $elements as $i => $element ) {
+			$elements[ $i ] = (object) $element;
+		}
+
 		if ( $args['dropdown'] ) {
 			$args['name'] = 'lang_choice_' . $args['dropdown'];
 			$args['class'] = 'pll-switcher-select';

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -252,12 +252,9 @@ class PLL_Switcher {
 		}
 
 		// Cast each elements to stdClass because $walker::walk() expects an array of objects.
-		$elements = array_map(
-			function( $element ) {
-				return (object) $element;
-			},
-			$elements
-		);
+		foreach ( $elements as $i => $element ) {
+			$elements[ $i ] = (object) $element;
+		}
 
 		/**
 		 * Filter the whole html markup returned by the 'pll_the_languages' template tag

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -251,7 +251,7 @@ class PLL_Switcher {
 			$walker = new PLL_Walker_List();
 		}
 
-		// Cast each elements to stdClass because $walker::walk() expects an array of objects.
+		// Cast each element to stdClass because $walker::walk() expects an array of objects.
 		foreach ( $elements as $i => $element ) {
 			$elements[ $i ] = (object) $element;
 		}

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -241,11 +241,6 @@ class PLL_Switcher {
 			return $elements;
 		}
 
-		// Cast each elements to stdClass.
-		foreach ( $elements as $i => $element ) {
-			$elements[ $i ] = (object) $element;
-		}
-
 		if ( $args['dropdown'] ) {
 			$args['name'] = 'lang_choice_' . $args['dropdown'];
 			$args['class'] = 'pll-switcher-select';
@@ -255,6 +250,14 @@ class PLL_Switcher {
 		} else {
 			$walker = new PLL_Walker_List();
 		}
+
+		// Cast each elements to stdClass because $walker::walk() expects an array of objects.
+		$elements = array_map(
+			function( $element ) {
+				return (object) $element;
+			},
+			$elements
+		);
 
 		/**
 		 * Filter the whole html markup returned by the 'pll_the_languages' template tag

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -23,15 +23,16 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string   $output            Passed by reference. Used to append additional content.
-	 * @param object   $element           The data object.
-	 * @param int      $depth             Depth of the item.
-	 * @param array    $args              An array of additional arguments.
-	 * @param int      $current_object_id ID of the current item.
+	 * @param string $output            Passed by reference. Used to append additional content.
+	 * @param object $element           The data object.
+	 * @param int    $depth             Depth of the item.
+	 * @param array  $args              An array of additional arguments.
+	 * @param int    $current_object_id ID of the current item.
 	 * @return void
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value_type = $args['value'];
+		$element = $this->convert_to_standard_class( $element );
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
@@ -46,22 +47,19 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object   $element           Data object.
-	 * @param array    $children_elements List of elements to continue traversing.
-	 * @param int      $max_depth         Max depth to traverse.
-	 * @param int      $depth             Depth of current element.
-	 * @param array    $args              An array of arguments.
-	 * @param string   $output            Passed by reference. Used to append additional content.
+	 * @param object $element           Data object.
+	 * @param array  $children_elements List of elements to continue traversing.
+	 * @param int    $max_depth         Max depth to traverse.
+	 * @param int    $depth             Depth of current element.
+	 * @param array  $args              An array of arguments.
+	 * @param string $output            Passed by reference. Used to append additional content.
 	 * @return void
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-		if ( $element instanceof PLL_Language ) {
-			// Let's create a stdClass from the language object to allow dynamic properties.
-			$element = $element->get_object_vars();
-			$element = (object) $element;
-		}
-		$element = (object) $element; // Make sure we have an object
-		$element->parent = $element->id = 0; // Don't care about this
+		$element = $this->convert_to_standard_class( $element );
+
+		$element->parent = $element->id = 0; // Don't care about this.
+
 		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
 	}
 
@@ -126,5 +124,27 @@ class PLL_Walker_Dropdown extends Walker {
 		);
 
 		return $output;
+	}
+
+	/**
+	 * Converts a given value into a stdClass object. Mostly used to transform
+	 * a `PLL_Language` object and allow dynamic properties.
+	 *
+	 * @since 3.4
+	 *
+	 * @param mixed $element Element to cast into stdClass.
+	 * @return stdClass Converted element.
+	 */
+	private function convert_to_standard_class( $element ) {
+		if ( $element instanceof PLL_Language ) {
+			// PLL_Language doesn't allow dynamic properties.
+			$element = $element->get_object_vars();
+		} elseif ( is_object( $element ) ) {
+			$element = get_object_vars( $element );
+		}
+
+		$element = (object) $element; // Make sure we have a stdCLass object.
+
+		return $element;
 	}
 }

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -43,29 +43,6 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 	}
 
 	/**
-	 * Overrides Walker::display_element as expects an object with a parent property.
-	 *
-	 * @since 1.2
-	 *
-	 * @param PLL_Language|stdClass $element           Data object. `PLL_language` in our case.
-	 * @param array                 $children_elements List of elements to continue traversing.
-	 * @param int                   $max_depth         Max depth to traverse.
-	 * @param int                   $depth             Depth of current element.
-	 * @param array                 $args              An array of arguments.
-	 * @param string                $output            Passed by reference. Used to append additional content.
-	 * @return void
-	 */
-	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-		if ( $element instanceof PLL_Language ) {
-			$element = $element->to_std_class();
-		}
-
-		$element->parent = $element->id = 0; // Don't care about this.
-
-		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
-	}
-
-	/**
 	 * Starts the output of the dropdown list
 	 *
 	 * @since 1.2

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -23,19 +23,15 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string                $output            Passed by reference. Used to append additional content.
-	 * @param PLL_Language|stdClass $element           The data object. `PLL_Language` or `stdClass` in our case.
-	 * @param int                   $depth             Depth of the item.
-	 * @param array                 $args              An array of additional arguments.
-	 * @param int                   $current_object_id ID of the current item.
+	 * @param string   $output            Passed by reference. Used to append additional content.
+	 * @param stdClass $element           The data object. `PLL_Language` or `stdClass` in our case.
+	 * @param int      $depth             Depth of the item.
+	 * @param array    $args              An array of additional arguments.
+	 * @param int      $current_object_id ID of the current item.
 	 * @return void
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value_type = $args['value'];
-
-		if ( $element instanceof PLL_Language ) {
-			$element = $element->to_standard_class();
-		}
 
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -19,7 +19,7 @@ class PLL_Walker_Dropdown extends Walker {
 	public $db_fields = array( 'parent' => 'parent', 'id' => 'id' );
 
 	/**
-	 * Outputs one element
+	 * Outputs one element.
 	 *
 	 * @since 1.2
 	 *

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -24,7 +24,7 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @since 1.2
 	 *
 	 * @param string   $output            Passed by reference. Used to append additional content.
-	 * @param stdClass $element           The data object. `PLL_Language` or `stdClass` in our case.
+	 * @param stdClass $element           The data object.
 	 * @param int      $depth             Depth of the item.
 	 * @param array    $args              An array of additional arguments.
 	 * @param int      $current_object_id ID of the current item.
@@ -32,7 +32,6 @@ class PLL_Walker_Dropdown extends Walker {
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value_type = $args['value'];
-
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -68,14 +68,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 	public function walk( $elements, $max_depth, ...$args ) { // // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
 		$output = '';
 
-		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
-			// Backward compatibility with Polylang < 2.6.7
-			$this->trigger_walk_error();
-			$args = $max_depth;
-			$max_depth = -1;
-		} else {
-			$args = isset( $args[0] ) ? $args[0] : array();
-		}
+		$this->maybe_fix_walk_args( $max_depth, $args );
 
 		$args = wp_parse_args( $args, array( 'value' => 'slug', 'name' => 'lang_choice' ) );
 

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -23,16 +23,20 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string $output            Passed by reference. Used to append additional content.
-	 * @param object $element           The data object.
-	 * @param int    $depth             Depth of the item.
-	 * @param array  $args              An array of additional arguments.
-	 * @param int    $current_object_id ID of the current item.
+	 * @param string                $output            Passed by reference. Used to append additional content.
+	 * @param PLL_Language|stdClass $element           The data object. `PLL_Language` or `stdClass` in our case.
+	 * @param int                   $depth             Depth of the item.
+	 * @param array                 $args              An array of additional arguments.
+	 * @param int                   $current_object_id ID of the current item.
 	 * @return void
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value_type = $args['value'];
-		$element = $this->convert_to_standard_class( $element );
+
+		if ( $element instanceof PLL_Language ) {
+			$element = $element->to_standard_class();
+		}
+
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
@@ -47,16 +51,18 @@ class PLL_Walker_Dropdown extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $element           Data object.
-	 * @param array  $children_elements List of elements to continue traversing.
-	 * @param int    $max_depth         Max depth to traverse.
-	 * @param int    $depth             Depth of current element.
-	 * @param array  $args              An array of arguments.
-	 * @param string $output            Passed by reference. Used to append additional content.
+	 * @param PLL_Language|stdClass $element           Data object. `PLL_language` in our case.
+	 * @param array                 $children_elements List of elements to continue traversing.
+	 * @param int                   $max_depth         Max depth to traverse.
+	 * @param int                   $depth             Depth of current element.
+	 * @param array                 $args              An array of arguments.
+	 * @param string                $output            Passed by reference. Used to append additional content.
 	 * @return void
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-		$element = $this->convert_to_standard_class( $element );
+		if ( $element instanceof PLL_Language ) {
+			$element = $element->to_standard_class();
+		}
 
 		$element->parent = $element->id = 0; // Don't care about this.
 
@@ -79,10 +85,12 @@ class PLL_Walker_Dropdown extends Walker {
 	 * class    => the class attribute
 	 * disabled => disables the dropdown if set to 1
 	 *
-	 * @param array $elements  An array of elements.
+	 * @param array $elements  An array of `PLL_language` or `stdClass` elements.
 	 * @param int   $max_depth The maximum hierarchical depth.
 	 * @param mixed ...$args   Additional arguments.
 	 * @return string The hierarchical item output.
+	 *
+	 * @phpstan-param array<PLL_Language|stdClass> $elements
 	 */
 	public function walk( $elements, $max_depth, ...$args ) { // // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
 		$output = '';
@@ -124,27 +132,5 @@ class PLL_Walker_Dropdown extends Walker {
 		);
 
 		return $output;
-	}
-
-	/**
-	 * Converts a given value into a stdClass object. Mostly used to transform
-	 * a `PLL_Language` object and allow dynamic properties.
-	 *
-	 * @since 3.4
-	 *
-	 * @param mixed $element Element to cast into stdClass.
-	 * @return stdClass Converted element.
-	 */
-	private function convert_to_standard_class( $element ) {
-		if ( $element instanceof PLL_Language ) {
-			// PLL_Language doesn't allow dynamic properties.
-			$element = $element->get_object_vars();
-		} elseif ( is_object( $element ) ) {
-			$element = get_object_vars( $element );
-		}
-
-		$element = (object) $element; // Make sure we have a stdCLass object.
-
-		return $element;
 	}
 }

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -7,8 +7,9 @@
  * Displays languages in a dropdown list
  *
  * @since 1.2
+ * @since 3.4 Extends `PLL_Walker` now.
  */
-class PLL_Walker_Dropdown extends Walker {
+class PLL_Walker_Dropdown extends PLL_Walker {
 	/**
 	 * Database fields to use.
 	 *
@@ -91,15 +92,7 @@ class PLL_Walker_Dropdown extends Walker {
 		$output = '';
 
 		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
-			// Backward compatibility with Polylang < 2.6.7
-			if ( WP_DEBUG ) {
-				trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
-					sprintf(
-						'%s was called incorrectly. The method expects an integer as second parameter since Polylang 2.6.7',
-						__METHOD__
-					)
-				);
-			}
+			$this->trigger_walk_error();
 			$args = $max_depth;
 			$max_depth = -1;
 		} else {

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -56,7 +56,7 @@ class PLL_Walker_Dropdown extends Walker {
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
 		if ( $element instanceof PLL_Language ) {
-			$element = $element->to_standard_class();
+			$element = $element->to_std_class();
 		}
 
 		$element->parent = $element->id = 0; // Don't care about this.

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -69,6 +69,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 		$output = '';
 
 		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
+			// Backward compatibility with Polylang < 2.6.7
 			$this->trigger_walk_error();
 			$args = $max_depth;
 			$max_depth = -1;

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -24,7 +24,7 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @since 1.2
 	 *
 	 * @param string   $output            Passed by reference. Used to append additional content.
-	 * @param stdClass $element           The data object.
+	 * @param object   $element           The data object.
 	 * @param int      $depth             Depth of the item.
 	 * @param array    $args              An array of additional arguments.
 	 * @param int      $current_object_id ID of the current item.
@@ -42,11 +42,11 @@ class PLL_Walker_Dropdown extends Walker {
 	}
 
 	/**
-	 * Overrides Walker::display_element as expects an object with a parent property
+	 * Overrides Walker::display_element as expects an object with a parent property.
 	 *
 	 * @since 1.2
 	 *
-	 * @param stdClass $element           Data object.
+	 * @param object   $element           Data object.
 	 * @param array    $children_elements List of elements to continue traversing.
 	 * @param int      $max_depth         Max depth to traverse.
 	 * @param int      $depth             Depth of current element.
@@ -55,6 +55,11 @@ class PLL_Walker_Dropdown extends Walker {
 	 * @return void
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
+		if ( $element instanceof PLL_Language ) {
+			// Let's create a stdClass from the language object to allow dynamic properties.
+			$element = $element->get_object_vars();
+			$element = (object) $element;
+		}
 		$element = (object) $element; // Make sure we have an object
 		$element->parent = $element->id = 0; // Don't care about this
 		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -46,29 +46,6 @@ class PLL_Walker_List extends PLL_Walker {
 	}
 
 	/**
-	 * Overrides Walker::display_element as it expects an object with a parent property
-	 *
-	 * @since 1.2
-	 *
-	 * @param PLL_Language|stdClass $element           Data object. `PLL_language` in our case.
-	 * @param array                 $children_elements List of elements to continue traversing.
-	 * @param int                   $max_depth         Max depth to traverse.
-	 * @param int                   $depth             Depth of current element.
-	 * @param array                 $args              An array of arguments.
-	 * @param string                $output            Passed by reference. Used to append additional content.
-	 * @return void
-	 */
-	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-		if ( $element instanceof PLL_Language ) {
-			$element = $element->to_std_class();
-		}
-
-		$element->parent = $element->id = 0; // Don't care about this.
-
-		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
-	}
-
-	/**
 	 * Overrides Walker:walk to set depth argument
 	 *
 	 * @since 1.2

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -58,6 +58,7 @@ class PLL_Walker_List extends PLL_Walker {
 	 */
 	public function walk( $elements, $max_depth, ...$args ) { // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
 		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
+			// Backward compatibility with Polylang < 2.6.7
 			$this->trigger_walk_error();
 			$args = $max_depth;
 			$max_depth = -1;

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -57,14 +57,7 @@ class PLL_Walker_List extends PLL_Walker {
 	 * @return string The hierarchical item output.
 	 */
 	public function walk( $elements, $max_depth, ...$args ) { // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
-		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
-			// Backward compatibility with Polylang < 2.6.7
-			$this->trigger_walk_error();
-			$args = $max_depth;
-			$max_depth = -1;
-		} else {
-			$args = isset( $args[0] ) ? $args[0] : array();
-		}
+		$this->maybe_fix_walk_args( $max_depth, $args );
 
 		return parent::walk( $elements, $max_depth, $args );
 	}

--- a/include/walker-list.php
+++ b/include/walker-list.php
@@ -7,8 +7,9 @@
  * Displays a language list
  *
  * @since 1.2
+ * @since 3.4 Extends `PLL_Walker` now.
  */
-class PLL_Walker_List extends Walker {
+class PLL_Walker_List extends PLL_Walker {
 	/**
 	 * Database fields to use.
 	 *
@@ -49,17 +50,21 @@ class PLL_Walker_List extends Walker {
 	 *
 	 * @since 1.2
 	 *
-	 * @param stdClass $element           Data object.
-	 * @param array    $children_elements List of elements to continue traversing.
-	 * @param int      $max_depth         Max depth to traverse.
-	 * @param int      $depth             Depth of current element.
-	 * @param array    $args              An array of arguments.
-	 * @param string   $output            Passed by reference. Used to append additional content.
+	 * @param PLL_Language|stdClass $element           Data object. `PLL_language` in our case.
+	 * @param array                 $children_elements List of elements to continue traversing.
+	 * @param int                   $max_depth         Max depth to traverse.
+	 * @param int                   $depth             Depth of current element.
+	 * @param array                 $args              An array of arguments.
+	 * @param string                $output            Passed by reference. Used to append additional content.
 	 * @return void
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-		$element = (object) $element; // Make sure we have an object
-		$element->parent = $element->id = 0; // Don't care about this
+		if ( $element instanceof PLL_Language ) {
+			$element = $element->to_std_class();
+		}
+
+		$element->parent = $element->id = 0; // Don't care about this.
+
 		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
 	}
 
@@ -76,15 +81,7 @@ class PLL_Walker_List extends Walker {
 	 */
 	public function walk( $elements, $max_depth, ...$args ) { // phpcs:ignore WordPressVIPMinimum.Classes.DeclarationCompatibility.DeclarationCompatibility
 		if ( is_array( $max_depth ) ) { // @phpstan-ignore-line
-			// Backward compatibility with Polylang < 2.6.7
-			if ( WP_DEBUG ) {
-				trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
-					sprintf(
-						'%s was called incorrectly. The method expects an integer as second parameter since Polylang 2.6.7',
-						__METHOD__
-					)
-				);
-			}
+			$this->trigger_walk_error();
 			$args = $max_depth;
 			$max_depth = -1;
 		} else {

--- a/include/walker.php
+++ b/include/walker.php
@@ -56,7 +56,7 @@ class PLL_Walker extends Walker {
 	 * @return void
 	 */
 	protected function maybe_fix_walk_args( &$max_depth, &$args ) {
-		if ( is_int( $max_depth ) ) {
+		if ( ! is_array( $max_depth ) ) {
 			$args = isset( $args[0] ) ? $args[0] : array();
 			return;
 		}

--- a/include/walker.php
+++ b/include/walker.php
@@ -54,13 +54,10 @@ class PLL_Walker extends Walker {
 	 */
 	protected function trigger_walk_error() {
 		// Backward compatibility with Polylang < 2.6.7
-		if ( WP_DEBUG ) {
-			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
-				sprintf(
-					'%s was called incorrectly. The method expects an integer as second parameter since Polylang 2.6.7',
-					__METHOD__
-				)
-			);
-		}
+		_doing_it_wrong(
+			__CLASS__ . '::walk()',
+			'The method expects an integer as second parameter.',
+			'2.6.7'
+		);
 	}
 }

--- a/include/walker.php
+++ b/include/walker.php
@@ -56,7 +56,7 @@ class PLL_Walker extends Walker {
 	 * @return void
 	 */
 	protected function maybe_fix_walk_args( &$max_depth, &$args ) {
-		if ( ! is_array( $max_depth ) ) {
+		if ( is_int( $max_depth ) ) {
 			$args = isset( $args[0] ) ? $args[0] : array();
 			return;
 		}

--- a/include/walker.php
+++ b/include/walker.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * A class for displaying various tree-like language structures.
+ *
+ * Extend the `PLL_Walker` class to use it, and implement some of the methods from `Walker`.
+ * See: {https://developer.wordpress.org/reference/classes/walker/#methods}.
+ *
+ * @since 3.4
+ */
+class PLL_Walker extends Walker {
+	/**
+	 * Database fields to use.
+	 *
+	 * @see https://developer.wordpress.org/reference/classes/walker/#properties Walker::$db_fields.
+	 *
+	 * @var string[]
+	 */
+	public $db_fields = array( 'parent' => 'parent', 'id' => 'id' );
+
+	/**
+	 * Overrides Walker::display_element as it expects an object with a parent property.
+	 *
+	 * @since 1.2
+	 * @since 3.4 Refactored and moved in `PLL_Walker`.
+	 *
+	 * @param PLL_Language|stdClass $element           Data object. `PLL_language` in our case.
+	 * @param array                 $children_elements List of elements to continue traversing.
+	 * @param int                   $max_depth         Max depth to traverse.
+	 * @param int                   $depth             Depth of current element.
+	 * @param array                 $args              An array of arguments.
+	 * @param string                $output            Passed by reference. Used to append additional content.
+	 * @return void
+	 */
+	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
+		if ( $element instanceof PLL_Language ) {
+			$element = $element->to_std_class();
+		}
+
+		$element->parent = $element->id = 0; // Don't care about this.
+
+		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
+	}
+
+	/**
+	 * Triggers an error for misuse of `PLL_Walker::walk()`.
+	 *
+	 * @since 3.4
+	 *
+	 * @return void
+	 */
+	protected function trigger_walk_error() {
+		// Backward compatibility with Polylang < 2.6.7
+		if ( WP_DEBUG ) {
+			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
+				sprintf(
+					'%s was called incorrectly. The method expects an integer as second parameter since Polylang 2.6.7',
+					__METHOD__
+				)
+			);
+		}
+	}
+}

--- a/include/walker.php
+++ b/include/walker.php
@@ -46,18 +46,28 @@ class PLL_Walker extends Walker {
 	}
 
 	/**
-	 * Triggers an error for misuse of `PLL_Walker::walk()`.
+	 * Sets `PLL_Walker::walk()` arguments as it should
+	 * and triggers an error in case of misuse of them.
 	 *
 	 * @since 3.4
 	 *
+	 * @param array|int $max_depth The maximum hierarchical depth. Passed by reference.
+	 * @param array     $args      Additional arguments. Passed by reference.
 	 * @return void
 	 */
-	protected function trigger_walk_error() {
+	protected function maybe_fix_walk_args( &$max_depth, &$args ) {
+		if ( ! is_array( $max_depth ) ) {
+			$args = isset( $args[0] ) ? $args[0] : array();
+			return;
+		}
+
 		// Backward compatibility with Polylang < 2.6.7
 		_doing_it_wrong(
 			__CLASS__ . '::walk()',
 			'The method expects an integer as second parameter.',
 			'2.6.7'
 		);
+		$args      = $max_depth;
+		$max_depth = -1;
 	}
 }

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -268,7 +268,7 @@ class PLL_Admin_Site_Health {
 		foreach ( $this->model->get_languages_list() as $language ) {
 			$fields = array();
 
-			foreach ( $language->get_object_vars() as $key => $value ) {
+			foreach ( $language->to_array() as $key => $value ) {
 				if ( in_array( $key, $this->exclude_language_keys(), true ) ) {
 					continue;
 				}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -921,11 +921,6 @@ parameters:
 			path: include/translated-term.php
 
 		-
-			message: "#^Parameter \\#1 \\$args of function wp_parse_args expects array\\|object\\|string, mixed given\\.$#"
-			count: 1
-			path: include/walker-dropdown.php
-
-		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, bool\\|string given\\.$#"
 			count: 1
 			path: include/widget-languages.php


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1577

In order to get rid of the remaining dynamic property in PLL_Walker_Dropdown, I propose to create a new method to convert into `stdClass` any value before being passed to parent method `Walker::display_element()`.