### PR TITLE
Fix the display of PLL_Language::$term_props in the health site.

### DIFF
--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -318,7 +318,7 @@ class PLL_Admin_Site_Health {
 
 			$keys_with_language_taxonomy = array_map(
 				function ( $key, $language_taxonomy ) {
-					return $language_taxonomy . '/' . $key;
+					return "{$language_taxonomy}/{$key}";
 				},
 				array_keys( $item ),
 				$language_taxonomy_array

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -305,7 +305,7 @@ class PLL_Admin_Site_Health {
 	/**
 	 * Adds term props data to the info languages array.
 	 *
-	 * @since 3.3
+	 * @since 3.4
 	 *
 	 * @param array $value The term props data.
 	 * @return array The term props data formatted for the info languages tab.

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -324,7 +324,7 @@ class PLL_Admin_Site_Health {
 				$language_taxonomy_array
 			);
 
-			$value = array_combine( array_values( $keys_with_language_taxonomy ), array_values( $item ) );
+			$value = array_combine( $keys_with_language_taxonomy, $item );
 			if ( is_array( $value ) ) {
 				$return_value = array_merge( $return_value, $value );
 			}

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -257,7 +257,7 @@ class PLL_Admin_Site_Health {
 	}
 
 	/**
-	 * Add Polylang Languages settings to Site Health Informations tab.
+	 * Adds Polylang Languages settings to Site Health Information tab.
 	 *
 	 * @since 2.8
 	 *
@@ -278,7 +278,12 @@ class PLL_Admin_Site_Health {
 				}
 
 				$fields[ $key ]['label'] = $key;
-				$fields[ $key ]['value'] = $value;
+
+				if ( 'term_props' === $key ) {
+					$fields[ $key ]['value'] = $this->get_info_term_props( $value );
+				} else {
+					$fields[ $key ]['value'] = $value;
+				}
 
 				if ( 'term_group' === $key ) {
 					$fields[ $key ]['label'] = 'order'; // Changed for readability but not translated as other keys are not.
@@ -295,6 +300,35 @@ class PLL_Admin_Site_Health {
 		}
 
 		return $debug_info;
+	}
+
+	/**
+	 * Adds term props data to the info languages array.
+	 *
+	 * @since 3.3
+	 *
+	 * @param array $value The term props data.
+	 * @return array The term props data formatted for the info languages tab.
+	 */
+	protected function get_info_term_props( $value ) {
+		$return_value = array();
+
+		foreach ( $value as $language_taxonomy => $item ) {
+			$language_taxonomy_array = array_fill( 0, count( $item ), $language_taxonomy );
+
+			$keys_with_language_taxonomy = array_map(
+				function ( $key, $language_taxonomy ) {
+					return $language_taxonomy . '/' . $key;
+				},
+				array_keys( $item ),
+				$language_taxonomy_array
+			);
+
+			$value = array_combine( array_values( $keys_with_language_taxonomy ), array_values( $item ) );
+
+			$return_value = array_merge( $return_value, $value );
+		}
+		return $return_value;
 	}
 
 	/**

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -279,7 +279,7 @@ class PLL_Admin_Site_Health {
 
 				$fields[ $key ]['label'] = $key;
 
-				if ( 'term_props' === $key ) {
+				if ( 'term_props' === $key && is_array( $value ) ) {
 					$fields[ $key ]['value'] = $this->get_info_term_props( $value );
 				} else {
 					$fields[ $key ]['value'] = $value;

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -325,8 +325,9 @@ class PLL_Admin_Site_Health {
 			);
 
 			$value = array_combine( array_values( $keys_with_language_taxonomy ), array_values( $item ) );
-
-			$return_value = array_merge( $return_value, $value );
+			if ( is_array( $value ) ) {
+				$return_value = array_merge( $return_value, $value );
+			}
 		}
 		return $return_value;
 	}

--- a/tests/phpunit/tests/test-admin-site-health.php
+++ b/tests/phpunit/tests/test-admin-site-health.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * Class Admin_Site_Health_Test
+ */
+class Admin_Site_Health_Test extends PLL_UnitTestCase {
+
+	/**
+	 * @var PLL_Admin_Site_Health
+	 */
+	private $site_health;
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+	}
+
+	/**
+	 * Performs setup tasks for every test.
+	 *
+	 * @since 3.3
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$links_model     = self::$model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+
+		$this->site_health = new PLL_Admin_Site_Health( $this->pll_admin );
+	}
+
+	public function test_info_languages_term_props() {
+		$info = $this->site_health->info_languages( array() );
+
+		$this->assertIsArray( $info, 'Info should be an array.' );
+		$this->assertCount( 2, $info, 'Info should contain two elements.' );
+
+		$this->assertArrayHasKey( 'pll_language_en', $info, 'Info should have an entry with pll_language_en key.' );
+		$this->assertArrayHasKey( 'pll_language_fr', $info, 'Info should have an entry with pll_language_fr key.' );
+		$this->assertArrayHasKey( 'term_props', $info['pll_language_en']['fields'], 'Info should have an entry with term_props key.' );
+
+		$info = $info['pll_language_en']['fields'];
+		$this->assertSame( 'term_props', $info['term_props']['label'], 'The label of the term_props entry should be term_props' );
+
+		$this->assertIsArray( $info['term_props']['value'], 'This should be an array' );
+		$this->assertCount( 6, $info['term_props']['value'], 'This should contain 6 elements.' );
+
+		$this->assertArrayHasKey( 'term_language/term_id', $info['term_props']['value'], 'The value of the term_props entry should have an entry with term_language/term_id key.' );
+		$this->assertArrayHasKey( 'term_language/term_taxonomy_id', $info['term_props']['value'], 'The value of the term_props entry should have an entry with term_language/term_taxonomy_id key.' );
+		$this->assertArrayHasKey( 'term_language/count', $info['term_props']['value'], 'The value of the term_props entry should have an entry with term_language/count key.' );
+		$this->assertArrayHasKey( 'language/term_id', $info['term_props']['value'], 'The value of the term_props entry should have an entry with language/term_id key.' );
+		$this->assertArrayHasKey( 'language/term_taxonomy_id', $info['term_props']['value'], 'The value of the term_props entry should have an entry with language/term_taxonomy_id key.' );
+		$this->assertArrayHasKey( 'language/count', $info['term_props']['value'], 'The value of the term_props entry should have an entry with language/count key.' );
+
+		$en = $this->pll_admin->model->get_language( 'en' );
+		$this->assertSame( $en->get_tax_prop( 'language', 'term_id' ), $info['term_props']['value']['language/term_id'] );
+		$this->assertSame( $en->get_tax_prop( 'language', 'term_taxonomy_id' ), $info['term_props']['value']['language/term_taxonomy_id'] );
+		$this->assertSame( $en->get_tax_prop( 'language', 'count' ), $info['term_props']['value']['language/count'] );
+		$this->assertSame( $en->get_tax_prop( 'term_language', 'term_id' ), $info['term_props']['value']['term_language/term_id'] );
+		$this->assertSame( $en->get_tax_prop( 'term_language', 'term_taxonomy_id' ), $info['term_props']['value']['term_language/term_taxonomy_id'] );
+		$this->assertSame( $en->get_tax_prop( 'term_language', 'count' ), $info['term_props']['value']['term_language/count'] );
+	}
+}

--- a/tests/phpunit/tests/test-admin-site-health.php
+++ b/tests/phpunit/tests/test-admin-site-health.php
@@ -25,8 +25,6 @@ class Admin_Site_Health_Test extends PLL_UnitTestCase {
 
 	/**
 	 * Performs setup tasks for every test.
-	 *
-	 * @since 3.3
 	 */
 	public function set_up() {
 		parent::set_up();


### PR DESCRIPTION
Fix https://github.com/polylang/polylang/issues/1241

Format the values of `term_props` to have the following display : 
```
language/term_id: xxx
language/term_taxonomy_id: xxx
language/count: xx
term_language/term_id: xxx
term_language/term_taxonomy_id: xxx
term_language/count: xx
```

And add a test. 

