### PR TITLE
WordPress managers do not detect Polylang Pro update

### DIFF
--- a/include/license.php
+++ b/include/license.php
@@ -91,7 +91,7 @@ class PLL_License {
 		}
 
 		// Updater
-		add_action( 'plugins_loaded', array( $this, 'auto_updater' ), 10 );
+		$this->auto_updater();
 
 		// Register settings
 		add_filter( 'pll_settings_licenses', array( $this, 'settings' ) );

--- a/include/license.php
+++ b/include/license.php
@@ -92,7 +92,6 @@ class PLL_License {
 
 		// Updater
 		add_action( 'plugins_loaded', array( $this, 'auto_updater' ), 10 );
-		add_action( 'cli_init', array( $this, 'auto_updater' ), 0 ); // For WP CLI.
 
 		// Register settings
 		add_filter( 'pll_settings_licenses', array( $this, 'settings' ) );
@@ -114,7 +113,7 @@ class PLL_License {
 	 */
 	public function auto_updater() {
 
-		if ( ! is_admin() ) {
+		if ( ! defined( 'PLL_ADMIN' ) || ! PLL_ADMIN ) {
 			return;
 		}
 

--- a/include/license.php
+++ b/include/license.php
@@ -91,7 +91,7 @@ class PLL_License {
 		}
 
 		// Updater
-		add_action( 'admin_init', array( $this, 'auto_updater' ), 0 );
+		add_action( 'plugins_loaded', array( $this, 'auto_updater' ), 10 );
 		add_action( 'cli_init', array( $this, 'auto_updater' ), 0 ); // For WP CLI.
 
 		// Register settings
@@ -113,6 +113,11 @@ class PLL_License {
 	 * @return void
 	 */
 	public function auto_updater() {
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		$args = array(
 			'version'   => $this->version,
 			'license'   => $this->license_key,

--- a/include/license.php
+++ b/include/license.php
@@ -92,6 +92,7 @@ class PLL_License {
 
 		// Updater
 		add_action( 'plugins_loaded', array( $this, 'auto_updater' ), 10 );
+		do_action( 'qm/debug', 'auto_updater() hooked.' );
 
 		// Register settings
 		add_filter( 'pll_settings_licenses', array( $this, 'settings' ) );
@@ -114,8 +115,8 @@ class PLL_License {
 	public function auto_updater() {
 		$action = current_action();
 		$polylang = PLL();
-		do_action( 'qm/debug', "Current action: {$action}" );
-		do_action( 'qm/debug', "Polylang context: {$polylang::class}" );
+		do_action( 'qm/debug', "auto_updater() called with the current action: {$action}" );
+		do_action( 'qm/debug', get_class( $polylang ) );
 
 		$args = array(
 			'version'   => $this->version,

--- a/include/license.php
+++ b/include/license.php
@@ -92,7 +92,6 @@ class PLL_License {
 
 		// Updater
 		add_action( 'plugins_loaded', array( $this, 'auto_updater' ), 10 );
-		do_action( 'qm/debug', 'auto_updater() hooked.' );
 
 		// Register settings
 		add_filter( 'pll_settings_licenses', array( $this, 'settings' ) );
@@ -113,11 +112,6 @@ class PLL_License {
 	 * @return void
 	 */
 	public function auto_updater() {
-		$action = current_action();
-		$polylang = PLL();
-		do_action( 'qm/debug', "auto_updater() called with the current action: {$action}" );
-		do_action( 'qm/debug', get_class( $polylang ) );
-
 		$args = array(
 			'version'   => $this->version,
 			'license'   => $this->license_key,

--- a/include/license.php
+++ b/include/license.php
@@ -112,11 +112,6 @@ class PLL_License {
 	 * @return void
 	 */
 	public function auto_updater() {
-
-		if ( ! defined( 'PLL_ADMIN' ) || ! PLL_ADMIN ) {
-			return;
-		}
-
 		$args = array(
 			'version'   => $this->version,
 			'license'   => $this->license_key,

--- a/include/license.php
+++ b/include/license.php
@@ -112,6 +112,11 @@ class PLL_License {
 	 * @return void
 	 */
 	public function auto_updater() {
+		$action = current_action();
+		$polylang = PLL();
+		do_action( 'qm/debug', "Current action: {$action}" );
+		do_action( 'qm/debug', "Polylang context: {$polylang::class}" );
+
 		$args = array(
 			'version'   => $this->version,
 			'license'   => $this->license_key,

--- a/polylang.php
+++ b/polylang.php
@@ -53,7 +53,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 	}
 } else {
 	// Go on loading the plugin
-	define( 'POLYLANG_VERSION', '3.2' );
+	define( 'POLYLANG_VERSION', '3.4-dev' );
 	define( 'PLL_MIN_WP_VERSION', '5.7' );
 	define( 'PLL_MIN_PHP_VERSION', '5.6' );
 

--- a/polylang.php
+++ b/polylang.php
@@ -53,7 +53,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 	}
 } else {
 	// Go on loading the plugin
-	define( 'POLYLANG_VERSION', '3.4-dev' );
+	define( 'POLYLANG_VERSION', '3.2' );
 	define( 'PLL_MIN_WP_VERSION', '5.7' );
 	define( 'PLL_MIN_PHP_VERSION', '5.6' );
 


### PR DESCRIPTION
WordPress manger like ManageWP & UmbrellaWP are bypassing some WordPress hooks (admin_init is one of them)
Tested and works with UmbrellaWP

Reported on https://secure.helpscout.net/conversation/2170319527/22959?folderId=3655443