### PR TITLE
Load settings views in an action

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -291,6 +291,12 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function display_languages_form() {
+		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
+		}
+
 		$list_table = new PLL_Table_Languages();
 		$list_table->prepare_items( $this->model->get_languages_list() );
 		include __DIR__ . '/view-tab-lang.php';
@@ -304,8 +310,8 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function display_strings_form() {
-				$string_table = new PLL_Table_String( $this->model->get_languages_list() );
-				$string_table->prepare_items();
+		$string_table = new PLL_Table_String( $this->model->get_languages_list() );
+		$string_table->prepare_items();
 		include __DIR__ . '/view-tab-strings.php';
 	}
 
@@ -330,12 +336,7 @@ class PLL_Settings extends PLL_Admin_Base {
 	public function languages_page() {
 		// Handle user input.
 		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
-		} else {
-			$this->handle_actions( $action );
-		}
+		$this->handle_actions( $action );
 
 		// Displays the page.
 		include __DIR__ . '/view-languages.php';

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -47,12 +47,17 @@ class PLL_Settings extends PLL_Admin_Base {
 
 		add_action( 'admin_init', array( $this, 'register_settings_modules' ) );
 
-		// Adds screen options and the about box in the languages admin panel
+		// Adds screen options and the about box in the languages admin panel.
 		add_action( 'load-toplevel_page_mlang', array( $this, 'load_page' ) );
 		add_action( 'load-languages_page_mlang_strings', array( $this, 'load_page_strings' ) );
 
-		// Saves per-page value in screen option
+		// Saves per-page value in screen option.
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
+
+		// Displays the page content.
+		add_action( 'pll_settings_active_tab_lang', array( $this, 'display_languages_form' ) );
+		add_action( 'pll_settings_active_tab_strings', array( $this, 'display_strings_form' ) );
+		add_action( 'pll_settings_active_tab_settings', array( $this, 'display_settings_form' ) );
 	}
 
 	/**
@@ -279,28 +284,51 @@ class PLL_Settings extends PLL_Admin_Base {
 	}
 
 	/**
-	 * Displays the 3 tabs pages: languages, strings translations, settings
-	 * Also manages user input for these pages
+	 * Displays the languages form and table.
+	 *
+	 * @since 3.4
+	 *
+	 * @return void
+	 */
+	public function display_languages_form() {
+		$list_table = new PLL_Table_Languages();
+		$list_table->prepare_items( $this->model->get_languages_list() );
+		include __DIR__ . '/view-tab-lang.php';
+	}
+
+	/**
+	 * Displays the strings translations table.
+	 *
+	 * @since 3.4
+	 *
+	 * @return void
+	 */
+	public function display_strings_form() {
+				$string_table = new PLL_Table_String( $this->model->get_languages_list() );
+				$string_table->prepare_items();
+		include __DIR__ . '/view-tab-strings.php';
+	}
+
+	/**
+	 * Displays the settings form.
+	 *
+	 * @since 3.4
+	 *
+	 * @return void
+	 */
+	public function display_settings_form() {
+		include __DIR__ . '/view-tab-settings.php';
+	}
+
+	/**
+	 * Displays the wrapper and manages user input for the languages, translations and settings pages.
 	 *
 	 * @since 0.1
 	 *
 	 * @return void
 	 */
 	public function languages_page() {
-		switch ( $this->active_tab ) {
-			case 'lang':
-				// Prepare the list table of languages
-				$list_table = new PLL_Table_Languages();
-				$list_table->prepare_items( $this->model->get_languages_list() );
-				break;
-
-			case 'strings':
-				$string_table = new PLL_Table_String( $this->model->get_languages_list() );
-				$string_table->prepare_items();
-				break;
-		}
-
-		// Handle user input
+		// Handle user input.
 		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
@@ -309,7 +337,7 @@ class PLL_Settings extends PLL_Admin_Base {
 			$this->handle_actions( $action );
 		}
 
-		// Displays the page
+		// Displays the page.
 		include __DIR__ . '/view-languages.php';
 	}
 

--- a/settings/view-languages.php
+++ b/settings/view-languages.php
@@ -14,22 +14,12 @@ require ABSPATH . 'wp-admin/options-head.php'; // Displays the errors messages a
 <div class="wrap">
 	<h1><?php echo esc_html( $GLOBALS['title'] ); ?></h1>
 	<?php
-	switch ( $this->active_tab ) {
-		case 'lang':     // Languages tab
-		case 'strings':  // String translations tab
-		case 'settings': // Settings tab
-			include __DIR__ . '/view-tab-' . $this->active_tab . '.php';
-			// Intentional fall-through to upgrade to fire the action below.
-
-		default:
-			/**
-			 * Fires when loading the active Polylang settings tab
-			 * Allows plugins to add their own tab
-			 *
-			 * @since 1.5.1
-			 */
-			do_action( 'pll_settings_active_tab_' . $this->active_tab );
-			break;
-	}
+	/**
+	 * Fires when loading the active Polylang settings tab
+	 * Allows plugins to add their own tab
+	 *
+	 * @since 1.5.1
+	 */
+	do_action( 'pll_settings_active_tab_' . $this->active_tab );
 	?>
 </div><!-- wrap -->


### PR DESCRIPTION
See https://secure.helpscout.net/conversation/2210277357 for reference.

Combining the filter `pll_settings_tabs` and the action `pll_settings_active_tab_{$active_tab}` allows to easily add a new page to the Polylang admin menu or to remove the existing ones. However, this combination has initially not been thought to replace an existing page.

Typically, if the goal is to replace the table in the translations page, it requires to
- Remove the current tab and add a new one (with a different slug as the current slug will automatically our current table) with the filter `pll_settings_tabs`.
- With the action `pll_settings_active_tab_{$active_tab}`:
  - Instanciate the new translations table.
  - Load the current strings view 

This is OK for Polylang but this doesn't load the import export metaboxes in Polylang Pro. So keeping them would require more uneasy steps.

In this PR, all the views are loaded using the action  `pll_settings_active_tab_{$active_tab}`. This allows to easily unhook them.

So if we take our example above to replace the table in the translations pages, this would require to:
- Unhook the new method `displays_strings_form()`
- With the action `pll_settings_active_tab_strings` (Keeping the current slug) :
  - Instanciate the new translations table.
  - Load the current strings view 

In this case, keeping the `strings` slug allows Polylang Pro to work as expected.
