### PR TITLE
New `$is_default` property in `PLL_Language`.

### DIFF
--- a/admin/admin-filters.php
+++ b/admin/admin-filters.php
@@ -46,8 +46,8 @@ class PLL_Admin_Filters extends PLL_Filters {
 	public function personal_options_update( $user_id ) {
 		// Biography translations
 		foreach ( $this->model->get_languages_list() as $lang ) {
-			$meta = $lang->slug == $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
-			$description = empty( $_POST[ 'description_' . $lang->slug ] ) ? '' : trim( $_POST[ 'description_' . $lang->slug ] ); // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
+			$meta        = $lang->is_default ? 'description' : 'description_' . $lang->slug;
+			$description = empty( $_POST[ 'description_' . $lang->slug ] ) ? '' : trim( $_POST[ 'description_' . $lang->slug ] );  // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
 
 			/** This filter is documented in wp-includes/user.php */
 			$description = apply_filters( 'pre_user_description', $description ); // Applies WP default filter wp_filter_kses
@@ -65,7 +65,7 @@ class PLL_Admin_Filters extends PLL_Filters {
 	 */
 	public function personal_options( $profileuser ) {
 		foreach ( $this->model->get_languages_list() as $lang ) {
-			$meta = $lang->slug == $this->options['default_lang'] ? 'description' : 'description_' . $lang->slug;
+			$meta        = $lang->is_default ? 'description' : 'description_' . $lang->slug;
 			$description = get_user_meta( $profileuser->ID, $meta, true );
 
 			printf(

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -224,7 +224,7 @@ class PLL_Admin_Model extends PLL_Model {
 			}
 
 			// Update the default language option if necessary
-			if ( $this->options['default_lang'] === $old_slug ) {
+			if ( $lang->is_default ) {
 				$this->options['default_lang'] = $slug;
 			}
 		}

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -93,7 +93,7 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Oops ! we are deleting the default language...
 		// Need to do this before loosing the information for default category translations
-		if ( $this->options['default_lang'] == $lang->slug ) {
+		if ( $lang->is_default ) {
 			$slugs = $this->get_languages_list( array( 'fields' => 'slug' ) );
 			$slugs = array_diff( $slugs, array( $lang->slug ) );
 
@@ -224,7 +224,7 @@ class PLL_Admin_Model extends PLL_Model {
 			}
 
 			// Update the default language option if necessary
-			if ( $this->options['default_lang'] == $old_slug ) {
+			if ( $this->options['default_lang'] === $old_slug ) {
 				$this->options['default_lang'] = $slug;
 			}
 		}

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -224,7 +224,7 @@ abstract class PLL_Choose_Lang {
 		}
 
 		// We are already on the right page
-		if ( $this->options['default_lang'] == $this->curlang->slug && $this->options['hide_default'] ) {
+		if ( $this->curlang->is_default && $this->options['hide_default'] ) {
 			$this->set_curlang_in_query( $GLOBALS['wp_query'] );
 
 			/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -191,7 +191,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @return null|string
 	 */
 	public function get_user_metadata( $null, $id, $meta_key, $single ) {
-		return 'description' === $meta_key && ! $this->curlang->is_default ? get_user_meta( $id, 'description_' . $this->curlang->slug, $single ) : $null;
+		return 'description' === $meta_key && ! empty( $this->curlang ) && ! $this->curlang->is_default ? get_user_meta( $id, 'description_' . $this->curlang->slug, $single ) : $null;
 	}
 
 	/**

--- a/frontend/frontend-filters.php
+++ b/frontend/frontend-filters.php
@@ -191,7 +191,7 @@ class PLL_Frontend_Filters extends PLL_Filters {
 	 * @return null|string
 	 */
 	public function get_user_metadata( $null, $id, $meta_key, $single ) {
-		return 'description' === $meta_key && $this->curlang->slug !== $this->options['default_lang'] ? get_user_meta( $id, 'description_' . $this->curlang->slug, $single ) : $null;
+		return 'description' === $meta_key && ! $this->curlang->is_default ? get_user_meta( $id, 'description_' . $this->curlang->slug, $single ) : $null;
 	}
 
 	/**

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -251,7 +251,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 						$infos = $this->explode_location( $loc );
 						if ( $infos['lang'] === $this->curlang->slug ) {
 							$menus[ $infos['location'] ] = (int) $value;
-						} elseif ( $this->curlang->slug === $this->options['default_lang'] ) {
+						} elseif ( $this->curlang->is_default ) {
 							$menus[ $loc ] = (int) $value;
 						}
 					}

--- a/include/filters.php
+++ b/include/filters.php
@@ -394,7 +394,7 @@ class PLL_Filters {
 
 		if ( $user = get_user_by( 'email', $email_address ) ) {
 			foreach ( $this->model->get_languages_list() as $lang ) {
-				if ( $lang->slug !== $this->options['default_lang'] && $value = get_user_meta( $user->ID, 'description_' . $lang->slug, true ) ) {
+				if ( ! $lang->is_default && $value = get_user_meta( $user->ID, 'description_' . $lang->slug, true ) ) {
 					$user_data_to_export[] = array(
 						/* translators: %s is a language native name */
 						'name'  => sprintf( __( 'User description - %s', 'polylang' ), $lang->name ),

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -41,13 +41,14 @@ class PLL_Language_Factory {
 	 *
 	 * @since 3.4
 	 *
-	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
-	 *                         `language` and `term_language` are mandatory keys.
+	 * @param WP_Term[] $terms   List of language terms, with the language taxonomy names as array keys.
+	 *                           `language` and `term_language` are mandatory keys.
+	 * @param array     $options Array of Polylang's options.
 	 * @return PLL_Language
 	 *
 	 * @phpstan-param array{language:WP_Term, term_language:WP_Term}&array<string, WP_Term> $terms
 	 */
-	public static function get_from_terms( array $terms ) {
+	public static function get_from_terms( array $terms, array $options ) {
 		$languages = self::get_languages();
 		$data      = array(
 			'name'       => $terms['language']->name,
@@ -93,6 +94,8 @@ class PLL_Language_Factory {
 				$data['facebook'] = $languages[ $data['locale'] ]['facebook'];
 			}
 		}
+
+		$data['is_default'] = $options['default_lang'] === $data['slug'];
 
 		$flag_props = self::get_flag( $data['flag_code'], $data['name'], $data['slug'], $data['locale'] );
 		$data       = array_merge( $data, $flag_props );

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -18,7 +18,7 @@ class PLL_Language_Factory {
 	 *
 	 * @phpstan-var array<string, array<string, string>>
 	 */
-	private $languages;
+	private static $languages;
 
 	/**
 	 * Polylang's options.
@@ -191,11 +191,11 @@ class PLL_Language_Factory {
 	 * @phpstan-return array<string, array<string, string>>
 	 */
 	private function get_languages() {
-		if ( empty( $this->languages ) ) {
-			$this->languages = include POLYLANG_DIR . '/settings/languages.php';
+		if ( empty( self::$languages ) ) {
+			self::$languages = include POLYLANG_DIR . '/settings/languages.php';
 		}
 
-		return $this->languages;
+		return self::$languages;
 	}
 
 

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -18,7 +18,26 @@ class PLL_Language_Factory {
 	 *
 	 * @phpstan-var array<string, array<string, string>>
 	 */
-	private static $languages;
+	private $languages;
+
+	/**
+	 * Polylang's options.
+	 *
+	 * @var array
+	 */
+	private $options;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $options Array of Poylang's options passed by reference.
+	 * @return void
+	 */
+	public function __construct( &$options ) {
+		$this->options = &$options;
+	}
 
 	/**
 	 * Returns a language object matching the given data, looking up in cached transient.
@@ -32,8 +51,8 @@ class PLL_Language_Factory {
 	 *
 	 * @phpstan-param LanguageData $language_data
 	 */
-	public static function get( $language_data ) {
-		return new PLL_Language( self::sanitize_data( $language_data ) );
+	public function get( $language_data ) {
+		return new PLL_Language( $this->sanitize_data( $language_data ) );
 	}
 
 	/**
@@ -41,21 +60,20 @@ class PLL_Language_Factory {
 	 *
 	 * @since 3.4
 	 *
-	 * @param WP_Term[] $terms   List of language terms, with the language taxonomy names as array keys.
-	 *                           `language` and `term_language` are mandatory keys.
-	 * @param array     $options Array of Polylang's options.
+	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
+	 *                         `language` and `term_language` are mandatory keys.
 	 * @return PLL_Language
 	 *
 	 * @phpstan-param array{language:WP_Term, term_language:WP_Term}&array<string, WP_Term> $terms
 	 */
-	public static function get_from_terms( array $terms, array $options ) {
-		$languages = self::get_languages();
+	public function get_from_terms( array $terms ) {
+		$languages = $this->get_languages();
 		$data      = array(
 			'name'       => $terms['language']->name,
 			'slug'       => $terms['language']->slug,
 			'term_group' => $terms['language']->term_group,
 			'term_props' => array(),
-			'is_default' => $options['default_lang'] === $terms['language']->slug,
+			'is_default' => $this->options['default_lang'] === $terms['language']->slug,
 		);
 
 		foreach ( $terms as $term ) {
@@ -96,7 +114,7 @@ class PLL_Language_Factory {
 			}
 		}
 
-		$flag_props = self::get_flag( $data['flag_code'], $data['name'], $data['slug'], $data['locale'] );
+		$flag_props = $this->get_flag( $data['flag_code'], $data['name'], $data['slug'], $data['locale'] );
 		$data       = array_merge( $data, $flag_props );
 
 		$additional_data = array();
@@ -124,7 +142,7 @@ class PLL_Language_Factory {
 
 		$data = array_merge( $data, array_intersect_key( $additional_data, $allowed_additional_data ) );
 
-		return new PLL_Language( self::sanitize_data( $data ) );
+		return new PLL_Language( $this->sanitize_data( $data ) );
 	}
 
 	/**
@@ -138,7 +156,7 @@ class PLL_Language_Factory {
 	 *
 	 * @phpstan-return LanguageData
 	 */
-	private static function sanitize_data( array $data ) {
+	private function sanitize_data( array $data ) {
 		foreach ( $data['term_props'] as $tax => $props ) {
 			$data['term_props'][ $tax ] = array_map( 'absint', $props );
 		}
@@ -172,12 +190,12 @@ class PLL_Language_Factory {
 	 *
 	 * @phpstan-return array<string, array<string, string>>
 	 */
-	private static function get_languages() {
-		if ( empty( self::$languages ) ) {
-			self::$languages = include POLYLANG_DIR . '/settings/languages.php';
+	private function get_languages() {
+		if ( empty( $this->languages ) ) {
+			$this->languages = include POLYLANG_DIR . '/settings/languages.php';
 		}
 
-		return self::$languages;
+		return $this->languages;
 	}
 
 
@@ -207,7 +225,7 @@ class PLL_Language_Factory {
 	 *     custom_flag?: non-empty-string
 	 * }
 	 */
-	private static function get_flag( $flag_code, $name, $slug, $locale ) {
+	private function get_flag( $flag_code, $name, $slug, $locale ) {
 		$flags = array(
 			'flag' => PLL_Language::get_flag_informations( $flag_code ),
 		);

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -55,6 +55,7 @@ class PLL_Language_Factory {
 			'slug'       => $terms['language']->slug,
 			'term_group' => $terms['language']->term_group,
 			'term_props' => array(),
+			'is_default' => $options['default_lang'] === $terms['language']->slug,
 		);
 
 		foreach ( $terms as $term ) {
@@ -94,8 +95,6 @@ class PLL_Language_Factory {
 				$data['facebook'] = $languages[ $data['locale'] ]['facebook'];
 			}
 		}
-
-		$data['is_default'] = $options['default_lang'] === $data['slug'];
 
 		$flag_props = self::get_flag( $data['flag_code'], $data['name'], $data['slug'], $data['locale'] );
 		$data       = array_merge( $data, $flag_props );

--- a/include/language.php
+++ b/include/language.php
@@ -38,7 +38,8 @@
  *     page_on_front: int<0, max>,
  *     page_for_posts: int<0, max>,
  *     active: bool,
- *     fallbacks?: array<non-empty-string>
+ *     fallbacks?: array<non-empty-string>,
+ *     is_default?: bool
  * }
  */
 class PLL_Language {
@@ -215,6 +216,13 @@ class PLL_Language {
 	public $fallbacks = array();
 
 	/**
+	 * Whether the language is the default one.
+	 *
+	 * @var boolean
+	 */
+	public $is_default = false;
+
+	/**
 	 * Stores language term properties (like term IDs and counts) for each language taxonomy (`language`,
 	 * `term_language`, etc).
 	 * This stores the values of the properties `$term_id` + `$term_taxonomy_id` + `$count` (`language`), `$tl_term_id`
@@ -280,6 +288,7 @@ class PLL_Language {
 	 *     @type int      $page_for_posts  Optional. ID of the page for posts in this language.
 	 *     @type bool     $active          Whether or not the language is active. Default `true`.
 	 *     @type string[] $fallbacks       List of WordPress language locales. Ex: array( 'en_GB' ).
+	 *     @type bool     $is_default      Optional. Whether or not the language is the default one.
 	 * }
 	 *
 	 * @phpstan-param LanguageData $language_data

--- a/include/language.php
+++ b/include/language.php
@@ -39,7 +39,7 @@
  *     page_for_posts: int<0, max>,
  *     active: bool,
  *     fallbacks?: array<non-empty-string>,
- *     is_default?: bool
+ *     is_default: bool
  * }
  */
 class PLL_Language {
@@ -220,7 +220,7 @@ class PLL_Language {
 	 *
 	 * @var boolean
 	 */
-	public $is_default = false;
+	public $is_default;
 
 	/**
 	 * Stores language term properties (like term IDs and counts) for each language taxonomy (`language`,
@@ -288,7 +288,7 @@ class PLL_Language {
 	 *     @type int      $page_for_posts  Optional. ID of the page for posts in this language.
 	 *     @type bool     $active          Whether or not the language is active. Default `true`.
 	 *     @type string[] $fallbacks       List of WordPress language locales. Ex: array( 'en_GB' ).
-	 *     @type bool     $is_default      Optional. Whether or not the language is the default one.
+	 *     @type bool     $is_default      Whether or not the language is the default one.
 	 * }
 	 *
 	 * @phpstan-param LanguageData $language_data

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -104,7 +104,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 			$language = $language->to_array();
 		}
 
-		if ( $this->options['hide_default'] && $language['slug'] == $this->options['default_lang'] ) {
+		if ( $this->options['hide_default'] && $language['is_default'] ) {
 			return trailingslashit( $this->home );
 		}
 		$url = home_url( '/?page_id=' . $language['page_on_front'] );

--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -95,7 +95,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		$languages = array();
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( ! $this->options['hide_default'] || $this->options['default_lang'] != $language->slug ) {
+			if ( ! $this->options['hide_default'] || ! $language->is_default ) {
 				$languages[] = $language->slug;
 			}
 		}

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -135,7 +135,7 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 			$language = $language->to_array();
 		}
 
-		if ( $this->options['hide_default'] && $language['slug'] === $this->options['default_lang'] ) {
+		if ( $this->options['hide_default'] && $language['is_default'] ) {
 			return trailingslashit( $this->home );
 		}
 		$url = home_url( $this->root . get_page_uri( $language['page_on_front'] ) );

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -63,7 +63,7 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 		$languages = array();
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( ! $this->options['hide_default'] || $this->options['default_lang'] != $language->slug ) {
+			if ( ! $this->options['hide_default'] || ! $language->is_default ) {
 				$languages[] = $language->slug;
 			}
 		}

--- a/include/model.php
+++ b/include/model.php
@@ -794,7 +794,7 @@ class PLL_Model {
 			 *     array<non-empty-string, WP_Term>
 			 * ) $lang_terms
 			 */
-			$languages[] = PLL_Language_Factory::get_from_terms( $lang_terms );
+			$languages[] = PLL_Language_Factory::get_from_terms( $lang_terms, $this->options );
 		}
 
 		// We will need the languages list to allow its access in the filter below.

--- a/include/model.php
+++ b/include/model.php
@@ -136,9 +136,13 @@ class PLL_Model {
 					$languages = $this->get_languages_from_taxonomies();
 				} else {
 					// Create the languages directly from arrays stored in the transient.
-					foreach ( $languages as $k => $v ) {
-						$languages[ $k ] = PLL_Language_Factory::get( $v );
-					}
+					$languages = array_map(
+						array( new PLL_Language_Factory( $this->options ), 'get' ),
+						$languages
+					);
+
+					// Remove potential empty language.
+					$languages = array_filter( $languages );
 
 					// Re-index.
 					$languages = array_values( $languages );
@@ -782,20 +786,20 @@ class PLL_Model {
 		// Restore the right order after the first `array_reverse()`.
 		$terms_by_slug = array_reverse( $terms_by_slug );
 
-		$languages = array();
-
-		foreach ( $terms_by_slug as $lang_terms ) {
-			/**
-			 * @var (
-			 *     array{
-			 *         language: WP_Term,
-			 *         term_language: WP_Term
-			 *     }&
-			 *     array<non-empty-string, WP_Term>
-			 * ) $lang_terms
-			 */
-			$languages[] = PLL_Language_Factory::get_from_terms( $lang_terms, $this->options );
-		}
+		/**
+		 * @var (
+		 *     array{
+		 *         string: array{
+		 *             language: WP_Term,
+		 *             term_language: WP_Term
+		 *         }&array<non-empty-string, WP_Term>
+		 *     }
+		 * ) $terms_by_slug
+		 */
+		$languages = array_map(
+			array( new PLL_Language_Factory( $this->options ), 'get_from_terms' ),
+			array_values( $terms_by_slug )
+		);
 
 		// We will need the languages list to allow its access in the filter below.
 		$this->cache->set( 'languages', $languages );

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -110,7 +110,7 @@ class PLL_Nav_Menu {
 	 * @return string
 	 */
 	public function combine_location( $loc, $lang ) {
-		return $loc . ( strpos( $loc, '___' ) || $this->options['default_lang'] === $lang->slug ? '' : '___' . $lang->slug );
+		return $loc . ( strpos( $loc, '___' ) || $lang->is_default ? '' : '___' . $lang->slug );
 	}
 
 	/**

--- a/integrations/jetpack/jetpack.php
+++ b/integrations/jetpack/jetpack.php
@@ -76,7 +76,7 @@ class PLL_Jetpack {
 	 */
 	public function grunion_contact_form_field_html_filter( $r, $field_label ) {
 		if ( function_exists( 'icl_translate' ) ) {
-			$curlang = pll_current_language();
+			$curlang = pll_current_language( \OBJECT );
 			if ( empty( $curlang ) || ! $curlang->is_default ) {
 				$label_translation = icl_translate( 'jetpack ', $field_label . '_label', $field_label );
 				$r = str_replace( $field_label, $label_translation, $r );

--- a/integrations/jetpack/jetpack.php
+++ b/integrations/jetpack/jetpack.php
@@ -76,8 +76,7 @@ class PLL_Jetpack {
 	 */
 	public function grunion_contact_form_field_html_filter( $r, $field_label ) {
 		if ( function_exists( 'icl_translate' ) ) {
-			$curlang = pll_current_language( \OBJECT );
-			if ( empty( $curlang ) || ! $curlang->is_default ) {
+			if ( pll_current_language() !== pll_default_language() ) {
 				$label_translation = icl_translate( 'jetpack ', $field_label . '_label', $field_label );
 				$r = str_replace( $field_label, $label_translation, $r );
 			}

--- a/integrations/jetpack/jetpack.php
+++ b/integrations/jetpack/jetpack.php
@@ -76,7 +76,8 @@ class PLL_Jetpack {
 	 */
 	public function grunion_contact_form_field_html_filter( $r, $field_label ) {
 		if ( function_exists( 'icl_translate' ) ) {
-			if ( pll_current_language() !== pll_default_language() ) {
+			$curlang = pll_current_language();
+			if ( empty( $curlang ) || ! $curlang->is_default ) {
 				$label_translation = icl_translate( 'jetpack ', $field_label . '_label', $field_label );
 				$r = str_replace( $field_label, $label_translation, $r );
 			}

--- a/modules/wizard/view-wizard-step-home-page.php
+++ b/modules/wizard/view-wizard-step-home-page.php
@@ -71,7 +71,7 @@ foreach ( $languages as $language ) {
 				echo $language->flag;  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $language->name ) . ' ' . esc_html( $language->locale ) . ' ';
 				?>
-				<?php if ( $language->slug === $default_language ) : ?>
+				<?php if ( $language->is_default ) : ?>
 					<span class="icon-default-lang">
 						<span class="screen-reader-text">
 							<?php esc_html_e( 'Default language', 'polylang' ); ?>
@@ -118,7 +118,7 @@ foreach ( $languages as $language ) {
 				echo $lg->flag;  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $lg->name ) . ' ' . esc_html( $lg->locale ) . ' ';
 				?>
-				<?php if ( $lg->slug === $default_language ) : ?>
+				<?php if ( $lg->is_default ) : ?>
 					<span class="icon-default-lang">
 						<span class="screen-reader-text">
 							<?php esc_html_e( 'Default language', 'polylang' ); ?>

--- a/modules/wizard/view-wizard-step-languages.php
+++ b/modules/wizard/view-wizard-step-languages.php
@@ -83,7 +83,7 @@ $languages_list = array_diff_key(
 			esc_attr( $lg->locale ),
 			esc_html( $lg->name ),
 			$lg->flag,  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			$default_language === $lg->slug ? ' <span class="icon-default-lang"><span class="screen-reader-text">' . esc_html__( 'Default language', 'polylang' ) . '</span></span>' : ''
+			$lg->is_default ? ' <span class="icon-default-lang"><span class="screen-reader-text">' . esc_html__( 'Default language', 'polylang' ) . '</span></span>' : ''
 		);
 	}
 	?>

--- a/modules/wizard/view-wizard-step-untranslated-contents.php
+++ b/modules/wizard/view-wizard-step-untranslated-contents.php
@@ -12,7 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 };
 
 $languages_list = $this->model->get_languages_list();
-$default_language = ! empty( $languages_list ) ? $this->options['default_lang'] : '';
 ?>
 <h2><?php esc_html_e( 'Content without language', 'polylang' ); ?></h2>
 <p>
@@ -30,7 +29,7 @@ $default_language = ! empty( $languages_list ) ? $this->options['default_lang'] 
 				esc_attr( $lg->locale ),
 				esc_html( $lg->name ),
 				esc_html( $lg->flag ),
-				$lg->slug === $default_language ? ' selected="selected"' : ''
+				$lg->is_default ? ' selected="selected"' : ''
 			);
 		}
 		?>

--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -114,12 +114,13 @@ class PLL_WPML_Compat {
 
 			// Assign translations of the old string to the new string, except for the default language.
 			foreach ( $languages as $language ) {
-				if ( pll_default_language() !== $language->slug ) {
-					$mo = new PLL_MO();
-					$mo->import_from_db( $language );
-					$mo->add_entry( $mo->make_entry( $string, $mo->translate( $exist_string ) ) );
-					$mo->export_to_db( $language );
+				if ( $language->is_default ) {
+					continue;
 				}
+				$mo = new PLL_MO();
+				$mo->import_from_db( $language );
+				$mo->add_entry( $mo->make_entry( $string, $mo->translate( $exist_string ) ) );
+				$mo->export_to_db( $language );
 			}
 			$this->unregister_string( $context, $name );
 		}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -457,7 +457,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$slug on PLL_Language\\|null\\.$#"
-			count: 3
+			count: 1
 			path: frontend/frontend-filters.php
 
 		-
@@ -1184,11 +1184,6 @@ parameters:
 			message: "#^Variable \\$errors in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: settings/settings.php
-
-		-
-			message: "#^Cannot access offset 'default_lang' on mixed\\.$#"
-			count: 1
-			path: settings/table-languages.php
 
 		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, string\\|null given\\.$#"

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -97,7 +97,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 		<table id="pll-domains-table" class="form-table" <?php echo 3 == $this->options['force_lang'] ? '' : 'style="display: none;"'; ?>>
 			<?php
 			foreach ( $this->model->get_languages_list() as  $lg ) {
-				$url = isset( $this->options['domains'][ $lg->slug ] ) ? $this->options['domains'][ $lg->slug ] : ( $lg->slug == $this->options['default_lang'] ? $this->links_model->home : '' );
+				$url = isset( $this->options['domains'][ $lg->slug ] ) ? $this->options['domains'][ $lg->slug ] : ( $lg->is_default ? $this->links_model->home : '' );
 				printf(
 					'<tr><td><label for="pll-domain[%1$s]">%2$s</label></td>' .
 					'<td><input name="domains[%1$s]" id="pll-domain[%1$s]" type="text" value="%3$s" class="regular-text code" aria-required="true" /></td></tr>',

--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -106,9 +106,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_default_lang( $item ) {
-		$options = get_option( 'polylang' );
-
-		if ( $options['default_lang'] != $item->slug ) {
+		if ( ! $item->is_default ) {
 			$s = sprintf(
 				'<div class="row-actions"><span class="default-lang">
 				<a class="icon-default-lang" title="%1$s" href="%2$s"><span class="screen-reader-text">%3$s</span></a>

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -163,7 +163,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'custom_flag',
 			'active',
 			'fallbacks',
-			'is_default'
+			'is_default',
 		);
 
 		$languages = get_transient( 'pll_languages_list' );

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -163,11 +163,12 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'custom_flag',
 			'active',
 			'fallbacks',
+			'is_default'
 		);
 
 		$languages = get_transient( 'pll_languages_list' );
 		$language  = reset( $languages );
-		$this->assertEqualSets( $properties, array_keys( $language ) );
+		$this->assertSameSets( $properties, array_keys( $language ) );
 
 		// Let's check PLL_Language::$term_props.
 		$this->assertArrayHasKey( 'language', $language['term_props'] );


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/1600
Add a new property `$is_default` to `PLL_Language`.

## Why?
To ease default language tests as well as to easily pass this piece of data to JS scripts (through REST for instance).

## How?
- Introduce new prop `$is_default` in `PLL_Language` class and make it mandatory.
- Inject Polylang's options in `PLL_Language_Factory::get_from_terms()` to pass `$is_default` correctly to `PLL_Language` constructor. This is not useful for the method `PLL_Language_Factory::get()` since it's used to create language with the transient (which should already have the property set).
- Use this prop everywhere we test if a given language is the default one.

