### PR TITLE
Introduce the class PLL_Options

### DIFF
--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -25,6 +25,13 @@ class PLL_Admin_Default_Term {
 	protected $pref_lang;
 
 	/**
+	 * Reference to Polylang options array
+	 *
+	 * @var PLL_Options
+	 */
+	protected $options;
+
+	/**
 	 * Array of registered taxonomy names for which Polylang manages languages and translations.
 	 *
 	 * @var string[]

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -10,6 +10,13 @@
  */
 class PLL_Admin_Filters_Term {
 	/**
+	 * Stores the plugin options.
+	 *
+	 * @var PLL_Options
+	 */
+	public $options;
+
+	/**
 	 * @var PLL_Model
 	 */
 	public $model;

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -55,7 +55,6 @@ class PLL_Admin_Model extends PLL_Model {
 		if ( empty( $this->options['default_lang'] ) ) {
 			// If this is the first language created, set it as default language
 			$this->options['default_lang'] = $args['slug'];
-			update_option( 'polylang', $this->options );
 		}
 
 		// Refresh languages.
@@ -156,7 +155,6 @@ class PLL_Admin_Model extends PLL_Model {
 		$this->clean_languages_cache();
 		$this->get_languages_list();
 
-		update_option( 'polylang', $this->options );
 		flush_rewrite_rules(); // refresh rewrite rules
 		return true;
 	}
@@ -235,8 +233,6 @@ class PLL_Admin_Model extends PLL_Model {
 				$this->options['default_lang'] = $slug;
 			}
 		}
-
-		update_option( 'polylang', $this->options );
 
 		// And finally update the language itself.
 		$this->update_secondary_language_terms( $args['slug'], $args['name'], $lang );
@@ -534,7 +530,6 @@ class PLL_Admin_Model extends PLL_Model {
 
 		// Update options
 		$this->options['default_lang'] = $slug;
-		update_option( 'polylang', $this->options );
 
 		$this->clean_languages_cache();
 		flush_rewrite_rules();

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -52,7 +52,7 @@ class PLL_Admin_Model extends PLL_Model {
 		// The other language taxonomies.
 		$this->update_secondary_language_terms( $args['slug'], $args['name'] );
 
-		if ( ! isset( $this->options['default_lang'] ) ) {
+		if ( empty( $this->options['default_lang'] ) ) {
 			// If this is the first language created, set it as default language
 			$this->options['default_lang'] = $args['slug'];
 			update_option( 'polylang', $this->options );

--- a/admin/admin-nav-menu.php
+++ b/admin/admin-nav-menu.php
@@ -181,7 +181,6 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 			}
 		}
 
-		update_option( 'polylang', $this->options );
 		return $locations;
 	}
 
@@ -273,8 +272,6 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 					}
 				}
 			}
-
-			update_option( 'polylang', $this->options );
 		}
 	}
 }

