### PR TITLE
Allow to cache all kinds of object types.

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -63,12 +63,14 @@ class PLL_Model {
 	 * @param array $options Polylang options.
 	 */
 	public function __construct( &$options ) {
-		$this->options = &$options;
+		global $wp_object_cache;
 
-		$this->cache = new PLL_Cache();
+		$this->options              = &$options;
+		$this->cache                = new PLL_Cache();
 		$this->translatable_objects = new PLL_Translatable_Objects();
-		$this->post = $this->translatable_objects->register( new PLL_Translated_Post( $this ) ); // Translated post sub model.
-		$this->term = $this->translatable_objects->register( new PLL_Translated_Term( $this ) ); // Translated term sub model.
+		$translatable_object_cache  = new PLL_Translatable_WP_Object_Cache( $wp_object_cache );
+		$this->post                 = $this->translatable_objects->register( new PLL_Translated_Post( $this, $translatable_object_cache ) );  // Translated post sub model.
+		$this->term                 = $this->translatable_objects->register( new PLL_Translated_Term( $this, $translatable_object_cache ) );  // Translated term sub model.
 
 		// We need to clean languages cache when editing a language and when modifying the permalink structure.
 		add_action( 'edited_term_taxonomy', array( $this, 'clean_languages_cache' ), 10, 2 );

--- a/include/translatable-abstract-object-cache.php
+++ b/include/translatable-abstract-object-cache.php
@@ -46,7 +46,7 @@ abstract class PLL_Translatable_Abstract_Object_Cache {
 	 * @param string $cache_type Cache type to use.
 	 * @return self
 	 *
-	 * @phpstan-var non-empty-string $cache_type
+	 * @phpstan-param non-empty-string $cache_type
 	 */
 	public function register_type( $cache_type ) {
 		$this->cache_type = $cache_type;
@@ -80,7 +80,7 @@ abstract class PLL_Translatable_Abstract_Object_Cache {
 	 * @since 3.4
 	 *
 	 * @param array $args Array of arguments to get data from the cache.
-	 * @return int[] Array of object IDs (could be anything, like post or term for instance).
+	 * @return mixed Array of object IDs (could be anything, like post or term for instance) if data has been cached.
 	 */
 	abstract public function get( $args );
 
@@ -98,7 +98,7 @@ abstract class PLL_Translatable_Abstract_Object_Cache {
 	 *
 	 * @since 3.4
 	 *
-	 * @return mixed Anything indicating the last change (e.g UNIX timestamp, DateTime...).
+	 * @return string UNIX timestamp indicating the last change .
 	 */
 	abstract public function get_last_changed();
 
@@ -114,12 +114,23 @@ abstract class PLL_Translatable_Abstract_Object_Cache {
 	 * @param string[] $tax_to_cache List of taxonomies to cache.
 	 * @return array Filtered array of arguments to add data to the cache.
 	 *
-	 * @phpstan-var non-empty-string $type
-	 * @phpstan-var non-empty-string $tax_language
-	 * @phpstan-var list<non-empty-string> $tax_to_cache
+	 * @phpstan-param non-empty-string $type
+	 * @phpstan-param non-empty-string $tax_language
+	 * @phpstan-param list<non-empty-string> $tax_to_cache
 	 */
 	public function filter_add_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
-		// TODO: implement here.
+		/**
+		 * Filters the arguments passed to `PLL_Translatable_Abstract_Object_Cache::add()`.
+		 *
+		 * @since 3.4
+		 *
+		 * @param array    $args         Array of arguments to add data to the cache.
+		 * @param int[]    $object_ids   List of object IDs.
+		 * @param string   $type         Identifier that must be unique for each type of content.
+		 * @param string   $tax_language Taxonomy name for the languages.
+		 * @param string[] $tax_to_cache List of taxonomies to cache.
+		 */
+		return apply_filters( 'pll_pre_add_to_object_cache', $args, $object_ids, $type, $tax_language, $tax_to_cache );
 	}
 
 	/**
@@ -134,12 +145,23 @@ abstract class PLL_Translatable_Abstract_Object_Cache {
 	 * @param string[] $tax_to_cache List of taxonomies to cache.
 	 * @return array Filtered array of arguments to save data to the cache.
 	 *
-	 * @phpstan-var non-empty-string $type
-	 * @phpstan-var non-empty-string $tax_language
-	 * @phpstan-var list<non-empty-string> $tax_to_cache
+	 * @phpstan-param non-empty-string $type
+	 * @phpstan-param non-empty-string $tax_language
+	 * @phpstan-param list<non-empty-string> $tax_to_cache
 	 */
 	public function filter_set_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
-		// TODO: implement here.
+		/**
+		 * Filters the arguments passed to `PLL_Translatable_Abstract_Object_Cache::set()`.
+		 *
+		 * @since 3.4
+		 *
+		 * @param array    $args         Array of arguments to save data to the cache.
+		 * @param int[]    $object_ids   List of object IDs.
+		 * @param string   $type         Identifier that must be unique for each type of content.
+		 * @param string   $tax_language Taxonomy name for the languages.
+		 * @param string[] $tax_to_cache List of taxonomies to cache.
+		 */
+		return apply_filters( 'pll_pre_set_to_object_cache', $args, $object_ids, $type, $tax_language, $tax_to_cache );
 	}
 
 	/**
@@ -154,11 +176,22 @@ abstract class PLL_Translatable_Abstract_Object_Cache {
 	 * @param string[] $tax_to_cache List of taxonomies to cache.
 	 * @return array Filtered array of arguments to get data from the cache.
 	 *
-	 * @phpstan-var non-empty-string $type
-	 * @phpstan-var non-empty-string $tax_language
-	 * @phpstan-var list<non-empty-string> $tax_to_cache
+	 * @phpstan-param non-empty-string $type
+	 * @phpstan-param non-empty-string $tax_language
+	 * @phpstan-param list<non-empty-string> $tax_to_cache
 	 */
 	public function filter_get_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
-		// TODO: implement here.
+		/**
+		 * Filters the arguments passed to `PLL_Translatable_Abstract_Object_Cache::get()`.
+		 *
+		 * @since 3.4
+		 *
+		 * @param array    $args         Array of arguments to get data from the cache.
+		 * @param int[]    $object_ids   List of object IDs.
+		 * @param string   $type         Identifier that must be unique for each type of content.
+		 * @param string   $tax_language Taxonomy name for the languages.
+		 * @param string[] $tax_to_cache List of taxonomies to cache.
+		 */
+		return apply_filters( 'pll_pre_set_to_object_cache', $args, $object_ids, $type, $tax_language, $tax_to_cache );
 	}
 }

--- a/include/translatable-abstract-object-cache.php
+++ b/include/translatable-abstract-object-cache.php
@@ -11,37 +11,153 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.4
  */
 abstract class PLL_Translatable_Abstract_Object_Cache {
+	/**
+	 * Cache type of the current object.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
 	protected $cache_type;
+
+	/**
+	 * Object to handle cache if needed.
+	 *
+	 * @var object|null
+	 */
 	protected $cache_object;
 
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.4
+	 *
+	 * @param object|null $cache_object Optional. Cache object to use inside `PLL_Translatable_Abstract_Object_Cache`. Default to `null`.
+	 */
 	public function __construct( $cache_object = null ) {
 		$this->cache_object = $cache_object;
 	}
 
+	/**
+	 * Registers the type of cache the current object will handle.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $cache_type Cache type to use.
+	 * @return self
+	 *
+	 * @phpstan-var non-empty-string $cache_type
+	 */
 	public function register_type( $cache_type ) {
 		$this->cache_type = $cache_type;
 
 		return $this;
 	}
 
-	public function add( $args ) {}
+	/**
+	 * Adds data to the cache without overriding.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $args Array of arguments to add data to the cache.
+	 * @return bool Whether or not data has been added.
+	 */
+	abstract public function add( $args );
 
-	public function set( $args ) {}
+	/**
+	 * Saves data to the cache.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $args Array of arguments to save data to the cache.
+	 * @return bool Whether or not data has been saved.
+	 */
+	abstract public function set( $args );
 
-	public function get( $args ) {}
+	/**
+	 * Retrieves the cache contents from the cache.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $args Array of arguments to get data from the cache.
+	 * @return int[] Array of object IDs (could be anything, like post or term for instance).
+	 */
+	abstract public function get( $args );
 
-	public function set_last_changed() {}
+	/**
+	 * Sets the last changed time for the current cache type group.
+	 *
+	 * @since 3.4
+	 *
+	 * @return bool Whether or not last change has been set.
+	 */
+	abstract public function set_last_changed();
 
-	public function get_last_changed() {}
+	/**
+	 * Gets last changed date for the current cache type group.
+	 *
+	 * @since 3.4
+	 *
+	 * @return mixed Anything indicating the last change (e.g UNIX timestamp, DateTime...).
+	 */
+	abstract public function get_last_changed();
 
+	/**
+	 * Filters arguments to use in `self::add()`.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array    $args         Array of arguments to add data to the cache.
+	 * @param int[]    $object_ids   List of object IDs.
+	 * @param string   $type         Identifier that must be unique for each type of content.
+	 * @param string   $tax_language Taxonomy name for the languages.
+	 * @param string[] $tax_to_cache List of taxonomies to cache.
+	 * @return array Filtered array of arguments to add data to the cache.
+	 *
+	 * @phpstan-var non-empty-string $type
+	 * @phpstan-var non-empty-string $tax_language
+	 * @phpstan-var list<non-empty-string> $tax_to_cache
+	 */
 	public function filter_add_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
 		// TODO: implement here.
 	}
 
+	/**
+	 * Filters arguments to use in `self::set()`.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array    $args         Array of arguments to save data to the cache.
+	 * @param int[]    $object_ids   List of object IDs.
+	 * @param string   $type         Identifier that must be unique for each type of content.
+	 * @param string   $tax_language Taxonomy name for the languages.
+	 * @param string[] $tax_to_cache List of taxonomies to cache.
+	 * @return array Filtered array of arguments to save data to the cache.
+	 *
+	 * @phpstan-var non-empty-string $type
+	 * @phpstan-var non-empty-string $tax_language
+	 * @phpstan-var list<non-empty-string> $tax_to_cache
+	 */
 	public function filter_set_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
 		// TODO: implement here.
 	}
 
+	/**
+	 * Filters arguments to use in `self::get()`.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array    $args         Array of arguments to get data from the cache.
+	 * @param int[]    $object_ids   List of object IDs.
+	 * @param string   $type         Identifier that must be unique for each type of content.
+	 * @param string   $tax_language Taxonomy name for the languages.
+	 * @param string[] $tax_to_cache List of taxonomies to cache.
+	 * @return array Filtered array of arguments to get data from the cache.
+	 *
+	 * @phpstan-var non-empty-string $type
+	 * @phpstan-var non-empty-string $tax_language
+	 * @phpstan-var list<non-empty-string> $tax_to_cache
+	 */
 	public function filter_get_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
 		// TODO: implement here.
 	}

--- a/include/translatable-abstract-object-cache.php
+++ b/include/translatable-abstract-object-cache.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Abstract class to handle cache mechanism into `PLL_Translatable_Object`.
+ *
+ * @since 3.4
+ */
+abstract class PLL_Translatable_Abstract_Object_Cache {
+	protected $cache_type;
+	protected $cache_object;
+
+	public function __construct( $cache_object = null ) {
+		$this->cache_object = $cache_object;
+	}
+
+	public function register_type( $cache_type ) {
+		$this->cache_type = $cache_type;
+
+		return $this;
+	}
+
+	public function add( $args ) {}
+
+	public function set( $args ) {}
+
+	public function get( $args ) {}
+
+	public function set_last_changed() {}
+
+	public function get_last_changed() {}
+
+	public function filter_add_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
+		// TODO: implement here.
+	}
+
+	public function filter_set_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
+		// TODO: implement here.
+	}
+
+	public function filter_get_args( $args, $object_ids, $type, $tax_language, $tax_to_cache ) {
+		// TODO: implement here.
+	}
+}

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -66,6 +66,13 @@ abstract class PLL_Translatable_Object {
 	protected $object_type = null;
 
 	/**
+	 * Used to handle cache for the current object.
+	 *
+	 * @var PLL_Translatable_Abstract_Object_Cache
+	 */
+	protected $object_cache;
+
+	/**
 	 * Contains database-related informations that can be used in some of this class methods.
 	 * These are specific to the table containing the objects.
 	 *
@@ -90,11 +97,13 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @since 3.4
 	 *
-	 * @param PLL_Model $model Instance of `PLL_Model`, passed by reference.
+	 * @param PLL_Model                              $model                     Instance of `PLL_Model`, passed by reference.
+	 * @param PLL_Translatable_Abstract_Object_Cache $object_cache Instance of `PLL_Translatable_Abstract_Object_Cache`.
 	 */
-	public function __construct( PLL_Model &$model ) {
+	public function __construct( PLL_Model &$model, PLL_Translatable_Abstract_Object_Cache $object_cache ) {
 		$this->model          = $model;
 		$this->tax_to_cache[] = $this->tax_language;
+		$this->$object_cache  = $object_cache->register_type( $this->cache_type );
 
 		/*
 		 * Register our taxonomy as soon as possible.

--- a/include/translatable-wp-object-cache.php
+++ b/include/translatable-wp-object-cache.php
@@ -11,22 +11,60 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.4
  */
 class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_Cache {
+	/**
+	 * Adds data to the WordPress cache without overriding.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $args Array of arguments to add data to the cache.
+	 * @return bool Whether or not data has been added.
+	 */
 	public function add( $args ) {
 		// TODO: implement here.
 	}
 
+	/**
+	 * Saves data to the WordPress cache.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $args Array of arguments to save data to the cache.
+	 * @return bool Whether or not data has been saved.
+	 */
 	public function set( $args ) {
 		// TODO: implement here.
 	}
 
+	/**
+	 * Retrieves the cache contents from the WordPress cache.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $args Array of arguments to get data from the cache.
+	 * @return int[] Array of object IDs (could be anything, like post or term for instance).
+	 */
 	public function get( $args ) {
 		// TODO: implement here.
 	}
 
+	/**
+	 * Sets the last changed time for the current cache type group.
+	 *
+	 * @since 3.4
+	 *
+	 * @return bool Whether or not last change has been set.
+	 */
 	public function set_last_changed() {
 		// TODO: implement here.
 	}
 
+	/**
+	 * Gets last changed date for the current cache type group.
+	 *
+	 * @since 3.4
+	 *
+	 * @return mixed Anything indicating the last change (e.g UNIX timestamp, DateTime...).
+	 */
 	public function get_last_changed() {
 		// TODO: implement here.
 	}

--- a/include/translatable-wp-object-cache.php
+++ b/include/translatable-wp-object-cache.php
@@ -16,11 +16,18 @@ class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_
 	 *
 	 * @since 3.4
 	 *
-	 * @param array $args Array of arguments to add data to the cache.
+	 * @param array $args {
+	 *   Array of arguments to add data to the cache.
+	 *   @type int|string $key   The cache key to use for retrieval later.
+	 *   @type mixed      $data  The data to add to the cache.
+	 *   @type string     $group Optional. The group to add the cache to. Default empty.
+	 * }
 	 * @return bool Whether or not data has been added.
+	 *
+	 * @phpstan-param array{key: int|string, data: mixed, group?: non-empty-string} $args
 	 */
 	public function add( $args ) {
-		// TODO: implement here.
+		return wp_cache_add( $args['key'], $args['data'], isset( $args['group'] ) ? $args['group'] : '' );
 	}
 
 	/**
@@ -28,11 +35,18 @@ class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_
 	 *
 	 * @since 3.4
 	 *
-	 * @param array $args Array of arguments to save data to the cache.
+	 * @param array $args {
+	 *   Array of arguments to save data to the cache.
+	 *   @type int|string $key   The cache key to use for retrieval later.
+	 *   @type mixed      $data  The data to store in the cache.
+	 *   @type string     $group Optional. The group to add the cache to. Default empty.
+	 * }
 	 * @return bool Whether or not data has been saved.
+	 *
+	 * @phpstan-param array{key: int|string, data: mixed, group?: non-empty-string} $args
 	 */
 	public function set( $args ) {
-		// TODO: implement here.
+		return wp_cache_set( $args['key'], $args['data'], isset( $args['group'] ) ? $args['group'] : '' );
 	}
 
 	/**
@@ -40,11 +54,17 @@ class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_
 	 *
 	 * @since 3.4
 	 *
-	 * @param array $args Array of arguments to get data from the cache.
-	 * @return int[] Array of object IDs (could be anything, like post or term for instance).
+	 * @param array $args {
+	 *    Array of arguments to get data from the cache.
+	 *   @type int|string $key   The key under which the cache contents are stored.
+	 *   @type string     $group Optional. Where the cache contents are grouped. Default empty.
+	 * }
+	 * @return mixed Array of object IDs (could be anything, like post or term for instance) if data has been cached.
+	 *
+	 * @phpstan-param array{key: int|string, group?: string} $args
 	 */
 	public function get( $args ) {
-		// TODO: implement here.
+		return wp_cache_get( $args['key'], isset( $args['group'] ) ? $args['group'] : '' );
 	}
 
 	/**
@@ -55,7 +75,7 @@ class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_
 	 * @return bool Whether or not last change has been set.
 	 */
 	public function set_last_changed() {
-		// TODO: implement here.
+		return wp_cache_set( 'last_changed', microtime(), $this->cache_type );
 	}
 
 	/**
@@ -63,9 +83,12 @@ class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_
 	 *
 	 * @since 3.4
 	 *
-	 * @return mixed Anything indicating the last change (e.g UNIX timestamp, DateTime...).
+	 * @return string UNIX timestamp indicating the last change.
 	 */
 	public function get_last_changed() {
-		// TODO: implement here.
+		/**
+		 * @phpstan-var non-empty-string
+		 */
+		return wp_cache_get( 'last_changed', $this->cache_type );
 	}
 }

--- a/include/translatable-wp-object-cache.php
+++ b/include/translatable-wp-object-cache.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class to handle WordPress cache mechanism into `PLL_Translatable_Object`.
+ *
+ * @since 3.4
+ */
+class PLL_Translatable_WP_Object_Cache extends PLL_Translatable_Abstract_Object_Cache {
+	public function add( $args ) {
+		// TODO: implement here.
+	}
+
+	public function set( $args ) {
+		// TODO: implement here.
+	}
+
+	public function get( $args ) {
+		// TODO: implement here.
+	}
+
+	public function set_last_changed() {
+		// TODO: implement here.
+	}
+
+	public function get_last_changed() {
+		// TODO: implement here.
+	}
+}

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -26,10 +26,11 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Model $model Instance of `PLL_Model`.
+	 * @param PLL_Model                              $model        Instance of `PLL_Model`.
+	 * @param PLL_Translatable_Abstract_Object_Cache $object_cache Instance of `PLL_Translatable_Abstract_Object_Cache`.
 	 */
-	public function __construct( PLL_Model &$model ) {
-		parent::__construct( $model );
+	public function __construct( PLL_Model &$model, PLL_Translatable_Abstract_Object_Cache $object_cache ) {
+		parent::__construct( $model, $object_cache );
 
 		$this->tax_to_cache[] = $this->tax_translations;
 

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -56,9 +56,10 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Model $model Instance of `PLL_Model`.
+	 * @param PLL_Model                              $model        Instance of `PLL_Model`.
+	 * @param PLL_Translatable_Abstract_Object_Cache $object_cache Instance of `PLL_Translatable_Abstract_Object_Cache`.
 	 */
-	public function __construct( PLL_Model &$model ) {
+	public function __construct( PLL_Model &$model, PLL_Translatable_Abstract_Object_Cache $object_cache ) {
 		$this->db = array(
 			'table'         => $GLOBALS['wpdb']->posts,
 			'id_column'     => 'ID',
@@ -66,7 +67,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 			'default_alias' => $GLOBALS['wpdb']->posts,
 		);
 
-		parent::__construct( $model );
+		parent::__construct( $model, $object_cache );
 
 		// Keep hooks in constructor for backward compatibility.
 		$this->init();

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -66,9 +66,10 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Model $model Instance of `PLL_Model`.
+	 * @param PLL_Model                              $model        Instance of `PLL_Model`.
+	 * @param PLL_Translatable_Abstract_Object_Cache $object_cache Instance of `PLL_Translatable_Abstract_Object_Cache`.
 	 */
-	public function __construct( PLL_Model &$model ) {
+	public function __construct( PLL_Model &$model, PLL_Translatable_Abstract_Object_Cache $object_cache ) {
 		$this->db = array(
 			'table'         => $GLOBALS['wpdb']->term_taxonomy,
 			'id_column'     => 'term_id',
@@ -76,7 +77,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			'default_alias' => 't',
 		);
 
-		parent::__construct( $model );
+		parent::__construct( $model, $object_cache );
 
 		// Keep hooks in constructor for backward compatibility.
 		$this->init();

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -196,9 +196,12 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 	 * @covers PLL_Translated_Object::save_translations()
 	 */
 	public function test_dont_save_translations_with_incorrect_language() {
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
-		$model = new PLL_Model( $options );
-		$model->post = new PLL_Translated_Post( $model );
+		global $wp_object_cache;
+
+		$options                   = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
+		$model                     = new PLL_Model( $options );
+		$translatable_object_cache = new PLL_Translatable_WP_Object_Cache( $wp_object_cache );
+		$model->post               = new PLL_Translated_Post( $model, $translatable_object_cache );
 
 		$this->dont_save_translations_with_incorrect_language( $model->post );
 	}

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -69,9 +69,12 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 	}
 
 	public function test_dont_save_translations_with_incorrect_language() {
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
-		$model = new PLL_Model( $options );
-		$model->term = new PLL_Translated_Term( $model );
+		global $wp_object_cache;
+
+		$options                   = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
+		$model                     = new PLL_Model( $options );
+		$translatable_object_cache = new PLL_Translatable_WP_Object_Cache( $wp_object_cache );
+		$model->term               = new PLL_Translated_Term( $model, $translatable_object_cache );
 
 		$this->dont_save_translations_with_incorrect_language( $model->term );
 	}


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-wc/issues/502 (see last "Polylang" task).

## Purpose
Allow both external and WordPress object to use cache trough `PLL_Translatable_Object` methods.

## How?
Externalize the way we handle cache in a new class. Make this very class extendable and opened to all kinds of cache objects (even no cache object is allowed).

Here is a diagram showing this new architecture (along an example of how it can be used for unknown object cache)
![translatable-object-cache](https://user-images.githubusercontent.com/69580439/219051821-1e3da73b-b8f8-40bd-bc30-fe653799a39f.png)

*Note: No test has been written yet, I'll wait until the implementation of the idea is validated*