### PR TITLE
Avoid a fatal error if the WPML registered string option is corrupted

### DIFF
--- a/modules/wpml/wpml-compat.php
+++ b/modules/wpml/wpml-compat.php
@@ -23,7 +23,7 @@ class PLL_WPML_Compat {
 	 *
 	 * @var array
 	 */
-	protected static $strings;
+	protected static $strings = array();
 
 	/**
 	 * @var PLL_WPML_API
@@ -41,6 +41,10 @@ class PLL_WPML_Compat {
 		$this->api = new PLL_WPML_API();
 
 		self::$strings = get_option( 'polylang_wpml_strings', array() );
+
+		if ( ! is_array( self::$strings ) ) {
+			self::$strings = array(); // In case the serialized option is corrupted.
+		}
 
 		add_action( 'pll_language_defined', array( $this, 'define_constants' ) );
 		add_action( 'pll_no_language_defined', array( $this, 'define_constants' ) );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1654