### PR TITLE
Improvement following #1195

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -401,8 +401,10 @@ class PLL_Language {
 	 * @return void
 	 */
 	private function deprecated_property( $property, $replacement ) {
-		/** This filter is documented in wordpress/wp-includes/functions.php */
-		if ( WP_DEBUG && apply_filters( 'deprecated_function_trigger_error', true ) ) {
+		/**
+		 * This filter doesn't exist in WordPress core yet, but let's use a similar system as `deprecated_function_trigger_error`.
+		 */
+		if ( WP_DEBUG && apply_filters( 'deprecated_property_trigger_error', true ) ) {
 			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				sprintf(
 					"Class property %1\$s::\$%2\$s is deprecated, use %1\$s::%3\$s instead.\nError handler",

--- a/include/language.php
+++ b/include/language.php
@@ -630,7 +630,7 @@ class PLL_Language {
 	 *
 	 * @since 3.4
 	 *
-	 * @param string $context Whether or not properties should be filtered. Accepts `raw` or `display`.
+	 * @param string $context Whether or not properties should be filtered. Accepts `db` or `display`.
 	 *                        Default to `display` which filters some properties.
 	 *
 	 * @return array Array of language object properties.
@@ -640,7 +640,7 @@ class PLL_Language {
 	public function get_object_vars( $context = 'display' ) {
 		$language = get_object_vars( $this );
 
-		if ( 'display' === $context ) {
+		if ( 'db' !== $context ) {
 			$language['home_url']   = $this->get_home_url();
 			$language['search_url'] = $this->get_search_url();
 		}

--- a/include/language.php
+++ b/include/language.php
@@ -402,7 +402,14 @@ class PLL_Language {
 	 */
 	private function deprecated_property( $property, $replacement ) {
 		/**
-		 * This filter doesn't exist in WordPress core yet, but let's use a similar system as `deprecated_function_trigger_error`.
+		 * Filters whether to trigger an error for deprecated properties.
+		 *
+		 * The filter name is intentionnaly not prefixed to use the same as WordPress
+		 * in case it is added in the future. 
+		 *
+		 * @since 3.4
+		 *
+		 * @param bool $trigger Whether to trigger the error for deprecated properties. Default true.
 		 */
 		if ( WP_DEBUG && apply_filters( 'deprecated_property_trigger_error', true ) ) {
 			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error

--- a/include/language.php
+++ b/include/language.php
@@ -339,7 +339,7 @@ class PLL_Language {
 
 			$this->deprecated_property( $property, $url_getter );
 
-			return $this->{$url_getter}();
+			return $this->{$url_getter};
 		}
 
 		// Undefined property.

--- a/include/language.php
+++ b/include/language.php
@@ -630,16 +630,17 @@ class PLL_Language {
 	 *
 	 * @since 3.4
 	 *
-	 * @param bool $raw Whether or not properties should be raw. Default to `false`.
+	 * @param string $context Whether or not properties should be filtered. Accepts `raw` or `display`.
+	 *                        Default to `display` which filters some properties.
 	 *
 	 * @return array Array of language object properties.
 	 *
 	 * @phpstan-return LanguageData
 	 */
-	public function get_object_vars( $raw = false ) {
+	public function get_object_vars( $context = 'display' ) {
 		$language = get_object_vars( $this );
 
-		if ( ! $raw ) {
+		if ( 'display' === $context ) {
 			$language['home_url']   = $this->get_home_url();
 			$language['search_url'] = $this->get_search_url();
 		}

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -101,7 +101,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 	 */
 	public function front_page_url( $language ) {
 		if ( $language instanceof PLL_Language ) {
-			$language = $language->get_object_vars( true );
+			$language = $language->get_object_vars();
 		}
 
 		if ( $this->options['hide_default'] && $language['slug'] == $this->options['default_lang'] ) {

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -132,7 +132,7 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	 */
 	public function front_page_url( $language ) {
 		if ( $language instanceof PLL_Language ) {
-			$language = $language->get_object_vars( true );
+			$language = $language->get_object_vars();
 		}
 
 		if ( $this->options['hide_default'] && $language['slug'] === $this->options['default_lang'] ) {

--- a/include/model.php
+++ b/include/model.php
@@ -822,7 +822,7 @@ class PLL_Model {
 		 */
 		$languages_data = array_map(
 			function ( $language ) {
-				return $language->get_object_vars( 'raw' );
+				return $language->get_object_vars( 'db' );
 			},
 			$languages
 		);

--- a/include/model.php
+++ b/include/model.php
@@ -822,7 +822,7 @@ class PLL_Model {
 		 */
 		$languages_data = array_map(
 			function ( $language ) {
-				return $language->get_object_vars( true );
+				return $language->get_object_vars( 'raw' );
 			},
 			$languages
 		);


### PR DESCRIPTION
After the #1195 review, there is still some improvement to do:
- `PLL_LAnguage::get_object_vars()` should accept a string and not a boolean to improve readability when called.
- Create a new filter `deprecated_property_trigger_error`, it doesn't exist in WordPress core yet but could be in a near future.
- Fix a syntax error in `PLL_Language::__get()` on a dynamic call to method.