### PR TITLE
Ease creation of 3rd party language taxonomies

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -239,7 +239,7 @@ class Polylang {
 			 */
 			do_action( 'pll_model_init', $model );
 
-			$model->maybe_add_missing_3rd_party_language_terms();
+			$model->maybe_create_language_terms();
 
 			/**
 			 * Fires after the $polylang object is created and before the API is loaded

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -189,6 +189,7 @@ class Polylang {
 		 * @param string $class either PLL_Model or PLL_Admin_Model
 		 */
 		$class = apply_filters( 'pll_model', PLL_SETTINGS || self::is_wizard() ? 'PLL_Admin_Model' : 'PLL_Model' );
+		/** @var PLL_Model $model */
 		$model = new $class( $options );
 
 		if ( ! $model->has_languages() ) {
@@ -225,6 +226,20 @@ class Polylang {
 		if ( ! empty( $class ) ) {
 			$links_model = $model->get_links_model();
 			$polylang    = new $class( $links_model );
+
+			/**
+			 * Fires after Polylang's model init.
+			 * This is the best place to register a custom table (see `PLL_Model`'s constructor).
+			 * /!\ This hook is fired *before* the $polylang object is available.
+			 * /!\ The languages are also not available yet.
+			 *
+			 * @since 3.4
+			 *
+			 * @param PLL_Model $model Polylang model.
+			 */
+			do_action( 'pll_model_init', $model );
+
+			$model->maybe_add_missing_3rd_party_language_terms();
 
 			/**
 			 * Fires after the $polylang object is created and before the API is loaded

--- a/include/model.php
+++ b/include/model.php
@@ -820,31 +820,16 @@ class PLL_Model {
 		}
 
 		// We have at least one unknown 3rd party language taxonomy.
-		$this->add_missing_secondary_language_terms( $new_taxonomies );
-
-		// Keep the previous values, so this is triggered only once per taxonomy.
-		$this->options['language_taxonomies'] = array_merge( $known_taxonomies, $new_taxonomies );
-		update_option( 'polylang', $this->options );
-	}
-
-	/**
-	 * Adds the missing language terms for the secondary language taxonomies.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string[]|null $taxonomies Optional. List of language taxonomies to deal with. An empty value means all of
-	 *                                  them. Defauls to all taxonomies.
-	 * @return void
-	 *
-	 * @phpstan-param array<non-empty-string>|null $taxonomies
-	 */
-	public function add_missing_secondary_language_terms( array $taxonomies = null ) {
 		foreach ( $this->get_languages_list() as $language ) {
-			$this->update_secondary_language_terms( $language->slug, $language->name, $language, $taxonomies );
+			$this->update_secondary_language_terms( $language->slug, $language->name, $language, $new_taxonomies );
 		}
 
 		// Clear the cache, so the new `term_id` and `term_taxonomy_id` appear in the languages list.
 		$this->clean_languages_cache();
+
+		// Keep the previous values, so this is triggered only once per taxonomy.
+		$this->options['language_taxonomies'] = array_merge( $known_taxonomies, $new_taxonomies );
+		update_option( 'polylang', $this->options );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -734,6 +734,35 @@ class PLL_Model {
 	}
 
 	/**
+	 * Assigns the default language to objects in mass.
+	 *
+	 * @since 1.2
+	 * @since 3.4 Moved from PLL_Admin_Model class.
+	 * @since 3.4 Change method signature.
+	 *
+	 * @param int $limit Max number of posts or terms to return. Defaults to -1 (no limit).
+	 * @return void
+	 *
+	 * @phpstan-param -1|positive-int $limit
+	 */
+	public function set_language_in_mass( $limit = -1 ) {
+		$nolang = $this->get_objects_with_no_lang( $limit );
+
+		if ( empty( $nolang ) ) {
+			return;
+		}
+
+		/** @var PLL_Language $lang */
+		$lang = $this->get_default_language();
+
+		foreach ( $this->translatable_objects as $type => $object ) {
+			if ( ! empty( $nolang[ "{$type}s" ] ) ) {
+				$object->set_language_in_mass( $nolang[ "{$type}s" ], $lang );
+			}
+		}
+	}
+
+	/**
 	 * Filters the ORDERBY clause of the languages query.
 	 * This allows to order languages by `term_group` and `term_id`.
 	 *

--- a/include/model.php
+++ b/include/model.php
@@ -770,29 +770,32 @@ class PLL_Model {
 	 * @return void
 	 */
 	public function maybe_add_missing_3rd_party_language_terms() {
-		$cur_taxonomies = array_diff(
+		$registered_taxonomies = array_diff(
 			$this->translatable_objects->get_taxonomy_names( array( 'language' ) ),
 			// Exclude the post and term language taxonomies from the list.
 			array( $this->post->get_tax_language(), $this->term->get_tax_language() )
 		);
 
-		if ( empty( $cur_taxonomies ) ) {
+		if ( empty( $registered_taxonomies ) ) {
 			// No 3rd party language taxonomies.
 			return;
 		}
 
 		// We have at least one 3rd party language taxonomy.
-		$prev_taxonomies = (array) get_option( 'pll_3rd_party_languages', array() );
-		$diff_taxonomies = array_diff( $cur_taxonomies, $prev_taxonomies );
+		$known_taxonomies = ! empty( $this->options['3rd_party_taxonomies'] ) && is_array( $this->options['3rd_party_taxonomies'] ) ? $this->options['3rd_party_taxonomies'] : array();
+		$new_taxonomies   = array_diff( $registered_taxonomies, $known_taxonomies );
 
-		if ( empty( $diff_taxonomies ) ) {
+		if ( empty( $new_taxonomies ) ) {
 			// No new 3rd party language taxonomies.
 			return;
 		}
 
-		$this->add_missing_secondary_language_terms( $diff_taxonomies );
+		// We have at least one unknown 3rd party language taxonomy.
+		$this->add_missing_secondary_language_terms( $new_taxonomies );
 
-		update_option( 'pll_3rd_party_languages', $diff_taxonomies );
+		// Keep the previous values, so this is triggered only once per taxonomy.
+		$this->options['3rd_party_taxonomies'] = array_merge( $known_taxonomies, $new_taxonomies );
+		update_option( 'polylang', $this->options );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -853,7 +853,7 @@ class PLL_Model {
 			}
 
 			/** @var PLL_Language $language */
-			if ( $language->slug !== $slug || $language->name !== $name ) {
+			if ( "pll_{$language->slug}" !== $slug || $language->name !== $name ) {
 				// Something has changed.
 				wp_update_term( $term_id, $object->get_tax_language(), array( 'slug' => $slug, 'name' => $name ) );
 			}

--- a/include/model.php
+++ b/include/model.php
@@ -285,6 +285,21 @@ class PLL_Model {
 	}
 
 	/**
+	 * Returns the default language.
+	 *
+	 * @since 3.4
+	 *
+	 * @return PLL_Language|false Default language object, `false` if no language found.
+	 */
+	public function get_default_language() {
+		if ( empty( $this->options['default_lang'] ) ) {
+			return false;
+		}
+
+		return $this->get_language( $this->options['default_lang'] );
+	}
+
+	/**
 	 * Adds terms clauses to the term query to filter them by languages.
 	 *
 	 * @since 1.2
@@ -798,21 +813,6 @@ class PLL_Model {
 
 		// Clear the cache, so the new `term_id` and `term_taxonomy_id` appear in the languages list.
 		$this->clean_languages_cache();
-	}
-
-	/**
-	 * Returns the default language.
-	 *
-	 * @since 3.4
-	 *
-	 * @return PLL_Language|false Default language object, `false` if no language found.
-	 */
-	public function get_default_language() {
-		if ( empty( $this->options['default_lang'] ) ) {
-			return false;
-		}
-
-		return $this->get_language( $this->options['default_lang'] );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -840,7 +840,7 @@ class PLL_Model {
 	 * @param string            $slug       Language term slug (with or without the `pll_` prefix).
 	 * @param string            $name       Language name (label).
 	 * @param PLL_Language|null $language   Optional. A language object. Required to update the existing terms.
-	 * @param string[]|null     $taxonomies Optional. List of language taxonomies to deal with. An empty value means
+	 * @param string[]          $taxonomies Optional. List of language taxonomies to deal with. An empty value means
 	 *                                      all of them. Defauls to all taxonomies.
 	 * @return void
 	 *
@@ -848,7 +848,7 @@ class PLL_Model {
 	 * @phpstan-param non-empty-string $name
 	 * @phpstan-param array<non-empty-string>|null $taxonomies
 	 */
-	protected function update_secondary_language_terms( $slug, $name, PLL_Language $language = null, array $taxonomies = null ) {
+	protected function update_secondary_language_terms( $slug, $name, PLL_Language $language = null, array $taxonomies = array() ) {
 		$slug = 0 === strpos( $slug, 'pll_' ) ? $slug : "pll_$slug";
 
 		foreach ( $this->translatable_objects->get_secondary_translatable_objects() as $object ) {

--- a/include/model.php
+++ b/include/model.php
@@ -798,7 +798,7 @@ class PLL_Model {
 	 *
 	 * @return void
 	 */
-	public function maybe_add_missing_3rd_party_language_terms() {
+	public function maybe_create_language_terms() {
 		$registered_taxonomies = array_diff(
 			$this->translatable_objects->get_taxonomy_names( array( 'language' ) ),
 			// Exclude the post and term language taxonomies from the list.
@@ -811,7 +811,7 @@ class PLL_Model {
 		}
 
 		// We have at least one 3rd party language taxonomy.
-		$known_taxonomies = ! empty( $this->options['3rd_party_taxonomies'] ) && is_array( $this->options['3rd_party_taxonomies'] ) ? $this->options['3rd_party_taxonomies'] : array();
+		$known_taxonomies = ! empty( $this->options['language_taxonomies'] ) && is_array( $this->options['language_taxonomies'] ) ? $this->options['language_taxonomies'] : array();
 		$new_taxonomies   = array_diff( $registered_taxonomies, $known_taxonomies );
 
 		if ( empty( $new_taxonomies ) ) {
@@ -823,7 +823,7 @@ class PLL_Model {
 		$this->add_missing_secondary_language_terms( $new_taxonomies );
 
 		// Keep the previous values, so this is triggered only once per taxonomy.
-		$this->options['3rd_party_taxonomies'] = array_merge( $known_taxonomies, $new_taxonomies );
+		$this->options['language_taxonomies'] = array_merge( $known_taxonomies, $new_taxonomies );
 		update_option( 'polylang', $this->options );
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -591,16 +591,6 @@ parameters:
 			path: include/base.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:get_links_model\\(\\)\\.$#"
-			count: 1
-			path: include/class-polylang.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:has_languages\\(\\)\\.$#"
-			count: 2
-			path: include/class-polylang.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:init\\(\\)\\.$#"
 			count: 1
 			path: include/class-polylang.php

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -240,17 +240,7 @@ class PLL_Settings extends PLL_Admin_Base {
 			case 'content-default-lang':
 				check_admin_referer( 'content-default-lang' );
 
-				if ( $nolang = $this->model->get_objects_with_no_lang() ) {
-					/** @var PLL_Language $lang */
-					$lang = $this->model->get_default_language();
-
-					if ( ! empty( $nolang['posts'] ) ) {
-						$this->model->post->set_language_in_mass( $nolang['posts'], $lang );
-					}
-					if ( ! empty( $nolang['terms'] ) ) {
-						$this->model->term->set_language_in_mass( $nolang['terms'], $lang );
-					}
-				}
+				$this->model->set_language_in_mass();
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )
 				break;

--- a/tests/phpunit/data/translatable-foo.php
+++ b/tests/phpunit/data/translatable-foo.php
@@ -1,0 +1,30 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Translatable custom table.
+ */
+class PLLTest_Translatable_Foo extends PLL_Translatable_Object {
+
+	protected $tax_language = 'foo_language';
+	protected $object_type = 'foo';
+	protected $type = 'foo';
+	protected $cache_type = 'foos';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.8
+	 *
+	 * @param PLL_Model $model Instance of `PLL_Model`.
+	 */
+	public function __construct( PLL_Model &$model ) {
+		$this->db = array(
+			'table'         => $GLOBALS['wpdb']->prefix . 'foo',
+			'id_column'     => 'id',
+			'default_alias' => $GLOBALS['wpdb']->prefix . 'foo',
+		);
+
+		parent::__construct( $model );
+	}
+}

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -207,7 +207,14 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertFalse( self::$model->is_translated_post_type( 'attachment' ) );
 	}
 
-	public function test_create_missing_language_terms() {
+	public function test_maybe_create_language_terms() {
+		// Translatable custom table.
+		require_once PLL_TEST_DATA_DIR . 'translatable-foo.php';
+
+		$foo = new PLLTest_Translatable_Foo( self::$model );
+		$tax = $foo->get_tax_language();
+		self::$model->translatable_objects->register( $foo );
+
 		// Languages we'll work with.
 		self::create_language( 'es_ES' );
 		self::create_language( 'de_DE' );
@@ -216,15 +223,15 @@ class Model_Test extends PLL_UnitTestCase {
 		$term_ids = array();
 		foreach ( self::$model->get_languages_list() as $language ) {
 			if ( 'es' === $language->slug || 'de' === $language->slug ) {
-				$term_ids[] = $language->get_tax_prop( 'term_language', 'term_id' );
+				$term_ids[] = $language->get_tax_prop( $tax, 'term_id' );
 			}
 		}
 		$term_ids = array_filter( $term_ids );
-		$this->assertCount( 2, $term_ids, "Expected to have 1 'term_language' term_id per new language." );
+		$this->assertCount( 2, $term_ids, "Expected to have 1 '$tax' term_id per new language." );
 
 		// Delete terms.
 		foreach ( $term_ids as $term_id ) {
-			wp_delete_term( $term_id, 'term_language' );
+			wp_delete_term( $term_id, $tax );
 		}
 
 		self::$model->clean_languages_cache();
@@ -232,30 +239,30 @@ class Model_Test extends PLL_UnitTestCase {
 		// Make sure the terms are deleted.
 		foreach ( self::$model->get_languages_list() as $language ) {
 			if ( 'es' === $language->slug || 'de' === $language->slug ) {
-				$this->assertSame( 0, $language->get_tax_prop( 'term_language', 'term_id' ), "Expected to have no 'term_language' term_ids for the new languages." );
-				$this->assertSame( 0, $language->get_tax_prop( 'term_language', 'term_taxonomy_id' ), "Expected to have no 'term_language' term_taxonomy_ids for the new languages." );
+				$this->assertSame( 0, $language->get_tax_prop( $tax, 'term_id' ), "Expected to have no '$tax' term_ids for the new languages." );
+				$this->assertSame( 0, $language->get_tax_prop( $tax, 'term_taxonomy_id' ), "Expected to have no '$tax' term_taxonomy_ids for the new languages." );
 			}
 		}
 
 		// Re-create missing terms.
-		self::$model->add_missing_secondary_language_terms();
+		self::$model->maybe_create_language_terms();
 
 		// Make sure the terms are re-created.
 		$tt_ids = array();
 		$slugs  = array();
 		foreach ( self::$model->get_languages_list() as $language ) {
 			if ( 'es' === $language->slug || 'de' === $language->slug ) {
-				$tt_id             = $language->get_tax_prop( 'term_language', 'term_taxonomy_id' );
-				$term_id           = $language->get_tax_prop( 'term_language', 'term_id' );
+				$tt_id             = $language->get_tax_prop( $tax, 'term_taxonomy_id' );
+				$term_id           = $language->get_tax_prop( $tax, 'term_id' );
 				$tt_ids[]          = $tt_id;
 				$slugs[ $term_id ] = "pll_{$language->slug}";
-				$this->assertNotSame( 0, $term_id, "Expected to have new 'term_language' term_ids for the new languages." );
-				$this->assertNotSame( 0, $tt_id, "Expected to have new 'term_language' term_taxonomy_ids for the new languages." );
+				$this->assertNotSame( 0, $term_id, "Expected to have new '$tax' term_ids for the new languages." );
+				$this->assertNotSame( 0, $tt_id, "Expected to have new '$tax' term_taxonomy_ids for the new languages." );
 			}
 		}
 		$terms = get_terms(
 			array(
-				'taxonomy'         => 'term_language',
+				'taxonomy'         => $tax,
 				'hide_empty'       => false,
 				'fields'           => 'id=>slug',
 				'term_taxonomy_id' => $tt_ids,

--- a/uninstall.php
+++ b/uninstall.php
@@ -111,7 +111,6 @@ class PLL_Uninstall {
 		delete_option( 'polylang_wpml_strings' ); // Strings registered with icl_register_string
 		delete_option( 'polylang_licenses' );
 		delete_option( 'pll_dismissed_notices' );
-		delete_option( 'pll_3rd_party_languages' );
 
 		// Delete transients
 		delete_transient( 'pll_languages_list' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -111,6 +111,7 @@ class PLL_Uninstall {
 		delete_option( 'polylang_wpml_strings' ); // Strings registered with icl_register_string
 		delete_option( 'polylang_licenses' );
 		delete_option( 'pll_dismissed_notices' );
+		delete_option( 'pll_3rd_party_languages' );
 
 		// Delete transients
 		delete_transient( 'pll_languages_list' );


### PR DESCRIPTION
This PR makes easier for 3rd party developers to translate custom DB tables.

## Register a language taxonomy

This introduces the hook `pll_model_init`: it can be used to register a 3rd party language taxonomy (by using `PLL_Translatable_Objects::register()`).

## Create the language taxonomy term

This also introduces the method `PLL_Model::maybe_add_missing_3rd_party_language_terms()`: it is called right after the hook `pll_model_init`, and creates the terms for 3rd party language taxonomies. Internally it uses a new entry in Polylang's option that contains the list of the 3rd party language taxonomies: if the list of the registered taxonomies (`PLL_Translatable_Objects`) has items that are not in the list from the option, the process begins.

Note that `language` and `term_language` are excluded from this automatic term creation.

## Bug fix

This PR also includes a bug fix in `PLL_Model::update_secondary_language_terms()`: `wp_update_term()` was always called, even when there were no changes in the term. This was because of term slug comparison (both slugs must have the `pll_` prefix.

## Other
The method `PLL_Model::get_default_language()` has been moved up in the class, to be right after `get_language()`. This keeps `maybe_create_language_terms()` and `update_secondary_language_terms()` together.