### PR TITLE
New parameter `hide_default` in `PLL_Model::get_languages_list()`.

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -92,13 +92,12 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	 * @return string The modified url.
 	 */
 	public function remove_language_from_link( $url ) {
-		$languages = array();
-
-		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( ! $this->options['hide_default'] || ! $language->is_default ) {
-				$languages[] = $language->slug;
-			}
-		}
+		$languages = $this->model->get_languages_list(
+			array(
+				'hide_default' => $this->options['hide_default'],
+				'fields'       => 'slug',
+			)
+		);
 
 		if ( ! empty( $languages ) ) {
 			$root = ( false === strpos( $url, '://' ) ) ? $this->home_relative . $this->root : preg_replace( '#^https?://#', '://', $this->home . '/' . $this->root );

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -60,13 +60,12 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 	 * @return string The modified url.
 	 */
 	public function remove_language_from_link( $url ) {
-		$languages = array();
-
-		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( ! $this->options['hide_default'] || ! $language->is_default ) {
-				$languages[] = $language->slug;
-			}
-		}
+		$languages = $this->model->get_languages_list(
+			array(
+				'hide_default' => $this->options['hide_default'],
+				'fields'       => 'slug',
+			)
+		);
 
 		if ( ! empty( $languages ) ) {
 			$url = preg_replace( '#://(' . implode( '|', $languages ) . ')\.#', $this->www, $url );

--- a/include/model.php
+++ b/include/model.php
@@ -185,9 +185,10 @@ class PLL_Model {
 		$languages = array_filter(
 			$languages,
 			function( $lang ) use ( $args ) {
-				$empty_to_hide   = isset( $args['hide_empty'] ) && $args['hide_empty'] && empty( $lang->get_tax_prop( 'language', 'count' ) );
-				$default_to_hide = isset( $args['hide_default'] ) && $args['hide_default'] && $lang->is_default;
-				return ! ( $empty_to_hide || $default_to_hide );
+				$keep_empty   = empty( $args['hide_empty'] ) || $lang->get_tax_prop( 'language', 'count' );
+				$keep_default = empty( $args['hide_default'] ) || ! $lang->is_default;
+				return $keep_empty && $keep_default;
+
 			}
 		);
 

--- a/include/model.php
+++ b/include/model.php
@@ -116,8 +116,9 @@ class PLL_Model {
 	 * @since 0.1
 	 *
 	 * @param array $args {
-	 *   @type bool  $hide_empty Hides languages with no posts if set to true ( defaults to false ).
-	 *   @type string $fields    Returns only that field if set; {@see PLL_Language} for a list of fields.
+	 *   @type bool  $hide_empty   Hides languages with no posts if set to true (defaults to `false`).
+	 *   @type bool  $hide_default Hides default language from the list (default to `false`).
+	 *   @type string $fields      Returns only that field if set; {@see PLL_Language} for a list of fields.
 	 * }
 	 * @return array List of PLL_Language objects or PLL_Language object properties.
 	 */
@@ -188,6 +189,11 @@ class PLL_Model {
 					unset( $languages[ $key ] );
 				}
 			}
+		}
+
+		// Remove default language if requested.
+		if ( ! empty( $args['hide_default'] ) ) {
+			$languages = wp_list_filter( $languages, array( 'is_default', true ) );
 		}
 
 		return empty( $args['fields'] ) ? $languages : wp_list_pluck( $languages, $args['fields'] );

--- a/include/model.php
+++ b/include/model.php
@@ -116,9 +116,9 @@ class PLL_Model {
 	 * @since 0.1
 	 *
 	 * @param array $args {
-	 *   @type bool  $hide_empty   Hides languages with no posts if set to true (defaults to `false`).
-	 *   @type bool  $hide_default Hides default language from the list (default to `false`).
-	 *   @type string $fields      Returns only that field if set; {@see PLL_Language} for a list of fields.
+	 *   @type bool   $hide_empty   Hides languages with no posts if set to `true` (defaults to `false`).
+	 *   @type bool   $hide_default Hides default language from the list (default to `false`).
+	 *   @type string $fields       Returns only that field if set; {@see PLL_Language} for a list of fields.
 	 * }
 	 * @return array List of PLL_Language objects or PLL_Language object properties.
 	 */

--- a/include/model.php
+++ b/include/model.php
@@ -192,6 +192,8 @@ class PLL_Model {
 			}
 		);
 
+		$languages = array_values( $languages ); // Re-index.
+
 		return empty( $args['fields'] ) ? $languages : wp_list_pluck( $languages, $args['fields'] );
 	}
 

--- a/include/model.php
+++ b/include/model.php
@@ -182,19 +182,14 @@ class PLL_Model {
 			$this->is_creating_language_objects = false;
 		}
 
-		// Remove empty languages if requested.
-		if ( ! empty( $args['hide_empty'] ) ) {
-			foreach ( $languages as $key => $language ) {
-				if ( empty( $language->get_tax_prop( 'language', 'count' ) ) ) {
-					unset( $languages[ $key ] );
-				}
+		$languages = array_filter(
+			$languages,
+			function( $lang ) use ( $args ) {
+				$empty_to_hide   = isset( $args['hide_empty'] ) && $args['hide_empty'] && empty( $lang->get_tax_prop( 'language', 'count' ) );
+				$default_to_hide = isset( $args['hide_default'] ) && $args['hide_default'] && $lang->is_default;
+				return ! ( $empty_to_hide || $default_to_hide );
 			}
-		}
-
-		// Remove default language if requested.
-		if ( ! empty( $args['hide_default'] ) ) {
-			$languages = wp_list_filter( $languages, array( 'is_default', true ) );
-		}
+		);
 
 		return empty( $args['fields'] ) ? $languages : wp_list_pluck( $languages, $args['fields'] );
 	}

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -249,17 +249,14 @@ class PLL_WPSEO {
 	public function add_post_type_archive( $str ) {
 		$post_type     = substr( substr( current_filter(), 14 ), 0, -8 );
 		$post_type_obj = get_post_type_object( $post_type );
-		$languages     = wp_list_filter(
-			PLL()->model->get_languages_list(
-				array(
-					'hide_default' => PLL()->options['hide_default'],
-				),
-			),
-			array( 'active' => false ),
-			'NOT'
-		);
+		$languages     = wp_list_filter( PLL()->model->get_languages_list(), array( 'active' => false ), 'NOT' );
 
 		if ( 'post' === $post_type ) {
+			if ( ! empty( PLL()->options['hide_default'] ) ) {
+				// The home url is of course already added by WPSEO.
+				$languages = wp_list_filter( $languages, array( 'slug' => pll_default_language() ), 'NOT' );
+			}
+
 			foreach ( $languages as $lang ) {
 				$str .= $this->format_sitemap_url( pll_home_url( $lang->slug ), $post_type );
 			}
@@ -268,6 +265,9 @@ class PLL_WPSEO {
 			$slug = ( true === $post_type_obj->has_archive ) ? $post_type_obj->rewrite['slug'] : $post_type_obj->has_archive;
 
 			if ( ! wpcom_vip_get_page_by_path( $slug ) ) {
+				// The post type archive in the current language is already added by WPSEO.
+				$languages = wp_list_filter( $languages, array( 'slug' => pll_current_language() ), 'NOT' );
+
 				foreach ( $languages as $lang ) {
 					PLL()->curlang = $lang; // Switch the language to get the correct archive link.
 					$link = get_post_type_archive_link( $post_type );

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -249,14 +249,17 @@ class PLL_WPSEO {
 	public function add_post_type_archive( $str ) {
 		$post_type     = substr( substr( current_filter(), 14 ), 0, -8 );
 		$post_type_obj = get_post_type_object( $post_type );
-		$languages     = wp_list_filter( PLL()->model->get_languages_list(), array( 'active' => false ), 'NOT' );
+		$languages     = wp_list_filter(
+			PLL()->model->get_languages_list(
+				array(
+					'hide_default' => PLL()->options['hide_default'],
+				),
+			),
+			array( 'active' => false ),
+			'NOT'
+		);
 
 		if ( 'post' === $post_type ) {
-			if ( ! empty( PLL()->options['hide_default'] ) ) {
-				// The home url is of course already added by WPSEO.
-				$languages = wp_list_filter( $languages, array( 'slug' => pll_default_language() ), 'NOT' );
-			}
-
 			foreach ( $languages as $lang ) {
 				$str .= $this->format_sitemap_url( pll_home_url( $lang->slug ), $post_type );
 			}
@@ -265,9 +268,6 @@ class PLL_WPSEO {
 			$slug = ( true === $post_type_obj->has_archive ) ? $post_type_obj->rewrite['slug'] : $post_type_obj->has_archive;
 
 			if ( ! wpcom_vip_get_page_by_path( $slug ) ) {
-				// The post type archive in the current language is already added by WPSEO.
-				$languages = wp_list_filter( $languages, array( 'slug' => pll_current_language() ), 'NOT' );
-
 				foreach ( $languages as $lang ) {
 					PLL()->curlang = $lang; // Switch the language to get the correct archive link.
 					$link = get_post_type_archive_link( $post_type );

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -82,14 +82,15 @@ class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	public function rewrite_rules( $rules ) {
 		global $wp_rewrite;
 
-		$languages = $this->model->get_languages_list( array( 'fields' => 'slug' ) );
+		$languages = $this->model->get_languages_list(
+			array(
+				'fields'       => 'slug',
+				'hide_default' => $this->options['hide_default'],
+			)
+		);
 
 		if ( empty( $languages ) ) {
 			return $rules;
-		}
-
-		if ( $this->options['hide_default'] ) {
-			$languages = array_diff( $languages, array( $this->options['default_lang'] ) );
 		}
 
 		$slug = $wp_rewrite->root . ( $this->options['rewrite'] ? '^' : '^language/' ) . '(' . implode( '|', $languages ) . ')/';

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -25,6 +25,8 @@ class Model_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $post_id, 'en' );
 
 		$this->assertSame( array( 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_empty' => true ) ) );
+		$this->assertSame( array( 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_default' => true ) ) );
+		$this->assertSame( array(), self::$model->get_languages_list( array( 'fields' => 'slug', 'hide_default' => true, 'hide_empty' => true ) ) );
 	}
 
 	public function test_languages_list_order() {


### PR DESCRIPTION
## What?
Filter out default language from languages list if required.

## Why?
Since the default language is "manually" removed in some places, refactor the logic to clean the code.

## How?
Add a new parameter `hide_default` to `PLL_Model::get_languages_list()` and use it when necessary.

**Note: Unit tests will break until #1228 is merged since it requires `PLL_Language::$is_default` property to be available.**