### PR TITLE
PHPStan for WP 6.2

### DIFF
--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -112,7 +112,7 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 				// Since WP 6.2.
 				$hosts[ $lang ] = \WpOrg\Requests\IdnaEncoder::encode( $host );
 			} else {
-				// Compat WP < 6.2.
+				// Backward compatibility with WP < 6.2.
 				$hosts[ $lang ] = Requests_IDNAEncoder::encode( $host );
 			}
 		}

--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -99,11 +99,20 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 		$hosts = array();
 		foreach ( $this->options['domains'] as $lang => $domain ) {
 			$host = wp_parse_url( $domain, PHP_URL_HOST );
+
+			if ( ! is_string( $host ) ) {
+				continue;
+			}
+
 			// The function idn_to_ascii() is much faster than the WordPress method.
 			if ( function_exists( 'idn_to_ascii' ) ) {
 				// The use of the constant is mandatory in PHP 7.2 and PHP 7.3 to avoid a deprecated notice.
 				$hosts[ $lang ] = defined( 'INTL_IDNA_VARIANT_UTS46' ) ? idn_to_ascii( $host, 0, INTL_IDNA_VARIANT_UTS46 ) : idn_to_ascii( $host );
+			} elseif ( class_exists( 'WpOrg\Requests\IdnaEncoder' ) ) {
+				// Since WP 6.2.
+				$hosts[ $lang ] = \WpOrg\Requests\IdnaEncoder::encode( $host );
 			} else {
+				// Compat WP < 6.2.
 				$hosts[ $lang ] = Requests_IDNAEncoder::encode( $host );
 			}
 		}

