### PR TITLE
Add a new method query_objects_with_no_lang().

### DIFF
--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -392,7 +392,7 @@ abstract class PLL_Translatable_Object {
 	 * @since 3.4
 	 *
 	 * @param string $sql A prepared SQL query for object IDs with no language.
-	 * @return mixed An array of numeric object IDs.
+	 * @return string[] An array of numeric object IDs.
 	 */
 	protected function query_objects_with_no_lang( $sql ) {
 		$key          = md5( $sql );


### PR DESCRIPTION
## What?
Fixes partially https://github.com/polylang/polylang-wc/issues/502 (see last "Polylang" task).

## Why?
To allow third party to override the way objects with no language are queried (especially when the cache is hit).
For instance, if a third party doesn't use  `wp_cache_set_last_changed()`, the way we are using the cache won't work anymore.

## How?
Add a new protected method `PLL_Translatable_Object::query_objects_with_no_lang()`.