### PR TITLE
Fixes PLL_Language::get_prop()

### DIFF
--- a/include/language-deprecated.php
+++ b/include/language-deprecated.php
@@ -216,7 +216,7 @@ abstract class PLL_Language_Deprecated {
 	 * @phpstan-return non-empty-string
 	 */
 	protected function get_deprecated_url_property( $property ) {
-		return $this->{self::DEPRECATED_URL_PROPERTIES[ $property ]}();
+		return $this->{self::DEPRECATED_URL_PROPERTIES[ $property ]};
 	}
 
 	/**

--- a/include/language-deprecated.php
+++ b/include/language-deprecated.php
@@ -34,7 +34,7 @@ abstract class PLL_Language_Deprecated {
 	 */
 	const DEPRECATED_URL_PROPERTIES = array(
 		'home_url'   => 'get_home_url',
-		'search_url' => 'get_seach_url',
+		'search_url' => 'get_search_url',
 	);
 
 	/**
@@ -216,7 +216,7 @@ abstract class PLL_Language_Deprecated {
 	 * @phpstan-return non-empty-string
 	 */
 	protected function get_deprecated_url_property( $property ) {
-		return $this->{self::DEPRECATED_URL_PROPERTIES[ $property ]};
+		return $this->{self::DEPRECATED_URL_PROPERTIES[ $property ]}();
 	}
 
 	/**

--- a/include/language.php
+++ b/include/language.php
@@ -641,9 +641,9 @@ class PLL_Language extends PLL_Language_Deprecated {
 		}
 
 		// Composite property like 'term_language:term_taxonomy_id'.
-		if ( preg_match( '/^(.{1,32}):(term_id|term_taxonomy_id|count)$/', $property, $matches ) ) {
-			/** @var array{0:non-empty-string, 1:'term_id'|'term_taxonomy_id'|'count'} $matches */
-			return $this->get_tax_prop( $matches[0], $matches[1] );
+		if ( preg_match( '/^(?<tax>.{1,32}):(?<field>term_id|term_taxonomy_id|count)$/', $property, $matches ) ) {
+			/** @var array{tax:non-empty-string, field:'term_id'|'term_taxonomy_id'|'count'} $matches */
+			return $this->get_tax_prop( $matches['tax'], $matches['field'] );
 		}
 
 		// Any other public property.

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -23,6 +23,7 @@ if ( ! defined( 'PLL_TEST_DATA_DIR' ) ) {
 	define( 'PLL_TEST_DATA_DIR', dirname( __DIR__ ) . '/data/' );
 }
 
+require_once __DIR__ . '/polyfills.php';
 require_once __DIR__ . '/testcase-trait.php';
 require_once __DIR__ . '/testcase.php';
 require_once __DIR__ . '/testcase-ajax.php';

--- a/tests/phpunit/includes/polyfills.php
+++ b/tests/phpunit/includes/polyfills.php
@@ -1,0 +1,44 @@
+<?php
+
+if ( ! function_exists( 'did_filter' ) ) {
+	// Mimic apply_filters()'s counter.
+	global $wp_filters;
+
+	if ( ! isset( $wp_filters ) || ! is_array( $wp_filters ) ) {
+		$wp_filters = array();
+	}
+
+	add_filter(
+		'all',
+		function( $hook_name ) {
+			global $wp_filters;
+
+			if ( ! isset( $wp_filters[ $hook_name ] ) ) {
+				$wp_filters[ $hook_name ] = 1;
+			} else {
+				++$wp_filters[ $hook_name ];
+			}
+		}
+	);
+
+	/**
+	 * Retrieves the number of times a filter has been applied during the current request.
+	 *
+	 * @since 3.4
+	 * @since WP 6.1.0
+	 *
+	 * @global int[] $wp_filters Stores the number of times each filter was triggered.
+	 *
+	 * @param string $hook_name The name of the filter hook.
+	 * @return int The number of times the filter hook has been applied.
+	 */
+	function did_filter( $hook_name ) {
+		global $wp_filters;
+
+		if ( ! isset( $wp_filters[ $hook_name ] ) ) {
+			return 0;
+		}
+
+		return $wp_filters[ $hook_name ];
+	}
+}

--- a/tests/phpunit/includes/polyfills.php
+++ b/tests/phpunit/includes/polyfills.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Polyfills `did_filter()` for backward compatibilit with WP < 6.1.
+ * Polyfills `did_filter()` for backward compatibility with WP < 6.1.
  */
 if ( ! function_exists( 'did_filter' ) ) {
 	// Mimic apply_filters()'s counter.

--- a/tests/phpunit/includes/polyfills.php
+++ b/tests/phpunit/includes/polyfills.php
@@ -1,5 +1,7 @@
 <?php
-
+/**
+ * Polyfills `did_filter()` for backward compatibilit with WP < 6.1.
+ */
 if ( ! function_exists( 'did_filter' ) ) {
 	// Mimic apply_filters()'s counter.
 	global $wp_filters;
@@ -25,7 +27,6 @@ if ( ! function_exists( 'did_filter' ) ) {
 	 * Retrieves the number of times a filter has been applied during the current request.
 	 *
 	 * @since 3.4
-	 * @since WP 6.1.0
 	 *
 	 * @global int[] $wp_filters Stores the number of times each filter was triggered.
 	 *

--- a/tests/phpunit/tests/test-language.php
+++ b/tests/phpunit/tests/test-language.php
@@ -41,12 +41,13 @@ class Language_Test extends PLL_UnitTestCase {
 	 */
 	public function test_get_prop() {
 		// Test deprecated properties.
-		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+		$language = $this->language; // php 5.6 ¯\_(ツ)_/¯
+		foreach ( $language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
 			$this->assertArrayHasKey( $args[1], $this->data['term_props'][ $args[0] ] );
 			$this->assertSame( $this->data['term_props'][ $args[0] ][ $args[1] ], $this->language->get_prop( $prop ) );
 		}
-		foreach ( $this->language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+		foreach ( $language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
 			$this->assertSame( $this->data[ $prop ], $this->language->get_prop( $prop ) );
 		}
 
@@ -76,12 +77,13 @@ class Language_Test extends PLL_UnitTestCase {
 			$count = did_filter( 'deprecated_property_trigger_error' );
 		}
 
-		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+		$language = $this->language; // php 5.6 ¯\_(ツ)_/¯
+		foreach ( $language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
 			$this->assertArrayHasKey( $args[1], $this->data['term_props'][ $args[0] ] );
 			$this->assertSame( $this->data['term_props'][ $args[0] ][ $args[1] ], $this->language->$prop );
 		}
-		foreach ( $this->language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+		foreach ( $language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
 			$this->assertSame( $this->data[ $prop ], $this->language->$prop );
 		}
 
@@ -102,10 +104,11 @@ class Language_Test extends PLL_UnitTestCase {
 	 */
 	public function test___isset() {
 		// Test deprecated properties.
-		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+		$language = $this->language; // php 5.6 ¯\_(ツ)_/¯
+		foreach ( $language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertTrue( isset( $this->language->$prop ) );
 		}
-		foreach ( $this->language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+		foreach ( $language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
 			$this->assertTrue( isset( $this->language->$prop ) );
 		}
 

--- a/tests/phpunit/tests/test-language.php
+++ b/tests/phpunit/tests/test-language.php
@@ -67,10 +67,7 @@ class Language_Test extends PLL_UnitTestCase {
 	 */
 	public function test___get() {
 		// Test deprecated properties.
-		$did_filter = function_exists( 'did_filter' );
-		if ( $did_filter ) {
-			$count = did_filter( 'deprecated_property_trigger_error' );
-		}
+		$count = did_filter( 'deprecated_property_trigger_error' );
 
 		foreach ( PLL_Language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
@@ -81,10 +78,8 @@ class Language_Test extends PLL_UnitTestCase {
 			$this->assertSame( $this->data[ $prop ], $this->language->$prop );
 		}
 
-		if ( $did_filter ) {
-			$expected_count = $count + count( PLL_Language::DEPRECATED_TERM_PROPERTIES ) + count( PLL_Language::DEPRECATED_URL_PROPERTIES );
-			$this->assertSame( $expected_count, did_filter( 'deprecated_property_trigger_error' ) );
-		}
+		$expected_count = $count + count( PLL_Language::DEPRECATED_TERM_PROPERTIES ) + count( PLL_Language::DEPRECATED_URL_PROPERTIES );
+		$this->assertSame( $expected_count, did_filter( 'deprecated_property_trigger_error' ) );
 
 		// Test unknown property.
 		$this->assertNull( $this->language->foobar );

--- a/tests/phpunit/tests/test-language.php
+++ b/tests/phpunit/tests/test-language.php
@@ -41,13 +41,12 @@ class Language_Test extends PLL_UnitTestCase {
 	 */
 	public function test_get_prop() {
 		// Test deprecated properties.
-		$language = $this->language; // php 5.6 ¯\_(ツ)_/¯
-		foreach ( $language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+		foreach ( PLL_Language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
 			$this->assertArrayHasKey( $args[1], $this->data['term_props'][ $args[0] ] );
 			$this->assertSame( $this->data['term_props'][ $args[0] ][ $args[1] ], $this->language->get_prop( $prop ) );
 		}
-		foreach ( $language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+		foreach ( PLL_Language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
 			$this->assertSame( $this->data[ $prop ], $this->language->get_prop( $prop ) );
 		}
 
@@ -77,18 +76,17 @@ class Language_Test extends PLL_UnitTestCase {
 			$count = did_filter( 'deprecated_property_trigger_error' );
 		}
 
-		$language = $this->language; // php 5.6 ¯\_(ツ)_/¯
-		foreach ( $language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+		foreach ( PLL_Language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
 			$this->assertArrayHasKey( $args[1], $this->data['term_props'][ $args[0] ] );
 			$this->assertSame( $this->data['term_props'][ $args[0] ][ $args[1] ], $this->language->$prop );
 		}
-		foreach ( $language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+		foreach ( PLL_Language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
 			$this->assertSame( $this->data[ $prop ], $this->language->$prop );
 		}
 
 		if ( $did_filter ) {
-			$expected_count = $count + count( $this->language::DEPRECATED_TERM_PROPERTIES ) + count( $this->language::DEPRECATED_URL_PROPERTIES );
+			$expected_count = $count + count( PLL_Language::DEPRECATED_TERM_PROPERTIES ) + count( PLL_Language::DEPRECATED_URL_PROPERTIES );
 			$this->assertSame( $expected_count, did_filter( 'deprecated_property_trigger_error' ) );
 		}
 
@@ -104,11 +102,10 @@ class Language_Test extends PLL_UnitTestCase {
 	 */
 	public function test___isset() {
 		// Test deprecated properties.
-		$language = $this->language; // php 5.6 ¯\_(ツ)_/¯
-		foreach ( $language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+		foreach ( PLL_Language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertTrue( isset( $this->language->$prop ) );
 		}
-		foreach ( $language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+		foreach ( PLL_Language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
 			$this->assertTrue( isset( $this->language->$prop ) );
 		}
 

--- a/tests/phpunit/tests/test-language.php
+++ b/tests/phpunit/tests/test-language.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Tests for PLL_Language and PLL_Language_Deprecated.
+ */
+class Language_Test extends PLL_UnitTestCase {
+
+	/**
+	 * @var PLL_Language
+	 */
+	private $language;
+
+	/**
+	 * @var array
+	 */
+	private $data;
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+		self::create_language( 'en_US' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		remove_action( 'deprecated_property_trigger_error', '__return_false', 581698 );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->language = self::$model->get_default_language();
+		$this->assertInstanceOf( PLL_Language::class, $this->language );
+		$this->data = $this->language->to_array();
+
+		add_action( 'deprecated_property_trigger_error', '__return_false', 581698 );
+	}
+
+	/**
+	 * PLL_Language::get_prop()
+	 */
+	public function test_get_prop() {
+		// Test deprecated properties.
+		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
+			$this->assertArrayHasKey( $args[1], $this->data['term_props'][ $args[0] ] );
+			$this->assertSame( $this->data['term_props'][ $args[0] ][ $args[1] ], $this->language->get_prop( $prop ) );
+		}
+		foreach ( $this->language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+			$this->assertSame( $this->data[ $prop ], $this->language->get_prop( $prop ) );
+		}
+
+		// Test composite properties.
+		foreach ( array( 'language', 'term_language' ) as $tax ) {
+			foreach ( array( 'term_id', 'term_taxonomy_id', 'count' ) as $field ) {
+				$this->assertArrayHasKey( $tax, $this->data['term_props'] );
+				$this->assertArrayHasKey( $field, $this->data['term_props'][ $tax ] );
+				$this->assertSame( $this->data['term_props'][ $tax ][ $field ], $this->language->get_prop( "$tax:$field" ) );
+			}
+		}
+
+		// Test a public property.
+		$this->assertSame( $this->data['flag_code'], $this->language->get_prop( 'flag_code' ) );
+
+		// Test unknown property.
+		$this->assertFalse( $this->language->get_prop( 'foobar' ) );
+	}
+
+	/**
+	 * PLL_Language::__get()
+	 */
+	public function test___get() {
+		// Test deprecated properties.
+		$did_filter = function_exists( 'did_filter' ) ? 'did_filter' : 'did_action';
+		$count      = $did_filter( 'deprecated_property_trigger_error' );
+
+		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
+			$this->assertArrayHasKey( $args[1], $this->data['term_props'][ $args[0] ] );
+			$this->assertSame( $this->data['term_props'][ $args[0] ][ $args[1] ], $this->language->$prop );
+		}
+		foreach ( $this->language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+			$this->assertSame( $this->data[ $prop ], $this->language->$prop );
+		}
+
+		$expected_count = $count + count( $this->language::DEPRECATED_TERM_PROPERTIES ) + count( $this->language::DEPRECATED_URL_PROPERTIES );
+		$this->assertSame( $expected_count, $did_filter( 'deprecated_property_trigger_error' ) );
+
+		// Test unknown property.
+		$this->assertNull( $this->language->foobar );
+
+		// Test a public property.
+		$this->assertSame( $this->data['flag_code'], $this->language->flag_code );
+	}
+
+	/**
+	 * PLL_Language::__isset()
+	 */
+	public function test___isset() {
+		// Test deprecated properties.
+		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
+			$this->assertTrue( isset( $this->language->$prop ) );
+		}
+		foreach ( $this->language::DEPRECATED_URL_PROPERTIES as $prop => $callback ) {
+			$this->assertTrue( isset( $this->language->$prop ) );
+		}
+
+		// Test unknown property.
+		$this->assertFalse( isset( $this->language->foobar ) );
+
+		// Test a public property.
+		$this->assertTrue( isset( $this->language->flag_code ) );
+	}
+
+	/**
+	 * PLL_Language::get_tax_prop()
+	 */
+	public function test_get_tax_prop() {
+		foreach ( $this->data['term_props'] as $tax => $fields ) {
+			foreach ( $fields as $field => $value ) {
+				$this->assertSame( $value, $this->language->get_tax_prop( $tax, $field ) );
+			}
+		}
+
+		$this->assertSame( 0, $this->language->get_tax_prop( 'foobar', 'term_taxonomy_id' ) );
+		$this->assertSame( 0, $this->language->get_tax_prop( 'language', 'foobar' ) );
+	}
+
+	/**
+	 * PLL_Language::get_tax_props()
+	 */
+	public function test_get_tax_props() {
+		$expected = array();
+
+		foreach ( $this->data['term_props'] as $tax => $fields ) {
+			$expected[ $tax ] = $fields['term_taxonomy_id'];
+		}
+
+		$this->assertSame( $expected, $this->language->get_tax_props( 'term_taxonomy_id' ) );
+		$this->assertSame( $this->data['term_props'], $this->language->get_tax_props() );
+	}
+}

--- a/tests/phpunit/tests/test-language.php
+++ b/tests/phpunit/tests/test-language.php
@@ -22,10 +22,6 @@ class Language_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 	}
 
-	public static function wpTearDownAfterClass() {
-		remove_action( 'deprecated_property_trigger_error', '__return_false', 581698 );
-	}
-
 	public function set_up() {
 		parent::set_up();
 
@@ -33,7 +29,7 @@ class Language_Test extends PLL_UnitTestCase {
 		$this->assertInstanceOf( PLL_Language::class, $this->language );
 		$this->data = $this->language->to_array();
 
-		add_action( 'deprecated_property_trigger_error', '__return_false', 581698 );
+		add_action( 'deprecated_property_trigger_error', '__return_false' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-language.php
+++ b/tests/phpunit/tests/test-language.php
@@ -71,8 +71,10 @@ class Language_Test extends PLL_UnitTestCase {
 	 */
 	public function test___get() {
 		// Test deprecated properties.
-		$did_filter = function_exists( 'did_filter' ) ? 'did_filter' : 'did_action';
-		$count      = $did_filter( 'deprecated_property_trigger_error' );
+		$did_filter = function_exists( 'did_filter' );
+		if ( $did_filter ) {
+			$count = did_filter( 'deprecated_property_trigger_error' );
+		}
 
 		foreach ( $this->language::DEPRECATED_TERM_PROPERTIES as $prop => $args ) {
 			$this->assertArrayHasKey( $args[0], $this->data['term_props'] );
@@ -83,8 +85,10 @@ class Language_Test extends PLL_UnitTestCase {
 			$this->assertSame( $this->data[ $prop ], $this->language->$prop );
 		}
 
-		$expected_count = $count + count( $this->language::DEPRECATED_TERM_PROPERTIES ) + count( $this->language::DEPRECATED_URL_PROPERTIES );
-		$this->assertSame( $expected_count, $did_filter( 'deprecated_property_trigger_error' ) );
+		if ( $did_filter ) {
+			$expected_count = $count + count( $this->language::DEPRECATED_TERM_PROPERTIES ) + count( $this->language::DEPRECATED_URL_PROPERTIES );
+			$this->assertSame( $expected_count, did_filter( 'deprecated_property_trigger_error' ) );
+		}
 
 		// Test unknown property.
 		$this->assertNull( $this->language->foobar );


### PR DESCRIPTION
When using a regex for a composite property name in `PLL_Language::get_prop()`, the matches `1` and `2` should have been used instead of `0` (full match) and `1`.
This PR fixes this issue by using named capturing groups.

This PR also fixes a typo in the value of `PLL_Language::DEPRECATED_URL_PROPERTIES` and adds several tests.