### PR TITLE
Fix pages sorting with get_pages() in WP 6.3

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -333,9 +333,13 @@ class PLL_Admin_Classic_Editor {
 	 */
 	public function page_attributes_dropdown_pages_args( $dropdown_args, $post ) {
 		$dropdown_args['lang'] = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
+
 		if ( ! $dropdown_args['lang'] ) {
 			$dropdown_args['lang'] = $this->pref_lang;
+			return $dropdown_args;
 		}
+
+		$dropdown_args['lang'] = $dropdown_args['lang']->slug;
 
 		return $dropdown_args;
 	}

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -334,11 +334,7 @@ class PLL_Admin_Classic_Editor {
 	public function page_attributes_dropdown_pages_args( $dropdown_args, $post ) {
 		$language = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
 
-		if ( empty( $language ) ) {
-			$dropdown_args['lang'] = $this->pref_lang->slug;
-		} else {
-			$dropdown_args['lang'] = $language->slug;
-		}
+		$dropdown_args['lang'] = empty( $language ) ? $this->pref_lang->slug : $language->slug;
 
 		return $dropdown_args;
 	}

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -335,13 +335,10 @@ class PLL_Admin_Classic_Editor {
 		$language = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( empty( $language ) ) {
+			$language = $this->pref_lang;
+		}
 
-			if ( empty( $this->pref_lang ) ) {
-				return $dropdown_args;
-			}
-
-			$dropdown_args['lang'] = $this->pref_lang->slug;
-		} else {
+		if ( ! empty( $language ) ) {
 			$dropdown_args['lang'] = $language->slug;
 		}
 

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -334,7 +334,16 @@ class PLL_Admin_Classic_Editor {
 	public function page_attributes_dropdown_pages_args( $dropdown_args, $post ) {
 		$language = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
 
-		$dropdown_args['lang'] = empty( $language ) ? $this->pref_lang->slug : $language->slug;
+		if ( empty( $language ) ) {
+
+			if ( empty( $this->pref_lang ) ) {
+				return $dropdown_args;
+			}
+
+			$dropdown_args['lang'] = $this->pref_lang->slug;
+		} else {
+			$dropdown_args['lang'] = $language->slug;
+		}
 
 		return $dropdown_args;
 	}

--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -332,14 +332,13 @@ class PLL_Admin_Classic_Editor {
 	 * @return array Modified arguments.
 	 */
 	public function page_attributes_dropdown_pages_args( $dropdown_args, $post ) {
-		$dropdown_args['lang'] = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
+		$language = isset( $_POST['lang'] ) ? $this->model->get_language( sanitize_key( $_POST['lang'] ) ) : $this->model->post->get_language( $post->ID ); // phpcs:ignore WordPress.Security.NonceVerification
 
-		if ( ! $dropdown_args['lang'] ) {
-			$dropdown_args['lang'] = $this->pref_lang;
-			return $dropdown_args;
+		if ( empty( $language ) ) {
+			$dropdown_args['lang'] = $this->pref_lang->slug;
+		} else {
+			$dropdown_args['lang'] = $language->slug;
 		}
-
-		$dropdown_args['lang'] = $dropdown_args['lang']->slug;
 
 		return $dropdown_args;
 	}

--- a/include/filters.php
+++ b/include/filters.php
@@ -43,6 +43,8 @@ class PLL_Filters {
 	 * @param object $polylang
 	 */
 	public function __construct( &$polylang ) {
+		global $wp_version;
+
 		$this->links_model = &$polylang->links_model;
 		$this->model = &$polylang->model;
 		$this->options = &$polylang->options;
@@ -58,7 +60,11 @@ class PLL_Filters {
 		add_filter( 'comments_clauses', array( $this, 'comments_clauses' ), 10, 2 );
 
 		// Filters the get_pages function according to the current language
-		add_filter( 'get_pages', array( $this, 'get_pages' ), 10, 2 );
+		if ( ! version_compare( $wp_version, '6.3.alpha', '>=' ) ) {
+			// Backward compatibility with WP < 6.3.
+			add_filter( 'get_pages', array( $this, 'get_pages' ), 10, 2 );
+		}
+		add_filter( 'get_pages_query_args', array( $this, 'get_pages_query_args' ), 10, 2 );
 
 		// Rewrites next and previous post links to filter them by language
 		add_filter( 'get_previous_post_join', array( $this, 'posts_join' ), 10, 5 );
@@ -233,6 +239,22 @@ class PLL_Filters {
 
 		$once = false; // In case get_pages() is called another time.
 		return $pages;
+	}
+
+	/**
+	 * Filters the WP_Query in get_pages() per language.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $query_args  Array of arguments passed to WP_Query.
+	 * @param array $parsed_args Array of get_pages() arguments.
+	 * @return array Array of arguments passed to WP_Query with the language.
+	 */
+	public function get_pages_query_args( $query_args, $parsed_args ) {
+		if ( isset( $parsed_args['lang'] ) ) {
+			$query_args['lang'] = $parsed_args['lang'];
+		}
+		return $query_args;
 	}
 
 	/**

--- a/include/filters.php
+++ b/include/filters.php
@@ -251,12 +251,19 @@ class PLL_Filters {
 	 * @return array Array of arguments passed to WP_Query with the language.
 	 */
 	public function get_pages_query_args( $query_args, $parsed_args ) {
-		if ( isset( $parsed_args['lang'] ) ) {
-			if ( $parsed_args['lang'] instanceof PLL_Language ) {
-				$parsed_args['lang'] = $parsed_args['lang']->slug;
-			}
-			$query_args['lang'] = $parsed_args['lang'];
+		if ( isset( $parsed_args['lang'] ) && '' === $parsed_args['lang'] ) {
+			$query_args['lang'] = '';
+			return $query_args;
 		}
+
+		$language = empty( $parsed_args['lang'] ) ? $this->curlang : $this->model->get_language( $parsed_args['lang'] );
+
+		if ( empty( $language ) || ! $this->model->is_translated_post_type( $parsed_args['post_type'] ) ) {
+			return $query_args;
+		}
+
+		$query_args['lang'] = $language->slug;
+
 		return $query_args;
 	}
 

--- a/include/filters.php
+++ b/include/filters.php
@@ -251,19 +251,9 @@ class PLL_Filters {
 	 * @return array Array of arguments passed to WP_Query with the language.
 	 */
 	public function get_pages_query_args( $query_args, $parsed_args ) {
-		if ( isset( $parsed_args['lang'] ) && '' === $parsed_args['lang'] ) {
-			$query_args['lang'] = '';
-			return $query_args;
+		if ( isset( $parsed_args['lang'] ) ) {
+			$query_args['lang'] = $parsed_args['lang'];
 		}
-
-		$language = empty( $parsed_args['lang'] ) ? $this->curlang : $this->model->get_language( $parsed_args['lang'] );
-
-		if ( empty( $language ) || ! $this->model->is_translated_post_type( $parsed_args['post_type'] ) ) {
-			$query_args['lang'] = '';
-			return $query_args;
-		}
-
-		$query_args['lang'] = $language->slug;
 
 		return $query_args;
 	}

--- a/include/filters.php
+++ b/include/filters.php
@@ -259,6 +259,7 @@ class PLL_Filters {
 		$language = empty( $parsed_args['lang'] ) ? $this->curlang : $this->model->get_language( $parsed_args['lang'] );
 
 		if ( empty( $language ) || ! $this->model->is_translated_post_type( $parsed_args['post_type'] ) ) {
+			$query_args['lang'] = '';
 			return $query_args;
 		}
 

--- a/include/filters.php
+++ b/include/filters.php
@@ -252,6 +252,9 @@ class PLL_Filters {
 	 */
 	public function get_pages_query_args( $query_args, $parsed_args ) {
 		if ( isset( $parsed_args['lang'] ) ) {
+			if ( $parsed_args['lang'] instanceof PLL_Language ) {
+				$parsed_args['lang'] = $parsed_args['lang']->slug;
+			}
 			$query_args['lang'] = $parsed_args['lang'];
 		}
 		return $query_args;

--- a/include/filters.php
+++ b/include/filters.php
@@ -60,7 +60,7 @@ class PLL_Filters {
 		add_filter( 'comments_clauses', array( $this, 'comments_clauses' ), 10, 2 );
 
 		// Filters the get_pages function according to the current language
-		if ( version_compare( $wp_version, '6.3.alpha', '<' ) ) {
+		if ( version_compare( $wp_version, '6.3-alpha', '<' ) ) {
 			// Backward compatibility with WP < 6.3.
 			add_filter( 'get_pages', array( $this, 'get_pages' ), 10, 2 );
 		}

--- a/include/filters.php
+++ b/include/filters.php
@@ -60,7 +60,7 @@ class PLL_Filters {
 		add_filter( 'comments_clauses', array( $this, 'comments_clauses' ), 10, 2 );
 
 		// Filters the get_pages function according to the current language
-		if ( ! version_compare( $wp_version, '6.3.alpha', '>=' ) ) {
+		if ( version_compare( $wp_version, '6.3.alpha', '<' ) ) {
 			// Backward compatibility with WP < 6.3.
 			add_filter( 'get_pages', array( $this, 'get_pages' ), 10, 2 );
 		}

--- a/include/filters.php
+++ b/include/filters.php
@@ -244,7 +244,7 @@ class PLL_Filters {
 	/**
 	 * Filters the WP_Query in get_pages() per language.
 	 *
-	 * @since 3.4
+	 * @since 3.4.3
 	 *
 	 * @param array $query_args  Array of arguments passed to WP_Query.
 	 * @param array $parsed_args Array of get_pages() arguments.

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -86,6 +86,8 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	public function test_page_lang_choice() {
 		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // we need this for the pages dropdown
 
+		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
+
 		// possible parents
 		$en = self::factory()->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1617

See https://core.trac.wordpress.org/ticket/12821.

Now that `get_pages()` uses a `WP_Query`, our pages are always filtered by the current language, even if we pass a language argument to `get_pages()`.

A [PR](https://github.com/WordPress/wordpress-develop/pull/4386) has been opened with a filter to allow us to filter the `$query_args`.

This PR uses this filter to add the language passed as argument to `get_pages()` to the `WP_Query`.