### PR TITLE
Prevent deprecation warnings in API functions

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -47,26 +47,11 @@ function pll_the_languages( $args = array() ) {
  * @since 0.8.1
  *
  * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|int|bool|string[]|PLL_Language The requested field or object for the current language, false if the field isn't set or if current language doesn't exist yet.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the current language, `false` if the field isn't set or if current language doesn't exist yet.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
- *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
- *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
- *                     $field is 'term_group' ? int : (
- *                         $field is 'is_rtl' ? int<0, 1> : (
- *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : (
- *                                     $field is 'is_default' ? bool : false
- *                                 )
- *                             )
- *                         )
- *                     )
- *                 )
- *             )
- *         )
+ *         $field is 'slug' ? non-empty-string : string|int|bool|list<non-empty-string>
  *     )
  * )|false
  */
@@ -89,26 +74,11 @@ function pll_current_language( $field = 'slug' ) {
  * @since 1.0
  *
  * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|int|bool|string[]|PLL_Language The requested field or object for the default language. False if none.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the default language, `false` if the field isn't set or if default language doesn't exist yet.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
- *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
- *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
- *                     $field is 'term_group' ? int : (
- *                         $field is 'is_rtl' ? int<0, 1> : (
- *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : (
- *                                     $field is 'is_default' ? bool : false
- *                                 )
- *                             )
- *                         )
- *                     )
- *                 )
- *             )
- *         )
+ *         $field is 'slug' ? non-empty-string : string|int|bool|list<non-empty-string>
  *     )
  * )|false
  */
@@ -472,26 +442,11 @@ function pll_save_term_translations( $arr ) {
  *
  * @param int    $post_id Post ID.
  * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that post.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that post.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
- *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
- *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
- *                     $field is 'term_group' ? int : (
- *                         $field is 'is_rtl' ? int<0, 1> : (
- *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : (
- *                                     $field is 'is_default' ? bool : false
- *                                 )
- *                             )
- *                         )
- *                     )
- *                 )
- *             )
- *         )
+ *         $field is 'slug' ? non-empty-string : string|int|bool|list<non-empty-string>
  *     )
  * )|false
  */
@@ -513,26 +468,11 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  *
  * @param int    $term_id Term ID.
  * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that term.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that term.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
- *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
- *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
- *                     $field is 'term_group' ? int : (
- *                         $field is 'is_rtl' ? int<0, 1> : (
- *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : (
- *                                     $field is 'is_default' ? bool : false
- *                                 )
- *                             )
- *                         )
- *                     )
- *                 )
- *             )
- *         )
+ *         $field is 'slug' ? non-empty-string : string|int|bool|list<non-empty-string>
  *     )
  * )|false
  */

