### PR TITLE
Deprecate language list filters

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -597,7 +597,7 @@ class PLL_Language {
 	public function get_display_flag_url() {
 		$flag_url = empty( $this->custom_flag_url ) ? $this->flag_url : $this->custom_flag_url;
 
-		if ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) {
+		if ( ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) || ( defined( 'PLL_CACHE_HOME_URL' ) && ! PLL_CACHE_HOME_URL ) ) {
 			/**
 			 * Let's use `site_url()` so the returned URL will be filtered properly according to the current domain.
 			 */

--- a/include/language.php
+++ b/include/language.php
@@ -405,7 +405,7 @@ class PLL_Language {
 		 * Filters whether to trigger an error for deprecated properties.
 		 *
 		 * The filter name is intentionnaly not prefixed to use the same as WordPress
-		 * in case it is added in the future.
+		 * in case it is added in the future. 
 		 *
 		 * @since 3.4
 		 *
@@ -597,14 +597,10 @@ class PLL_Language {
 	public function get_display_flag_url() {
 		$flag_url = empty( $this->custom_flag_url ) ? $this->flag_url : $this->custom_flag_url;
 
-		if ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) {
-			/**
-			 * Let's use `site_url()` so the returned URL will be filtered properly according to the current domain.
-			 */
-			return site_url( set_url_scheme( $flag_url, 'relative' ) );
-		}
-
-		return $flag_url;
+		/**
+		 * Let's use `site_url()` so the returned URL will be filtered properly according to the current domain.
+		 */
+		return site_url( set_url_scheme( $flag_url, 'relative' ) );
 	}
 
 	/**

--- a/include/language.php
+++ b/include/language.php
@@ -597,7 +597,7 @@ class PLL_Language {
 	public function get_display_flag_url() {
 		$flag_url = empty( $this->custom_flag_url ) ? $this->flag_url : $this->custom_flag_url;
 
-		if ( ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) || ( defined( 'PLL_CACHE_HOME_URL' ) && ! PLL_CACHE_HOME_URL ) ) {
+		if ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) {
 			/**
 			 * Let's use `site_url()` so the returned URL will be filtered properly according to the current domain.
 			 */

--- a/include/language.php
+++ b/include/language.php
@@ -405,7 +405,7 @@ class PLL_Language {
 		 * Filters whether to trigger an error for deprecated properties.
 		 *
 		 * The filter name is intentionnaly not prefixed to use the same as WordPress
-		 * in case it is added in the future. 
+		 * in case it is added in the future.
 		 *
 		 * @since 3.4
 		 *
@@ -597,10 +597,14 @@ class PLL_Language {
 	public function get_display_flag_url() {
 		$flag_url = empty( $this->custom_flag_url ) ? $this->flag_url : $this->custom_flag_url;
 
-		/**
-		 * Let's use `site_url()` so the returned URL will be filtered properly according to the current domain.
-		 */
-		return site_url( set_url_scheme( $flag_url, 'relative' ) );
+		if ( defined( 'PLL_CACHE_LANGUAGES' ) && ! PLL_CACHE_LANGUAGES ) {
+			/**
+			 * Let's use `site_url()` so the returned URL will be filtered properly according to the current domain.
+			 */
+			return site_url( set_url_scheme( $flag_url, 'relative' ) );
+		}
+
+		return $flag_url;
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -150,10 +150,12 @@ class PLL_Model {
 			 * /!\ This filter is fired *before* the $polylang object is available.
 			 *
 			 * @since 1.8
+			 * @since 3.4 Deprecated.
+			 * @deprecated
 			 *
 			 * @param PLL_Language[] $languages The list of language objects.
 			 */
-			$languages = apply_filters( 'pll_after_languages_cache', $languages );
+			$languages = apply_filters_deprecated( 'pll_after_languages_cache', array( $languages ), '3.4', 'pll_additional_language_data' );
 			$this->cache->set( 'languages', $languages );
 			$this->is_creating_language_objects = false;
 		}
@@ -809,11 +811,13 @@ class PLL_Model {
 		 * /!\ This filter is fired *before* the $polylang object is available.
 		 *
 		 * @since 1.7.5
+		 * @since 3.4 Deprecated.
+		 * @deprecated
 		 *
 		 * @param PLL_Language[] $languages The list of language objects.
 		 * @param PLL_Model      $model     PLL_Model object.
 		 */
-		$languages = apply_filters( 'pll_languages_list', $languages, $this );
+		$languages = apply_filters_deprecated( 'pll_languages_list', array( $languages, $this ), '3.4', 'pll_additional_language_data' );
 
 		/*
 		 * Don't store directly objects as it badly break with some hosts ( GoDaddy ) due to race conditions when using object cache.

--- a/include/model.php
+++ b/include/model.php
@@ -150,12 +150,12 @@ class PLL_Model {
 			 * /!\ This filter is fired *before* the $polylang object is available.
 			 *
 			 * @since 1.8
-			 * @since 3.4 Deprecated.
+			 * @since 3.4 Deprecated. If you used this hook to filter URLs, you may hook `'site_url'` instead.
 			 * @deprecated
 			 *
 			 * @param PLL_Language[] $languages The list of language objects.
 			 */
-			$languages = apply_filters_deprecated( 'pll_after_languages_cache', array( $languages ), '3.4', 'pll_additional_language_data' );
+			$languages = apply_filters_deprecated( 'pll_after_languages_cache', array( $languages ), '3.4' );
 			$this->cache->set( 'languages', $languages );
 			$this->is_creating_language_objects = false;
 		}


### PR DESCRIPTION
Since the languages list has been refactored to contain immutable objects, the filters `pll_languages_list` and `pll_after_languages_cache` are deprecated.

- `pll_languages_list` is replaced by `pll_additional_language_data`.
- `pll_after_languages_cache` has no replacements: since its purpose was to be able to filter the URLs after the cache, we can't say that `pll_additional_language_data` is a fitted replacement (which is triggered before the `PLL_Language` objects are even created, so, long before the cache. However, a comment has been added to advise to hook `'site_url'` instead (not added in the deprecation notice because the hook could be used for something else).
- A bit unrelated to this PR, but while discussing the previous point's cache issue, we discovered that `get_display_flag_url()` didn't use the constants `PLL_CACHE_LANGUAGES` and `PLL_CACHE_HOME_URL` like `get_home_url()` and `get_search_url()` do, so they have been added. Props @Hug0-Drelon for the idea.

This PR should not be merged before https://github.com/polylang/polylang-wc/pull/548, as Polylang for WooCommerce still uses those filters.