### PR TITLE
Removes mo_id from PLL_Language

### DIFF
--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -132,12 +132,14 @@ class PLL_Admin_Default_Term {
 	 * @return void
 	 */
 	public function create_default_term( $lang, $taxonomy ) {
-		$lang = $this->model->get_language( $lang );
+		if ( $lang instanceof PLL_Language ) {
+			$lang = $lang->slug;
+		}
 
 		// create a new term
 		// FIXME this is translated in admin language when we would like it in $lang
 		$cat_name = __( 'Uncategorized', 'polylang' );
-		$cat_slug = sanitize_title( $cat_name . '-' . $lang->slug );
+		$cat_slug = sanitize_title( $cat_name . '-' . $lang );
 		$cat = wp_insert_term( $cat_name, $taxonomy, array( 'slug' => $cat_slug ) );
 
 		// check that the term was not previously created ( in case the language was deleted and recreated )

--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -132,14 +132,12 @@ class PLL_Admin_Default_Term {
 	 * @return void
 	 */
 	public function create_default_term( $lang, $taxonomy ) {
-		if ( $lang instanceof PLL_Language ) {
-			$lang = $lang->slug;
-		}
+		$lang = $this->model->get_language( $lang );
 
 		// create a new term
 		// FIXME this is translated in admin language when we would like it in $lang
 		$cat_name = __( 'Uncategorized', 'polylang' );
-		$cat_slug = sanitize_title( $cat_name . '-' . $lang );
+		$cat_slug = sanitize_title( $cat_name . '-' . $lang->slug );
 		$cat = wp_insert_term( $cat_name, $taxonomy, array( 'slug' => $cat_slug ) );
 
 		// check that the term was not previously created ( in case the language was deleted and recreated )

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -58,6 +58,12 @@ class PLL_Admin_Model extends PLL_Model {
 			update_option( 'polylang', $this->options );
 		}
 
+		// Refresh languages.
+		$this->clean_languages_cache();
+		$this->get_languages_list();
+
+		flush_rewrite_rules(); // Refresh rewrite rules.
+
 		/**
 		 * Fires when a language is added.
 		 *
@@ -66,12 +72,6 @@ class PLL_Admin_Model extends PLL_Model {
 		 * @param array $args Arguments used to create the language. @see PLL_Admin_Model::add_language().
 		 */
 		do_action( 'pll_add_language', $args );
-
-		// Refresh languages.
-		$this->clean_languages_cache();
-		$this->get_languages_list();
-
-		flush_rewrite_rules(); // Refresh rewrite rules.
 
 		return true;
 	}

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -58,10 +58,6 @@ class PLL_Admin_Model extends PLL_Model {
 			update_option( 'polylang', $this->options );
 		}
 
-		// Init a PLL_MO for this language
-		$mo = new PLL_MO();
-		$mo->export_to_db_from_id( $r['term_id'] );
-
 		/**
 		 * Fires when a language is added.
 		 *

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -58,7 +58,7 @@ class PLL_Admin_Model extends PLL_Model {
 			update_option( 'polylang', $this->options );
 		}
 
-		// Init a mo_id for this language
+		// Init a PLL_MO for this language
 		$mo = new PLL_MO();
 		$mo->export_to_db_from_id( $r['term_id'] );
 
@@ -139,12 +139,6 @@ class PLL_Admin_Model extends PLL_Model {
 		foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
 			delete_user_meta( $user_id, 'pll_filter_content', $lang->slug );
 			delete_user_meta( $user_id, 'description_' . $lang->slug );
-		}
-
-		// Delete the string translations
-		$mo_id = PLL_MO::get_id( $lang );
-		if ( ! empty( $mo_id ) ) {
-			wp_delete_post( $mo_id );
 		}
 
 		// Delete domain

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -58,11 +58,9 @@ class PLL_Admin_Model extends PLL_Model {
 			update_option( 'polylang', $this->options );
 		}
 
-		$this->clean_languages_cache(); // Update the languages list now !
-
 		// Init a mo_id for this language
 		$mo = new PLL_MO();
-		$mo->export_to_db( $this->get_language( $args['slug'] ) );
+		$mo->export_to_db_from_id( $r['term_id'] );
 
 		/**
 		 * Fires when a language is added.

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -237,6 +237,13 @@ class PLL_Admin_Model extends PLL_Model {
 		$description = $this->build_language_metas( $args );
 		wp_update_term( $lang->get_tax_prop( 'language', 'term_id' ), 'language', array( 'slug' => $slug, 'name' => $args['name'], 'description' => $description, 'term_group' => (int) $args['term_group'] ) );
 
+		// Refresh languages.
+		$this->clean_languages_cache();
+		$this->get_languages_list();
+
+		// Refresh rewrite rules.
+		flush_rewrite_rules();
+
 		/**
 		 * Fires after a language is updated.
 		 *
@@ -257,13 +264,6 @@ class PLL_Admin_Model extends PLL_Model {
 		 * @param PLL_Language $lang Previous value of the language beeing edited.
 		 */
 		do_action( 'pll_update_language', $args, $lang );
-
-		// Refresh languages.
-		$this->clean_languages_cache();
-		$this->get_languages_list();
-
-		// Refresh rewrite rules.
-		flush_rewrite_rules();
 
 		return true;
 	}

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -56,8 +56,6 @@ class PLL_Language_Factory {
 			'term_props' => array(),
 		);
 
-		update_term_meta( $terms['language']->term_id, '_pll_strings_translations', PLL_MO::get_strings( $terms['language']->term_id ), true );
-
 		foreach ( $terms as $term ) {
 			$data['term_props'][ $term->taxonomy ] = array(
 				'term_id'          => $term->term_id,

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -54,8 +54,9 @@ class PLL_Language_Factory {
 			'slug'       => $terms['language']->slug,
 			'term_group' => $terms['language']->term_group,
 			'term_props' => array(),
-			'mo_id'      => PLL_MO::get_id_from_term_id( $terms['language']->term_id ),
 		);
+
+		update_term_meta( $terms['language']->term_id, '_pll_strings_translations', PLL_MO::get_strings( $terms['language']->term_id ), true );
 
 		foreach ( $terms as $term ) {
 			$data['term_props'][ $term->taxonomy ] = array(
@@ -144,7 +145,7 @@ class PLL_Language_Factory {
 
 		$data['is_rtl'] = ! empty( $data['is_rtl'] ) ? 1 : 0;
 
-		$positive_fields = array( 'mo_id', 'term_group', 'page_on_front', 'page_for_posts' );
+		$positive_fields = array( 'term_group', 'page_on_front', 'page_for_posts' );
 
 		foreach ( $positive_fields as $field ) {
 			$data[ $field ] = ! empty( $data[ $field ] ) ? absint( $data[ $field ] ) : 0;

--- a/include/language.php
+++ b/include/language.php
@@ -331,21 +331,6 @@ class PLL_Language {
 			return $this->{$url_getter}();
 		}
 
-		if ( 'mo_id' === $property ) {
-			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				esc_html(
-					sprintf(
-						"Class property %s::%s is deprecated, use get_term_meta() instead to get the strings translations.\nError handler",
-						esc_html( get_class( $this ) ),
-						esc_html( $property )
-					)
-				),
-				E_USER_DEPRECATED
-			);
-
-			return null;
-		}
-
 		// Undefined property.
 		if ( ! property_exists( $this, $property ) ) {
 			return null;

--- a/include/language.php
+++ b/include/language.php
@@ -331,6 +331,21 @@ class PLL_Language {
 			return $this->{$url_getter}();
 		}
 
+		if ( 'mo_id' === $property ) {
+			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				esc_html(
+					sprintf(
+						"Class property %s::%s is deprecated, use get_term_meta() instead to get the strings translations.\nError handler",
+						esc_html( get_class( $this ) ),
+						esc_html( $property )
+					)
+				),
+				E_USER_DEPRECATED
+			);
+
+			return null;
+		}
+
 		// Undefined property.
 		if ( ! property_exists( $this, $property ) ) {
 			return null;
@@ -393,7 +408,7 @@ class PLL_Language {
 		/**
 		 * Filters whether to trigger an error for deprecated properties.
 		 *
-		 * The filter name is intentionnaly not prefixed to use the same as WordPress
+		 * The filter name is intentionally not prefixed to use the same as WordPress
 		 * in case it is added in the future.
 		 *
 		 * @since 3.4

--- a/include/language.php
+++ b/include/language.php
@@ -27,7 +27,6 @@
  *     flag_code: non-empty-string,
  *     term_group: int,
  *     is_rtl: int<0, 1>,
- *     mo_id: int<0, max>,
  *     facebook?: string,
  *     home_url: non-empty-string,
  *     search_url: non-empty-string,
@@ -139,15 +138,6 @@ class PLL_Language {
 	 * @phpstan-var non-empty-string
 	 */
 	public $host;
-
-	/**
-	 * ID of the post storing strings translations.
-	 *
-	 * @var int
-	 *
-	 * @phpstan-var int<0, max>
-	 */
-	public $mo_id;
 
 	/**
 	 * ID of the page on front in this language (set from pll_additional_language_data filter).
@@ -278,7 +268,6 @@ class PLL_Language {
 	 *     @type string   $flag_code       Code of the flag.
 	 *     @type int      $term_group      Order of the language when displayed in a list of languages.
 	 *     @type int      $is_rtl          `1` if the language is rtl, `0` otherwise.
-	 *     @type int      $mo_id           ID of the post storing strings translations.
 	 *     @type string   $facebook        Optional. Facebook locale.
 	 *     @type string   $home_url        Home URL in this language.
 	 *     @type string   $search_url      Home URL to use in search forms.

--- a/include/mo.php
+++ b/include/mo.php
@@ -24,7 +24,7 @@ class PLL_MO extends MO {
 		/*
 		 * It would be convenient to store the whole object, but it would take a huge space in DB.
 		 * So let's keep only the strings in an array.
-		 * The strings are slashed to avoid breaking slashed strings in update_post_meta.
+		 * The strings are slashed to avoid breaking slashed strings in update_term_meta.
 		 * @see https://codex.wordpress.org/Function_Reference/update_post_meta#Character_Escaping.
 		 */
 		$strings = array();

--- a/include/mo.php
+++ b/include/mo.php
@@ -8,7 +8,7 @@
  *
  * @since 1.2
  * @since 2.1 Stores the strings in a post meta instead of post content to avoid unserialize issues (See #63)
- * @since 3.4 Stores the strings in a term meta instead of post meta.
+ * @since 3.4 Stores the strings into language taxonomy term meta instead of a post meta.
  */
 class PLL_MO extends MO {
 

--- a/include/mo.php
+++ b/include/mo.php
@@ -34,6 +34,20 @@ class PLL_MO extends MO {
 	 * @return void
 	 */
 	public function export_to_db( $lang ) {
+		$this->export_to_db_from_id( $lang->term_id, $lang->mo_id );
+	}
+
+
+	/**
+	 * Writes a PLL_MO object into a custom post meta.
+	 *
+	 * @since 3.4
+	 *
+	 * @param int $term_id  The language term id.
+	 * @param int $mo_id The language mo id.
+	 * @return void
+	 */
+	public function export_to_db_from_id( $term_id, $mo_id = 0 ) {
 		/*
 		 * It would be convenient to store the whole object but it would take a huge space in DB.
 		 * So let's keep only the strings in an array.
@@ -45,17 +59,15 @@ class PLL_MO extends MO {
 			$strings[] = wp_slash( array( $entry->singular, $this->translate( $entry->singular ) ) );
 		}
 
-		if ( empty( $lang->mo_id ) ) {
+		if ( empty( $mo_id ) ) {
 			$post = array(
-				'post_title'  => 'polylang_mo_' . $lang->term_id,
+				'post_title'  => 'polylang_mo_' . $term_id,
 				'post_status' => 'private', // To avoid a conflict with WP Super Cache. See https://wordpress.org/support/topic/polylang_mo-and-404s-take-2
 				'post_type'   => 'polylang_mo',
 			);
 			$mo_id = wp_insert_post( $post );
-			update_post_meta( $mo_id, '_pll_strings_translations', $strings );
-		} else {
-			update_post_meta( $lang->mo_id, '_pll_strings_translations', $strings );
 		}
+		update_post_meta( $mo_id, '_pll_strings_translations', $strings );
 	}
 
 	/**

--- a/include/mo.php
+++ b/include/mo.php
@@ -8,25 +8,12 @@
  *
  * @since 1.2
  * @since 2.1 Stores the strings in a post meta instead of post content to avoid unserialize issues (See #63)
+ * @since 3.4 Stores the strings in a term meta instead of post meta.
  */
 class PLL_MO extends MO {
 
 	/**
-	 * Registers the polylang_mo custom post type, only at first object creation
-	 *
-	 * @since 1.2
-	 */
-	public function __construct() {
-		if ( ! post_type_exists( 'polylang_mo' ) ) {
-			$labels = array( 'name' => __( 'Strings translations', 'polylang' ) );
-			register_post_type( 'polylang_mo', array( 'labels' => $labels, 'rewrite' => false, 'query_var' => false, '_pll' => true ) );
-
-			add_action( 'pll_add_language', array( $this, 'clean_cache' ) );
-		}
-	}
-
-	/**
-	 * Writes a PLL_MO object into a custom post meta.
+	 * Writes the strings into a term meta.
 	 *
 	 * @since 1.2
 	 *
@@ -34,22 +21,20 @@ class PLL_MO extends MO {
 	 * @return void
 	 */
 	public function export_to_db( $lang ) {
-		$this->export_to_db_from_id( $lang->term_id, $lang->mo_id );
+		$this->export_to_db_from_id( $lang->term_id );
 	}
 
-
 	/**
-	 * Writes a PLL_MO object into a custom post meta.
+	 * Writes the strings into a term meta.
 	 *
 	 * @since 3.4
 	 *
-	 * @param int $term_id  The language term id.
-	 * @param int $mo_id The language mo id.
+	 * @param int $term_id The language term id.
 	 * @return void
 	 */
-	public function export_to_db_from_id( $term_id, $mo_id = 0 ) {
+	public function export_to_db_from_id( $term_id ) {
 		/*
-		 * It would be convenient to store the whole object but it would take a huge space in DB.
+		 * It would be convenient to store the whole object, but it would take a huge space in DB.
 		 * So let's keep only the strings in an array.
 		 * The strings are slashed to avoid breaking slashed strings in update_post_meta.
 		 * @see https://codex.wordpress.org/Function_Reference/update_post_meta#Character_Escaping.
@@ -59,83 +44,48 @@ class PLL_MO extends MO {
 			$strings[] = wp_slash( array( $entry->singular, $this->translate( $entry->singular ) ) );
 		}
 
-		if ( empty( $mo_id ) ) {
-			$post = array(
-				'post_title'  => 'polylang_mo_' . $term_id,
-				'post_status' => 'private', // To avoid a conflict with WP Super Cache. See https://wordpress.org/support/topic/polylang_mo-and-404s-take-2
-				'post_type'   => 'polylang_mo',
-			);
-			$mo_id = wp_insert_post( $post );
-		}
-		update_post_meta( $mo_id, '_pll_strings_translations', $strings );
+		update_term_meta( $term_id, '_pll_strings_translations', $strings );
 	}
 
 	/**
-	 * Reads a PLL_MO object from a custom post meta.
+	 * Reads a PLL_MO object from the term meta.
 	 *
 	 * @since 1.2
+	 * @since 3.4 Reads a PLL_MO from the term meta.
 	 *
 	 * @param PLL_Language $lang The language in which we want to get strings.
 	 * @return void
 	 */
 	public function import_from_db( $lang ) {
-		if ( ! empty( $lang->mo_id ) ) {
-			$strings = get_post_meta( $lang->mo_id, '_pll_strings_translations', true );
-			if ( is_array( $strings ) ) {
-				foreach ( $strings as $msg ) {
-					$this->add_entry( $this->make_entry( $msg[0], $msg[1] ) );
-				}
-			}
+		$strings = get_term_meta( $lang->term_id, '_pll_strings_translations', true );
+		if ( empty( $strings ) || ! is_array( $strings ) ) {
+			return;
+		}
+
+		foreach ( $strings as $msg ) {
+			$this->add_entry( $this->make_entry( $msg[0], $msg[1] ) );
 		}
 	}
 
 	/**
-	 * Returns the post ID of the post storing the strings translations.
-	 *
-	 * @since 1.4
-	 *
-	 * @param PLL_Language $lang The language object.
-	 * @return int|null
-	 *
-	 * @phpstan-return positive-int|null
-	 */
-	public static function get_id( $lang ) {
-		return self::get_id_from_term_id( $lang->term_id );
-	}
-
-	/**
-	 * Returns the post ID of the post storing the strings translations.
+	 * Returns the strings translations.
 	 *
 	 * @since 3.4
 	 *
 	 * @param int $term_id The language term ID.
-	 * @return int|null
-	 *
-	 * @phpstan-return positive-int|null
+	 * @return array
 	 */
-	public static function get_id_from_term_id( $term_id ) {
+	public static function get_strings( $term_id ) {
 		global $wpdb;
 
-		$ids = wp_cache_get( 'polylang_mo_ids' );
-
-		if ( empty( $ids ) ) {
-			$ids = $wpdb->get_results( "SELECT post_title, ID FROM $wpdb->posts WHERE post_type='polylang_mo'", OBJECT_K );
-			wp_cache_add( 'polylang_mo_ids', $ids );
-		}
-
-		// The mo id for a language can be transiently empty.
-		return isset( $ids[ 'polylang_mo_' . $term_id ] ) ? $ids[ 'polylang_mo_' . $term_id ]->ID : null;
-	}
-
-	/**
-	 * Invalidate the cache when adding a new language
-	 *
-	 * @since 2.0.5
-	 *
-	 * @return void
-	 */
-	public function clean_cache() {
-		wp_cache_delete( 'polylang_mo_ids' );
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_value FROM $wpdb->termmeta
+				WHERE term_id=%s AND META_KEY='_pll_strings_translations'",
+				$term_id
+			),
+			ARRAY_A
+		);
 	}
 
 	/**

--- a/include/mo.php
+++ b/include/mo.php
@@ -21,18 +21,6 @@ class PLL_MO extends MO {
 	 * @return void
 	 */
 	public function export_to_db( $lang ) {
-		$this->export_to_db_from_id( $lang->term_id );
-	}
-
-	/**
-	 * Writes the strings into a term meta.
-	 *
-	 * @since 3.4
-	 *
-	 * @param int $term_id The language term id.
-	 * @return void
-	 */
-	public function export_to_db_from_id( $term_id ) {
 		/*
 		 * It would be convenient to store the whole object, but it would take a huge space in DB.
 		 * So let's keep only the strings in an array.
@@ -44,7 +32,7 @@ class PLL_MO extends MO {
 			$strings[] = wp_slash( array( $entry->singular, $this->translate( $entry->singular ) ) );
 		}
 
-		update_term_meta( $term_id, '_pll_strings_translations', $strings );
+		update_term_meta( $lang->term_id, '_pll_strings_translations', $strings );
 	}
 
 	/**
@@ -65,34 +53,6 @@ class PLL_MO extends MO {
 		foreach ( $strings as $msg ) {
 			$this->add_entry( $this->make_entry( $msg[0], $msg[1] ) );
 		}
-	}
-
-	/**
-	 * Returns the strings translations.
-	 *
-	 * @since 3.4
-	 *
-	 * @param int $term_id The language term ID.
-	 * @return array
-	 */
-	public static function get_strings( $term_id ) {
-		global $wpdb;
-
-		$strings = wp_cache_get( 'polylang_strings_translations' );
-
-		if ( empty( $strings ) ) {
-			$strings =  $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT meta_value FROM $wpdb->termmeta
-				WHERE term_id=%s AND META_KEY='_pll_strings_translations'",
-					$term_id
-				),
-				ARRAY_A
-			);
-			wp_cache_add( 'polylang_strings_translations', $strings );
-		}
-
-		return $strings;
 	}
 
 	/**

--- a/include/mo.php
+++ b/include/mo.php
@@ -78,14 +78,21 @@ class PLL_MO extends MO {
 	public static function get_strings( $term_id ) {
 		global $wpdb;
 
-		return $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT meta_value FROM $wpdb->termmeta
+		$strings = wp_cache_get( 'polylang_strings_translations' );
+
+		if ( empty( $strings ) ) {
+			$strings =  $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT meta_value FROM $wpdb->termmeta
 				WHERE term_id=%s AND META_KEY='_pll_strings_translations'",
-				$term_id
-			),
-			ARRAY_A
-		);
+					$term_id
+				),
+				ARRAY_A
+			);
+			wp_cache_add( 'polylang_strings_translations', $strings );
+		}
+
+		return $strings;
 	}
 
 	/**

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -231,14 +231,15 @@ class PLL_Upgrade {
 		}
 
 		foreach ( $posts as $post ) {
+			$meta = get_post_meta( $post->ID, '_pll_strings_translations', true );
+
+			$term_id = (int) substr( $post->post_title, 12 );
 			wp_delete_post( $post->ID );
 
-			$meta = get_post_meta( $post->ID, '_pll_strings_translations', true );
 			if ( empty( $meta ) || ! is_array( $meta ) ) {
 				continue;
 			}
 
-			$term_id = (int) substr( $post->post_title, 12 );
 			update_term_meta( $term_id, '_pll_strings_translations', wp_slash( $meta ) );
 		}
 	}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -236,11 +236,6 @@ parameters:
 			path: admin/admin-model.php
 
 		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_MO\\:\\:export_to_db\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
-			count: 1
-			path: admin/admin-model.php
-
-		-
 			message: "#^Cannot access offset 'nav_menu_locations' on mixed\\.$#"
 			count: 3
 			path: admin/admin-nav-menu.php

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -154,7 +154,6 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'home_url',
 			'search_url',
 			'host',
-			'mo_id',
 			'page_on_front',
 			'page_for_posts',
 			'flag_code',

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -114,9 +114,6 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $post_group->term_taxonomy_id ) ) );
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $term_group->term_taxonomy_id ) ) );
 
-		// No strings translations, bug fixed in 2.2.1
-		$this->assertEmpty( get_term_meta( $english->term_id, '_pll_strings_translations', true ) );
-
 		// Users metas
 		$this->assertEmpty( $wpdb->get_results( "SELECT * FROM {$wpdb->usermeta} WHERE meta_key='pll_filter_content'" ) );
 		$this->assertEmpty( $wpdb->get_results( "SELECT * FROM {$wpdb->usermeta} WHERE meta_key='description_fr'" ) );

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -47,6 +47,7 @@ class Install_Test extends PLL_UnitTestCase {
 		$english = self::$model->get_language( 'en' );
 
 		self::create_language( 'fr_FR' );
+		$french = self::$model->get_language( 'fr' );
 
 		// Posts and terms
 		$en = self::factory()->post->create();
@@ -85,6 +86,11 @@ class Install_Test extends PLL_UnitTestCase {
 
 		update_post_meta( $item_id, '_pll_menu_item', array() );
 
+		// Strings translations
+		$_mo = new PLL_MO();
+		$_mo->add_entry( $_mo->make_entry( 'test', 'test fr' ) );
+		$_mo->export_to_db( self::$model->get_language( 'fr' ) );
+
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );
 		}
@@ -120,5 +126,8 @@ class Install_Test extends PLL_UnitTestCase {
 
 		// Language switcher menu items
 		$this->assertEmpty( get_post( $item_id ) );
+
+		// Strings translations
+		$this->assertEmpty( get_term_meta( $french->term_id ) );
 	}
 }

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -115,7 +115,7 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id=%d", $term_group->term_taxonomy_id ) ) );
 
 		// No strings translations, bug fixed in 2.2.1
-		$this->assertEmpty( get_post( $english->mo_id ) );
+		$this->assertEmpty( get_term_meta( $english->term_id, '_pll_strings_translations', true ) );
 
 		// Users metas
 		$this->assertEmpty( $wpdb->get_results( "SELECT * FROM {$wpdb->usermeta} WHERE meta_key='pll_filter_content'" ) );

--- a/uninstall.php
+++ b/uninstall.php
@@ -84,21 +84,6 @@ class PLL_Uninstall {
 			wp_delete_post( $id, true );
 		}
 
-		// Delete the strings translations.
-		register_post_type( 'polylang_mo', array( 'rewrite' => false, 'query_var' => false ) );
-		$ids = get_posts(
-			array(
-				'post_type'   => 'polylang_mo',
-				'post_status' => 'any',
-				'numberposts' => -1,
-				'nopaging'    => true,
-				'fields'      => 'ids',
-			)
-		);
-		foreach ( $ids as $id ) {
-			wp_delete_post( $id, true );
-		}
-
 		// Delete all what is related to languages and translations
 		$term_ids = array();
 		$tt_ids   = array();
@@ -112,6 +97,7 @@ class PLL_Uninstall {
 			$term_ids = array_unique( $term_ids );
 			$wpdb->query( "DELETE FROM {$wpdb->terms} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM {$wpdb->term_taxonomy} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( "DELETE FROM {$wpdb->termmeta} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		if ( ! empty( $tt_ids ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -97,7 +97,7 @@ class PLL_Uninstall {
 			$term_ids = array_unique( $term_ids );
 			$wpdb->query( "DELETE FROM {$wpdb->terms} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( "DELETE FROM {$wpdb->term_taxonomy} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( "DELETE FROM {$wpdb->termmeta} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( "DELETE FROM {$wpdb->termmeta} WHERE term_id IN ( " . implode( ',', $term_ids ) . " ) AND meta_key='_pll_strings_translations'" ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		if ( ! empty( $tt_ids ) ) {


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1584
See also (https://github.com/polylang/polylang/pull/1195#discussion_r1069686911

Delete the `polylang_mo` post type and its associated meta `_pll_strings_translations` to replace it with a term meta linked to the language term.