### PR TITLE
Simplify code to get objects with no language

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -622,11 +622,7 @@ class PLL_Model {
 
 		foreach ( $this->translatable_objects as $type => $object ) {
 			// The trailing 's' in the array key is for backward compatibility.
-			if ( $object instanceof PLL_Translatable_Object_With_Types_Interface ) {
-				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit, $object->get_translated_object_types() );
-			} else {
-				$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
-			}
+			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
 		}
 
 		/**

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -43,7 +43,7 @@ trait PLL_Translatable_Object_With_Types_Trait {
 	 */
 	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array() ) {
 		if ( empty( $args ) ) {
-			return '';
+			$args = $this->get_translated_object_types();
 		}
 
 		return sprintf(

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -373,12 +373,7 @@ abstract class PLL_Translatable_Object {
 			return array();
 		}
 
-		$sql = $this->get_objects_with_no_lang_sql( $language_ids, $limit, $args );
-
-		if ( empty( $sql ) ) {
-			return array();
-		}
-
+		$sql        = $this->get_objects_with_no_lang_sql( $language_ids, $limit, $args );
 		$object_ids = $this->query_objects_with_no_lang( $sql );
 
 		return array_values( $this->sanitize_int_ids_list( $object_ids ) );


### PR DESCRIPTION
This PR changes how we handle `get_objects_with_no_lang()` for objects with types.