### PR TITLE
Don't remove legacy strings translations at upgrade

### DIFF
--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -226,6 +226,7 @@ class PLL_Upgrade {
 				'nopaging' => true,
 			)
 		);
+
 		if ( ! is_array( $posts ) ) {
 			return;
 		}
@@ -234,7 +235,8 @@ class PLL_Upgrade {
 			$meta = get_post_meta( $post->ID, '_pll_strings_translations', true );
 
 			$term_id = (int) substr( $post->post_title, 12 );
-			wp_delete_post( $post->ID );
+
+			// Do not delete post metas in case a user needs to rollback to Polylang < 3.4.
 
 			if ( empty( $meta ) || ! is_array( $meta ) ) {
 				continue;

--- a/uninstall.php
+++ b/uninstall.php
@@ -84,6 +84,24 @@ class PLL_Uninstall {
 			wp_delete_post( $id, true );
 		}
 
+		/*
+		 * Backward compatibility with Polylang < 3.4.
+		 * Delete the legacy strings translations.
+		 */
+		register_post_type( 'polylang_mo', array( 'rewrite' => false, 'query_var' => false ) );
+		$ids = get_posts(
+			array(
+				'post_type'   => 'polylang_mo',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'nopaging'    => true,
+				'fields'      => 'ids',
+			)
+		);
+		foreach ( $ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+
 		// Delete all what is related to languages and translations
 		$term_ids = array();
 		$tt_ids   = array();


### PR DESCRIPTION
Follow-up of #1209 

I propose not to remove immediately the strings translations stored in the post metas. This is to avoid loosing them all if a user needs to rollback to a version < 3.4. We can remove them in a later release. 