### PR TITLE
Add annotation for PHP 8.1+

### DIFF
--- a/include/translatable-objects.php
+++ b/include/translatable-objects.php
@@ -59,6 +59,7 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	 *
 	 * @phpstan-return ArrayIterator<string, PLL_Translatable_Object>
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator( $this->objects );
 	}


### PR DESCRIPTION
in #1160, we forgot to add the annotation `#[\ReturnTypeWillChange]` to the method `PLL_Translatable_Objects::getIterator()`. This is required for PHP 8.1+ to avoid a deprecated notice.