### PR TITLE
Get ready for WP 6.2

### DIFF
--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -134,10 +134,7 @@ class PLL_Admin_Model extends PLL_Model {
 		}
 
 		// Delete the string translations
-		$post = wpcom_vip_get_page_by_title( 'polylang_mo_' . $lang->term_id, OBJECT, 'polylang_mo' );
-		if ( $post instanceof WP_Post ) {
-			wp_delete_post( $post->ID );
-		}
+		wp_delete_post( PLL_MO::get_id( $lang ) );
 
 		// Delete domain
 		unset( $this->options['domains'][ $lang->slug ] );

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -111,7 +111,10 @@ class PLL_Frontend_Filters_Search {
 	public function admin_bar_search_menu( $wp_admin_bar ) {
 		$form  = '<form action="' . esc_url( home_url( '/' ) ) . '" method="get" id="adminbarsearch">';
 		$form .= '<input class="adminbar-input" name="s" id="adminbar-search" type="text" value="" maxlength="150" />';
-		$form .= '<label for="adminbar-search" class="screen-reader-text">' . esc_html__( 'Search', 'polylang' ) . '</label>';
+		$form .= '<label for="adminbar-search" class="screen-reader-text">' .
+					/* translators: Hidden accessibility text. */
+					esc_html__( 'Search', 'polylang' ) .
+				'</label>';
 		$form .= '<input type="submit" class="adminbar-button" value="' . esc_attr__( 'Search', 'polylang' ) . '" />';
 		$form .= '</form>';
 

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -12,6 +12,6 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_wp_admin_bar() {
-		$this->check_method( 'ab8f67e85e5623c4c211f67ecd57093a', '5.8', 'wp_admin_bar_search_menu' );
+		$this->check_method( 'cc6308276c4e0553f75da06592f881cb', '6.2', 'wp_admin_bar_search_menu' );
 	}
 }


### PR DESCRIPTION
- [x] remove call to `wpcom_vip_get_page_by_title()` which uses `get_page_by_title()` which will be deprecated in WP 6.2 => 4f7ae2a91e23a0c57976fa29eb3fc89e71d84b6e
- ~~[ ] `WP_Widget_Calendar::widget()` will evolve in WP 6.2 and we have to check if we need to apply this changes in our code
Test doesn't break on travis 🤔~~ only on windows environment.
- ~~[ ] `get_calendar()` will evolve in WP 6.2 and we have to check if we need to apply this changes in our code
Test doesn't break on travis 🤔~~ only on windows environment.
- [x] ` wp_admin_bar_search_menu()` will evolve in WP 6.2 and we have to check if we need to apply this changes in our code
See https://core.trac.wordpress.org/ticket/29748, https://github.com/WordPress/wordpress-develop/pull/3970 and updated in https://core.trac.wordpress.org/changeset/55276 
=> Just add a translators comment
