### PR TITLE
Prevent "unknown propertiy" warnings

### DIFF
--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -158,8 +158,10 @@ class PLL_OLT_Manager {
 		 */
 		do_action_ref_array( 'pll_translate_labels', array( &$this->labels ) );
 
-		// Free memory
-		unset( $this->default_locale, $this->list_textdomains, $this->labels );
+		// Free memory.
+		$this->default_locale   = null;
+		$this->list_textdomains = array();
+		$this->labels           = array();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1236.

At the end of `PLL_OLT_Manager::load_textdomains()`, reset the properties to their default value instead of unseting them.