### PR TITLE
Make `term_language` taxonomy optional when creating languages.

### DIFF
--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -61,10 +61,11 @@ class PLL_Language_Factory {
 	 * @since 3.4
 	 *
 	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
-	 *                         `language` and `term_language` are mandatory keys.
+	 *                         `language` is a mandatory keys, `term_language` should be too in a
+	 *                         fully operational environment.
 	 * @return PLL_Language
 	 *
-	 * @phpstan-param array{language:WP_Term, term_language:WP_Term}&array<string, WP_Term> $terms
+	 * @phpstan-param array{language:WP_Term, term_language?:WP_Term}&array<string, WP_Term> $terms
 	 */
 	public function get_from_terms( array $terms ) {
 		$languages = $this->get_languages();

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -61,7 +61,7 @@ class PLL_Language_Factory {
 	 * @since 3.4
 	 *
 	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
-	 *                         `language` is a mandatory keys, `term_language` should be too in a
+	 *                         `language` is a mandatory key, `term_language` should be too in a
 	 *                         fully operational environment.
 	 * @return PLL_Language
 	 *

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -65,7 +65,7 @@ class PLL_Language_Factory {
 	 *                         fully operational environment.
 	 * @return PLL_Language
 	 *
-	 * @phpstan-param array{language:WP_Term, term_language?:WP_Term}&array<string, WP_Term> $terms
+	 * @phpstan-param array{language:WP_Term}&array<string, WP_Term> $terms
 	 */
 	public function get_from_terms( array $terms ) {
 		$languages = $this->get_languages();

--- a/include/language.php
+++ b/include/language.php
@@ -18,7 +18,7 @@
  * @phpstan-type LanguageData array{
  *     term_props: array{
  *         language: LanguagePropData,
- *         term_language: LanguagePropData
+ *         term_language?: LanguagePropData
  *     },
  *     name: non-empty-string,
  *     slug: non-empty-string,
@@ -252,7 +252,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @phpstan-var array{
 	 *         language: LanguagePropData,
-	 *         term_language: LanguagePropData
+	 *         term_language?: LanguagePropData
 	 *     }
 	 *     &array<non-empty-string, LanguagePropData>
 	 */

--- a/include/language.php
+++ b/include/language.php
@@ -18,8 +18,7 @@
  * @phpstan-type LanguageData array{
  *     term_props: array{
  *         language: LanguagePropData,
- *         term_language?: LanguagePropData
- *     },
+ *     }&array<non-empty-string, LanguagePropData>,
  *     name: non-empty-string,
  *     slug: non-empty-string,
  *     locale: non-empty-string,
@@ -252,7 +251,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @phpstan-var array{
 	 *         language: LanguagePropData,
-	 *         term_language?: LanguagePropData
 	 *     }
 	 *     &array<non-empty-string, LanguagePropData>
 	 */

--- a/include/model.php
+++ b/include/model.php
@@ -911,7 +911,6 @@ class PLL_Model {
 		 *     array{
 		 *         string: array{
 		 *             language: WP_Term,
-		 *             term_language?: WP_Term
 		 *         }&array<non-empty-string, WP_Term>
 		 *     }
 		 * ) $terms_by_slug

--- a/include/model.php
+++ b/include/model.php
@@ -911,7 +911,7 @@ class PLL_Model {
 		 *     array{
 		 *         string: array{
 		 *             language: WP_Term,
-		 *             term_language: WP_Term
+		 *             term_language?: WP_Term
 		 *         }&array<non-empty-string, WP_Term>
 		 *     }
 		 * ) $terms_by_slug

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -247,4 +247,24 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
 	}
+
+	public function test_create_language_object_without_term_language_tax() {
+		self::create_language( 'en_US' );
+		self::$model->clean_languages_cache();
+		$term_language_args = array(
+			'taxonomy' => 'term_language',
+			'hide_empty' => false,
+		);
+		$terms_to_delete = get_terms( $term_language_args );
+
+		foreach ( $terms_to_delete as $term ) {
+			wp_delete_term( $term->term_id, 'term_language' );
+		}
+
+		$this->assertEmpty( get_terms( $term_language_args ) );
+
+		$language = self::$model->get_language( 'en' );
+
+		$this->assertInstanceOf( PLL_Language::class, $language );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1609

## What?
Do not set `term_language` as mandatory when creating `PLL_Language` objects.

## Why?
`term_language` terms deletion may occur during database cleaning.

## How?
Adapt PHPStan documentation and make `term_language` optional.