### PR TITLE
Don't set update plugins transient to null

### DIFF
--- a/include/license.php
+++ b/include/license.php
@@ -149,8 +149,8 @@ class PLL_License {
 		$this->license_key = $license_key;
 		$this->api_request( 'activate_license' );
 
-		// Tell WordPress to look for updates
-		set_site_transient( 'update_plugins', null );
+		// Tell WordPress to look for updates.
+		delete_site_transient( 'update_plugins' );
 		return $this;
 	}
 


### PR DESCRIPTION
To force WordPress to check for the plugins updates we use to set the transient `update_plugins` to `null`.

This works as expected but it may be a source of conflict as WordPress usually deletes the transient to obtain the same result. Indeed, in our case `get_site_transient()` returns `null` instead of `false`. If a 3rd party plugin explicitely tests the retrun value against `false` instead the expected object, then it will result in a fatal error.