### PR TITLE
Fix infinite loop in wizard 🧙‍♂️

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -775,14 +775,14 @@ class PLL_Model {
 	 * @param PLL_Language|null $lang  Optional. The language to assign to objects. Defaults to `null` (default language).
 	 * @param string[]          $types Optional. Types to handle (@see PLL_Translatable_Object::get_type()). Defaults
 	 *                                 to an empty array (all types).
-	 * @return string[] The types that may still have non-translated objects.
+	 * @return void
 	 */
 	public function set_language_in_mass( PLL_Language $lang = null, array $types = array() ) {
 		if ( empty( $lang ) ) {
 			$lang = $this->get_default_language();
 
 			if ( empty( $lang ) ) {
-				return array();
+				return;
 			}
 		}
 
@@ -790,7 +790,7 @@ class PLL_Model {
 		$nolang = $this->get_objects_with_no_lang( 1000, $types );
 
 		if ( empty( $nolang ) ) {
-			return array();
+			return;
 		}
 
 		/**
@@ -815,10 +815,10 @@ class PLL_Model {
 		}
 
 		if ( empty( $types_with_objects ) ) {
-			return array();
+			return;
 		}
 
-		return $this->set_language_in_mass( $lang, $types_with_objects );
+		$this->set_language_in_mass( $lang, $types_with_objects );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -770,7 +770,6 @@ class PLL_Model {
 	 * @since 1.2
 	 * @since 3.4 Moved from PLL_Admin_Model class.
 	 *            Removed `$limit` parameter, added `$lang` and `$types` parameters.
-	 *            Returns the types that may still have non-translated objects.
 	 *
 	 * @param PLL_Language|null $lang  Optional. The language to assign to objects. Defaults to `null` (default language).
 	 * @param string[]          $types Optional. Types to handle (@see PLL_Translatable_Object::get_type()). Defaults

--- a/include/model.php
+++ b/include/model.php
@@ -776,8 +776,8 @@ class PLL_Model {
 	 *                                 to an empty array (all types).
 	 * @return void
 	 */
-	public function set_language_in_mass( PLL_Language $lang = null, array $types = array() ) {
-		if ( empty( $lang ) ) {
+	public function set_language_in_mass( $lang = null, array $types = array() ) {
+		if ( ! $lang instanceof PLL_Language ) {
 			$lang = $this->get_default_language();
 
 			if ( empty( $lang ) ) {

--- a/include/model.php
+++ b/include/model.php
@@ -666,14 +666,17 @@ class PLL_Model {
 	}
 
 	/**
-	 * Returns posts and terms ids without language ( used in settings ).
+	 * Returns a list of IDs of objects without language (used in settings and wizard).
 	 *
 	 * @since 0.9
-	 * @since 2.2.6 Add the $limit argument.
+	 * @since 2.2.6 Added the `$limit` parameter.
+	 * @since 3.4 Added the `$types` parameter.
 	 *
-	 * @param int $limit Max number of posts or terms to return. Defaults to -1 (no limit).
-	 * @return array {
-	 *     Objects without language.
+	 * @param int      $limit Optional. Max number of IDs to return. Defaults to -1 (no limit).
+	 * @param string[] $types Optional. Types to handle (@see PLL_Translatable_Object::get_type()). Defaults to
+	 *                        an empty array (all types).
+	 * @return int[][]|false {
+	 *     IDs of objects without language.
 	 *
 	 *     @type int[] $posts Array of post ids.
 	 *     @type int[] $terms Array of term ids.
@@ -681,33 +684,52 @@ class PLL_Model {
 	 *
 	 * @phpstan-param -1|positive-int $limit
 	 */
-	public function get_objects_with_no_lang( $limit = -1 ) {
+	public function get_objects_with_no_lang( $limit = -1, array $types = array() ) {
 		/**
-		 * Filters the max number of posts or terms to return when searching objects with no language.
+		 * Filters the max number of IDs to return when searching objects with no language.
 		 * This filter can be used to decrease the memory usage in case the number of objects
 		 * without language is too big. Using a negative value is equivalent to have no limit.
 		 *
 		 * @since 2.2.6
+		 * @since 3.4 Added the `$types` parameter.
 		 *
-		 * @param int $limit Max number of posts or terms to retrieve from the database.
+		 * @param int      $limit Max number of IDs to retrieve from the database.
+		 * @param string[] $types Types to handle (@see PLL_Translatable_Object::get_type()). An empty array means all
+		 *                        types.
 		 */
-		$limit   = apply_filters( 'get_objects_with_no_lang_limit', $limit );
+		$limit   = apply_filters( 'get_objects_with_no_lang_limit', $limit, $types );
 		$limit   = $limit < 1 ? -1 : max( (int) $limit, 1 );
 		$objects = array();
 
 		foreach ( $this->translatable_objects as $type => $object ) {
+			if ( ! empty( $types ) && ! in_array( $type, $types, true ) ) {
+				continue;
+			}
+
+			$ids = $object->get_objects_with_no_lang( $limit );
+
+			if ( empty( $ids ) ) {
+				continue;
+			}
+
 			// The trailing 's' in the array key is for backward compatibility.
-			$objects[ "{$type}s" ] = $object->get_objects_with_no_lang( $limit );
+			$objects[ "{$type}s" ] = $ids;
 		}
 
+		$objects = ! empty( $objects ) ? $objects : false;
+
 		/**
-		 * Filters the list of untranslated posts ids and terms ids
+		 * Filters the list of IDs of untranslated objects.
 		 *
 		 * @since 0.9
+		 * @since 3.4 Added the `$limit` and `$types` parameters.
 		 *
-		 * @param array|false $objects false if no ids found, list of post and/or term ids otherwise.
+		 * @param int[][]|false $objects List of lists of object IDs, `false` if no IDs found.
+		 * @param int           $limit   Max number of IDs to retrieve from the database.
+		 * @param string[]      $types   Types to handle (@see PLL_Translatable_Object::get_type()). An empty array
+		 *                               means all types.
 		 */
-		return apply_filters( 'pll_get_objects_with_no_lang', empty( array_filter( $objects ) ) ? false : $objects );
+		return apply_filters( 'pll_get_objects_with_no_lang', $objects, $limit, $types );
 	}
 
 	/**
@@ -747,28 +769,56 @@ class PLL_Model {
 	 *
 	 * @since 1.2
 	 * @since 3.4 Moved from PLL_Admin_Model class.
-	 * @since 3.4 Change method signature.
+	 *            Removed `$limit` parameter, added `$lang` and `$types` parameters.
+	 *            Returns the types that may still have non-translated objects.
 	 *
-	 * @param int $limit Max number of posts or terms to return. Defaults to -1 (no limit).
-	 * @return void
-	 *
-	 * @phpstan-param -1|positive-int $limit
+	 * @param PLL_Language|null $lang  Optional. The language to assign to objects. Defaults to `null` (default language).
+	 * @param string[]          $types Optional. Types to handle (@see PLL_Translatable_Object::get_type()). Defaults
+	 *                                 to an empty array (all types).
+	 * @return string[] The types that may still have non-translated objects.
 	 */
-	public function set_language_in_mass( $limit = -1 ) {
-		$nolang = $this->get_objects_with_no_lang( $limit );
+	public function set_language_in_mass( PLL_Language $lang = null, array $types = array() ) {
+		if ( empty( $lang ) ) {
+			$lang = $this->get_default_language();
 
-		if ( empty( $nolang ) ) {
-			return;
-		}
-
-		/** @var PLL_Language $lang */
-		$lang = $this->get_default_language();
-
-		foreach ( $this->translatable_objects as $type => $object ) {
-			if ( ! empty( $nolang[ "{$type}s" ] ) ) {
-				$object->set_language_in_mass( $nolang[ "{$type}s" ], $lang );
+			if ( empty( $lang ) ) {
+				return array();
 			}
 		}
+
+		// 1000 is an arbitrary value that will be filtered by `get_objects_with_no_lang_limit`.
+		$nolang = $this->get_objects_with_no_lang( 1000, $types );
+
+		if ( empty( $nolang ) ) {
+			return array();
+		}
+
+		/**
+		 * Keep track of types where we set the language:
+		 * those are types where we may have more items to process if we have more than 1000 items in total.
+		 * This will prevent unecessary SQL queries in the next recursion: if we have 0 items in this recursion for
+		 * a type, we'll still have 0 in the next one, no need for a new query.
+		 */
+		$types_with_objects = array();
+
+		foreach ( $this->translatable_objects as $type => $object ) {
+			if ( empty( $nolang[ "{$type}s" ] ) ) {
+				continue;
+			}
+
+			if ( ! empty( $types ) && ! in_array( $type, $types, true ) ) {
+				continue;
+			}
+
+			$object->set_language_in_mass( $nolang[ "{$type}s" ], $lang );
+			$types_with_objects[] = $type;
+		}
+
+		if ( empty( $types_with_objects ) ) {
+			return array();
+		}
+
+		return $this->set_language_in_mass( $lang, $types_with_objects );
 	}
 
 	/**

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -485,20 +485,27 @@ abstract class PLL_Translatable_Object {
 		if ( empty( $tt_id ) ) {
 			return;
 		}
+		$ids = array_map( 'intval', $ids );
+		$ids = array_filter( $ids );
+
+		if ( empty( $ids ) ) {
+			return;
+		}
 
 		$values = array();
-		$ids    = array_map( 'intval', $ids );
 
 		foreach ( $ids as $id ) {
 			$values[] = $wpdb->prepare( '( %d, %d )', $id, $tt_id );
 		}
 
-		if ( ! empty( $values ) ) {
-			// PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( "INSERT INTO {$wpdb->term_relationships} ( object_id, term_taxonomy_id ) VALUES " . implode( ',', array_unique( $values ) ) );
-			$lang->update_count(); // Updating term count is mandatory ( thanks to AndyDeGroo )
-		}
+		// PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "INSERT INTO {$wpdb->term_relationships} ( object_id, term_taxonomy_id ) VALUES " . implode( ',', array_unique( $values ) ) );
 
+		// Updating term count is mandatory (thanks to AndyDeGroo).
+		$lang->update_count();
 		clean_term_cache( $ids, $this->tax_language );
+
+		// Invalidate our cache.
+		wp_cache_set( 'last_changed', microtime(), $this->cache_type );
 	}
 }

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -700,15 +700,8 @@ class PLL_Wizard {
 
 		$language = $this->model->get_language( $lang );
 
-		if ( ! empty( $language ) ) {
-			while ( $nolang = $this->model->get_objects_with_no_lang( 1000 ) ) {
-				if ( ! empty( $nolang['posts'] ) ) {
-					$this->model->post->set_language_in_mass( $nolang['posts'], $language );
-				}
-				if ( ! empty( $nolang['terms'] ) ) {
-					$this->model->term->set_language_in_mass( $nolang['terms'], $language );
-				}
-			}
+		if ( $language instanceof PLL_Language ) {
+			$this->model->set_language_in_mass( $language );
 		}
 
 		wp_safe_redirect( esc_url_raw( $this->get_next_step_link() ) );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -776,11 +776,6 @@ parameters:
 			path: include/model.php
 
 		-
-			message: "#^Method PLL_Model\\:\\:get_objects_with_no_lang\\(\\) should return array but returns array\\|false\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
 			message: "#^Parameter \\#1 \\$.+ of function md5 expects string, mixed given\\.$#"
 			count: 1
 			path: include/model.php


### PR DESCRIPTION
Fixes [#1635](https://github.com/polylang/polylang-pro/issues/1635).

This PR fixes 2 bugs that can trigger an infinite loop when assigning a language to untranslated objects in the wizard.

## Cache issue

The main difference between `settings.php` and the wizard is this:
```php
while ( $nolang = $this->model->get_objects_with_no_lang( 1000 ) ) {
```
Since we expect lots of items in the wizard, we create chunks of 1000 items and loop through the chunks.
The issue is that `PLL_Translatable_Object::query_objects_with_no_lang()` stores the result into a cache but `set_language_in_mass()` doesn't clean this cache. This leads to `get_objects_with_no_lang()` to return the same results over and over instead of returning the values for the next chunk.

### Solution

Invalidate our cache at the end of `PLL_Translatable_Object::set_language_in_mass()`.

## Object types issue

#1242 re-introduced `PLL_Model::set_language_in_mass()` and used it in `settings.php`, but forgot to use it in the wizard as well. This can lead to `get_objects_with_no_lang()` to return results for a custom DB table, but these results would never be processed, leading again to an infinite loop.

### Solution

The wizard still needs to loop through chunks of IDs, so why not make it internal to `PLL_Model::get_objects_with_no_lang()`?
`PLL_Model::get_objects_with_no_lang()` and `PLL_Model::set_language_in_mass()` have been revamped:
- The `1000` limit is now internal.
- Instead of using `while`, `set_language_in_mass()` is now recursive. This prevents some unecessary SQL queries by using `get_objects_with_no_lang()` only for the types that may have untranslated items.

PS: I suggest to move all the "no_lang/in_mass" stuff from `PLL_Model` to a dedicated class in a future PR.