### PR TITLE
Use PLL_Model->has_languages() when checking for languages existance

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -124,7 +124,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		$tabs = array( 'lang' => __( 'Languages', 'polylang' ) );
 
 		// Only if at least one language has been created
-		if ( $this->model->get_languages_list() ) {
+		if ( $this->model->has_languages() ) {
 			$tabs['strings'] = __( 'Translations', 'polylang' );
 		}
 
@@ -203,7 +203,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		}
 
 		foreach ( $scripts as $script => $v ) {
-			if ( in_array( $screen->base, $v[0] ) && ( $v[2] || $this->model->get_languages_list() ) ) {
+			if ( in_array( $screen->base, $v[0] ) && ( $v[2] || $this->model->has_languages() ) ) {
 				wp_enqueue_script( 'pll_' . $script, plugins_url( '/js/build/' . $script . $suffix . '.js', POLYLANG_ROOT_FILE ), $v[1], POLYLANG_VERSION, $v[3] );
 				if ( 'classic-editor' === $script || 'block-editor' === $script ) {
 					wp_set_script_translations( 'pll_' . $script, 'polylang' );
@@ -238,7 +238,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * @return void
 	 */
 	public function customize_controls_enqueue_scripts() {
-		if ( $this->model->get_languages_list() ) {
+		if ( $this->model->has_languages() ) {
 			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 			wp_enqueue_script( 'pll_widgets', plugins_url( '/js/build/widgets' . $suffix . '.js', POLYLANG_ROOT_FILE ), array( 'jquery' ), POLYLANG_VERSION, true );
 			$this->add_inline_scripts();

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -87,7 +87,7 @@ class PLL_Admin extends PLL_Admin_Base {
 
 		// Setup filters for admin pages
 		// Priority 5 to make sure filters are there before customize_register is fired
-		if ( $this->model->get_languages_list() ) {
+		if ( $this->model->has_languages() ) {
 			add_action( 'wp_loaded', array( $this, 'add_filters' ), 5 );
 		}
 	}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -228,7 +228,7 @@ class PLL_Frontend extends PLL_Base {
 		parent::switch_blog( $new_blog_id, $prev_blog_id );
 
 		// Need to check that some languages are defined when user is logged in, has several blogs, some without any languages.
-		if ( $this->is_active_on_new_blog( $new_blog_id, $prev_blog_id ) && did_action( 'pll_language_defined' ) && $this->model->get_languages_list() ) {
+		if ( $this->is_active_on_new_blog( $new_blog_id, $prev_blog_id ) && did_action( 'pll_language_defined' ) && $this->model->has_languages() ) {
 			static $restore_curlang;
 			if ( empty( $restore_curlang ) ) {
 				$restore_curlang = $this->curlang->slug; // To always remember the current language through blogs.

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -161,7 +161,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	 */
 	public function add_permastruct() {
 		// Language information always in front of the uri ( 'with_front' => false ).
-		if ( $this->model->get_languages_list() ) {
+		if ( $this->model->has_languages() ) {
 			add_permastruct( 'language', $this->options['rewrite'] ? '%language%' : 'language/%language%', array( 'with_front' => false ) );
 		}
 	}
@@ -180,7 +180,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		 * to add the filters only once and if all custom post types and taxonomies
 		 * have been registered.
 		 */
-		if ( $this->model->get_languages_list() && did_action( 'wp_loaded' ) && ! has_filter( 'language_rewrite_rules', '__return_empty_array' ) ) {
+		if ( $this->model->has_languages() && did_action( 'wp_loaded' ) && ! has_filter( 'language_rewrite_rules', '__return_empty_array' ) ) {
 			add_filter( 'language_rewrite_rules', '__return_empty_array' ); // Suppress the rules created by WordPress for our taxonomy.
 
 			foreach ( $this->get_rewrite_rules_filters() as $type ) {

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -72,7 +72,7 @@ class PLL_REST_Request extends PLL_Base {
 	public function init() {
 		parent::init();
 
-		if ( ! $this->model->get_languages_list() ) {
+		if ( ! $this->model->has_languages() ) {
 			return;
 		}
 

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -361,10 +361,9 @@ abstract class PLL_Translatable_Object {
 	 * @phpstan-return list<positive-int>
 	 */
 	public function get_objects_with_no_lang( $limit, array $args = array() ) {
-		$languages = $this->model->get_languages_list();
-
 		$language_ids = array();
-		foreach ( $languages as $language ) {
+
+		foreach ( $this->model->get_languages_list() as $language ) {
 			$language_ids[] = $language->get_tax_prop( $this->get_tax_language(), 'term_taxonomy_id' );
 		}
 

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -65,7 +65,7 @@ class PLL_Settings extends PLL_Admin_Base {
 	public function register_settings_modules() {
 		$modules = array();
 
-		if ( $this->model->get_languages_list() ) {
+		if ( $this->model->has_languages() ) {
 			$modules = array(
 				'PLL_Settings_Url',
 				'PLL_Settings_Browser',


### PR DESCRIPTION
This PR is only for consistency: since those `get_languages_list()` are used after the languages are ready, these changes are not mandatory.