--- a/include/api.php
+++ b/include/api.php
@@ -45,8 +45,12 @@ function pll_the_languages( $args = array() ) {
  *
  * @api
  * @since 0.8.1
+ * @since 3.4 Accepts composite values.
  *
- * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @param string $field Optional, the language field to return (@see PLL_Language), defaults to `'slug'`.
+ *                      Pass `\OBJECT` constant to get the language object. A composite value can be used for language
+ *                      term property values, in the form of `{language_taxonomy_name}:{property_name}` (see
+ *                      {@see PLL_Language::get_tax_prop()} for the possible values). Ex: `term_language:term_taxonomy_id`.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the current language, `false` if the field isn't set or if current language doesn't exist yet.
  *
  * @phpstan-return (
@@ -72,8 +76,12 @@ function pll_current_language( $field = 'slug' ) {
  *
  * @api
  * @since 1.0
+ * @since 3.4 Accepts composite values.
  *
- * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @param string $field Optional, the language field to return (@see PLL_Language), defaults to `'slug'`.
+ *                      Pass `\OBJECT` constant to get the language object. A composite value can be used for language
+ *                      term property values, in the form of `{language_taxonomy_name}:{property_name}` (see
+ *                      {@see PLL_Language::get_tax_prop()} for the possible values). Ex: `term_language:term_taxonomy_id`.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the default language, `false` if the field isn't set or if default language doesn't exist yet.
  *
  * @phpstan-return (
@@ -439,9 +447,13 @@ function pll_save_term_translations( $arr ) {
  *
  * @api
  * @since 1.5.4
+ * @since 3.4 Accepts composite values for `$field`.
  *
  * @param int    $post_id Post ID.
- * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @param string $field Optional, the language field to return (@see PLL_Language), defaults to `'slug'`.
+ *                      Pass `\OBJECT` constant to get the language object. A composite value can be used for language
+ *                      term property values, in the form of `{language_taxonomy_name}:{property_name}` (see
+ *                      {@see PLL_Language::get_tax_prop()} for the possible values). Ex: `term_language:term_taxonomy_id`.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that post.
  *
  * @phpstan-return (
@@ -465,9 +477,13 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  *
  * @api
  * @since 1.5.4
+ * @since 3.4 Accepts composite values for `$field`.
  *
  * @param int    $term_id Term ID.
- * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @param string $field Optional, the language field to return (@see PLL_Language), defaults to `'slug'`.
+ *                      Pass `\OBJECT` constant to get the language object. A composite value can be used for language
+ *                      term property values, in the form of `{language_taxonomy_name}:{property_name}` (see
+ *                      {@see PLL_Language::get_tax_prop()} for the possible values). Ex: `term_language:term_taxonomy_id`.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that term.
  *
  * @phpstan-return (

--- a/include/api.php
+++ b/include/api.php
@@ -49,12 +49,12 @@ function pll_the_languages( $args = array() ) {
  * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the current language, false if the field isn't set or if current language doesn't exist yet.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
  *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
@@ -91,12 +91,12 @@ function pll_current_language( $field = 'slug' ) {
  * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the default language. False if none.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
  *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
@@ -474,12 +474,12 @@ function pll_save_term_translations( $arr ) {
  * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that post.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
  *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
@@ -515,12 +515,12 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that term.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
  *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
- *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (

--- a/include/api.php
+++ b/include/api.php
@@ -49,7 +49,7 @@ function pll_the_languages( $args = array() ) {
  * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the current language, false if the field isn't set or if current language doesn't exist yet.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
@@ -58,7 +58,9 @@ function pll_the_languages( $args = array() ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : (
+ *                                     $field is 'is_default' ? bool : false
+ *                                 )
  *                             )
  *                         )
  *                     )
@@ -89,7 +91,7 @@ function pll_current_language( $field = 'slug' ) {
  * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the default language. False if none.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
@@ -98,7 +100,9 @@ function pll_current_language( $field = 'slug' ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : (
+ *                                     $field is 'is_default' ? bool : false
+ *                                 )
  *                             )
  *                         )
  *                     )
@@ -470,7 +474,7 @@ function pll_save_term_translations( $arr ) {
  * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that post.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
@@ -479,7 +483,9 @@ function pll_save_term_translations( $arr ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : (
+ *                                     $field is 'is_default' ? bool : false
+ *                                 )
  *                             )
  *                         )
  *                     )
@@ -509,7 +515,7 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
  * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that term.
  *
- * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $field
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
  *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
@@ -518,7 +524,9 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? list<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : (
+ *                                     $field is 'is_default' ? bool : false
+ *                                 )
  *                             )
  *                         )
  *                     )

--- a/include/api.php
+++ b/include/api.php
@@ -41,24 +41,43 @@ function pll_the_languages( $args = array() ) {
 
 /**
  * Returns the current language on frontend.
- * Returns the language set in admin language filter on backend ( false if set to all languages ).
+ * Returns the language set in admin language filter on backend (false if set to all languages).
  *
  * @api
  * @since 0.8.1
  *
- * @param string $field Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|PLL_Language|false The requested field or object for the current language, false if field isn't set or if current language doesn't exist yet.
+ * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the current language, false if the field isn't set or if current language doesn't exist yet.
+ *
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-return (
+ *     $field is \OBJECT ? PLL_Language : (
+ *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
+ *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                     $field is 'term_group' ? int : (
+ *                         $field is 'is_rtl' ? int<0, 1> : (
+ *                             $field is 'active' ? bool : (
+ *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                             )
+ *                         )
+ *                     )
+ *                 )
+ *             )
+ *         )
+ *     )
+ * )|false
  */
 function pll_current_language( $field = 'slug' ) {
 	if ( empty( PLL()->curlang ) ) {
 		return false;
 	}
 
-	if ( OBJECT === $field ) {
+	if ( \OBJECT === $field ) {
 		return PLL()->curlang;
 	}
 
-	return isset( PLL()->curlang->$field ) ? PLL()->curlang->$field : false;
+	return PLL()->curlang->get_prop( $field );
 }
 
 /**
@@ -67,8 +86,27 @@ function pll_current_language( $field = 'slug' ) {
  * @api
  * @since 1.0
  *
- * @param string $field Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|PLL_Language|false The requested field or object for the default language. False if none.
+ * @param string $field Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the default language. False if none.
+ *
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-return (
+ *     $field is \OBJECT ? PLL_Language : (
+ *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
+ *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                     $field is 'term_group' ? int : (
+ *                         $field is 'is_rtl' ? int<0, 1> : (
+ *                             $field is 'active' ? bool : (
+ *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                             )
+ *                         )
+ *                     )
+ *                 )
+ *             )
+ *         )
+ *     )
+ * )|false
  */
 function pll_default_language( $field = 'slug' ) {
 	if ( empty( PLL()->options['default_lang'] ) ) {
@@ -81,11 +119,11 @@ function pll_default_language( $field = 'slug' ) {
 		return false;
 	}
 
-	if ( OBJECT === $field ) {
+	if ( \OBJECT === $field ) {
 		return $lang;
 	}
 
-	return isset( $lang->$field ) ? $lang->$field : false;
+	return $lang->get_prop( $field );
 }
 
 /**
@@ -429,25 +467,36 @@ function pll_save_term_translations( $arr ) {
  * @since 1.5.4
  *
  * @param int    $post_id Post ID.
- * @param string $field Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|PLL_Language|false The requested field or object for the post language, false if no language is associated to that post.
+ * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that post.
+ *
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-return (
+ *     $field is \OBJECT ? PLL_Language : (
+ *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
+ *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                     $field is 'term_group' ? int : (
+ *                         $field is 'is_rtl' ? int<0, 1> : (
+ *                             $field is 'active' ? bool : (
+ *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                             )
+ *                         )
+ *                     )
+ *                 )
+ *             )
+ *         )
+ *     )
+ * )|false
  */
 function pll_get_post_language( $post_id, $field = 'slug' ) {
 	$lang = PLL()->model->post->get_language( $post_id );
 
-	if ( empty( $lang ) ) {
-		return false;
-	}
-
-	if ( OBJECT === $field ) {
+	if ( empty( $lang ) || \OBJECT === $field ) {
 		return $lang;
 	}
 
-	if ( ! isset( $lang->$field ) ) {
-		return false;
-	}
-
-	return $lang->$field;
+	return $lang->get_prop( $field );
 }
 
 /**
@@ -457,25 +506,36 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  * @since 1.5.4
  *
  * @param int    $term_id Term ID.
- * @param string $field Optional, the language field to return ( @see PLL_Language ), defaults to 'slug'. Pass OBJECT constant to get the language object.
- * @return string|PLL_Language|false The requested field or object for the term language, false if no language is associated to that term.
+ * @param string $field   Optional, the language field to return (@see PLL_Language), defaults to 'slug'. Pass OBJECT constant to get the language object.
+ * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, false if no language is associated to that term.
+ *
+ * @phpstan-param \OBJECT|'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $field
+ * @phpstan-return (
+ *     $field is \OBJECT ? PLL_Language : (
+ *         $field is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
+ *             $field is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
+ *                 $field is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+ *                     $field is 'term_group' ? int : (
+ *                         $field is 'is_rtl' ? int<0, 1> : (
+ *                             $field is 'active' ? bool : (
+ *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                             )
+ *                         )
+ *                     )
+ *                 )
+ *             )
+ *         )
+ *     )
+ * )|false
  */
 function pll_get_term_language( $term_id, $field = 'slug' ) {
 	$lang = PLL()->model->term->get_language( $term_id );
 
-	if ( empty( $lang ) ) {
-		return false;
-	}
-
-	if ( OBJECT === $field ) {
+	if ( empty( $lang ) || \OBJECT === $field ) {
 		return $lang;
 	}
 
-	if ( ! isset( $lang->$field ) ) {
-		return false;
-	}
-
-	return $lang->$field;
+	return $lang->get_prop( $field );
 }
 
 /**

--- a/include/api.php
+++ b/include/api.php
@@ -58,7 +58,7 @@ function pll_the_languages( $args = array() ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : false
  *                             )
  *                         )
  *                     )
@@ -98,7 +98,7 @@ function pll_current_language( $field = 'slug' ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : false
  *                             )
  *                         )
  *                     )
@@ -479,7 +479,7 @@ function pll_save_term_translations( $arr ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : false
  *                             )
  *                         )
  *                     )
@@ -518,7 +518,7 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  *                     $field is 'term_group' ? int : (
  *                         $field is 'is_rtl' ? int<0, 1> : (
  *                             $field is 'active' ? bool : (
- *                                 $field is 'fallbacks' ? array<non-empty-string> : false
+ *                                 $field is 'fallbacks' ? list<non-empty-string> : false
  *                             )
  *                         )
  *                     )

--- a/include/language-deprecated.php
+++ b/include/language-deprecated.php
@@ -15,7 +15,7 @@ abstract class PLL_Language_Deprecated {
 	 *
 	 * @private
 	 *
-	 * @var array[]
+	 * @var string[][]
 	 */
 	const DEPRECATED_TERM_PROPERTIES = array(
 		'term_taxonomy_id'    => array( 'language', 'term_taxonomy_id' ),

--- a/include/language-deprecated.php
+++ b/include/language-deprecated.php
@@ -8,7 +8,7 @@
  *
  * @since 3.4
  */
-abstract class PLL_Language_Deprecation {
+abstract class PLL_Language_Deprecated {
 
 	/**
 	 * List of deprecated term properties and related arguments to use with `get_tax_prop()`.

--- a/include/language-deprecated.php
+++ b/include/language-deprecated.php
@@ -26,15 +26,15 @@ abstract class PLL_Language_Deprecated {
 	);
 
 	/**
-	 * List of deprecated URL properties.
+	 * List of deprecated URL properties and related getter to use.
 	 *
 	 * @private
 	 *
-	 * @var int[]
+	 * @var string[]
 	 */
 	const DEPRECATED_URL_PROPERTIES = array(
-		'home_url'   => 1,
-		'search_url' => 1,
+		'home_url'   => 'get_home_url',
+		'search_url' => 'get_seach_url',
 	);
 
 	/**
@@ -216,8 +216,7 @@ abstract class PLL_Language_Deprecated {
 	 * @phpstan-return non-empty-string
 	 */
 	protected function get_deprecated_url_property( $property ) {
-		$url_getter = "get_{$property}";
-		return $this->{$url_getter}();
+		return $this->{self::DEPRECATED_URL_PROPERTIES[ $property ]}();
 	}
 
 	/**

--- a/include/language-deprecation.php
+++ b/include/language-deprecation.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Holds everything related to deprecated properties of `PLL_Language`.
+ *
+ * @since 3.4
+ */
+abstract class PLL_Language_Deprecation {
+
+	/**
+	 * List of deprecated term properties and related arguments to use with `get_tax_prop()`.
+	 *
+	 * @private
+	 *
+	 * @var array[]
+	 */
+	const DEPRECATED_TERM_PROPERTIES = array(
+		'term_taxonomy_id'    => array( 'language', 'term_taxonomy_id' ),
+		'count'               => array( 'language', 'count' ),
+		'tl_term_id'          => array( 'term_language', 'term_id' ),
+		'tl_term_taxonomy_id' => array( 'term_language', 'term_taxonomy_id' ),
+		'tl_count'            => array( 'term_language', 'count' ),
+	);
+
+	/**
+	 * List of deprecated URL properties.
+	 *
+	 * @private
+	 *
+	 * @var int[]
+	 */
+	const DEPRECATED_URL_PROPERTIES = array(
+		'home_url'   => 1,
+		'search_url' => 1,
+	);
+
+	/**
+	 * Returns a language term property value (term ID, term taxonomy ID, or count).
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $taxonomy_name Name of the taxonomy.
+	 * @param string $prop_name     Name of the property: 'term_taxonomy_id', 'term_id', 'count'.
+	 * @return int
+	 *
+	 * @phpstan-param non-empty-string $taxonomy_name
+	 * @phpstan-param 'term_taxonomy_id'|'term_id'|'count' $prop_name
+	 * @phpstan-return int<0, max>
+	 */
+	abstract public function get_tax_prop( $taxonomy_name, $prop_name );
+
+	/**
+	 * Returns language's home URL. Takes care to render it dynamically if no cache is allowed.
+	 *
+	 * @since 3.4
+	 *
+	 * @return string Language home URL.
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	abstract public function get_home_url();
+
+	/**
+	 * Returns language's search URL. Takes care to render it dynamically if no cache is allowed.
+	 *
+	 * @since 3.4
+	 *
+	 * @return string Language search URL.
+	 *
+	 * @phpstan-return non-empty-string
+	 */
+	abstract public function get_search_url();
+
+	/**
+	 * Throws a depreciation notice if someone tries to get one of the following properties:
+	 * `term_taxonomy_id`, `count`, `tl_term_id`, `tl_term_taxonomy_id` or `tl_count`.
+	 *
+	 * Backward compatibility with Polylang < 3.4.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $property Property to get.
+	 * @return mixed Required property value.
+	 */
+	public function __get( $property ) {
+		// Deprecated property.
+		if ( $this->is_deprecated_term_property( $property ) ) {
+			$this->deprecated_property(
+				$property,
+				sprintf(
+					"get_tax_prop( '%s', '%s' )",
+					self::DEPRECATED_TERM_PROPERTIES[ $property ][0],
+					self::DEPRECATED_TERM_PROPERTIES[ $property ][1]
+				)
+			);
+
+			return $this->get_deprecated_term_property( $property );
+		}
+
+		if ( $this->is_deprecated_url_property( $property ) ) {
+			$this->deprecated_property( $property, "get_{$property}()" );
+
+			return $this->get_deprecated_url_property( $property );
+		}
+
+		// Undefined property.
+		if ( ! property_exists( $this, $property ) ) {
+			return null;
+		}
+
+		// The property is defined.
+		$ref = new ReflectionProperty( $this, $property );
+
+		// Public property.
+		if ( $ref->isPublic() ) {
+			return $this->{$property};
+		}
+
+		// Protected or private property.
+		$visibility = $ref->isPrivate() ? 'private' : 'protected';
+		$trace      = debug_backtrace(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection, WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$file       = isset( $trace[0]['file'] ) ? $trace[0]['file'] : '';
+		$line       = isset( $trace[0]['line'] ) ? $trace[0]['line'] : 0;
+		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			esc_html(
+				sprintf(
+					"Cannot access %s property %s::$%s in %s on line %d.\nError handler",
+					$visibility,
+					get_class( $this ),
+					$property,
+					$file,
+					$line
+				)
+			),
+			E_USER_ERROR
+		);
+	}
+
+	/**
+	 * Checks for a deprecated property.
+	 * Is triggered by calling `isset()` or `empty()` on inaccessible (protected or private) or non-existing properties.
+	 *
+	 * Backward compatibility with Polylang < 3.4.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $property A property name.
+	 * @return bool
+	 */
+	public function __isset( $property ) {
+		return $this->is_deprecated_term_property( $property ) || $this->is_deprecated_url_property( $property );
+	}
+
+	/**
+	 * Tells if the given term property is deprecated.
+	 *
+	 * @since 3.4
+	 * @see PLL_Language::DEPRECATED_TERM_PROPERTIES for the list of deprecated properties.
+	 *
+	 * @param string $property A property name.
+	 * @return bool
+	 *
+	 * @phpstan-assert-if-true key-of<PLL_Language::DEPRECATED_TERM_PROPERTIES> $property
+	 */
+	protected function is_deprecated_term_property( $property ) {
+		return array_key_exists( $property, self::DEPRECATED_TERM_PROPERTIES );
+	}
+
+	/**
+	 * Returns a deprecated term property's value.
+	 *
+	 * @since 3.4
+	 * @see PLL_Language::DEPRECATED_TERM_PROPERTIES for the list of deprecated properties.
+	 *
+	 * @param string $property A property name.
+	 * @return int
+	 *
+	 * @phpstan-param key-of<PLL_Language::DEPRECATED_TERM_PROPERTIES> $property
+	 * @phpstan-return int<0, max>
+	 */
+	protected function get_deprecated_term_property( $property ) {
+		return $this->get_tax_prop(
+			self::DEPRECATED_TERM_PROPERTIES[ $property ][0],
+			self::DEPRECATED_TERM_PROPERTIES[ $property ][1]
+		);
+	}
+
+	/**
+	 * Tells if the given URL property is deprecated.
+	 *
+	 * @since 3.4
+	 * @see PLL_Language::DEPRECATED_URL_PROPERTIES for the list of deprecated properties.
+	 *
+	 * @param string $property A property name.
+	 * @return bool
+	 *
+	 * @phpstan-assert-if-true key-of<PLL_Language::DEPRECATED_URL_PROPERTIES> $property
+	 */
+	protected function is_deprecated_url_property( $property ) {
+		return array_key_exists( $property, self::DEPRECATED_URL_PROPERTIES );
+	}
+
+	/**
+	 * Returns a deprecated URL property's value.
+	 *
+	 * @since 3.4
+	 * @see PLL_Language::DEPRECATED_URL_PROPERTIES for the list of deprecated properties.
+	 *
+	 * @param string $property A property name.
+	 * @return string
+	 *
+	 * @phpstan-param key-of<PLL_Language::DEPRECATED_URL_PROPERTIES> $property
+	 * @phpstan-return non-empty-string
+	 */
+	protected function get_deprecated_url_property( $property ) {
+		$url_getter = "get_{$property}";
+		return $this->{$url_getter}();
+	}
+
+	/**
+	 * Triggers a deprecated an error for a deprecated property.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $property    Deprecated property name.
+	 * @param string $replacement Method or property name to use instead.
+	 * @return void
+	 */
+	private function deprecated_property( $property, $replacement ) {
+		/**
+		 * Filters whether to trigger an error for deprecated properties.
+		 *
+		 * The filter name is intentionally not prefixed to use the same as WordPress
+		 * in case it is added in the future.
+		 *
+		 * @since 3.4
+		 *
+		 * @param bool $trigger Whether to trigger the error for deprecated properties. Default true.
+		 */
+		if ( ! WP_DEBUG || ! apply_filters( 'deprecated_property_trigger_error', true ) ) {
+			return;
+		}
+
+		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			sprintf(
+				"Class property %1\$s::\$%2\$s is deprecated, use %1\$s::%3\$s instead.\nError handler",
+				esc_html( get_class( $this ) ),
+				esc_html( $property ),
+				esc_html( $replacement )
+			),
+			E_USER_DEPRECATED
+		);
+	}
+}

--- a/include/language.php
+++ b/include/language.php
@@ -41,7 +41,7 @@
  *     fallbacks?: list<non-empty-string>
  * }
  */
-class PLL_Language extends PLL_Language_Deprecation {
+class PLL_Language extends PLL_Language_Deprecated {
 
 	/**
 	 * Language name. Ex: English.

--- a/include/language.php
+++ b/include/language.php
@@ -615,11 +615,11 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 * @param string $property A property name.
 	 * @return string|int|bool|string[] The requested property for the language, false if the property doesn't exist.
 	 *
-	 * @phpstan-param 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $property
+	 * @phpstan-param 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $property
 	 * @phpstan-return (
 	 *     $property is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
 	 *         $property is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
-	 *             $property is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+	 *             $property is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
 	 *                 $property is 'term_group' ? int : (
 	 *                     $property is 'is_rtl' ? int<0, 1> : (
 	 *                         $property is 'active' ? bool : (

--- a/include/language.php
+++ b/include/language.php
@@ -613,25 +613,10 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 * @since 3.4
 	 *
 	 * @param string $property A property name.
-	 * @return string|int|bool|string[] The requested property for the language, false if the property doesn't exist.
+	 * @return string|int|bool|string[] The requested property for the language, `false` if the property doesn't exist.
 	 *
-	 * @phpstan-param 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $property
 	 * @phpstan-return (
-	 *     $property is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
-	 *         $property is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
-	 *             $property is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'language:term_id'|'language:term_taxonomy_id'|'language:count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
-	 *                 $property is 'term_group' ? int : (
-	 *                     $property is 'is_rtl' ? int<0, 1> : (
-	 *                         $property is 'active' ? bool : (
-	 *                             $property is 'fallbacks' ? list<non-empty-string> : (
-	 *                                 $property is 'is_default' ? bool : false
-	 *                             )
-	 *                         )
-	 *                     )
-	 *                 )
-	 *             )
-	 *         )
-	 *     )
+	 *     $property is 'slug' ? non-empty-string : string|int|bool|list<non-empty-string>
 	 * )
 	 */
 	public function get_prop( $property ) {

--- a/include/language.php
+++ b/include/language.php
@@ -38,7 +38,7 @@
  *     page_on_front: int<0, max>,
  *     page_for_posts: int<0, max>,
  *     active: bool,
- *     fallbacks?: array<non-empty-string>
+ *     fallbacks?: list<non-empty-string>
  * }
  */
 class PLL_Language extends PLL_Language_Deprecation {
@@ -211,7 +211,7 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 *
 	 * @var string[]
 	 *
-	 * @phpstan-var array<non-empty-string>
+	 * @phpstan-var list<non-empty-string>
 	 */
 	public $fallbacks = array();
 
@@ -623,7 +623,7 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 *                 $property is 'term_group' ? int : (
 	 *                     $property is 'is_rtl' ? int<0, 1> : (
 	 *                         $property is 'active' ? bool : (
-	 *                             $property is 'fallbacks' ? array<non-empty-string> : false
+	 *                             $property is 'fallbacks' ? list<non-empty-string> : false
 	 *                         )
 	 *                     )
 	 *                 )

--- a/include/language.php
+++ b/include/language.php
@@ -612,7 +612,9 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 *
 	 * @since 3.4
 	 *
-	 * @param string $property A property name.
+	 * @param string $property A property name. A composite value can be used for language term property values, in the
+	 *                         form of `{language_taxonomy_name}:{property_name}` (see {@see PLL_Language::get_tax_prop()}
+	 *                         for the possible values). Ex: `term_language:term_taxonomy_id`.
 	 * @return string|int|bool|string[] The requested property for the language, `false` if the property doesn't exist.
 	 *
 	 * @phpstan-return (

--- a/include/language.php
+++ b/include/language.php
@@ -633,9 +633,7 @@ class PLL_Language extends PLL_Language_Deprecation {
 
 		// Composite property like 'term_language:term_taxonomy_id'.
 		if ( preg_match( '/^(.{1,32}):(term_id|term_taxonomy_id|count)$/', $property, $matches ) ) {
-			/**
-			 * @var array{0:non-empty-string, 1:'term_id'|'term_taxonomy_id'|'count'} $matches
-			 */
+			/** @var array{0:non-empty-string, 1:'term_id'|'term_taxonomy_id'|'count'} $matches */
 			return $this->get_tax_prop( $matches[0], $matches[1] );
 		}
 

--- a/include/language.php
+++ b/include/language.php
@@ -41,7 +41,8 @@
  *     fallbacks?: array<non-empty-string>
  * }
  */
-class PLL_Language {
+class PLL_Language extends PLL_Language_Deprecation {
+
 	/**
 	 * Language name. Ex: English.
 	 *
@@ -293,127 +294,6 @@ class PLL_Language {
 	}
 
 	/**
-	 * Throws a depreciation notice if someone tries to get one of the following properties:
-	 * `term_taxonomy_id`, `count`, `tl_term_id`, `tl_term_taxonomy_id` or `tl_count`.
-	 *
-	 * Backward compatibility with Polylang < 3.4.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string $property Property to get.
-	 * @return mixed Required property value.
-	 */
-	public function __get( $property ) {
-		$deprecated_term_properties = array(
-			'term_taxonomy_id'    => array( 'language', 'term_taxonomy_id' ),
-			'count'               => array( 'language', 'count' ),
-			'tl_term_id'          => array( 'term_language', 'term_id' ),
-			'tl_term_taxonomy_id' => array( 'term_language', 'term_taxonomy_id' ),
-			'tl_count'            => array( 'term_language', 'count' ),
-		);
-
-		// Deprecated property.
-		if ( array_key_exists( $property, $deprecated_term_properties ) ) {
-			$term_prop_type = $deprecated_term_properties[ $property ][0];
-			$term_prop      = $deprecated_term_properties[ $property ][1];
-			$prop_getter    = "get_tax_prop( '{$term_prop_type}', '{$term_prop}' )";
-
-			$this->deprecated_property( $property, $prop_getter );
-
-			return $this->term_props[ $term_prop_type ][ $term_prop ];
-		}
-
-		if ( 'search_url' === $property || 'home_url' === $property ) {
-			$url_getter = "get_{$property}";
-
-			$this->deprecated_property( $property, "{$url_getter}()" );
-
-			return $this->{$url_getter}();
-		}
-
-		// Undefined property.
-		if ( ! property_exists( $this, $property ) ) {
-			return null;
-		}
-
-		// The property is defined.
-		$ref = new ReflectionProperty( $this, $property );
-
-		// Public property.
-		if ( $ref->isPublic() ) {
-			return $this->{$property};
-		}
-
-		// Protected or private property.
-		$visibility = $ref->isPrivate() ? 'private' : 'protected';
-		$trace      = debug_backtrace(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection, WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
-		$file       = isset( $trace[0]['file'] ) ? $trace[0]['file'] : '';
-		$line       = isset( $trace[0]['line'] ) ? $trace[0]['line'] : 0;
-		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			esc_html(
-				sprintf(
-					"Cannot access %s property %s::$%s in %s on line %d.\nError handler",
-					$visibility,
-					get_class( $this ),
-					$property,
-					$file,
-					$line
-				)
-			),
-			E_USER_ERROR
-		);
-	}
-
-	/**
-	 * Checks for a deprecated property.
-	 * Is triggered by calling `isset()` or `empty()` on inaccessible (protected or private) or non-existing properties.
-	 *
-	 * Backward compatibility with Polylang < 3.4.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string $property A property name.
-	 * @return bool
-	 */
-	public function __isset( $property ) {
-		$deprecated_properties = array( 'term_taxonomy_id', 'count', 'tl_term_id', 'tl_term_taxonomy_id', 'tl_count', 'home_url', 'search_url' );
-		return in_array( $property, $deprecated_properties, true );
-	}
-
-	/**
-	 * Triggers a deprecated an error for a deprecated property.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string $property    Deprecated property name.
-	 * @param string $replacement Method or property name to use instead.
-	 * @return void
-	 */
-	private function deprecated_property( $property, $replacement ) {
-		/**
-		 * Filters whether to trigger an error for deprecated properties.
-		 *
-		 * The filter name is intentionally not prefixed to use the same as WordPress
-		 * in case it is added in the future.
-		 *
-		 * @since 3.4
-		 *
-		 * @param bool $trigger Whether to trigger the error for deprecated properties. Default true.
-		 */
-		if ( WP_DEBUG && apply_filters( 'deprecated_property_trigger_error', true ) ) {
-			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				sprintf(
-					"Class property %1\$s::\$%2\$s is deprecated, use %1\$s::%3\$s instead.\nError handler",
-					esc_html( get_class( $this ) ),
-					esc_html( $property ),
-					esc_html( $replacement )
-				),
-				E_USER_DEPRECATED
-			);
-		}
-	}
-
-	/**
 	 * Returns a language term property value (term ID, term taxonomy ID, or count).
 	 *
 	 * @since 3.4
@@ -435,29 +315,29 @@ class PLL_Language {
 	 *
 	 * @since 3.4
 	 *
-	 * @param string $field Name of the field to return. An empty string to return them all.
-	 * @return (int[]|int)[] Array keys are taxonomy names, array values depend of `$field`.
+	 * @param string $property Name of the field to return. An empty string to return them all.
+	 * @return (int[]|int)[] Array keys are taxonomy names, array values depend of `$property`.
 	 *
-	 * @phpstan-param 'term_taxonomy_id'|'term_id'|'count'|'' $field
+	 * @phpstan-param 'term_taxonomy_id'|'term_id'|'count'|'' $property
 	 * @phpstan-return array<non-empty-string, (
-	 *     $field is non-empty-string ?
+	 *     $property is non-empty-string ?
 	 *     (
-	 *         $field is 'count' ?
+	 *         $property is 'count' ?
 	 *         int<0, max> :
 	 *         positive-int
 	 *     ) :
 	 *     LanguagePropData
 	 * )>
 	 */
-	public function get_tax_props( $field = '' ) {
-		if ( empty( $field ) ) {
+	public function get_tax_props( $property = '' ) {
+		if ( empty( $property ) ) {
 			return $this->term_props;
 		}
 
 		$term_props = array();
 
 		foreach ( $this->term_props as $taxonomy_name => $props ) {
-			$term_props[ $taxonomy_name ] = $props[ $field ];
+			$term_props[ $taxonomy_name ] = $props[ $property ];
 		}
 
 		return $term_props;

--- a/include/language.php
+++ b/include/language.php
@@ -605,4 +605,56 @@ class PLL_Language extends PLL_Language_Deprecation {
 
 		return $this->search_url;
 	}
+
+	/**
+	 * Returns the value of a language property.
+	 * This is handy to get a property's value without worrying about triggering a deprecation warning or anything.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $property A property name.
+	 * @return string|int|bool|string[] The requested property for the language, false if the property doesn't exist.
+	 *
+	 * @phpstan-param 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $property
+	 * @phpstan-return (
+	 *     $property is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
+	 *         $property is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
+	 *             $property is 'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count' ? int<0, max> : (
+	 *                 $property is 'term_group' ? int : (
+	 *                     $property is 'is_rtl' ? int<0, 1> : (
+	 *                         $property is 'active' ? bool : (
+	 *                             $property is 'fallbacks' ? array<non-empty-string> : false
+	 *                         )
+	 *                     )
+	 *                 )
+	 *             )
+	 *         )
+	 *     )
+	 * )
+	 */
+	public function get_prop( $property ) {
+		// Deprecated property.
+		if ( $this->is_deprecated_term_property( $property ) ) {
+			return $this->get_deprecated_term_property( $property );
+		}
+
+		if ( $this->is_deprecated_url_property( $property ) ) {
+			return $this->get_deprecated_url_property( $property );
+		}
+
+		// Composite property like 'term_language:term_taxonomy_id'.
+		if ( preg_match( '/^(.{1,32}):(term_id|term_taxonomy_id|count)$/', $property, $matches ) ) {
+			/**
+			 * @var array{0:non-empty-string, 1:'term_id'|'term_taxonomy_id'|'count'} $matches
+			 */
+			return $this->get_tax_prop( $matches[0], $matches[1] );
+		}
+
+		// Any other public property.
+		if ( isset( $this->$property ) ) {
+			return $this->$property;
+		}
+
+		return false;
+	}
 }

--- a/include/language.php
+++ b/include/language.php
@@ -615,7 +615,7 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 * @param string $property A property name.
 	 * @return string|int|bool|string[] The requested property for the language, false if the property doesn't exist.
 	 *
-	 * @phpstan-param 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks' $property
+	 * @phpstan-param 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url'|'facebook'|'custom_flag_url'|'custom_flag'|'mo_id'|'page_on_front'|'page_for_posts'|'term_id'|'term_taxonomy_id'|'count'|'term_language:term_id'|'term_language:term_taxonomy_id'|'term_language:count'|'term_group'|'is_rtl'|'active'|'fallbacks'|'is_default' $property
 	 * @phpstan-return (
 	 *     $property is 'name'|'slug'|'locale'|'w3c'|'flag_code'|'host'|'flag_url'|'flag'|'home_url'|'search_url' ? non-empty-string : (
 	 *         $property is 'facebook'|'custom_flag_url'|'custom_flag' ? string : (
@@ -623,7 +623,9 @@ class PLL_Language extends PLL_Language_Deprecation {
 	 *                 $property is 'term_group' ? int : (
 	 *                     $property is 'is_rtl' ? int<0, 1> : (
 	 *                         $property is 'active' ? bool : (
-	 *                             $property is 'fallbacks' ? list<non-empty-string> : false
+	 *                             $property is 'fallbacks' ? list<non-empty-string> : (
+	 *                                 $property is 'is_default' ? bool : false
+	 *                             )
 	 *                         )
 	 *                     )
 	 *                 )


### PR DESCRIPTION
closes https://github.com/polylang/polylang-pro/issues/1592.

This PR introduces the abstract class `PLL_Language_Deprecation`, which is expected to be extended by `PLL_Language`.
Its aim is to regroup all the code related to `PLL_Language`'s deprecated properties.

This PR also introduces the method `PLL_Language::get_prop()` and uses it in the API functions. It allows to get `PLL_Language`'s property values without worrying about triggering a deprecation warning or anything.