--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -15,7 +15,7 @@ class PLL_Admin_Notices {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -12,7 +12,7 @@ class PLL_Canonical {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -12,7 +12,7 @@ abstract class PLL_Choose_Lang {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -294,6 +294,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 		if ( ! $menu && ! $args['theme_location'] ) {
 			$menus = wp_get_nav_menus();
 			foreach ( $menus as $menu_maybe ) {
+				/** @var WP_Term $menu_maybe */
 				if ( wp_get_nav_menu_items( $menu_maybe->term_id, array( 'update_post_term_cache' => false ) ) ) {
 					foreach ( $this->options['nav_menus'][ $theme ] as $menus ) {
 						if ( in_array( $menu_maybe->term_id, $menus ) && ! empty( $menus[ $this->curlang->slug ] ) ) {

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -22,9 +22,9 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	protected $links;
 
 	/**
-	 * Stores plugin's options.
+	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 

--- a/include/base.php
+++ b/include/base.php
@@ -13,7 +13,7 @@ abstract class PLL_Base {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 
@@ -143,7 +143,6 @@ abstract class PLL_Base {
 	 */
 	public function switch_blog( $new_blog_id, $prev_blog_id ) {
 		if ( $this->is_active_on_new_blog( $new_blog_id, $prev_blog_id ) ) {
-			$this->options = get_option( 'polylang' ); // Needed for menus.
 			remove_action( 'pre_option_rewrite_rules', array( $this->links_model, 'prepare_rewrite_rules' ) );
 			$this->links_model = $this->model->get_links_model();
 		}
@@ -166,7 +165,7 @@ abstract class PLL_Base {
 		 * The 2nd test is needed when Polylang is not networked activated.
 		 * The 3rd test is needed when Polylang is networked activated and a new site is created.
 		 */
-		return $new_blog_id !== $prev_blog_id && in_array( POLYLANG_BASENAME, $plugins ) && get_option( 'polylang' );
+		return $new_blog_id !== $prev_blog_id && in_array( POLYLANG_BASENAME, $plugins ) && ! empty( $this->options['version'] );
 	}
 
 	/**

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -165,10 +165,10 @@ class Polylang {
 		global $polylang;
 
 		self::define_constants();
-		$options = get_option( 'polylang' );
+		$options = new PLL_Options();
 
 		// Plugin upgrade
-		if ( $options && version_compare( $options['version'], POLYLANG_VERSION, '<' ) ) {
+		if ( ! empty( $options['version'] ) && version_compare( $options['version'], POLYLANG_VERSION, '<' ) ) {
 			$upgrade = new PLL_Upgrade( $options );
 			if ( ! $upgrade->upgrade() ) { // If the version is too old
 				return;
@@ -176,8 +176,8 @@ class Polylang {
 		}
 
 		// In some edge cases, it's possible that no options were found in the database. Load default options as we need some.
-		if ( ! $options ) {
-			$options = PLL_Install::get_default_options();
+		if ( empty( $options['version'] ) ) {
+			$options->merge( PLL_Options::get_reset_options() );
 		}
 
 		/**

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -12,7 +12,7 @@ class PLL_Filters_Links {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/include/filters.php
+++ b/include/filters.php
@@ -12,7 +12,7 @@ class PLL_Filters {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -23,7 +23,7 @@ class PLL_Language_Factory {
 	/**
 	 * Polylang's options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	private $options;
 
@@ -32,10 +32,10 @@ class PLL_Language_Factory {
 	 *
 	 * @since 3.4
 	 *
-	 * @param array $options Array of Poylang's options passed by reference.
+	 * @param PLL_Options $options Array of Poylang's options passed by reference.
 	 * @return void
 	 */
-	public function __construct( &$options ) {
+	public function __construct( PLL_Options &$options ) {
 		$this->options = &$options;
 	}
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -19,7 +19,7 @@ abstract class PLL_Links_Model {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/include/links.php
+++ b/include/links.php
@@ -12,7 +12,7 @@ class PLL_Links {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/include/model.php
+++ b/include/model.php
@@ -884,7 +884,7 @@ class PLL_Model {
 		}
 
 		// We have at least one 3rd party language taxonomy.
-		$known_taxonomies = ! empty( $this->options['language_taxonomies'] ) && is_array( $this->options['language_taxonomies'] ) ? $this->options['language_taxonomies'] : array();
+		$known_taxonomies = $this->options['language_taxonomies'];
 		$new_taxonomies   = array_diff( $registered_taxonomies, $known_taxonomies );
 
 		if ( empty( $new_taxonomies ) ) {

--- a/include/model.php
+++ b/include/model.php
@@ -19,7 +19,7 @@ class PLL_Model {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 
@@ -67,9 +67,9 @@ class PLL_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param array $options Polylang options.
+	 * @param PLL_Options $options Polylang options.
 	 */
-	public function __construct( &$options ) {
+	public function __construct( PLL_Options &$options ) {
 		$this->options = &$options;
 
 		$this->cache = new PLL_Cache();

--- a/include/model.php
+++ b/include/model.php
@@ -902,7 +902,6 @@ class PLL_Model {
 
 		// Keep the previous values, so this is triggered only once per taxonomy.
 		$this->options['language_taxonomies'] = array_merge( $known_taxonomies, $new_taxonomies );
-		update_option( 'polylang', $this->options );
 	}
 
 	/**

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -13,7 +13,7 @@ class PLL_Nav_Menu {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/include/options.php
+++ b/include/options.php
@@ -595,7 +595,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 
 				$this->options[ $this->current_blog_id ][ $offset ] = array_filter(
 					$value,
-					function( $v, $k ) {
+					function ( $v, $k ) {
 						return is_string( $v ) && ! empty( $v ) && is_string( $k ) && ! empty( $k );
 					},
 					ARRAY_FILTER_USE_BOTH
@@ -615,7 +615,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 				$this->options[ $this->current_blog_id ][ $offset ] = array_values(
 					array_filter(
 						$value,
-						function( $v ) {
+						function ( $v ) {
 							return is_string( $v ) && ! empty( $v );
 						}
 					)

--- a/include/options.php
+++ b/include/options.php
@@ -12,7 +12,7 @@
  * - Options are always defined: it is not possible to unset them from the list, they are set to their default value instead.
  * - Automatic cast + limited sanitization/validation (invalid values are not set).
  *
- * @since 3.5
+ * @since 3.7
  *
  * @implements ArrayAccess<non-falsy-string, mixed>
  * @implements Iterator<non-falsy-string, mixed>
@@ -170,7 +170,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	/**
 	 * Constructor.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 */
 	public function __construct() {
 		// Keep track of the blog ID.
@@ -190,7 +190,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * - stores the options.
 	 * Hooked to `switch_blog`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param int $blog_id The blog ID.
 	 * @return void
@@ -218,7 +218,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Stores the options into the database for all blogs.
 	 * Hooked to `shutdown`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return void
 	 */
@@ -254,7 +254,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	/**
 	 * Merge new options into the current ones.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param array ...$arrays Lists of new options.
 	 * @return self
@@ -276,7 +276,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	/**
 	 * Stores the options into the database.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return bool True if the options were updated, false otherwise.
 	 */
@@ -292,7 +292,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	/**
 	 * Returns all options.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return mixed[]
 	 *
@@ -305,7 +305,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	/**
 	 * Returns reset options.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return array
 	 *
@@ -337,7 +337,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Tells if an option exists.
 	 * Required by interface `ArrayAccess`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param string $offset The name of the option to check for.
 	 * @return bool
@@ -353,7 +353,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Returns the value of the specified option.
 	 * Required by interface `ArrayAccess`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param string $offset The name of the option to retrieve.
 	 * @return mixed
@@ -391,7 +391,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * This doesn't allow to set an unknown option.
 	 * Required by interface `ArrayAccess`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param string $offset The name of the option to assign the value to.
 	 * @param mixed  $value  The value to set.
@@ -414,7 +414,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * This doesn't allow to unset an option, this resets it to its default value instead.
 	 * Required by interface `ArrayAccess`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param string $offset The name of the option to unset.
 	 * @return void
@@ -435,7 +435,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Returns the number of options.
 	 * Required by interface `Countable`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return int
 	 */
@@ -447,7 +447,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Returns the value of the current option.
 	 * Required by interface `Iterator`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return mixed
 	 *
@@ -462,7 +462,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Returns the key of the current option.
 	 * Required by interface `Iterator`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return string
 	 *
@@ -477,7 +477,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Moves forward to next option.
 	 * Required by interface `Iterator`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return void
 	 */
@@ -490,7 +490,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Rewinds the Iterator to the first option.
 	 * Required by interface `Iterator`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return void
 	 */
@@ -503,7 +503,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Checks if current position is valid.
 	 * Required by interface `Iterator`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return bool
 	 */
@@ -514,7 +514,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	/**
 	 * Returns the data which can be serialized by `json_encode()`.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @return mixed[]
 	 *
@@ -530,7 +530,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * Also sets the property `$modified` if the value changes.
 	 * This doesn't do a full sanitization, only basic type-cast.
 	 *
-	 * @since 3.5
+	 * @since 3.7
 	 *
 	 * @param string $offset The name of the option to sanitize.
 	 * @param mixed  $value  The value to sanitize.

--- a/include/options.php
+++ b/include/options.php
@@ -18,7 +18,7 @@
  * @implements Iterator<non-falsy-string, mixed>
  *
  * @phpstan-type BoolDataKeys 'browser'|'hide_default'|'media_support'|'redirect_lang'|'rewrite'|'uninstall'
- * @phpstan-type ListDataKeys 'post_types'|'sync'|'taxonomies'
+ * @phpstan-type ListDataKeys 'language_taxonomies'|'post_types'|'sync'|'taxonomies'
  * @phpstan-type StringDataKeys 'default_lang'|'previous_version'|'version'
  * @phpstan-type NavMenuType array<
  *     non-falsy-string,
@@ -37,6 +37,7 @@
  *     first_activation: int<0, max>,
  *     force_lang: int-mask<0, 1, 2, 3>,
  *     hide_default: bool,
+ *     language_taxonomies: list<non-falsy-string>,
  *     media: array<non-falsy-string, 1>,
  *     media_support: bool,
  *     nav_menus: NavMenuType,
@@ -56,6 +57,7 @@
  *     first_activation: 0,
  *     force_lang: 0,
  *     hide_default: false,
+ *     language_taxonomies: list<non-falsy-string>,
  *     media: array<non-falsy-string, 1>,
  *     media_support: false,
  *     nav_menus: NavMenuType,
@@ -97,23 +99,24 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * @phpstan-var DefaultOptionsData
 	 */
 	const DEFAULTS = array(
-		'browser'          => false,
-		'default_lang'     => '',
-		'domains'          => array(),
-		'first_activation' => 0,
-		'force_lang'       => 0,
-		'hide_default'     => false,
-		'media'            => array(),
-		'media_support'    => false,
-		'nav_menus'        => array(),
-		'post_types'       => array(),
-		'previous_version' => '',
-		'redirect_lang'    => false,
-		'rewrite'          => false,
-		'sync'             => array(),
-		'taxonomies'       => array(),
-		'uninstall'        => false,
-		'version'          => '',
+		'browser'             => false,
+		'default_lang'        => '',
+		'domains'             => array(),
+		'first_activation'    => 0,
+		'force_lang'          => 0,
+		'hide_default'        => false,
+		'language_taxonomies' => array(),
+		'media'               => array(),
+		'media_support'       => false,
+		'nav_menus'           => array(),
+		'post_types'          => array(),
+		'previous_version'    => '',
+		'redirect_lang'       => false,
+		'rewrite'             => false,
+		'sync'                => array(),
+		'taxonomies'          => array(),
+		'uninstall'           => false,
+		'version'             => '',
 	);
 
 	/**
@@ -604,6 +607,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 				break;
 
 			// List with non falsy strings as array values.
+			case 'language_taxonomies':
 			case 'post_types':
 			case 'sync':
 			case 'taxonomies':

--- a/include/options.php
+++ b/include/options.php
@@ -6,7 +6,7 @@
 /**
  * Class that manages Polylang's options:
  * - Automatically stores the options into the database on `shutdown` if they have been modified.
- * - Behaves almost like an array (implements `ArrayAccess`, `Countable, `Iterator`, and `JsonSerializable`).
+ * - Behaves almost like an array (implements `ArrayAccess`, `Countable`, `Iterator`, and `JsonSerializable`).
  * - Handles `switch_to_blog()`.
  * - Whitelists options: it is not possible to add unknown options (not listed in PLL_Options::DEFAULTS).
  * - Options are always defined: it is not possible to unset them from the list, they are set to their default value instead.

--- a/include/options.php
+++ b/include/options.php
@@ -180,8 +180,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 		$this->option_keys = array_keys( self::DEFAULTS );
 		$this->init_options_for_blog( $this->blog_id );
 
-		$min = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -PHP_INT_MAX;
-		add_action( 'switch_blog', array( $this, 'init_options_for_blog' ), $min );
+		add_action( 'switch_blog', array( $this, 'init_options_for_blog' ), PHP_INT_MIN );
 		add_action( 'shutdown', array( $this, 'save_all' ) );
 	}
 
@@ -231,8 +230,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 			return;
 		}
 
-		$min = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -PHP_INT_MAX;
-		remove_action( 'switch_blog', array( $this, 'init_options_for_blog' ), $min );
+		remove_action( 'switch_blog', array( $this, 'init_options_for_blog' ), PHP_INT_MIN );
 
 		// Handle the original blog first, maybe this will prevent the use of `switch_to_blog()`.
 		if ( isset( $modified[ $this->blog_id ] ) && $this->current_blog_id === $this->blog_id ) {
@@ -261,7 +259,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * @param array ...$arrays Lists of new options.
 	 * @return self
 	 */
-	public function merge( array ...$arrays ) {
+	public function merge( array ...$arrays ): self {
 		$options = array_merge( ...$arrays );
 
 		// Whitelist options.
@@ -282,7 +280,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 *
 	 * @return bool True if the options were updated, false otherwise.
 	 */
-	public function save() {
+	public function save(): bool {
 		if ( ! $this->modified[ $this->current_blog_id ] ) {
 			return false;
 		}
@@ -300,7 +298,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 *
 	 * @phpstan-return OptionsData
 	 */
-	public function get_all() {
+	public function get_all(): array {
 		return $this->options[ $this->current_blog_id ];
 	}
 
@@ -313,7 +311,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 *
 	 * @phpstan-return ResetOptionsData
 	 */
-	public static function get_reset_options() {
+	public static function get_reset_options(): array {
 		/** @var ResetOptionsData */
 		return array_merge(
 			self::DEFAULTS,
@@ -347,7 +345,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 * @phpstan-param key-of<self::DEFAULTS> $offset
 	 */
 	#[\ReturnTypeWillChange]
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		return isset( $this->options[ $this->current_blog_id ][ $offset ] );
 	}
 
@@ -441,8 +439,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 *
 	 * @return int
 	 */
-	#[\ReturnTypeWillChange]
-	public function count() {
+	public function count(): int {
 		return count( $this->options[ $this->current_blog_id ] );
 	}
 
@@ -510,8 +507,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 *
 	 * @return bool
 	 */
-	#[\ReturnTypeWillChange]
-	public function valid() {
+	public function valid(): bool {
 		return isset( $this->option_keys[ $this->position ] );
 	}
 
@@ -542,7 +538,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 *
 	 * @phpstan-param key-of<self::DEFAULTS> $offset
 	 */
-	private function sanitize_and_set( $offset, $value ) {
+	private function sanitize_and_set( string $offset, $value ) {
 		$prev = $this->options[ $this->current_blog_id ][ $offset ];
 
 		switch ( $offset ) {

--- a/include/options.php
+++ b/include/options.php
@@ -177,7 +177,8 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 		$this->option_keys = array_keys( self::DEFAULTS );
 		$this->init_options_for_blog( $this->blog_id );
 
-		add_action( 'switch_blog', array( $this, 'init_options_for_blog' ), PHP_INT_MIN );
+		$min = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -PHP_INT_MAX;
+		add_action( 'switch_blog', array( $this, 'init_options_for_blog' ), $min );
 		add_action( 'shutdown', array( $this, 'save_all' ) );
 	}
 
@@ -227,7 +228,8 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 			return;
 		}
 
-		remove_action( 'switch_blog', array( $this, 'init_options_for_blog' ), PHP_INT_MIN );
+		$min = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -PHP_INT_MAX;
+		remove_action( 'switch_blog', array( $this, 'init_options_for_blog' ), $min );
 
 		// Handle the original blog first, maybe this will prevent the use of `switch_to_blog()`.
 		if ( isset( $modified[ $this->blog_id ] ) && $this->current_blog_id === $this->blog_id ) {
@@ -398,7 +400,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 */
 	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
-		if ( ! isset( self::DEFAULTS[ $offset ] ) ) {
+		if ( ! array_key_exists( $offset, self::DEFAULTS ) ) {
 			return;
 		}
 
@@ -420,7 +422,7 @@ class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable 
 	 */
 	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
-		if ( ! isset( self::DEFAULTS[ $offset ] ) || self::DEFAULTS[ $offset ] === $this->options[ $this->current_blog_id ][ $offset ] ) {
+		if ( ! array_key_exists( $offset, self::DEFAULTS ) || self::DEFAULTS[ $offset ] === $this->options[ $this->current_blog_id ][ $offset ] ) {
 			return;
 		}
 

--- a/include/options.php
+++ b/include/options.php
@@ -1,0 +1,645 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Class that manages Polylang's options:
+ * - Automatically stores the options into the database on `shutdown` if they have been modified.
+ * - Behaves almost like an array (implements `ArrayAccess`, `Countable, `Iterator`, and `JsonSerializable`).
+ * - Handles `switch_to_blog()`.
+ * - Whitelists options: it is not possible to add unknown options (not listed in PLL_Options::DEFAULTS).
+ * - Options are always defined: it is not possible to unset them from the list, they are set to their default value instead.
+ * - Automatic cast + limited sanitization/validation (invalid values are not set).
+ *
+ * @since 3.5
+ *
+ * @implements ArrayAccess<non-falsy-string, mixed>
+ * @implements Iterator<non-falsy-string, mixed>
+ *
+ * @phpstan-type BoolDataKeys 'browser'|'hide_default'|'media_support'|'redirect_lang'|'rewrite'|'uninstall'
+ * @phpstan-type ListDataKeys 'post_types'|'sync'|'taxonomies'
+ * @phpstan-type StringDataKeys 'default_lang'|'previous_version'|'version'
+ * @phpstan-type NavMenuType array<
+ *     non-falsy-string,
+ *     array<
+ *         non-falsy-string,
+ *         array<
+ *             non-falsy-string,
+ *             int<0, max>
+ *         >
+ *     >
+ * >
+ * @phpstan-type OptionsData array{
+ *     browser: bool,
+ *     default_lang: string,
+ *     domains: array<non-falsy-string, non-falsy-string>,
+ *     first_activation: int<0, max>,
+ *     force_lang: int-mask<0, 1, 2, 3>,
+ *     hide_default: bool,
+ *     media: array<non-falsy-string, 1>,
+ *     media_support: bool,
+ *     nav_menus: NavMenuType,
+ *     post_types: list<non-falsy-string>,
+ *     previous_version: string,
+ *     redirect_lang: bool,
+ *     rewrite: bool,
+ *     sync: list<non-falsy-string>,
+ *     taxonomies: list<non-falsy-string>,
+ *     uninstall: bool,
+ *     version: string
+ * }
+ * @phpstan-type DefaultOptionsData array{
+ *     browser: false,
+ *     default_lang: '',
+ *     domains: array<non-falsy-string, non-falsy-string>,
+ *     first_activation: 0,
+ *     force_lang: 0,
+ *     hide_default: false,
+ *     media: array<non-falsy-string, 1>,
+ *     media_support: false,
+ *     nav_menus: NavMenuType,
+ *     post_types: list<non-falsy-string>,
+ *     previous_version: '',
+ *     redirect_lang: false,
+ *     rewrite: false,
+ *     sync: list<non-falsy-string>,
+ *     taxonomies: list<non-falsy-string>,
+ *     uninstall: false,
+ *     version: ''
+ * }
+ * @phpstan-type ResetOptionsData array{
+ *     browser: false,
+ *     default_lang: '',
+ *     domains: array<non-falsy-string, non-falsy-string>,
+ *     first_activation: positive-int,
+ *     force_lang: 1,
+ *     hide_default: true,
+ *     media: array<non-falsy-string, 1>,
+ *     media_support: false,
+ *     nav_menus: NavMenuType,
+ *     post_types: list<non-falsy-string>,
+ *     previous_version: '',
+ *     redirect_lang: false,
+ *     rewrite: true,
+ *     sync: list<non-falsy-string>,
+ *     taxonomies: list<non-falsy-string>,
+ *     uninstall: false,
+ *     version: non-falsy-string
+ * }
+ */
+class PLL_Options implements ArrayAccess, Countable, Iterator, JsonSerializable {
+
+	const OPTION_NAME = 'polylang';
+
+	/**
+	 * @var mixed[]
+	 * @phpstan-var DefaultOptionsData
+	 */
+	const DEFAULTS = array(
+		'browser'          => false,
+		'default_lang'     => '',
+		'domains'          => array(),
+		'first_activation' => 0,
+		'force_lang'       => 0,
+		'hide_default'     => false,
+		'media'            => array(),
+		'media_support'    => false,
+		'nav_menus'        => array(),
+		'post_types'       => array(),
+		'previous_version' => '',
+		'redirect_lang'    => false,
+		'rewrite'          => false,
+		'sync'             => array(),
+		'taxonomies'       => array(),
+		'uninstall'        => false,
+		'version'          => '',
+	);
+
+	/**
+	 * Polylang's options, by blog ID.
+	 *
+	 * @var mixed[][]
+	 * @phpstan-var array<int, OptionsData>
+	 */
+	private $options = array();
+
+	/**
+	 * Tells if the options have been modified, by blog ID.
+	 *
+	 * @var bool[]
+	 * @phpstan-var array<int, bool>
+	 */
+	private $modified = array();
+
+	/**
+	 * Option keys.
+	 * Required to implement Iterator.
+	 *
+	 * @var string[]
+	 * @phpstan-var list<key-of<self::DEFAULTS>>
+	 */
+	private $option_keys;
+
+	/**
+	 * Option position.
+	 * Required to implement Iterator.
+	 *
+	 * @var int
+	 * @phpstan-var int<0, max>
+	 */
+	private $position = 0;
+
+	/**
+	 * The original blog ID.
+	 *
+	 * @var int
+	 */
+	private $blog_id;
+
+	/**
+	 * The current blog ID.
+	 *
+	 * @var int
+	 */
+	private $current_blog_id;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.5
+	 */
+	public function __construct() {
+		// Keep track of the blog ID.
+		$this->blog_id = (int) get_current_blog_id();
+
+		// Handle options.
+		$this->option_keys = array_keys( self::DEFAULTS );
+		$this->init_options_for_blog( $this->blog_id );
+
+		add_action( 'switch_blog', array( $this, 'init_options_for_blog' ), PHP_INT_MIN );
+		add_action( 'shutdown', array( $this, 'save_all' ) );
+	}
+
+	/**
+	 * Initializes options for the given blog:
+	 * - stores the blog ID,
+	 * - stores the options.
+	 * Hooked to `switch_blog`.
+	 *
+	 * @since 3.5
+	 *
+	 * @param int $blog_id The blog ID.
+	 * @return void
+	 */
+	public function init_options_for_blog( $blog_id ) {
+		$this->current_blog_id = (int) $blog_id;
+
+		if ( isset( $this->options[ $blog_id ] ) ) {
+			return;
+		}
+
+		// Store the new options.
+		$this->options[ $blog_id ] = self::DEFAULTS;
+		$options                   = get_option( self::OPTION_NAME );
+
+		if ( ! is_array( $options ) || empty( $options ) ) {
+			$this->modified[ $blog_id ] = true;
+			return;
+		}
+
+		$this->merge( $options );
+	}
+
+	/**
+	 * Stores the options into the database for all blogs.
+	 * Hooked to `shutdown`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return void
+	 */
+	public function save_all() {
+		// Find options that have been modified.
+		$modified = array_filter( $this->modified );
+
+		if ( empty( $modified ) ) {
+			return;
+		}
+
+		remove_action( 'switch_blog', array( $this, 'init_options_for_blog' ), PHP_INT_MIN );
+
+		// Handle the original blog first, maybe this will prevent the use of `switch_to_blog()`.
+		if ( isset( $modified[ $this->blog_id ] ) && $this->current_blog_id === $this->blog_id ) {
+			$this->save();
+			unset( $modified[ $this->blog_id ] );
+
+			if ( empty( $modified ) ) {
+				// All done, no need of `switch_to_blog()`.
+				return;
+			}
+		}
+
+		foreach ( $modified as $blog_id => $yup ) {
+			switch_to_blog( $blog_id );
+			$this->save();
+		}
+
+		restore_current_blog();
+	}
+
+	/**
+	 * Merge new options into the current ones.
+	 *
+	 * @since 3.5
+	 *
+	 * @param array ...$arrays Lists of new options.
+	 * @return self
+	 */
+	public function merge( array ...$arrays ) {
+		$options = array_merge( ...$arrays );
+
+		// Whitelist options.
+		$options = array_intersect_key( $options, self::DEFAULTS );
+
+		// Cast/sanitize options.
+		foreach ( $options as $offset => $value ) {
+			$this->sanitize_and_set( $offset, $value );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Stores the options into the database.
+	 *
+	 * @since 3.5
+	 *
+	 * @return bool True if the options were updated, false otherwise.
+	 */
+	public function save() {
+		if ( ! $this->modified[ $this->current_blog_id ] ) {
+			return false;
+		}
+
+		$this->modified[ $this->current_blog_id ] = false;
+		return update_option( self::OPTION_NAME, $this->options[ $this->current_blog_id ] );
+	}
+
+	/**
+	 * Returns all options.
+	 *
+	 * @since 3.5
+	 *
+	 * @return mixed[]
+	 *
+	 * @phpstan-return OptionsData
+	 */
+	public function get_all() {
+		return $this->options[ $this->current_blog_id ];
+	}
+
+	/**
+	 * Returns reset options.
+	 *
+	 * @since 3.5
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return ResetOptionsData
+	 */
+	public static function get_reset_options() {
+		/** @var ResetOptionsData */
+		return array_merge(
+			self::DEFAULTS,
+			/**
+			 * Other entries that are kept in their default value:
+			 * - browser:       false   The default language for the front page is not set by browser preference (was the opposite before 3.1).
+			 * - media_support: false   Do not support languages and translation for media by default (was the opposite before 3.1).
+			 * - redirect_lang: false   Do not redirect the language page to the homepage.
+			 * - sync:          array() Synchronisation is disabled by default (was the opposite before 1.2).
+			 * - uninstall:     false,  Do not remove data when uninstalling Polylang.
+			 */
+			array(
+				'first_activation' => time(),
+				'force_lang'       => 1,    // Add URL language information (was 0 before 1.7).
+				'hide_default'     => true, // Remove URL language information for default language (was the opposite before 2.1.5).
+				'rewrite'          => true, // Remove /language/ in permalinks (was the opposite before 0.7.2).
+				'version'          => POLYLANG_VERSION,
+			)
+		);
+	}
+
+	/**
+	 * Tells if an option exists.
+	 * Required by interface `ArrayAccess`.
+	 *
+	 * @since 3.5
+	 *
+	 * @param string $offset The name of the option to check for.
+	 * @return bool
+	 *
+	 * @phpstan-param key-of<self::DEFAULTS> $offset
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetExists( $offset ) {
+		return isset( $this->options[ $this->current_blog_id ][ $offset ] );
+	}
+
+	/**
+	 * Returns the value of the specified option.
+	 * Required by interface `ArrayAccess`.
+	 *
+	 * @since 3.5
+	 *
+	 * @param string $offset The name of the option to retrieve.
+	 * @return mixed
+	 *
+	 * @phpstan-param key-of<self::DEFAULTS> $offset
+	 * @phpstan-return (
+	 *     $offset is BoolDataKeys ? bool : (
+	 *         $offset is ListDataKeys ? list<non-falsy-string> : (
+	 *             $offset is StringDataKeys ? string : (
+	 *                 $offset is 'force_lang' ? int-mask<0, 1, 2, 3> : (
+	 *                     $offset is 'first_activation' ? int<0, max> : (
+	 *                         $offset is 'media' ? array<non-falsy-string, 1> : (
+	 *                             $offset is 'domains' ? array<non-falsy-string, non-falsy-string> : (
+	 *                                 $offset is 'nav_menus' ? NavMenuType : null
+	 *                             )
+	 *                         )
+	 *                     )
+	 *                 )
+	 *             )
+	 *         )
+	 *     )
+	 * )
+	 */
+	#[\ReturnTypeWillChange]
+	public function &offsetGet( $offset ) {
+		if ( ! isset( $this->options[ $this->current_blog_id ][ $offset ] ) ) {
+			return null;
+		}
+
+		return $this->options[ $this->current_blog_id ][ $offset ];
+	}
+
+	/**
+	 * Assigns a value to the specified option.
+	 * This doesn't allow to set an unknown option.
+	 * Required by interface `ArrayAccess`.
+	 *
+	 * @since 3.5
+	 *
+	 * @param string $offset The name of the option to assign the value to.
+	 * @param mixed  $value  The value to set.
+	 * @return void
+	 *
+	 * @phpstan-param key-of<self::DEFAULTS> $offset
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetSet( $offset, $value ) {
+		if ( ! isset( self::DEFAULTS[ $offset ] ) ) {
+			return;
+		}
+
+		$this->sanitize_and_set( $offset, $value );
+	}
+
+	/**
+	 * Resets an option.
+	 * Also sets the property `$modified` if the value changes.
+	 * This doesn't allow to unset an option, this resets it to its default value instead.
+	 * Required by interface `ArrayAccess`.
+	 *
+	 * @since 3.5
+	 *
+	 * @param string $offset The name of the option to unset.
+	 * @return void
+	 *
+	 * @phpstan-param key-of<self::DEFAULTS> $offset
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetUnset( $offset ) {
+		if ( ! isset( self::DEFAULTS[ $offset ] ) || self::DEFAULTS[ $offset ] === $this->options[ $this->current_blog_id ][ $offset ] ) {
+			return;
+		}
+
+		$this->options[ $this->current_blog_id ][ $offset ] = self::DEFAULTS[ $offset ];
+		$this->modified[ $this->current_blog_id ] = true;
+	}
+
+	/**
+	 * Returns the number of options.
+	 * Required by interface `Countable`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return int
+	 */
+	#[\ReturnTypeWillChange]
+	public function count() {
+		return count( $this->options[ $this->current_blog_id ] );
+	}
+
+	/**
+	 * Returns the value of the current option.
+	 * Required by interface `Iterator`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return mixed
+	 *
+	 * @phpstan-return bool|list<non-falsy-string>|string|int-mask<0, 1, 2, 3>|int<0, max>|array<non-falsy-string, 1>|array<non-falsy-string, non-falsy-string>|NavMenuType
+	 */
+	#[\ReturnTypeWillChange]
+	public function current() {
+		return $this->options[ $this->current_blog_id ][ $this->option_keys[ $this->position ] ];
+	}
+
+	/**
+	 * Returns the key of the current option.
+	 * Required by interface `Iterator`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return string
+	 *
+	 * @phpstan-return key-of<self::DEFAULTS>
+	 */
+	#[\ReturnTypeWillChange]
+	public function key() {
+		return $this->option_keys[ $this->position ];
+	}
+
+	/**
+	 * Moves forward to next option.
+	 * Required by interface `Iterator`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return void
+	 */
+	#[\ReturnTypeWillChange]
+	public function next() {
+		++$this->position;
+	}
+
+	/**
+	 * Rewinds the Iterator to the first option.
+	 * Required by interface `Iterator`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return void
+	 */
+	#[\ReturnTypeWillChange]
+	public function rewind() {
+		$this->position = 0;
+	}
+
+	/**
+	 * Checks if current position is valid.
+	 * Required by interface `Iterator`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return bool
+	 */
+	#[\ReturnTypeWillChange]
+	public function valid() {
+		return isset( $this->option_keys[ $this->position ] );
+	}
+
+	/**
+	 * Returns the data which can be serialized by `json_encode()`.
+	 *
+	 * @since 3.5
+	 *
+	 * @return mixed[]
+	 *
+	 * @phpstan-return OptionsData
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+		return $this->options[ $this->current_blog_id ];
+	}
+
+	/**
+	 * Type-casts/Sanitizes the given option value and sets it in the property.
+	 * Also sets the property `$modified` if the value changes.
+	 * This doesn't do a full sanitization, only basic type-cast.
+	 *
+	 * @since 3.5
+	 *
+	 * @param string $offset The name of the option to sanitize.
+	 * @param mixed  $value  The value to sanitize.
+	 * @return void
+	 *
+	 * @phpstan-param key-of<self::DEFAULTS> $offset
+	 */
+	private function sanitize_and_set( $offset, $value ) {
+		$prev = $this->options[ $this->current_blog_id ][ $offset ];
+
+		switch ( $offset ) {
+			// String.
+			case 'default_lang':
+			case 'previous_version':
+			case 'version':
+				if ( ! is_string( $value ) ) {
+					// Invalid.
+					return;
+				}
+
+				$this->options[ $this->current_blog_id ][ $offset ] = $value;
+				break;
+
+			// Bool.
+			case 'browser':
+			case 'hide_default':
+			case 'media_support':
+			case 'redirect_lang':
+			case 'rewrite':
+			case 'uninstall':
+				$this->options[ $this->current_blog_id ][ $offset ] = ! empty( $value );
+				break;
+
+			// Int-mask<0, 1, 2, 3>.
+			case 'force_lang':
+				if ( ! is_numeric( $value ) || $value < 0 || $value > 3 ) {
+					// Invalid.
+					return;
+				}
+
+				/** @var int-mask<0, 1, 2, 3> $value */
+				$this->options[ $this->current_blog_id ][ $offset ] = (int) $value;
+				break;
+
+			// Int<0, max>.
+			case 'first_activation':
+				if ( ! is_numeric( $value ) || $value < 0 ) {
+					// Invalid.
+					return;
+				}
+
+				/** @var int<0, max> $value */
+				$this->options[ $this->current_blog_id ][ $offset ] = (int) $value;
+				break;
+
+			// Array with non falsy strings as array keys and values.
+			case 'domains':
+				if ( ! is_array( $value ) ) {
+					// Invalid.
+					return;
+				}
+
+				$this->options[ $this->current_blog_id ][ $offset ] = array_filter(
+					$value,
+					function( $v, $k ) {
+						return is_string( $v ) && ! empty( $v ) && is_string( $k ) && ! empty( $k );
+					},
+					ARRAY_FILTER_USE_BOTH
+				);
+				break;
+
+			// List with non falsy strings as array values.
+			case 'post_types':
+			case 'sync':
+			case 'taxonomies':
+				if ( ! is_array( $value ) ) {
+					// Invalid.
+					return;
+				}
+
+				$this->options[ $this->current_blog_id ][ $offset ] = array_values(
+					array_filter(
+						$value,
+						function( $v ) {
+							return is_string( $v ) && ! empty( $v );
+						}
+					)
+				);
+				break;
+
+			// Array with non falsy strings as array keys.
+			case 'media':
+			case 'nav_menus':
+				if ( ! is_array( $value ) ) {
+					// Invalid.
+					return;
+				}
+
+				$this->options[ $this->current_blog_id ][ $offset ] = array_filter(
+					$value,
+					function ( $v, $k ) {
+						return is_string( $k ) && ! empty( $k );
+					},
+					ARRAY_FILTER_USE_BOTH
+				);
+				break;
+		}
+
+		if ( $prev !== $this->options[ $this->current_blog_id ][ $offset ] ) {
+			$this->modified[ $this->current_blog_id ] = true;
+		}
+	}
+}

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -106,7 +106,7 @@ class PLL_REST_Request extends PLL_Base {
 		if ( ! empty( $lang ) && is_string( $lang ) ) {
 			$this->curlang = $this->model->get_language( sanitize_key( $lang ) );
 
-			if ( empty( $this->curlang ) && ! empty( $this->options['default_lang'] ) && is_string( $this->options['default_lang'] ) ) {
+			if ( empty( $this->curlang ) && ! empty( $this->options['default_lang'] ) ) {
 				// A lang has been requested but it is invalid, let's fall back to the default one.
 				$this->curlang = $this->model->get_language( sanitize_key( $this->options['default_lang'] ) );
 			}

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -24,13 +24,6 @@ class PLL_Static_Pages {
 	public $page_for_posts = 0;
 
 	/**
-	 * Stores the plugin options.
-	 *
-	 * @var PLL_Options
-	 */
-	protected $options;
-
-	/**
 	 * @var PLL_Model
 	 */
 	protected $model;

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -24,6 +24,13 @@ class PLL_Static_Pages {
 	public $page_for_posts = 0;
 
 	/**
+	 * Stores the plugin options.
+	 *
+	 * @var PLL_Options
+	 */
+	protected $options;
+
+	/**
 	 * @var PLL_Model
 	 */
 	protected $model;

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -123,7 +123,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 		if ( false === $post_types ) {
 			$post_types = array( 'post' => 'post', 'page' => 'page', 'wp_block' => 'wp_block' );
 
-			if ( ! empty( $this->model->options['post_types'] ) && is_array( $this->model->options['post_types'] ) ) {
+			if ( ! empty( $this->model->options['post_types'] ) ) {
 				$post_types = array_merge( $post_types, array_combine( $this->model->options['post_types'], $this->model->options['post_types'] ) );
 			}
 

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -198,7 +198,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		if ( false === $taxonomies ) {
 			$taxonomies = array( 'category' => 'category', 'post_tag' => 'post_tag' );
 
-			if ( ! empty( $this->model->options['taxonomies'] ) && is_array( $this->model->options['taxonomies'] ) ) {
+			if ( ! empty( $this->model->options['taxonomies'] ) ) {
 				$taxonomies = array_merge( $taxonomies, array_combine( $this->model->options['taxonomies'], $this->model->options['taxonomies'] ) );
 			}
 

--- a/install/install-base.php
+++ b/install/install-base.php
@@ -131,4 +131,40 @@ class PLL_Install_Base {
 		$this->_activate();
 		restore_current_blog();
 	}
+
+	/**
+	 * Returns the plugin's options.
+	 *
+	 * @since 3.5
+	 *
+	 * @return PLL_Options|array
+	 */
+	protected function get_options() {
+		if ( function_exists( 'PLL' ) && isset( PLL()->model, PLL()->model->options ) ) {
+			return PLL()->model->options;
+		}
+
+		return (array) get_option( PLL_Options::OPTION_NAME, array() );
+	}
+
+	/**
+	 * Updates the plugin's options.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $options The options.
+	 * @return void
+	 */
+	protected function update_options( array $options ) {
+		if ( function_exists( 'PLL' ) && isset( PLL()->model, PLL()->model->options ) ) {
+			/**
+			 * The call to `save()` is necessary when in `switch_to_blog()` (see `PLL_Install_Base::do_for_all_blogs()`
+			 * and `PLL_Install_Base::new_site()`) because it avoids `PLL_Options::save_all()` to do another
+			 * `switch_to_blog()` loop.
+			 */
+			PLL()->model->options->merge( $options )->save();
+		} else {
+			update_option( PLL_Options::OPTION_NAME, $options );
+		}
+	}
 }

--- a/install/install-base.php
+++ b/install/install-base.php
@@ -140,8 +140,8 @@ class PLL_Install_Base {
 	 * @return PLL_Options|array
 	 */
 	protected function get_options() {
-		if ( function_exists( 'PLL' ) && isset( PLL()->model, PLL()->model->options ) ) {
-			return PLL()->model->options;
+		if ( isset( $GLOBALS['polylang'], $GLOBALS['polylang']->model, $GLOBALS['polylang']->model->options ) ) {
+			return $GLOBALS['polylang']->model->options;
 		}
 
 		return (array) get_option( PLL_Options::OPTION_NAME, array() );
@@ -156,13 +156,13 @@ class PLL_Install_Base {
 	 * @return void
 	 */
 	protected function update_options( array $options ) {
-		if ( function_exists( 'PLL' ) && isset( PLL()->model, PLL()->model->options ) ) {
+		if ( isset( $GLOBALS['polylang'], $GLOBALS['polylang']->model, $GLOBALS['polylang']->model->options ) ) {
 			/**
 			 * The call to `save()` is necessary when in `switch_to_blog()` (see `PLL_Install_Base::do_for_all_blogs()`
 			 * and `PLL_Install_Base::new_site()`) because it avoids `PLL_Options::save_all()` to do another
 			 * `switch_to_blog()` loop.
 			 */
-			PLL()->model->options->merge( $options )->save();
+			$GLOBALS['polylang']->model->options->merge( $options )->save();
 		} else {
 			update_option( PLL_Options::OPTION_NAME, $options );
 		}

--- a/install/install.php
+++ b/install/install.php
@@ -7,6 +7,8 @@
  * Polylang activation / de-activation class
  *
  * @since 1.7
+ *
+ * @phpstan-import-type ResetOptionsData from PLL_Options
  */
 class PLL_Install extends PLL_Install_Base {
 
@@ -85,23 +87,11 @@ class PLL_Install extends PLL_Install_Base {
 	 * @since 1.8
 	 *
 	 * @return array
+	 *
+	 * @phpstan-return ResetOptionsData
 	 */
 	public static function get_default_options() {
-		return array(
-			'browser'          => 0, // Default language for the front page is not set by browser preference (was the opposite before 3.1).
-			'rewrite'          => 1, // Remove /language/ in permalinks (was the opposite before 0.7.2).
-			'hide_default'     => 1, // Remove URL language information for default language (was the opposite before 2.1.5).
-			'force_lang'       => 1, // Add URL language information (was 0 before 1.7).
-			'redirect_lang'    => 0, // Do not redirect the language page to the homepage.
-			'media_support'    => 0, // Do not support languages and translation for media by default (was the opposite before 3.1).
-			'uninstall'        => 0, // Do not remove data when uninstalling Polylang.
-			'sync'             => array(), // Synchronisation is disabled by default (was the opposite before 1.2).
-			'post_types'       => array(),
-			'taxonomies'       => array(),
-			'domains'          => array(),
-			'version'          => POLYLANG_VERSION,
-			'first_activation' => time(),
-		);
+		return PLL_Options::get_reset_options();
 	}
 
 	/**
@@ -112,16 +102,16 @@ class PLL_Install extends PLL_Install_Base {
 	 * @return void
 	 */
 	protected function _activate() {
-		if ( $options = get_option( 'polylang' ) ) {
-			// Check if we will be able to upgrade
-			if ( version_compare( $options['version'], POLYLANG_VERSION, '<' ) ) {
+		$options = $this->get_options();
+
+		if ( empty( $options['version'] ) ) {
+			// Defines default values for options in case this is the first installation.
+			$this->update_options( PLL_Options::get_reset_options() );
+		}
+		elseif ( version_compare( $options['version'], POLYLANG_VERSION, '<' ) ) {
+			// Check if we will be able to upgrade.
 				$upgrade = new PLL_Upgrade( $options );
 				$upgrade->can_activate();
-			}
-		}
-		// Defines default values for options in case this is the first installation
-		else {
-			update_option( 'polylang', self::get_default_options() );
 		}
 
 		// Avoid 1 query on every pages if no wpml strings is registered

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -9,10 +9,11 @@
  * @since 1.2
  */
 class PLL_Upgrade {
+
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 
@@ -21,9 +22,9 @@ class PLL_Upgrade {
 	 *
 	 * @since 1.2
 	 *
-	 * @param array $options Polylang options
+	 * @param PLL_Options $options Polylang options
 	 */
-	public function __construct( &$options ) {
+	public function __construct( PLL_Options &$options ) {
 		$this->options = &$options;
 	}
 
@@ -115,7 +116,6 @@ class PLL_Upgrade {
 
 		$this->options['previous_version'] = $this->options['version']; // Remember the previous version of Polylang since v1.7.7
 		$this->options['version'] = POLYLANG_VERSION;
-		update_option( 'polylang', $this->options );
 	}
 
 	/**

--- a/integrations/domain-mapping/domain-mapping.php
+++ b/integrations/domain-mapping/domain-mapping.php
@@ -37,10 +37,8 @@ class PLL_Domain_Mapping {
 	 * @since 2.2
 	 */
 	public function dm_redirect_to_mapped_domain() {
-		$options = get_option( 'polylang' );
-
 		// The language is set from the subdomain or domain name
-		if ( $options['force_lang'] > 1 ) {
+		if ( PLL()->options['force_lang'] > 1 ) {
 			// Don't go further if we stopped loading the plugin early ( for example when deactivate-polylang=1 ).
 			if ( ! function_exists( 'PLL' ) ) {
 				return;
@@ -70,7 +68,7 @@ class PLL_Domain_Mapping {
 
 			if ( empty( $lang ) ) {
 				$status   = get_site_option( 'dm_301_redirect' ) ? '301' : '302'; // Honor status redirect option
-				$redirect = str_replace( '://' . $requested_host, '://' . $hosts[ $options['default_lang'] ], $requested_url );
+				$redirect = str_replace( '://' . $requested_host, '://' . $hosts[ PLL()->options['default_lang'] ], $requested_url );
 				wp_safe_redirect( $redirect, $status );
 				exit;
 			}

--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -44,7 +44,6 @@ class PLL_WP_Import extends WP_Import {
 			$languages = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false, 'orderby' => 'term_id' ) );
 			$default_lang = reset( $languages );
 			PLL()->options['default_lang'] = $default_lang->slug;
-			update_option( 'polylang', PLL()->options );
 		}
 
 		// Clean languages cache in case some of them were created during import.

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -22,7 +22,7 @@ class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 

--- a/modules/sync/settings-sync.php
+++ b/modules/sync/settings-sync.php
@@ -41,7 +41,6 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 */
 	public function deactivate() {
 		$this->options['sync'] = array();
-		update_option( 'polylang', $this->options );
 	}
 
 	/**

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -12,7 +12,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -13,7 +13,7 @@ class PLL_Sync_Tax {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -27,7 +27,7 @@ class PLL_Sync {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 

--- a/modules/wizard/view-wizard-step-media.php
+++ b/modules/wizard/view-wizard-step-media.php
@@ -11,10 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Don't access directly.
 };
 
-$default_options = PLL_Install::get_default_options();
-$options = wp_parse_args( get_option( 'polylang' ), $default_options );
-$media_support = $options['media_support'];
-
 $help_screenshot = '/modules/wizard/images/media-screen' . ( is_rtl() ? '-rtl' : '' ) . '.png';
 
 ?>
@@ -35,7 +31,7 @@ $help_screenshot = '/modules/wizard/images/media-screen' . ( is_rtl() ? '-rtl' :
 					id="pll-wizard-service-media"
 					type="checkbox"
 					name="media_support"
-					value="yes" <?php checked( $media_support ); ?>
+					value="yes" <?php checked( $this->options['media_support'] ); ?>
 				/>
 				<label for="pll-wizard-service-media" />
 			</span>

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -19,7 +19,7 @@ class PLL_Wizard {
 	/**
 	 * Reference to the Polylang options array.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	protected $options;
 
@@ -86,9 +86,9 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public static function start_wizard( $network_wide ) {
-		$options = get_option( 'polylang' );
+		$options = (array) get_option( PLL_Options::OPTION_NAME, array() );
 
-		if ( wp_doing_ajax() || $network_wide || ! empty( $options ) ) {
+		if ( wp_doing_ajax() || $network_wide || ! empty( $options['version'] ) ) {
 			return;
 		}
 		set_transient( 'pll_activation_redirect', 1, 30 );
@@ -638,8 +638,6 @@ class PLL_Wizard {
 		$media_support = isset( $_POST['media_support'] ) ? sanitize_key( $_POST['media_support'] ) === 'yes' : false;
 
 		$this->options['media_support'] = $media_support;
-
-		update_option( 'polylang', $this->options );
 
 		wp_safe_redirect( esc_url_raw( $this->get_next_step_link() ) );
 		exit;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -551,16 +551,6 @@ parameters:
 			path: include/base.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:get_links_model\\(\\)\\.$#"
-			count: 1
-			path: include/class-polylang.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:has_languages\\(\\)\\.$#"
-			count: 2
-			path: include/class-polylang.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:init\\(\\)\\.$#"
 			count: 1
 			path: include/class-polylang.php
@@ -692,11 +682,6 @@ parameters:
 
 		-
 			message: "#^Method PLL_Links_Domain\\:\\:add_language_to_link\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: include/links-domain.php
-
-		-
-			message: "#^Method PLL_Links_Domain\\:\\:get_hosts\\(\\) should return array\\<string\\> but returns array\\<string, string\\|false\\>\\.$#"
 			count: 1
 			path: include/links-domain.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -551,9 +551,14 @@ parameters:
 			path: include/base.php
 
 		-
-			message: "#^Property PLL_Base\\:\\:\\$options \\(array\\) does not accept mixed\\.$#"
+			message: "#^Call to an undefined method object\\:\\:get_links_model\\(\\)\\.$#"
 			count: 1
-			path: include/base.php
+			path: include/class-polylang.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:has_languages\\(\\)\\.$#"
+			count: 2
+			path: include/class-polylang.php
 
 		-
 			message: "#^Call to an undefined method object\\:\\:init\\(\\)\\.$#"
@@ -561,12 +566,7 @@ parameters:
 			path: include/class-polylang.php
 
 		-
-			message: "#^Cannot access offset 'version' on mixed\\.$#"
-			count: 1
-			path: include/class-polylang.php
-
-		-
-			message: "#^Parameter \\#1 \\$version1 of function version_compare expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$.+ of function trim expects string, string\\|null given\\.$#"
 			count: 1
 			path: include/class-polylang.php
 
@@ -696,6 +696,11 @@ parameters:
 			path: include/links-domain.php
 
 		-
+			message: "#^Method PLL_Links_Domain\\:\\:get_hosts\\(\\) should return array\\<string\\> but returns array\\<string, string\\|false\\>\\.$#"
+			count: 1
+			path: include/links-domain.php
+
+		-
 			message: "#^Method PLL_Links_Domain\\:\\:remove_language_from_link\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: include/links-domain.php
@@ -751,7 +756,7 @@ parameters:
 			path: include/model.php
 
 		-
-			message: "#^Method PLL_Nav_Menu\\:\\:explode_location\\(\\) should return array\\<string\\> but returns array\\<string, mixed\\>\\|false\\.$#"
+			message: "#^Method PLL_Nav_Menu\\:\\:explode_location\\(\\) should return array\\<string\\> but returns array\\<string, string\\>\\|false\\.$#"
 			count: 1
 			path: include/nav-menu.php
 
@@ -839,16 +844,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, bool\\|string given\\.$#"
 			count: 1
 			path: include/widget-languages.php
-
-		-
-			message: "#^Cannot access offset 'version' on mixed\\.$#"
-			count: 1
-			path: install/install.php
-
-		-
-			message: "#^Parameter \\#1 \\$version1 of function version_compare expects string, mixed given\\.$#"
-			count: 1
-			path: install/install.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$_last_checked\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -556,11 +556,6 @@ parameters:
 			path: include/class-polylang.php
 
 		-
-			message: "#^Parameter \\#1 \\$.+ of function trim expects string, string\\|null given\\.$#"
-			count: 1
-			path: include/class-polylang.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$options\\.$#"
 			count: 1
 			path: include/crud-posts.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,13 +46,13 @@ parameters:
 
 		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array<string, string\\>\\|false given\\.$#"
 			count: 1
 			path: include/translated-post.php
 
 		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array<string, string\\>\\|false given\\.$#"
 			count: 1
 			path: include/translated-term.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,3 +61,9 @@ parameters:
 			message: "#^Call to static method encode\\(\\) on an unknown class Requests_IDNAEncoder\\.$#"
 			count: 1
 			path: include/links-domain.php
+
+		# Ignored because PHPStan doesn't understand what happens with union types here: `$this->options[ $this->current_blog_id ][ $offset ] = self::DEFAULTS[ $offset ];`.
+		-
+			message: "#^Property PLL_Options::\\$options \\(array.+\\) does not accept non-empty-array<.+>\\.$#"
+			count: 1
+			path: include/options.php

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -166,7 +166,6 @@ class PLL_Settings_Module {
 	public function activate() {
 		if ( ! empty( $this->active_option ) ) {
 			$this->options[ $this->active_option ] = true;
-			update_option( 'polylang', $this->options );
 		}
 	}
 
@@ -180,7 +179,6 @@ class PLL_Settings_Module {
 	public function deactivate() {
 		if ( ! empty( $this->active_option ) ) {
 			$this->options[ $this->active_option ] = false;
-			update_option( 'polylang', $this->options );
 		}
 	}
 

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -12,7 +12,7 @@ class PLL_Settings_Module {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var PLL_Options
 	 */
 	public $options;
 
@@ -31,7 +31,8 @@ class PLL_Settings_Module {
 	/**
 	 * Stores if the module is active.
 	 *
-	 * @var bool
+	 * @var string|false
+	 * @phpstan-var key-of<PLL_Options::DEFAULTS>|false
 	 */
 	public $active_option;
 
@@ -240,9 +241,7 @@ class PLL_Settings_Module {
 		if ( isset( $_POST['module'] ) && $this->module === $_POST['module'] ) {
 			// It's up to the child class to decide which options are saved, whether there are errors or not
 			$post = array_diff_key( $_POST, array_flip( array( 'action', 'module', 'pll_ajax_backend', '_pll_nonce' ) ) );
-			$options = $this->update( $post );
-			$this->options = array_merge( $this->options, $options );
-			update_option( 'polylang', $this->options );
+			$this->options->merge( $this->update( $post ) );
 
 			// Refresh language cache in case home urls have been modified
 			$this->model->clean_languages_cache();

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -124,7 +124,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			<?php
 			printf(
 				'<input name="hide_default" type="checkbox" value="1" %s /> %s',
-				checked( $this->options['hide_default'], 1, false ),
+				checked( $this->options['hide_default'], true, false ),
 				esc_html__( 'Hide URL language information for default language', 'polylang' )
 			);
 			?>
@@ -146,7 +146,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			printf(
 				'<input name="rewrite" type="radio" value="1" %s %s/> %s',
 				disabled( $this->links_model->using_permalinks, false, false ),
-				checked( $this->options['rewrite'], 1, false ),
+				checked( $this->options['rewrite'], true, false ),
 				esc_html__( 'Remove /language/ in pretty permalinks', 'polylang' )
 			);
 			?>
@@ -157,7 +157,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			printf(
 				'<input name="rewrite" type="radio" value="0" %s %s/> %s',
 				disabled( $this->links_model->using_permalinks, false, false ),
-				checked( $this->options['rewrite'], 0, false ),
+				checked( $this->options['rewrite'], false, false ),
 				esc_html__( 'Keep /language/ in pretty permalinks', 'polylang' )
 			);
 			?>
@@ -179,7 +179,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			<?php
 			printf(
 				'<input name="redirect_lang" type="checkbox" value="1" %s/> %s',
-				checked( $this->options['redirect_lang'], 1, false ),
+				checked( $this->options['redirect_lang'], true, false ),
 				esc_html__( 'The front page URL contains the language code instead of the page name or page id', 'polylang' )
 			);
 			?>
@@ -307,8 +307,8 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function check_domains( $options ) {
-		$options = array_merge( $this->options, $options );
-		$model = new PLL_Model( $options );
+		$this->options->merge( $options );
+		$model = new PLL_Model( $this->options );
 		$links_model = $model->get_links_model();
 		foreach ( $this->model->get_languages_list() as $lang ) {
 			$url = add_query_arg( 'deactivate-polylang', 1, $links_model->home_url( $lang ) );

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -14,7 +14,7 @@ abstract class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.
 		add_filter( 'wp_doing_ajax', '__return_false' );
 
-		$this->options = get_option( 'polylang' );
+		$this->options = new PLL_Options();
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -10,7 +10,7 @@ trait PLL_UnitTestCase_Trait {
 	use PLL_Doing_It_Wrong_Trait;
 
 	/**
-	 * @var array|null
+	 * @var PLL_Options|null
 	 */
 	protected $options;
 
@@ -57,9 +57,13 @@ trait PLL_UnitTestCase_Trait {
 	 * @param WP_UnitTest_Factory $factory WP_UnitTest_Factory object.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-		$options = PLL_Install::get_default_options();
-		$options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
-		$options['media_support'] = 1; // Force option to pre 3.1 value otherwise phpunit tests break on Travis.
+		$options = ( new PLL_Options() )->merge(
+			PLL_Options::get_reset_options(),
+			array(
+				'hide_default'  => false, // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
+				'media_support' => true,  // Force option to pre 3.1 value otherwise phpunit tests break on Travis.
+			)
+		);
 		self::$model = new PLL_Admin_Model( $options );
 
 		remove_action( 'current_screen', '_load_remote_block_patterns' );

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -10,7 +10,7 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress-importer/wordpress-importer.php'
 			require_once POLYLANG_DIR . '/include/api.php';
 
 			self::$model->options['hide_default'] = 0;
-			update_option( 'polylang', self::$model->options ); // make sure we have options in DB ( needed by PLL_WP_Import )
+			self::$model->options->save(); // Make sure we have options in DB (needed by PLL_WP_Import).
 
 			if ( ! defined( 'WP_IMPORTING' ) ) {
 				define( 'WP_IMPORTING', true );
@@ -79,7 +79,6 @@ if ( file_exists( DIR_TESTROOT . '/../wordpress-importer/wordpress-importer.php'
 			$importer->import( $file );
 			ob_end_clean();
 
-			self::$model->options = get_option( 'polylang' );
 			$_POST = array();
 		}
 

--- a/tests/phpunit/tests/test-admin-block-editor-test.php
+++ b/tests/phpunit/tests/test-admin-block-editor-test.php
@@ -18,7 +18,7 @@ class PLL_Admin_Block_Editor_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
+		$options = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Admin_Model( $options );
 		$links_model = new PLL_Links_Default( $model );
 		$this->pll_admin = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -136,11 +136,11 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 		$GLOBALS['polylang'] = &$this->pll_env;
 
-		$this->options = array_merge(
-			PLL_Install::get_default_options(),
+		$this->options->merge(
+			PLL_Options::get_reset_options(),
 			array(
 				'default_lang' => 'en',
-				'hide_default' => 0,
+				'hide_default' => false,
 				'post_types'   => array(
 					'pllcanonical'   => 'pllcanonical',
 					'cptnotrewrited' => 'cptnotrewrited',

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -4,8 +4,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-
-		$options       = PLL_Install::get_default_options();
+		$options       = ( new PLL_Options() )->merge( PLL_Options::get_reset_options() );
 		$model         = new PLL_Admin_Model( $options );
 		$links_model   = $model->get_links_model();
 		$this->pll_env = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -13,8 +13,8 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 
 		register_taxonomy( 'custom_tax', 'post' );
 
-		$options                = array_merge(
-			PLL_Install::get_default_options(),
+		$options                = ( new PLL_Options() )->merge(
+			PLL_Options::get_reset_options(),
 			array(
 				'default_lang' => 'en',
 				'taxonomies'   => array( 'custom_tax' => 'custom_tax' ),

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -25,9 +25,9 @@ class Flags_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options       = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
-		$model         = new PLL_Model( $options );
-		$links_model   = new PLL_Links_Default( $model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
+		$options     = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
+		$model       = new PLL_Model( $options );
+		$links_model = new PLL_Links_Default( $model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -3,16 +3,25 @@
 class Install_Test extends PLL_UnitTestCase {
 
 	public function test_activate() {
-		delete_option( 'polylang' );
+		$links_model         = self::$model->get_links_model();
+		$GLOBALS['polylang'] = new PLL_Settings( $links_model );
+		self::$model->options->merge(
+			array(
+				'hide_default' => false,
+				'force_lang'   => 0,
+				'uninstall'    => true,
+				'sync'         => array( 'foo', 'bar' ),
+				'version'      => '',
+			)
+		);
 		do_action( 'activate_' . POLYLANG_BASENAME );
 
 		// Check a few options
-		$options = get_option( 'polylang' );
-		$this->assertEquals( 1, $options['hide_default'] );
-		$this->assertEquals( 1, $options['force_lang'] );
-		$this->assertEquals( 0, $options['uninstall'] );
-		$this->assertEmpty( $options['sync'] );
-		$this->assertEquals( POLYLANG_VERSION, $options['version'] );
+		$this->assertTrue( self::$model->options['hide_default'] );
+		$this->assertSame( 1, self::$model->options['force_lang'] );
+		$this->assertFalse( self::$model->options['uninstall'] );
+		$this->assertEmpty( self::$model->options['sync'] );
+		$this->assertSame( POLYLANG_VERSION, self::$model->options['version'] );
 	}
 
 	/**
@@ -25,7 +34,7 @@ class Install_Test extends PLL_UnitTestCase {
 			define( 'WP_UNINSTALL_PLUGIN', true );
 		}
 
-		do_action( 'activate_' . POLYLANG_BASENAME );
+		update_option( 'polylang', PLL_Options::get_reset_options() );
 
 		include_once dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php';
 		new PLL_Uninstall();
@@ -41,7 +50,7 @@ class Install_Test extends PLL_UnitTestCase {
 	public function test_uninstall_removing_data() {
 		global $wpdb;
 
-		do_action( 'activate_' . POLYLANG_BASENAME );
+		update_option( 'polylang', PLL_Options::get_reset_options() );
 
 		self::create_language( 'en_US' );
 		$english = self::$model->get_language( 'en' );

--- a/tests/phpunit/tests/test-languages-list.php
+++ b/tests/phpunit/tests/test-languages-list.php
@@ -3,9 +3,8 @@
 class Languages_List_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		self::create_language( 'en_US' );
-		$options                 = PLL_Install::get_default_options();
-		$options['default_lang'] = 'en';
-		$this->pll_model         = new PLL_Admin_Model( $options );
+		$options         = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
+		$this->pll_model = new PLL_Admin_Model( $options );
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -15,7 +15,7 @@ class Media_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options                        = array_merge( PLL_Install::get_default_options(), array( 'media_support' => 1, 'default_lang' => 'en' ) );
+		$options                        = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'media_support' => 1, 'default_lang' => 'en' ) );
 		$model                          = new PLL_Admin_Model( $options );
 		$links_model                    = new PLL_Links_Default( $model );
 		$this->pll_admin                = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -143,8 +143,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // our filter update_nav_menu_locations does not run due to security checks
 
-		$options = get_option( 'polylang' );
-		$this->assertEquals( array( 'en' => $menu_en, 'fr' => $menu_fr ), $options['nav_menus'][ $theme ][ $primary_location ] );
+		$this->assertEquals( array( 'en' => $menu_en, 'fr' => $menu_fr ), self::$model->options['nav_menus'][ $theme ][ $primary_location ] );
 
 		// setup filters
 		$nav_menu->admin_init();
@@ -152,8 +151,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		// delete a nav_menu
 		wp_delete_nav_menu( $menu_en );
 
-		$options = get_option( 'polylang' );
-		$this->assertEquals( array( 'fr' => $menu_fr ), $options['nav_menus'][ $theme ][ $primary_location ] );
+		$this->assertEquals( array( 'fr' => $menu_fr ), self::$model->options['nav_menus'][ $theme ][ $primary_location ] );
 	}
 
 	public function test_auto_add_pages_to_menu() {
@@ -425,8 +423,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		);
 
 		$mods = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
-		$options = get_option( 'polylang' );
-		$this->assertEqualSets( array( 'en' => 2, 'fr' => 3 ), $options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
+		$this->assertEqualSets( array( 'en' => 2, 'fr' => 3 ), self::$model->options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
 		$options = get_option( 'theme_mods_' . get_stylesheet() );
 		$this->assertEquals( 2, $options['nav_menu_locations'][ $primary_location ] );
 	}
@@ -455,8 +452,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'save-menu-locations' );
 
 		$mods = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
-		$options = get_option( 'polylang' );
-		$this->assertEqualSets( array( 'en' => 4, 'fr' => 5 ), $options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
+		$this->assertEqualSets( array( 'en' => 4, 'fr' => 5 ), self::$model->options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
 		$options = get_option( 'theme_mods_' . get_stylesheet() );
 		$this->assertEquals( 4, $options['nav_menu_locations'][ $primary_location ] );
 	}

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -37,13 +37,16 @@ class Single_Language_Test extends PLL_UnitTestCase {
 	public function test_front_page() {
 		global $wp_rewrite;
 
-		$options                  = PLL_Install::get_default_options();
-		$options['redirect_lang'] = 1;
-		$options['hide_default']  = 0;
-		$options['force_lang']    = 1;
-		$options['rewrite']       = 1;
-		$options['default_lang']  = 'en';
-		$model                    = new PLL_Model( $options );
+		$options = ( new PLL_Options() )->merge(
+			PLL_Options::get_reset_options(),
+			array(
+				'default_lang'  => 'en',
+				'hide_default'  => false,
+				'redirect_lang' => true,
+				'version'       => '3.3',
+			)
+		);
+		$model   = new PLL_Model( $options );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $this->home_en );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -15,8 +15,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options                       = ( new PLL_Options() )->merge( PLL_Options::get_reset_options() );
-		$options['default_lang']       = 'en'; // Default language is the first one created, see self::wpSetUpBeforeClass().
+		$options                       = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
 		$model                         = new PLL_Admin_Model( $options );
 		$links_model                   = new PLL_Links_Default( $model );
 		$this->pll_admin               = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -15,7 +15,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options                       = PLL_Install::get_default_options();
+		$options                       = ( new PLL_Options() )->merge( PLL_Options::get_reset_options() );
 		$options['default_lang']       = 'en'; // Default language is the first one created, see self::wpSetUpBeforeClass().
 		$model                         = new PLL_Admin_Model( $options );
 		$links_model                   = new PLL_Links_Default( $model );

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -238,8 +238,8 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 	 * @covers PLL_Translated_Post::get_db_infos()
 	 */
 	public function test_get_db_infos() {
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
-		$model = new PLL_Model( $options );
+		$options = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
+		$model   = new PLL_Model( $options );
 
 		$ref = new ReflectionMethod( $model->post, 'get_db_infos' );
 		$ref->setAccessible( true );

--- a/tests/phpunit/tests/test-translated-post.php
+++ b/tests/phpunit/tests/test-translated-post.php
@@ -226,7 +226,7 @@ class Translated_Post_Test extends PLL_Translated_Object_UnitTestCase {
 	 * @covers PLL_Translated_Object::save_translations()
 	 */
 	public function test_dont_save_translations_with_incorrect_language() {
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
+		$options = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Model( $options );
 		$model->post = new PLL_Translated_Post( $model );
 

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -105,7 +105,7 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 	}
 
 	public function test_dont_save_translations_with_incorrect_language() {
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
+		$options = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Model( $options );
 		$model->term = new PLL_Translated_Term( $model );
 

--- a/tests/phpunit/tests/test-translated-term.php
+++ b/tests/phpunit/tests/test-translated-term.php
@@ -117,8 +117,8 @@ class Translated_Term_Test extends PLL_Translated_Object_UnitTestCase {
 	 * @covers PLL_Translated_Term::get_db_infos()
 	 */
 	public function test_get_db_infos() {
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
-		$model = new PLL_Model( $options );
+		$options = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
+		$model   = new PLL_Model( $options );
 
 		$ref = new ReflectionMethod( $model->term, 'get_db_infos' );
 		$ref->setAccessible( true );

--- a/tests/phpunit/tests/test-upgrade.php
+++ b/tests/phpunit/tests/test-upgrade.php
@@ -17,10 +17,13 @@ class Upgrade_Test extends PLL_UnitTestCase {
 		update_user_meta( get_current_user_id(), 'pll_filter_content', 'en' );
 		remove_all_actions( 'admin_init' ); // Avoid to send WP headers when calling `do_action( 'admin_init' )`.
 
-		$options                 = PLL_Install::get_default_options();
-		$options['version']      = '3.3';
-		$options['default_lang'] = 'en';
-		update_option( 'polylang', $options );
+		$options     = ( new PLL_Options() )->merge(
+			PLL_Options::get_reset_options(),
+			array(
+				'default_lang' => 'en',
+				'version'      => '3.3',
+			)
+		);
 		$model       = new PLL_Admin_Model( $options );
 		$links_model = new PLL_Links_Default( $model );
 		$admin       = new PLL_Admin( $links_model );
@@ -71,6 +74,6 @@ class Upgrade_Test extends PLL_UnitTestCase {
 		}
 
 		$this->assertSameSets( $expected_transient, get_transient( 'pll_languages_list' ), 'Old pll_languages_list transient should have been deleted during upgrade.' );
-		$this->assertSame( POLYLANG_VERSION, get_option( 'polylang' )['version'], 'Polylang version should have been updated.' );
+		$this->assertSame( POLYLANG_VERSION, $options['version'], 'Polylang version should have been updated.' );
 	}
 }

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -217,7 +217,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 	public function test_widgets_language_filter_is_not_displayed_for_page_builders() {
 		set_current_screen( 'post' );
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en' ) );
+		$options = ( new PLL_Options() )->merge( PLL_Options::get_reset_options(), array( 'default_lang' => 'en' ) );
 		$model = new PLL_Admin_Model( $options );
 		$links_model = new PLL_Links_Default( $model );
 		$polylang = new PLL_Admin( $links_model );


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1160
Fixes #1236

This PR introduces a new class `PLL_Options` to manage Polylang's options.
This is requirement if someday we want to use a dependency Injection container.

## Key points

- This class implements `ArrayAccess`, meaning that values can still be accessed like with an array.
- It also implements `Iterator` (and `Countable`), meaning that we can still use `foreach`.
- It also implements `JsonSerializable`, meaning that using `json_encode()` will encode the options, not the class (this requires `JSON` to be available on the server though, which is always the case).
- The options are automatically stored into the dabase on `shutdown` if they have been modified. Note: the system is not perfect but enough for what we do: changing twice a value to revert it to its initial value is still counted as "modified", and will trigger an update. For example:
```php
var_dump( $options['default_language'] ); // 'en'
$options['default_language'] = 'fr'; // An update will be triggered.
$options['default_language'] = 'en'; // An update will still be triggered.
```
- `switch_to_blog()` is handled: the class stores the options of each necessary blog. It starts with the current blog by storing its options locally, then on the `switch_block` hook it will switch to the options of this blog (but fetch them first if not already stored locally) and consider them as "current options" (but still keep the options of the previous blog locally).
- Options are white-listed: it is not possible to add unknown options (not listed in PLL_Options::DEFAULTS). Ex:
```php
$options['foo'] = 4;
var_dump( $options['foo'] ); // null
```
- Options are always defined: it is not possible to unset them from the list, they are set to their default value instead. Ex:
```php
var_dump( $options['default_language'] ); // 'en'
$options['default_language'] = 'fr';
unset( $options['default_language'] );
var_dump( $options['default_language'] ); // 'en'
```
- Automatic cast + limited sanitization/validation: while values sent to the class should still be sanitized and validated, the class handles a part of this work. This is done when fetching the values from the database, and when values are updated locally in the class. This ensures we're working with the right types all along.
    - Invalid values are rejected:
```php
var_dump( $options['default_language'] ); // 'en'
$options['default_language'] = 4; // Not a string.
var_dump( $options['default_language'] ); // 'en'
```

- 
    - Values are casted:
```php
$options['hide_default'] = 1;
var_dump( $options['hide_default'] ); // true
$options['force_lang'] = '2';
var_dump( $options['force_lang'] ); // 2 (int)
```
-
    - Values are partially sanitized and partially validated:
```php
$options['domains'] = array(
	''   => 'example.org',
	'en' => '',
	'fr' => 'poof',
);
var_dump( $options['domains'] ); // `array( 'fr' => 'poof' )`: note that the domain is invalid but still stored.
```
-
    - For `media` and `nav_menus`, we only make sure that the array keys are non falsy strings.
- Using `array_merge()` on options will trigger a fatal error, so the method `PLL_Options::merge()` has been created:
```
$this->options->merge(
	array( 'hide_default' => true ),
	array( 'browser' => true, 'force_lang' => 2 ),
	array( 'media_support' => true )
);
```
- `PLL_Options::get_reset_options()` is used when `$options['version']` is empty (plugin init, plugin activation). `PLL_Install::get_default_options()` is a wrapper of this method. The word "reset" is used here instead of "default":
    - "default" is the "zero state" of the values: `$options['hide_default'] = false;`.
    - "reset" are the values on install: `$options['hide_default'] = true;`.
    - We could consider other wordings, like `get_install_options()` for example.

## PHPStan

This allows some type checks on our options. For example, PHPStan knows that `$options['default_lang']` is a string (that can be an empty string).
That's why some things have been removed in 75998cb.

## Other

- All `update_option( 'polylang', $options )` have been removed.
- In `PLL_Install`/`PLL_Install_Base` we're still using `get_option()` and `update_option()` because `PLL()` is not yet available in most cases.
- All `$options` class properties have been tagged `PLL_Options` instead of `array` (this allowed better PHPStan checks).

## Polylang Pro and Polylang for WooCommerce

- Both plugins must be updated.