### PR TITLE
Backward compatibility for `WP_Block_Editor_Context::$name` prop.

### DIFF
--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -49,7 +49,6 @@ class PLL_Admin_Block_Editor {
 	public function preload_paths( $preload_paths, $context ) {
 		if (
 			$context instanceof WP_Block_Editor_Context
-			&& 'core/edit-post' === $context->name
 			&& $context->post instanceof WP_Post
 			&& $this->model->is_translated_post_type( $context->post->post_type )
 		) {


### PR DESCRIPTION
## What?
Fixes https://app.travis-ci.com/github/polylang/polylang/jobs/599722687
`WP_Block_Editor_Context::$name` only available since WordPress 6.0. [See](https://github.com/WordPress/wordpress-develop/blob/6.2/src/wp-includes/class-wp-block-editor-context.php#L15-L58).

## How?
Remove test on the property, since if `WP_Block_Editor_Context::$post` is a `WP_Post` then the context is for post block editor.