### PR TITLE
Fix E_WARNING notice

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -66,7 +66,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	public function add_language_to_link( $url, $lang ) {
 		if ( ! empty( $lang ) ) {
 			$base = $this->options['rewrite'] ? '' : 'language/';
-			$slug = $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug . '/';
+			$slug = isset($this->options['default_lang']) && $this->options['default_lang'] == $lang->slug && $this->options['hide_default'] ? '' : $base . $lang->slug . '/';
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );
 
 			if ( false === strpos( $url, $new = $root . $slug ) ) {


### PR DESCRIPTION
Sometimes this line triggers E_WARNING with the following message: Undefined array key "default_lang".

This change prevents that from happening;