### PR TITLE
Reorder language terms by slug with language taxonomy first

### DIFF
--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -140,13 +140,13 @@ class PLL_Admin_Model extends PLL_Model {
 		// Delete domain
 		unset( $this->options['domains'][ $lang->slug ] );
 
-		/**
+		/*
 		 * Delete the language itself.
 		 *
 		 * Reverses the language taxonomies order is required to make sure 'language' is deleted in last.
 		 *
 		 * The initial order with the 'language' taxonomy at the beginning of 'PLL_Language::term_props' property
-		 * is done by PLL_Model::filter_language_terms_orderby()
+		 * is done by {@see PLL_Model::filter_language_terms_orderby()}
 		 */
 		foreach ( array_reverse( $lang->get_tax_props( 'term_id' ) ) as $taxonomy_name => $term_id ) {
 			wp_delete_term( $term_id, $taxonomy_name );

--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -140,8 +140,15 @@ class PLL_Admin_Model extends PLL_Model {
 		// Delete domain
 		unset( $this->options['domains'][ $lang->slug ] );
 
-		// Delete the language itself.
-		foreach ( $lang->get_tax_props( 'term_id' ) as $taxonomy_name => $term_id ) {
+		/**
+		 * Delete the language itself.
+		 *
+		 * Reverses the language taxonomies order is required to make sure 'language' is deleted in last.
+		 *
+		 * The initial order with the 'language' taxonomy at the beginning of 'PLL_Language::term_props' property
+		 * is done by PLL_Model::filter_language_terms_orderby()
+		 */
+		foreach ( array_reverse( $lang->get_tax_props( 'term_id' ) ) as $taxonomy_name => $term_id ) {
 			wp_delete_term( $term_id, $taxonomy_name );
 		}
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -78,7 +78,7 @@ class PLL_CRUD_Terms {
 		add_action( 'posts_selection', array( $this, 'unset_tax_query_lang' ), 0 );
 
 		// Deleting terms
-		add_action( 'pre_delete_term', array( $this, 'delete_term' ) );
+		add_action( 'pre_delete_term', array( $this, 'delete_term' ), 10, 2 );
 	}
 
 	/**
@@ -246,17 +246,12 @@ class PLL_CRUD_Terms {
 	 *
 	 * @since 0.1
 	 *
-	 * @param int $term_id
+	 * @param int    $term_id  Id of the term to delete.
+	 * @param string $taxonomy Name of the taxonomy.
 	 * @return void
 	 */
-	public function delete_term( $term_id ) {
-		$term = get_term( $term_id );
-
-		if ( ! $term instanceof WP_Term ) {
-			return;
-		}
-
-		if ( ! $this->model->is_translated_taxonomy( $term->taxonomy ) ) {
+	public function delete_term( $term_id, $taxonomy ) {
+		if ( ! $this->model->is_translated_taxonomy( $taxonomy ) ) {
 			return;
 		}
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -250,6 +250,17 @@ class PLL_CRUD_Terms {
 	 * @return void
 	 */
 	public function delete_term( $term_id ) {
+		$term = get_term( $term_id );
+
+		if ( ! $term instanceof WP_Term ) {
+			return;
+		}
+
+		if ( ! $this->model->is_translated_taxonomy( $term->taxonomy ) ) {
+			return;
+		}
+
+		// Delete translation and relationships only if the term is translatable.
 		$this->model->term->delete_translation( $term_id );
 		$this->model->term->delete_language( $term_id );
 	}

--- a/include/model.php
+++ b/include/model.php
@@ -775,6 +775,9 @@ class PLL_Model {
 	 * Filters the ORDERBY clause of the languages query.
 	 * This allows to order languages by `term_group` and `term_id`.
 	 *
+	 * Makes the all terms in 'language' taxonomy first in the returned result by respecting the 'term_group' order.
+	 * The goal is not to mix terms between all language taxomonomies.
+	 * 
 	 * @since 3.2.3
 	 *
 	 * @param  string   $orderby    `ORDERBY` clause of the terms query.
@@ -797,10 +800,6 @@ class PLL_Model {
 			return $orderby;
 		}
 
-		/**
-		 * Makes the all terms in 'language' taxonomy first in the returned result by respecting the 'term_group' order.
-		 * The goal is not to mix terms between all language taxomonomies.
-		 */
 		return sprintf( 'tt.taxonomy = "language" DESC, %1$s.term_group, %1$s.term_id', $matches['alias'] );
 	}
 

--- a/include/model.php
+++ b/include/model.php
@@ -913,13 +913,10 @@ class PLL_Model {
 		}
 
 		// Restore the right order after the first `array_reverse()`.
-		// Also keep the terms order with the 'language' taxonomy first.
+		// Also keep the terms order with the 'term_language' taxonomy first.
 		$terms_by_slug = array_reverse(
 			array_map(
 				function( $term_by_slug ) {
-					if ( 0 === $term_by_slug['language']->term_group ) {
-						return $term_by_slug;
-					}
 					return array_reverse( $term_by_slug );
 				},
 				$terms_by_slug

--- a/include/model.php
+++ b/include/model.php
@@ -797,7 +797,7 @@ class PLL_Model {
 			return $orderby;
 		}
 
-		return sprintf( '%1$s.term_group, %1$s.term_id', $matches['alias'] );
+		return sprintf( 'tt.taxonomy = "language", %1$s.term_group, %1$s.term_id', $matches['alias'] );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -914,14 +914,7 @@ class PLL_Model {
 
 		// Restore the right order after the first `array_reverse()`.
 		// Also keep the terms order with the 'term_language' taxonomy first.
-		$terms_by_slug = array_reverse(
-			array_map(
-				function( $term_by_slug ) {
-					return array_reverse( $term_by_slug );
-				},
-				$terms_by_slug
-			)
-		);
+		$terms_by_slug = array_reverse( array_map( 'array_reverse', $terms_by_slug ) );
 
 		/**
 		 * @var (

--- a/include/model.php
+++ b/include/model.php
@@ -773,11 +773,11 @@ class PLL_Model {
 
 	/**
 	 * Filters the ORDERBY clause of the languages query.
-	 * This allows to order languages by `term_group` and `term_id`.
 	 *
-	 * Makes the all terms in 'language' taxonomy first in the returned result by respecting the 'term_group' order.
-	 * The goal is not to mix terms between all language taxomonomies.
-	 * 
+	 * This allows to order languages terms by `taxonomy` first then by `term_group` and `term_id`.
+	 * Ordering terms by taxonomy allows not to mix terms between all language taxomonomies.
+	 * Having the "language' taxonomy first is important for {@see PLL_Admin_Model:delete_language()}.
+	 *
 	 * @since 3.2.3
 	 *
 	 * @param  string   $orderby    `ORDERBY` clause of the terms query.

--- a/include/model.php
+++ b/include/model.php
@@ -797,6 +797,10 @@ class PLL_Model {
 			return $orderby;
 		}
 
+		/**
+		 * Makes the all terms in 'language' taxonomy first in the returned result by respecting the 'term_group' order.
+		 * The goal is not to mix terms between all language taxomonomies.
+		 */
 		return sprintf( 'tt.taxonomy = "language" DESC, %1$s.term_group, %1$s.term_id', $matches['alias'] );
 	}
 

--- a/include/model.php
+++ b/include/model.php
@@ -913,7 +913,18 @@ class PLL_Model {
 		}
 
 		// Restore the right order after the first `array_reverse()`.
-		$terms_by_slug = array_reverse( $terms_by_slug );
+		// Also keep the terms order with the 'language' taxonomy first.
+		$terms_by_slug = array_reverse(
+			array_map(
+				function( $term_by_slug ) {
+					if ( 0 === $term_by_slug['language']->term_group ) {
+						return $term_by_slug;
+					}
+					return array_reverse( $term_by_slug );
+				},
+				$terms_by_slug
+			)
+		);
 
 		/**
 		 * @var (

--- a/include/model.php
+++ b/include/model.php
@@ -797,7 +797,7 @@ class PLL_Model {
 			return $orderby;
 		}
 
-		return sprintf( 'tt.taxonomy = "language", %1$s.term_group, %1$s.term_id', $matches['alias'] );
+		return sprintf( 'tt.taxonomy = "language" DESC, %1$s.term_group, %1$s.term_id', $matches['alias'] );
 	}
 
 	/**
@@ -897,24 +897,13 @@ class PLL_Model {
 	 * @phpstan-return list<PLL_Language>
 	 */
 	protected function get_languages_from_taxonomies() {
-		/*
-		 * Only terms of the taxonomy 'language' include a 'term_group' for the order.
-		 * `array_reverse()` allows to make sure that the next loop fills the array
-		 * with these terms first, allowing to keep the languages order.
-		 */
-		$reversed_terms = array_reverse( $this->get_language_terms() );
-
 		$terms_by_slug = array();
 
-		foreach ( $reversed_terms as $term ) {
+		foreach ( $this->get_language_terms() as $term ) {
 			// Except for language taxonomy term slugs, remove 'pll_' prefix from the other language taxonomy term slugs.
 			$key = 'language' === $term->taxonomy ? $term->slug : substr( $term->slug, 4 );
 			$terms_by_slug[ $key ][ $term->taxonomy ] = $term;
 		}
-
-		// Restore the right order after the first `array_reverse()`.
-		// Also keep the terms order with the 'term_language' taxonomy first.
-		$terms_by_slug = array_reverse( array_map( 'array_reverse', $terms_by_slug ) );
 
 		/**
 		 * @var (

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -273,7 +273,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 *
 	 * Polylang Pro #1626
 	 */
-	function test_delete_language_with_content_which_has_this_language() {
+	public function test_delete_language_with_content_which_has_this_language() {
 		$links_model  = self::$model->get_links_model();
 		$admin        = new PLL_Admin( $links_model );
 		$admin->terms = new PLL_CRUD_Terms( $admin );

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -26,14 +26,6 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 *
 	 * By default English language is added.
 	 *
-	 * @param array $args {
-	 *   @type string $name       Language name.
-	 *   @type string $slug       Language code.
-	 *   @type string $locale     WordPress locale.
-	 *   @type int    $rtl        1 if rtl language, 0 otherwise.
-	 *   @type string $flag       Optional, country code, {@see settings/flags.php}.
-	 *   @type int    $term_group Language order when displayed.
-	 * }
 	 * @return void
 	 */
 	private function add_language( $args = array() ) {
@@ -48,7 +40,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
 		$args = wp_parse_args( $args, $defaults );
 
-		$this->assertTrue( $this->pll_env->model->add_language( $args ), "{$args['name']} language wasn't added." );
+		$this->assertTrue( $this->pll_env->model->add_language( $args ),"{$args['name']} language wasn't added." );
 	}
 
 	public function test_add_and_delete_language() {

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -2,6 +2,15 @@
 
 class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
+
+	public function tear_down() {
+		foreach ( self::$model->get_languages_list() as $lang ) {
+			self::$model->delete_language( $lang->term_id );
+		}
+
+		parent::tear_down();
+	}
+
 	public function test_add_and_delete_language() {
 		// first language
 		$args = array(

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -266,5 +266,26 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$language = self::$model->get_language( 'en' );
 
 		$this->assertInstanceOf( PLL_Language::class, $language );
+		
+	/**
+	 * Test a second language deletion with 'term_group' > 0
+	 * and the language is assigned to a content.
+	 *
+	 * Polylang Pro #1626
+	 */
+	function test_delete_language_with_content_which_has_this_language() {
+		$links_model  = self::$model->get_links_model();
+		$admin        = new PLL_Admin( $links_model );
+		$admin->terms = new PLL_CRUD_Terms( $admin );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR', array( 'term_group' => 1 ) );
+
+		$fr = self::factory()->post->create();
+		self::$model->post->set_language( $fr, 'fr' );
+
+		$lang = self::$model->get_language( 'fr' );
+		self::$model->delete_language( $lang->term_id );
+		$this->assertCount( 1, self::$model->get_languages_list() );
 	}
 }

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -21,19 +21,31 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_add_and_delete_language() {
-		// first language
-		$args = array(
+	/**
+	 * Add a language
+	 *
+	 * By default English language is added.
+	 *
+	 * @return void
+	 */
+	private function add_language( $args = array() ) {
+		$defaults = array(
 			'name'       => 'English',
 			'slug'       => 'en',
 			'locale'     => 'en_US',
 			'rtl'        => 0,
 			'flag'       => 'us',
-			'term_group' => 2,
+			'term_group' => 0,
 		);
 
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$args = wp_parse_args( $args, $defaults );
 
+		$this->assertTrue( $this->pll_env->model->add_language( $args ),"{$args['name']} language wasn't added." );
+	}
+
+	public function test_add_and_delete_language() {
+		// First language: English.
+		$this->add_language( array( 'term_group' => 2 ) );
 		$lang = $this->pll_env->model->get_language( 'en' );
 
 		$this->assertEquals( 'English', $lang->name );
@@ -42,18 +54,17 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 0, $lang->is_rtl );
 		$this->assertEquals( 2, $lang->term_group );
 
-		// second language (rtl)
-		$args = array(
-			'name'       => 'العربية',
-			'slug'       => 'ar',
-			'locale'     => 'ar',
-			'rtl'        => 1,
-			'flag'       => 'arab',
-			'term_group' => 1,
+		// Second language (rtl).
+		$this->add_language(
+			array(
+				'name'       => 'العربية',
+				'slug'       => 'ar',
+				'locale'     => 'ar',
+				'rtl'        => 1,
+				'flag'       => 'arab',
+				'term_group' => 1,
+			)
 		);
-
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
-
 		$lang = $this->pll_env->model->get_language( 'ar' );
 
 		$this->assertEquals( 'العربية', $lang->name );
@@ -62,25 +73,25 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 1, $lang->is_rtl );
 		$this->assertEquals( 1, $lang->term_group );
 
-		// check default language
+		// Check default language.
 		$this->assertEquals( 'en', $this->pll_env->model->options['default_lang'] );
 
-		// check language order
+		// Check language order.
 		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), $this->pll_env->model->get_languages_list( array( 'fields' => 'slug' ) ) );
 
-		// attempt to create a language with the same slug as an existing one
+		// Attempt to create a language with the same slug as an existing one.
 		$this->pll_env->model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
 		$lang = $this->pll_env->model->get_language( 'en' );
 		$this->assertEquals( 'en_US', $lang->locale );
 		$this->assertFalse( $this->pll_env->model->get_language( 'en_GB' ) );
 		$this->assertEquals( 2, count( $this->pll_env->model->get_languages_list() ) );
 
-		// delete 1 language
+		// Delete 1 language.
 		$lang = $this->pll_env->model->get_language( 'en_US' );
 		$this->pll_env->model->delete_language( $lang->term_id );
 		$this->assertEquals( 'ar', $this->pll_env->model->options['default_lang'] );
 
-		// delete the last language
+		// Delete the last language.
 		$lang = $this->pll_env->model->get_language( 'ar' );
 		$this->pll_env->model->delete_language( $lang->term_id );
 		$this->assertEquals( array(), $this->pll_env->model->get_languages_list() );
@@ -100,7 +111,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$this->add_language( $args );
 
 		$lang = $this->pll_env->model->get_language( 'ar' );
 		$args['lang_id'] = $lang->term_id;
@@ -148,16 +159,8 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 * Issue #910
 	 */
 	public function test_language_properties_in_transient() {
-		$args = array(
-			'name'       => 'English',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 2,
-		);
+		$this->add_language( array( 'term_group' => 2 ) ); // English.
 
-		$this->pll_env->model->add_language( $args );
 		$this->pll_env->model->set_languages_ready();
 		$this->pll_env->model->get_languages_list(); // Saves the transient.
 
@@ -205,16 +208,8 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 * This test a conflict with Yoast SEO.
 	 */
 	public function test_create_language_when_term_link_requested_on_created_term() {
-		// first language
-		$args = array(
-			'name'       => 'English',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 2,
-		);
-		$this->pll_env->model->add_language( $args );
+		// First language: English.
+		$this->add_language( array( 'term_group' => 2 ) );
 
 		$links_model     = $this->pll_env->model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
@@ -239,58 +234,54 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			3
 		);
 
-		// second language
-		$args = array(
-			'name'       => 'Francais',
-			'slug'       => 'fr',
-			'locale'     => 'fr_FR',
-			'rtl'        => 0,
-			'flag'       => 'fr',
-			'term_group' => 2,
+		// Second language
+		$this->add_language(
+			array(
+				'name'       => 'Francais',
+				'slug'       => 'fr',
+				'locale'     => 'fr_FR',
+				'rtl'        => 0,
+				'flag'       => 'fr',
+				'term_group' => 2,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 	}
 
 	public function test_default_language_order() {
-		$args = array(
-			'name'       => 'English',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 0,
-		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$this->add_language(); // English
 
-		$args = array(
-			'name'       => 'Français',
-			'slug'       => 'fr',
-			'locale'     => 'fr_FR',
-			'rtl'        => 0,
-			'flag'       => 'fr',
-			'term_group' => 1,
+		$this->add_language(
+			array(
+				'name'       => 'Français',
+				'slug'       => 'fr',
+				'locale'     => 'fr_FR',
+				'rtl'        => 0,
+				'flag'       => 'fr',
+				'term_group' => 1,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$args = array(
-			'name'       => 'Deutsch',
-			'slug'       => 'de',
-			'locale'     => 'de_DE',
-			'rtl'        => 0,
-			'flag'       => 'de',
-			'term_group' => 2,
+		$this->add_language(
+			array(
+				'name'       => 'Deutsch',
+				'slug'       => 'de',
+				'locale'     => 'de_DE',
+				'rtl'        => 0,
+				'flag'       => 'de',
+				'term_group' => 2,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$args = array(
-			'name'       => 'Español',
-			'slug'       => 'es',
-			'locale'     => 'es_ES',
-			'rtl'        => 0,
-			'flag'       => 'es',
-			'term_group' => 3,
+		$this->add_language(
+			array(
+				'name'       => 'Español',
+				'slug'       => 'es',
+				'locale'     => 'es_ES',
+				'rtl'        => 0,
+				'flag'       => 'es',
+				'term_group' => 3,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
 		$expected = array(
 			'en',
@@ -303,17 +294,8 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_language_object_without_term_language_tax() {
-		$args = array(
-			'name'       => 'English',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 0,
-		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$this->add_language(); // English.
 
-		// $this->pll_env->model->clean_languages_cache();
 		$term_language_args = array(
 			'taxonomy' => 'term_language',
 			'hide_empty' => false,
@@ -340,25 +322,18 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	public function test_delete_language_with_content_which_has_this_language() {
 		$this->pll_env->terms = new PLL_CRUD_Terms( $this->pll_env );
 
-		$args = array(
-			'name'       => 'English',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 0,
-		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$this->add_language(); // English.
 
-		$args = array(
-			'name'       => 'Français',
-			'slug'       => 'fr',
-			'locale'     => 'fr_FR',
-			'rtl'        => 0,
-			'flag'       => 'fr',
-			'term_group' => 1,
+		$this->add_language(
+			array(
+				'name'       => 'Français',
+				'slug'       => 'fr',
+				'locale'     => 'fr_FR',
+				'rtl'        => 0,
+				'flag'       => 'fr',
+				'term_group' => 1,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 		$this->assertEquals( 'en', $this->pll_env->options['default_lang'] );
 
 		$fr = self::factory()->post->create();
@@ -391,46 +366,41 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	public function test_delete_language_with_content_which_has_this_language_and_with_clean_languages_cache() {
 		add_action( 'pre_delete_term', array( $this, 'clean_languages_cache_and_build_languages_list' ) );
 
-		// first language
-		$args = array(
-			'name'       => 'English',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 0,
-		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		// First language: English.
+		$this->add_language();
 
-		$args = array(
-			'name'       => 'Español',
-			'slug'       => 'es',
-			'locale'     => 'es_ES',
-			'rtl'        => 0,
-			'flag'       => 'es',
-			'term_group' => 3,
+		$this->add_language(
+			array(
+				'name'       => 'Español',
+				'slug'       => 'es',
+				'locale'     => 'es_ES',
+				'rtl'        => 0,
+				'flag'       => 'es',
+				'term_group' => 3,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$args = array(
-			'name'       => 'Deutsch',
-			'slug'       => 'de',
-			'locale'     => 'de_DE',
-			'rtl'        => 0,
-			'flag'       => 'de',
-			'term_group' => 2,
+		$this->add_language(
+			array(
+				'name'       => 'Deutsch',
+				'slug'       => 'de',
+				'locale'     => 'de_DE',
+				'rtl'        => 0,
+				'flag'       => 'de',
+				'term_group' => 2,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$args = array(
-			'name'       => 'Français',
-			'slug'       => 'fr',
-			'locale'     => 'fr_FR',
-			'rtl'        => 0,
-			'flag'       => 'fr',
-			'term_group' => 1,
+		$this->add_language(
+			array(
+				'name'       => 'Français',
+				'slug'       => 'fr',
+				'locale'     => 'fr_FR',
+				'rtl'        => 0,
+				'flag'       => 'fr',
+				'term_group' => 1,
+			)
 		);
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 		$this->assertEquals( 'en', $this->pll_env->options['default_lang'] );
 
 		$fr = self::factory()->post->create();

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -2,10 +2,18 @@
 
 class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
+	public function set_up() {
+		parent::set_up();
+
+		$options       = PLL_Install::get_default_options();
+		$model         = new PLL_Admin_Model( $options );
+		$links_model   = $model->get_links_model();
+		$this->pll_env = new PLL_Admin( $links_model );
+	}
 
 	public function tear_down() {
-		foreach ( self::$model->get_languages_list() as $lang ) {
-			self::$model->delete_language( $lang->term_id );
+		foreach ( $this->pll_env->model->get_languages_list() as $lang ) {
+			$this->pll_env->model->delete_language( $lang->term_id );
 		}
 
 		parent::tear_down();
@@ -22,9 +30,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 2,
 		);
 
-		$this->assertTrue( self::$model->add_language( $args ) );
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$lang = self::$model->get_language( 'en' );
+		$lang = $this->pll_env->model->get_language( 'en' );
 
 		$this->assertEquals( 'English', $lang->name );
 		$this->assertEquals( 'en', $lang->slug );
@@ -42,9 +50,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertTrue( self::$model->add_language( $args ) );
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$lang = self::$model->get_language( 'ar' );
+		$lang = $this->pll_env->model->get_language( 'ar' );
 
 		$this->assertEquals( 'العربية', $lang->name );
 		$this->assertEquals( 'ar', $lang->slug );
@@ -53,27 +61,27 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 1, $lang->term_group );
 
 		// check default language
-		$this->assertEquals( 'en', self::$model->options['default_lang'] );
+		$this->assertEquals( 'en', $this->pll_env->model->options['default_lang'] );
 
 		// check language order
-		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), $this->pll_env->model->get_languages_list( array( 'fields' => 'slug' ) ) );
 
 		// attempt to create a language with the same slug as an existing one
-		self::$model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
-		$lang = self::$model->get_language( 'en' );
+		$this->pll_env->model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
+		$lang = $this->pll_env->model->get_language( 'en' );
 		$this->assertEquals( 'en_US', $lang->locale );
-		$this->assertFalse( self::$model->get_language( 'en_GB' ) );
-		$this->assertEquals( 2, count( self::$model->get_languages_list() ) );
+		$this->assertFalse( $this->pll_env->model->get_language( 'en_GB' ) );
+		$this->assertEquals( 2, count( $this->pll_env->model->get_languages_list() ) );
 
 		// delete 1 language
-		$lang = self::$model->get_language( 'en_US' );
-		self::$model->delete_language( $lang->term_id );
-		$this->assertEquals( 'ar', self::$model->options['default_lang'] );
+		$lang = $this->pll_env->model->get_language( 'en_US' );
+		$this->pll_env->model->delete_language( $lang->term_id );
+		$this->assertEquals( 'ar', $this->pll_env->model->options['default_lang'] );
 
 		// delete the last language
-		$lang = self::$model->get_language( 'ar' );
-		self::$model->delete_language( $lang->term_id );
-		$this->assertEquals( array(), self::$model->get_languages_list() );
+		$lang = $this->pll_env->model->get_language( 'ar' );
+		$this->pll_env->model->delete_language( $lang->term_id );
+		$this->assertEquals( array(), $this->pll_env->model->get_languages_list() );
 	}
 
 	/**
@@ -90,14 +98,14 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertTrue( self::$model->add_language( $args ) );
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		$lang = self::$model->get_language( 'ar' );
+		$lang = $this->pll_env->model->get_language( 'ar' );
 		$args['lang_id'] = $lang->term_id;
 		$args['slug'] = 'ar';
-		$this->assertTrue( self::$model->update_language( $args ) );
+		$this->assertTrue( $this->pll_env->model->update_language( $args ) );
 
-		self::$model->delete_language( $lang->term_id );
+		$this->pll_env->model->delete_language( $lang->term_id );
 	}
 
 	public function test_invalid_languages() {
@@ -112,26 +120,26 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 1,
 		);
 
-		$this->assertWPError( self::$model->add_language( $args ), 'The language must have a name' );
+		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'The language must have a name' );
 
 		$args['name'] = 'English';
 		$args['locale'] = 'EN';
 
-		$this->assertWPError( self::$model->add_language( $args ), 'Enter a valid WordPress locale' );
+		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'Enter a valid WordPress locale' );
 
 		$args['locale'] = 'en-US';
 
-		$this->assertWPError( self::$model->add_language( $args ), 'Enter a valid WordPress locale' );
+		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'Enter a valid WordPress locale' );
 
 		$args['locale'] = 'en_US';
 		$args['slug'] = 'EN';
 
-		$this->assertWPError( self::$model->add_language( $args ), 'The language code contains invalid characters' );
+		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'The language code contains invalid characters' );
 
 		$args['slug'] = 'en';
 		$args['flag'] = 'en';
 
-		$this->assertWPError( self::$model->add_language( $args ), 'The flag does not exist' );
+		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'The flag does not exist' );
 	}
 
 	/**
@@ -147,9 +155,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'term_group' => 2,
 		);
 
-		self::$model->add_language( $args );
-		self::$model->set_languages_ready();
-		self::$model->get_languages_list(); // Saves the transient.
+		$this->pll_env->model->add_language( $args );
+		$this->pll_env->model->set_languages_ready();
+		$this->pll_env->model->get_languages_list(); // Saves the transient.
 
 		$properties = array(
 			'term_id',
@@ -204,9 +212,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'flag'       => 'us',
 			'term_group' => 2,
 		);
-		self::$model->add_language( $args );
+		$this->pll_env->model->add_language( $args );
 
-		$links_model     = self::$model->get_links_model();
+		$links_model     = $this->pll_env->model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
 		$pll_admin->options['hide_default'] = 1;
 		new PLL_Filters_Links( $pll_admin );
@@ -238,14 +246,49 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'flag'       => 'fr',
 			'term_group' => 2,
 		);
-		$this->assertTrue( self::$model->add_language( $args ) );
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 	}
 
 	public function test_default_language_order() {
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
-		self::create_language( 'de_DE' );
-		self::create_language( 'es_ES' );
+		$args = array(
+			'name'       => 'English',
+			'slug'       => 'en',
+			'locale'     => 'en_US',
+			'rtl'        => 0,
+			'flag'       => 'us',
+			'term_group' => 0,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Français',
+			'slug'       => 'fr',
+			'locale'     => 'fr_FR',
+			'rtl'        => 0,
+			'flag'       => 'fr',
+			'term_group' => 1,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Deutsch',
+			'slug'       => 'de',
+			'locale'     => 'de_DE',
+			'rtl'        => 0,
+			'flag'       => 'de',
+			'term_group' => 2,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Español',
+			'slug'       => 'es',
+			'locale'     => 'es_ES',
+			'rtl'        => 0,
+			'flag'       => 'es',
+			'term_group' => 3,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
 		$expected = array(
 			'en',
@@ -254,12 +297,21 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			'es',
 		);
 
-		$this->assertSameSetsWithIndex( $expected, self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
+		$this->assertSameSetsWithIndex( $expected, $this->pll_env->model->get_languages_list( array( 'fields' => 'slug' ) ) );
 	}
 
 	public function test_create_language_object_without_term_language_tax() {
-		self::create_language( 'en_US' );
-		self::$model->clean_languages_cache();
+		$args = array(
+			'name'       => 'English',
+			'slug'       => 'en',
+			'locale'     => 'en_US',
+			'rtl'        => 0,
+			'flag'       => 'us',
+			'term_group' => 0,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		// $this->pll_env->model->clean_languages_cache();
 		$term_language_args = array(
 			'taxonomy' => 'term_language',
 			'hide_empty' => false,
@@ -272,7 +324,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
 		$this->assertEmpty( get_terms( $term_language_args ) );
 
-		$language = self::$model->get_language( 'en' );
+		$language = $this->pll_env->model->get_language( 'en' );
 
 		$this->assertInstanceOf( PLL_Language::class, $language );
 	}
@@ -284,18 +336,102 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 * Polylang Pro #1626
 	 */
 	public function test_delete_language_with_content_which_has_this_language() {
-		$links_model  = self::$model->get_links_model();
-		$admin        = new PLL_Admin( $links_model );
-		$admin->terms = new PLL_CRUD_Terms( $admin );
+		$this->pll_env->terms = new PLL_CRUD_Terms( $this->pll_env );
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR', array( 'term_group' => 1 ) );
+		$args = array(
+			'name'       => 'English',
+			'slug'       => 'en',
+			'locale'     => 'en_US',
+			'rtl'        => 0,
+			'flag'       => 'us',
+			'term_group' => 0,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Français',
+			'slug'       => 'fr',
+			'locale'     => 'fr_FR',
+			'rtl'        => 0,
+			'flag'       => 'fr',
+			'term_group' => 1,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$this->assertEquals( 'en', $this->pll_env->options['default_lang'] );
 
 		$fr = self::factory()->post->create();
-		self::$model->post->set_language( $fr, 'fr' );
+		$this->pll_env->model->post->set_language( $fr, 'fr' );
 
-		$lang = self::$model->get_language( 'fr' );
-		self::$model->delete_language( $lang->term_id );
-		$this->assertCount( 1, self::$model->get_languages_list() );
+		$lang = $this->pll_env->model->get_language( 'fr' );
+		$this->pll_env->model->delete_language( $lang->term_id );
+		$this->assertCount( 1, $this->pll_env->model->get_languages_list() );
+	}
+
+	/**
+	 * Test a second language deletion with 'term_group' > 0
+	 * and the language is assigned to a content.
+	 *
+	 * A language cache clean up and a languages list built are also run during the language deletion process.
+	 *
+	 * Polylang Pro #1626
+	 */
+	public function test_delete_language_with_content_which_has_this_language_and_with_clean_languages_cache() {
+		add_action(
+			'pre_delete_term',
+			function( $term_id ) {
+				$this->pll_env->model->clean_languages_cache();
+				$this->pll_env->model->get_languages_list();
+			}
+		);
+
+		// first language
+		$args = array(
+			'name'       => 'English',
+			'slug'       => 'en',
+			'locale'     => 'en_US',
+			'rtl'        => 0,
+			'flag'       => 'us',
+			'term_group' => 0,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Español',
+			'slug'       => 'es',
+			'locale'     => 'es_ES',
+			'rtl'        => 0,
+			'flag'       => 'es',
+			'term_group' => 3,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Deutsch',
+			'slug'       => 'de',
+			'locale'     => 'de_DE',
+			'rtl'        => 0,
+			'flag'       => 'de',
+			'term_group' => 2,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+
+		$args = array(
+			'name'       => 'Français',
+			'slug'       => 'fr',
+			'locale'     => 'fr_FR',
+			'rtl'        => 0,
+			'flag'       => 'fr',
+			'term_group' => 1,
+		);
+		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
+		$this->assertEquals( 'en', $this->pll_env->options['default_lang'] );
+
+		$fr = self::factory()->post->create();
+		$this->pll_env->model->post->set_language( $fr, 'fr' );
+
+		$lang = $this->pll_env->model->get_language( 'fr' );
+		$this->pll_env->model->delete_language( $lang->term_id );
+		$this->assertCount( 3, $this->pll_env->model->get_languages_list() );
+		remove_all_actions( 'pre_delete_term' );
 	}
 }

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -22,7 +22,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_add_and_delete_language() {
-		// first language
+		// First language.
 		$args = array(
 			'name'       => 'English',
 			'slug'       => 'en',
@@ -42,7 +42,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 0, $lang->is_rtl );
 		$this->assertEquals( 2, $lang->term_group );
 
-		// second language (rtl)
+		// Second language (rtl).
 		$args = array(
 			'name'       => 'العربية',
 			'slug'       => 'ar',
@@ -62,25 +62,25 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 1, $lang->is_rtl );
 		$this->assertEquals( 1, $lang->term_group );
 
-		// check default language
+		// Check default language.
 		$this->assertEquals( 'en', $this->pll_env->model->options['default_lang'] );
 
-		// check language order
+		// Check language order.
 		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), $this->pll_env->model->get_languages_list( array( 'fields' => 'slug' ) ) );
 
-		// attempt to create a language with the same slug as an existing one
+		// Attempt to create a language with the same slug as an existing one.
 		$this->pll_env->model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
 		$lang = $this->pll_env->model->get_language( 'en' );
 		$this->assertEquals( 'en_US', $lang->locale );
 		$this->assertFalse( $this->pll_env->model->get_language( 'en_GB' ) );
 		$this->assertEquals( 2, count( $this->pll_env->model->get_languages_list() ) );
 
-		// delete 1 language
+		// Delete 1 language.
 		$lang = $this->pll_env->model->get_language( 'en_US' );
 		$this->pll_env->model->delete_language( $lang->term_id );
 		$this->assertEquals( 'ar', $this->pll_env->model->options['default_lang'] );
 
-		// delete the last language
+		// Delete the last language.
 		$lang = $this->pll_env->model->get_language( 'ar' );
 		$this->pll_env->model->delete_language( $lang->term_id );
 		$this->assertEquals( array(), $this->pll_env->model->get_languages_list() );
@@ -90,10 +90,10 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 * Bug fixed in 2.3.
 	 */
 	public function test_unique_language_code_if_same_as_locale() {
-		// First language
+		// First language.
 		$args = array(
 			'name'       => 'العربية',
-			'slug'       => 'a', // Intentional mistake
+			'slug'       => 'a', // Intentional mistake.
 			'locale'     => 'ar',
 			'rtl'        => 1,
 			'flag'       => 'arab',
@@ -202,10 +202,10 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * This test a conflict with Yoast SEO.
+	 * This tests a conflict with Yoast SEO.
 	 */
 	public function test_create_language_when_term_link_requested_on_created_term() {
-		// first language
+		// First language.
 		$args = array(
 			'name'       => 'English',
 			'slug'       => 'en',
@@ -239,7 +239,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 			3
 		);
 
-		// second language
+		// Second language.
 		$args = array(
 			'name'       => 'Francais',
 			'slug'       => 'fr',
@@ -313,7 +313,6 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		);
 		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
 
-		// $this->pll_env->model->clean_languages_cache();
 		$term_language_args = array(
 			'taxonomy' => 'term_language',
 			'hide_empty' => false,
@@ -391,7 +390,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	public function test_delete_language_with_content_which_has_this_language_and_with_clean_languages_cache() {
 		add_action( 'pre_delete_term', array( $this, 'clean_languages_cache_and_build_languages_list' ) );
 
-		// first language
+		// First language.
 		$args = array(
 			'name'       => 'English',
 			'slug'       => 'en',

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -266,7 +266,8 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$language = self::$model->get_language( 'en' );
 
 		$this->assertInstanceOf( PLL_Language::class, $language );
-		
+	}
+
 	/**
 	 * Test a second language deletion with 'term_group' > 0
 	 * and the language is assigned to a content.

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -12,6 +12,8 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	public function tear_down() {
+		remove_action( 'pre_delete_term', array( $this, 'clean_languages_cache_and_build_languages_list' ) );
+
 		foreach ( $this->pll_env->model->get_languages_list() as $lang ) {
 			$this->pll_env->model->delete_language( $lang->term_id );
 		}
@@ -368,6 +370,17 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	/**
+	 * Simulate cleaning the languages cache and building the langugages list
+	 * during the language deletion process by hooking to pre_delete_term.
+	 *
+	 * @return void
+	 */
+	public function clean_languages_cache_and_build_languages_list() {
+		$this->pll_env->model->clean_languages_cache();
+		$this->pll_env->model->get_languages_list();
+	}
+
+	/**
 	 * Test a second language deletion with 'term_group' > 0
 	 * and the language is assigned to a content.
 	 *
@@ -376,13 +389,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 * Polylang Pro #1626
 	 */
 	public function test_delete_language_with_content_which_has_this_language_and_with_clean_languages_cache() {
-		add_action(
-			'pre_delete_term',
-			function( $term_id ) {
-				$this->pll_env->model->clean_languages_cache();
-				$this->pll_env->model->get_languages_list();
-			}
-		);
+		add_action( 'pre_delete_term', array( $this, 'clean_languages_cache_and_build_languages_list' ) );
 
 		// first language
 		$args = array(
@@ -432,6 +439,5 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$lang = $this->pll_env->model->get_language( 'fr' );
 		$this->pll_env->model->delete_language( $lang->term_id );
 		$this->assertCount( 3, $this->pll_env->model->get_languages_list() );
-		remove_all_actions( 'pre_delete_term' );
 	}
 }

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -26,6 +26,14 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	 *
 	 * By default English language is added.
 	 *
+	 * @param array $args {
+	 *   @type string $name       Language name.
+	 *   @type string $slug       Language code.
+	 *   @type string $locale     WordPress locale.
+	 *   @type int    $rtl        1 if rtl language, 0 otherwise.
+	 *   @type string $flag       Optional, country code, {@see settings/flags.php}.
+	 *   @type int    $term_group Language order when displayed.
+	 * }
 	 * @return void
 	 */
 	private function add_language( $args = array() ) {
@@ -40,7 +48,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
 		$args = wp_parse_args( $args, $defaults );
 
-		$this->assertTrue( $this->pll_env->model->add_language( $args ),"{$args['name']} language wasn't added." );
+		$this->assertTrue( $this->pll_env->model->add_language( $args ), "{$args['name']} language wasn't added." );
 	}
 
 	public function test_add_and_delete_language() {


### PR DESCRIPTION
fixes https://github.com/polylang/polylang-pro/issues/1626

## Prerequisities

As it's explained in the #1626 is required to cause the issue:
- change the order (>0) of the language in the language settings page. It makes the `language` key first in the associative array passed to create the PLL_Language object. See https://github.com/polylang/polylang/blob/master/include/language-factory.php#L69. Otherwise without any order `term_language` key is first.
- have a content type (post or page) which this language is assigned. When we delete terms for the language taxonomies (`language` and `term_language`) See https://github.com/polylang/polylang/blob/master/admin/admin-model.php#L145 `wp_delete_term` WordPress function also removes taxonomies aasigned to content See https://github.com/WordPress/WordPress/blob/6.2/wp-includes/taxonomy.php#L2046-L2049
- In addition Polylang is hooked to `pre_delete_term` action tiggered by `wp_delete_term` WordPress function
See https://github.com/WordPress/WordPress/blob/6.2/wp-includes/taxonomy.php#L2022
and https://github.com/polylang/polylang/blob/3.3.2/include/crud-terms.php#L252-L255 
- Polylang is also hooked to `edited_term_taxonomy` action triggered in `_update_post_term_count` or `_update_generic_term_count` functions See https://github.com/WordPress/WordPress/blob/6.2/wp-includes/taxonomy.php#L4045-L4099 or https://github.com/WordPress/WordPress/blob/6.2/wp-includes/taxonomy.php#L4113-L4126. Polylang cleans the languages cache See https://github.com/polylang/polylang/blob/master/include/model.php#L235-L240

## What happens?

- The `language` term is deleted first by calling `wp_delete_term`  WordPress function.
- `wp_delete_term`  WordPress function then calls `wp_remove_object_terms` to remove language assignmnet to contents.
- `wp_remove_object_terms` calls `wp_update_term_count` which calls `_update_post_term_count` or `_update_generic_term_count` and then triggers the `edited_term_taxonomy` action.
- Polylang then cleans the language cache.
- The 'term_language' term is then deleted. However `wp_delete_term` tiggers `pre_delete_term` action which calls `PLL_CRUD_Terms::delete_term()` then `PLL_Translated_Term::delete_translation()` then `PLL_Translated_Term::get_translation()` then `PLL_Translated_Term::validate_translation()` where `PLL_Model::get_languages_list()` is called.
See https://github.com/polylang/polylang/blob/23b1a797bd3f71690a1ac68d87920340bbf08778/include/translated-object.php#L447
- At this point the languages cache is empty (no more cache and transient exist). So `PLL_Model::get_languages_from_taxonomies()` is called to build again the languages list. However the language term doesn't exist any more. Thus, when `PLL_Language_Factory::get_from_terms()` is called only the `term_language` key exists in the expected array parameter. The notice reported is thus triggered because the `language` key is referenced in the `PLL_Language_Factory::get_from_terms()` code unlike the `term_language` key. See https://github.com/polylang/polylang/blob/master/include/language-factory.php#L72-L74

## Proposal

This PR propose two kind of fixes.
- One to reverse the order of keys in the associative array passed to `PLL_Language_Factory::get_from_terms()`.
It makes `term_language` to be deleted first because it is created in the `PLL_Language` object properties first.
See https://github.com/polylang/polylang/blob/master/include/language-factory.php#L79-L85
- The other is to avoid to call  `PLL_Translated_Term::delete_translation()` on `pre_delete_term` action because a language isn't translatable. In fact it's also the case for all kind of terms. We need to check if a term is translatable before calling `PLL_Translated_Term::delete_translation()`.

