### PR TITLE
Fix languages not displayed if transient is an empty array

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -147,7 +147,7 @@ class PLL_Model {
 			} else {
 				$languages = get_transient( 'pll_languages_list' );
 
-				if ( empty( $languages) || ! is_array( $languages ) ) {
+				if ( empty( $languages ) || ! is_array( $languages ) ) {
 					// Create the languages from taxonomies.
 					$languages = $this->get_languages_from_taxonomies();
 				} else {

--- a/include/model.php
+++ b/include/model.php
@@ -147,7 +147,7 @@ class PLL_Model {
 			} else {
 				$languages = get_transient( 'pll_languages_list' );
 
-				if ( ! is_array( $languages ) ) {
+				if ( empty( $languages) || ! is_array( $languages ) ) {
 					// Create the languages from taxonomies.
 					$languages = $this->get_languages_from_taxonomies();
 				} else {


### PR DESCRIPTION
If for some reason (for example a database error), we don't succeed to get the language terms at some points, we cache an empty array in the transient. In such situation, the languages list display in the settings is empty and the Polylang settings are not displayed. The user is stucked not being able to refresh the transient (the URL modifications are not accessible anymore), not beign able to "re-create" the languages as they are already in the database (the user gets the error message "Impossible to add the language".

I experienced this issue after a manually created database error. This *may* explain some of the support issues reporting the above error.

I just propose to get the languages from the terms when the transient is empty.