--- a/include/model.php
+++ b/include/model.php
@@ -846,7 +846,7 @@ class PLL_Model {
 	 *
 	 * @phpstan-param non-empty-string $slug
 	 * @phpstan-param non-empty-string $name
-	 * @phpstan-param array<non-empty-string>|null $taxonomies
+	 * @phpstan-param array<non-empty-string> $taxonomies
 	 */
 	protected function update_secondary_language_terms( $slug, $name, PLL_Language $language = null, array $taxonomies = array() ) {
 		$slug = 0 === strpos( $slug, 'pll_' ) ? $slug : "pll_$slug";

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -98,7 +98,7 @@ class PLL_REST_Request extends PLL_Base {
 	 * @param WP_REST_Request $request Request used to generate the response.
 	 * @return mixed Untouched $result.
 	 *
-	 * @phpstan-param WP_REST_Request<array<non-falsy-string, mixed>> $request
+	 * @phpstan-param WP_REST_Request<array{lang?: string}> $request
 	 */
 	public function set_language( $result, $server, $request ) {
 		$lang = $request->get_param( 'lang' );

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -96,8 +96,9 @@ class PLL_REST_Request extends PLL_Base {
 	 * @param mixed           $result  Response to replace the requested version with. Remains untouched.
 	 * @param WP_REST_Server  $server  Server instance.
 	 * @param WP_REST_Request $request Request used to generate the response.
-	 *
 	 * @return mixed Untouched $result.
+	 *
+	 * @phpstan-param WP_REST_Request<array<non-falsy-string, mixed>> $request
 	 */
 	public function set_language( $result, $server, $request ) {
 		$lang = $request->get_param( 'lang' );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1121,11 +1121,6 @@ parameters:
 			path: settings/settings-licenses.php
 
 		-
-			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: settings/settings-module.php
-
-		-
 			message: "#^Method PLL_Settings_Module\\:\\:get_form\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: settings/settings-module.php
@@ -1152,11 +1147,6 @@ parameters:
 
 		-
 			message: "#^Property PLL_Settings\\:\\:\\$modules \\(array\\<PLL_Settings_Module\\>\\|null\\) does not accept array\\<object\\>\\.$#"
-			count: 1
-			path: settings/settings.php
-
-		-
-			message: "#^Variable \\$errors in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: settings/settings.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -736,22 +736,7 @@ parameters:
 			path: include/links-domain.php
 
 		-
-			message: "#^Method PLL_Links_Domain\\:\\:get_hosts\\(\\) should return array\\<string\\> but returns array\\<int\\|string, string\\|false\\>\\.$#"
-			count: 1
-			path: include/links-domain.php
-
-		-
 			message: "#^Method PLL_Links_Domain\\:\\:remove_language_from_link\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: include/links-domain.php
-
-		-
-			message: "#^Parameter \\#1 \\$domain of function idn_to_ascii expects string, string\\|false\\|null given\\.$#"
-			count: 2
-			path: include/links-domain.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of static method Requests_IDNAEncoder\\:\\:encode\\(\\) expects string, string\\|false\\|null given\\.$#"
 			count: 1
 			path: include/links-domain.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -346,7 +346,7 @@ parameters:
 			path: frontend/choose-lang-content.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function get_query_var expects string, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$.+ of function get_query_var expects string, string\\|false given\\.$#"
 			count: 1
 			path: frontend/choose-lang-content.php
 
@@ -511,7 +511,7 @@ parameters:
 			path: frontend/frontend-links.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<int, WP_Term\\>\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#1 \\$.+ of function wp_list_pluck expects array, array\\<int, WP_Term\\>\\|WP_Error given\\.$#"
 			count: 1
 			path: frontend/frontend-links.php
 
@@ -1001,12 +1001,12 @@ parameters:
 			path: modules/sync/sync-tax.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<WP_Term\\>\\|WP_Error given\\.$#"
+			message: "#^Parameter \\#1 \\$.+ of function wp_list_pluck expects array, array\\<WP_Term\\>\\|WP_Error given\\.$#"
 			count: 1
 			path: modules/sync/sync-tax.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of function wp_list_pluck expects array, array\\<WP_Term\\>\\|WP_Error\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$.+ of function wp_list_pluck expects array, array\\<WP_Term\\>\\|WP_Error\\|false given\\.$#"
 			count: 1
 			path: modules/sync/sync-tax.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,3 +61,9 @@ parameters:
 			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
 			count: 1
 			path: include/translated-term.php
+
+		# Ignored because the class Requests_IDNAEncoder exists in WP < 6.2.
+		-
+			message: "#^Call to static method encode\\(\\) on an unknown class Requests_IDNAEncoder\\.$#"
+			count: 1
+			path: include/links-domain.php


### PR DESCRIPTION
This PR fixes [these issues](https://app.travis-ci.com/github/polylang/polylang/jobs/599241509).

## Requests v2

The Requests library has been updated in WP 6.2. Everything has been namespaced and renamed, but the old class names can still be used, but it comes with a deprecation notice.
In `PLL_Links_Domain::get_hosts()` we use `Requests_IDNAEncoder::encode()` but PHPStan reports it as an unknown class now. This class has been renamed into `WpOrg\Requests\IdnaEncoder`, and it is now used in `get_hosts()`. However, PHPStan still doesn't know the old class (which has been kept for backward compatibility), so this message has been ignored in `phpstan.neon.dist`.

## Renamed parameters

`phpstan-baseline.neon` has been updated to take care of the following changes:
- The 1st parameter of `get_query_var()` has been renamed from `$var` to `$query_var`.
- The 1st parameter of `wp_list_pluck()` has been renamed from `$list`to `$input_list`.

## PLL_REST_Request::set_language()

By the time I pushed this PR to Github, a new WP stubs update brings a new issue:
```
Method PLL_REST_Request::set_language() has parameter $request with generic class WP_REST_Request but does not specify its types: T
You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.dist.
```
I don't know why this appears suddenly but it has been fixed by adding a `@phpstan-param` tag.

## Other

For an unknown reason, some things don't need to be ignored in `phpstan-baseline.neon` anymore, and have been removed.