### PR TITLE
Don't cache incomplete languages list

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -78,6 +78,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 		// Early instantiated to be able to correctly initialize language properties.
 		$this->static_pages = new PLL_Admin_Static_Pages( $this );
+		$this->model->set_languages_ready();
 	}
 
 	/**

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -93,6 +93,8 @@ class PLL_Frontend extends PLL_Base {
 		if ( 'page' === get_option( 'show_on_front' ) ) {
 			$this->static_pages = new PLL_Frontend_Static_Pages( $this );
 		}
+
+		$this->model->set_languages_ready();
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -855,7 +855,7 @@ class PLL_Model {
 		 */
 		$languages_data = array_map(
 			function ( $language ) {
-			return $language->to_array( 'db' );
+				return $language->to_array( 'db' );
 			},
 			$languages
 		);

--- a/include/model.php
+++ b/include/model.php
@@ -841,22 +841,26 @@ class PLL_Model {
 		 */
 		$languages = apply_filters( 'pll_languages_list', $languages, $this );
 
-		if ( $this->are_languages_ready() ) {
-			/**
-			 * Don't store directly objects as it badly break with some hosts ( GoDaddy ) due to race conditions when using object cache.
-			 * Thanks to captin411 for catching this!
-			 *
-			 * @see https://wordpress.org/support/topic/fatal-error-pll_model_languages_list?replies=8#post-6782255
-			 */
-			$languages_data = array_map(
-				function ( $language ) {
-				return $language->to_array( 'db' );
-				},
-				$languages
-			);
-
-			set_transient( 'pll_languages_list', $languages_data );
+		if ( ! $this->are_languages_ready() ) {
+			// Do not cache an incomplete list.
+			/** @var list<PLL_Language> $languages */
+			return $languages;
 		}
+
+		/**
+		 * Don't store directly objects as it badly break with some hosts ( GoDaddy ) due to race conditions when using object cache.
+		 * Thanks to captin411 for catching this!
+		 *
+		 * @see https://wordpress.org/support/topic/fatal-error-pll_model_languages_list?replies=8#post-6782255
+		 */
+		$languages_data = array_map(
+			function ( $language ) {
+			return $language->to_array( 'db' );
+			},
+			$languages
+		);
+
+		set_transient( 'pll_languages_list', $languages_data );
 
 		/** @var list<PLL_Language> $languages */
 		return $languages;

--- a/include/model.php
+++ b/include/model.php
@@ -125,7 +125,7 @@ class PLL_Model {
 		if ( ! $this->are_languages_ready() ) {
 			_doing_it_wrong(
 				__METHOD__ . '()',
-				"This function must not be called before the hook 'pll_pre_init'.",
+				"It must not be called before the hook 'pll_pre_init'.",
 				'3.4'
 			);
 		}

--- a/include/model.php
+++ b/include/model.php
@@ -123,11 +123,9 @@ class PLL_Model {
 	 */
 	public function get_languages_list( $args = array() ) {
 		if ( ! $this->are_languages_ready() ) {
-			/* translators: %s is the name of a hook. */
-			$message = function_exists( '__' ) ? __( 'This function must not be called before the hook %s.', 'polylang' ) : 'This function must not be called before the hook %s.';
 			_doing_it_wrong(
 				__METHOD__ . '()',
-				sprintf( esc_html( $message ), "'pll_pre_init'" ),
+				"This function must not be called before the hook 'pll_pre_init'.",
 				'3.4'
 			);
 		}

--- a/include/model.php
+++ b/include/model.php
@@ -54,6 +54,13 @@ class PLL_Model {
 	private $is_creating_language_objects = false;
 
 	/**
+	 * Tells if {@see PLL_Model::get_languages_list()} can be used.
+	 *
+	 * @var bool
+	 */
+	private $languages_ready = false;
+
+	/**
 	 * Constructor.
 	 * Setups translated objects sub models.
 	 * Setups filters and actions.
@@ -154,7 +161,11 @@ class PLL_Model {
 			 * @param PLL_Language[] $languages The list of language objects.
 			 */
 			$languages = apply_filters( 'pll_after_languages_cache', $languages );
-			$this->cache->set( 'languages', $languages );
+
+			if ( $this->are_languages_ready() ) {
+				$this->cache->set( 'languages', $languages );
+			}
+
 			$this->is_creating_language_objects = false;
 		}
 
@@ -168,6 +179,28 @@ class PLL_Model {
 		}
 
 		return empty( $args['fields'] ) ? $languages : wp_list_pluck( $languages, $args['fields'] );
+	}
+
+	/**
+	 * Tells if {@see PLL_Model::get_languages_list()} can be used.
+	 *
+	 * @since 3.4
+	 *
+	 * @return bool
+	 */
+	public function are_languages_ready() {
+		return $this->languages_ready;
+	}
+
+	/**
+	 * Sets the internal property `$languages_ready` to `true`, telling that {@see PLL_Model::get_languages_list()} can be used.
+	 *
+	 * @since 3.4
+	 *
+	 * @return void
+	 */
+	public function set_languages_ready() {
+		$this->languages_ready = true;
 	}
 
 	/**
@@ -797,9 +830,6 @@ class PLL_Model {
 			$languages[] = PLL_Language_Factory::get_from_terms( $lang_terms );
 		}
 
-		// We will need the languages list to allow its access in the filter below.
-		$this->cache->set( 'languages', $languages );
-
 		/**
 		 * Filters the list of languages *before* it is stored in the persistent cache.
 		 * /!\ This filter is fired *before* the $polylang object is available.
@@ -811,18 +841,22 @@ class PLL_Model {
 		 */
 		$languages = apply_filters( 'pll_languages_list', $languages, $this );
 
-		/*
-		 * Don't store directly objects as it badly break with some hosts ( GoDaddy ) due to race conditions when using object cache.
-		 * Thanks to captin411 for catching this!
-		 * @see https://wordpress.org/support/topic/fatal-error-pll_model_languages_list?replies=8#post-6782255
-		 */
-		$languages_data = array_map(
-			function ( $language ) {
-				return $language->get_object_vars( 'db' );
-			},
-			$languages
-		);
-		set_transient( 'pll_languages_list', $languages_data );
+		if ( $this->are_languages_ready() ) {
+			/**
+			 * Don't store directly objects as it badly break with some hosts ( GoDaddy ) due to race conditions when using object cache.
+			 * Thanks to captin411 for catching this!
+			 *
+			 * @see https://wordpress.org/support/topic/fatal-error-pll_model_languages_list?replies=8#post-6782255
+			 */
+			$languages_data = array_map(
+				function ( $language ) {
+					return $language->get_object_vars( 'db' );
+				},
+				$languages
+			);
+
+			set_transient( 'pll_languages_list', $languages_data );
+		}
 
 		/** @var list<PLL_Language> $languages */
 		return $languages;

--- a/include/model.php
+++ b/include/model.php
@@ -122,6 +122,16 @@ class PLL_Model {
 	 * @return array List of PLL_Language objects or PLL_Language object properties.
 	 */
 	public function get_languages_list( $args = array() ) {
+		if ( ! $this->are_languages_ready() ) {
+			/* translators: %s is the name of a hook. */
+			$message = function_exists( '__' ) ? __( 'This function must not be called before the hook %s.', 'polylang' ) : 'This function must not be called before the hook %s.';
+			_doing_it_wrong(
+				__METHOD__ . '()',
+				sprintf( esc_html( $message ), "'pll_pre_init'" ),
+				'3.4'
+			);
+		}
+
 		$languages = $this->cache->get( 'languages' );
 
 		if ( ! is_array( $languages ) ) {

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -60,6 +60,8 @@ class PLL_REST_Request extends PLL_Base {
 		if ( 'page' === get_option( 'show_on_front' ) ) {
 			$this->static_pages = new PLL_Static_Pages( $this );
 		}
+
+		$this->model->set_languages_ready();
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -66,17 +66,13 @@ trait PLL_UnitTestCase_Trait {
 
 		/**
 		 * Don't trigger an error if `PLL_Model::get_languages_list()` is called too early.
+		 * WP's test suite already does this in `WP_UnitTestCase_Base::set_up()`, but it happens too late because
+		 * we create our languages in `wpSetUpBeforeClass()` with `PLL_UnitTestCase::create_language()`, which calls
+		 * `PLL_Admin_Model::add_language()` => `PLL_Admin_Model::validate_lang()` => `PLL_Model::get_languages_list()`.
 		 *
 		 * @see PLL_UnitTestCase_Trait::doing_it_wrong_run()
 		 */
-		add_filter(
-			'doing_it_wrong_trigger_error',
-			function ( $trigger_error, $function_name ) {
-				return $trigger_error && 'PLL_Model::get_languages_list()' !== $function_name;
-			},
-			10,
-			2
-		);
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -183,7 +183,7 @@ trait PLL_UnitTestCase_Trait {
 
 	/**
 	 * Don't trigger an error if `PLL_Model::get_languages_list()` is called too early.
-	 * Note: the paramaters `$message` and `$version` are available since WP 6.1.
+	 * Note: the parameters `$message` and `$version` are available since WP 6.1.
 	 *
 	 * @since 3.4
 	 * @see WP_UnitTestCase_Base::doing_it_wrong_run()

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -183,6 +183,7 @@ trait PLL_UnitTestCase_Trait {
 
 	/**
 	 * Don't trigger an error if `PLL_Model::get_languages_list()` is called too early.
+	 * Note: the paramaters `$message` and `$version` are available since WP 6.1.
 	 *
 	 * @since 3.4
 	 * @see WP_UnitTestCase_Base::doing_it_wrong_run()
@@ -193,7 +194,7 @@ trait PLL_UnitTestCase_Trait {
 	 * @param string $version  The version of WordPress where the message was added.
 	 * @return void
 	 */
-	public function doing_it_wrong_run( $function, $message, $version ) {
+	public function doing_it_wrong_run( $function, $message = '', $version = '' ) {
 		if ( 'PLL_Model::get_languages_list()' === $function ) {
 			return;
 		}

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -63,6 +63,20 @@ trait PLL_UnitTestCase_Trait {
 
 		remove_action( 'current_screen', '_load_remote_block_patterns' );
 		remove_action( 'current_screen', '_load_remote_featured_patterns' );
+
+		/**
+		 * Don't trigger an error if `PLL_Model::get_languages_list()` is called too early.
+		 *
+		 * @see PLL_UnitTestCase_Trait::doing_it_wrong_run()
+		 */
+		add_filter(
+			'doing_it_wrong_trigger_error',
+			function ( $trigger_error, $function_name ) {
+				return $trigger_error && 'PLL_Model::get_languages_list()' !== $function_name;
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -165,5 +179,25 @@ trait PLL_UnitTestCase_Trait {
 		}
 
 		return static::$submenu;
+	}
+
+	/**
+	 * Don't trigger an error if `PLL_Model::get_languages_list()` is called too early.
+	 *
+	 * @since 3.4
+	 * @see WP_UnitTestCase_Base::doing_it_wrong_run()
+	 * @see PLL_UnitTestCase_Trait::wpSetUpBeforeClass()
+	 *
+	 * @param string $function The function to add.
+	 * @param string $message  A message explaining what has been done incorrectly.
+	 * @param string $version  The version of WordPress where the message was added.
+	 * @return void
+	 */
+	public function doing_it_wrong_run( $function, $message, $version ) {
+		if ( 'PLL_Model::get_languages_list()' === $function ) {
+			return;
+		}
+
+		parent::doing_it_wrong_run( $function, $message, $version );
 	}
 }

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -139,6 +139,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		);
 
 		self::$model->add_language( $args );
+		self::$model->set_languages_ready();
 		self::$model->get_languages_list(); // Saves the transient.
 
 		$properties = array(


### PR DESCRIPTION
This PR prevents caching the languages list until the languages are complete, which happens after the "static page" instance is created.
This also triggers a "doing it wrong" warning if the list is retrieved before it is complete.

I found 4 ways to achieve that:

1. `doing_action( 'pll_pre_init' ) || did_action( 'pll_pre_init' )`:
    - no need to modify anything else in the plugin,
    - but `'pll_pre_init'` is never fired during the tests, so the cache would never been enabled.
2. Custom property (boolean) in `PLL_Model`, set to `true` in the class `Polylang`, after instantiating the `$polylang` object:
    - slight performance improvement, compared to `doing_action()` + `did_action()`,
    - minor change outside `PLL_Model`,
    - but requires to set the property in all of our tests.
3. Custom property (boolean) in `PLL_Model`, set to `true` at the end of each "context" class' constructor (like `PLL_Base`):
    - slight performance improvement, compared to `doing_action()` + `did_action()`,
    - minor changes outside `PLL_Model`,
    - but not all tests instanciate a "context" class.
4. Custom property (boolean) set by a callback hooked on `'pll_pre_init'` with priority `PHP_INT_MIN`:
    - no need to modify anything else in the plugin,
    - but `'pll_pre_init'` is never fired during the tests, so the cache would never been enabled.

I chose the 3rd option because of the tiny performance improvement and because only 10% of the tests wouldn't trigger the cache.
Note: the warning is suppressed in tests for now, maybe we'll find a way to improve our setup in tests later.