### PR TITLE
Adds a test to check if there is a translation group after deleting a term translation.

### DIFF
--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -174,7 +174,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return;
 		}
 
-		if ( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM $wpdb->terms WHERE term_id = %d;", $id ) ) ) {
+		if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM $wpdb->terms WHERE term_id = %d;", $id ) ) ) {
 			return;
 		}
 

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -76,12 +76,24 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 		self::$model->term->set_language( $fr, 'fr' );
 
 		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
-		self::$model->term->delete_translation( $fr );
 
-		$translations = self::$model->term->get_translations( $fr );
-		$translation_group = wp_get_object_terms( $translations, 'term_translations' );
+		$this->assertEquals( self::$model->term->get_translation( $en, 'fr' ), $fr );
+		$this->assertEquals( self::$model->term->get_translation( $fr, 'en' ), $en );
 
-		$this->assertNotEmpty( $translation_group );
+		self::$model->term->save_translations( $en, compact( 'en' ) );
+
+		$this->assertFalse( self::$model->term->get_translation( $en, 'fr' ), $fr );
+		$this->assertFalse( self::$model->term->get_translation( $fr, 'en' ), $en );
+
+		$translations_fr = self::$model->term->get_translations( $fr );
+		$translation_group_fr = wp_get_object_terms( $translations_fr, 'term_translations' );
+		$this->assertNotEmpty( $translation_group_fr );
+
+		$translations_en = self::$model->term->get_translations( $en );
+		$translation_group_en = wp_get_object_terms( $translations_en, 'term_translations' );
+		$this->assertNotEmpty( $translation_group_en );
+
+		$this->assertNotSame( $translation_group_fr, $translation_group_en );
 	}
 
 	public function test_dont_save_translations_with_incorrect_language() {

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -68,6 +68,22 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 		$this->assertFalse( self::$model->term->get_translation( $de, 'fr' ) );
 	}
 
+	public function test_translation_group_after_term_translation_deletion() {
+		$en = self::factory()->term->create();
+		self::$model->term->set_language( $en, 'en' );
+
+		$fr = self::factory()->term->create();
+		self::$model->term->set_language( $fr, 'fr' );
+
+		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->delete_translation( $fr );
+
+		$translations = self::$model->term->get_translations( $fr );
+		$translation_group = wp_get_object_terms( $translations, 'term_translations' );
+
+		$this->assertNotEmpty( $translation_group );
+	}
+
 	public function test_dont_save_translations_with_incorrect_language() {
 		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Model( $options );


### PR DESCRIPTION
Partially fix https://github.com/polylang/polylang-pro/issues/1561

Also fixed a condition that was altered during this [refactor](https://github.com/polylang/polylang/pull/1149/files/87e4a60681a9aa2469164a198e6844dc1ea4261e#diff-e032a65105b897e18f606ba02898b2e0bd0f788b09d41586dcc9adb3ddce18d4L158).