### PR TITLE
Fix the lang extraction from URL

### DIFF
--- a/include/links-default.php
+++ b/include/links-default.php
@@ -84,10 +84,17 @@ class PLL_Links_Default extends PLL_Links_Model {
 	public function get_language_from_url( $url = '' ) {
 		if ( empty( $url ) ) {
 			$url = pll_get_requested_url();
+
+			if ( empty( $url ) ) {
+				return '';
+			}
 		}
 
-		$pattern = '#lang=(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')#';
-		return preg_match( $pattern, trailingslashit( $url ), $matches ) ? $matches[1] : ''; // $matches[1] is the slug of the requested language
+		$pattern = sprintf(
+			'#[?&]lang=(?<lang>%s)(?:$|&)#',
+			implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) )
+		);
+		return preg_match( $pattern, trailingslashit( $url ), $matches ) ? $matches['lang'] : ''; // $matches['lang'] is the slug of the requested language.
 	}
 
 	/**

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -84,10 +84,6 @@ class PLL_Links_Default extends PLL_Links_Model {
 	public function get_language_from_url( $url = '' ) {
 		if ( empty( $url ) ) {
 			$url = pll_get_requested_url();
-
-			if ( empty( $url ) ) {
-				return '';
-			}
 		}
 
 		$pattern = sprintf(

--- a/include/links-default.php
+++ b/include/links-default.php
@@ -94,7 +94,7 @@ class PLL_Links_Default extends PLL_Links_Model {
 			'#[?&]lang=(?<lang>%s)(?:$|&)#',
 			implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) )
 		);
-		return preg_match( $pattern, trailingslashit( $url ), $matches ) ? $matches['lang'] : ''; // $matches['lang'] is the slug of the requested language.
+		return preg_match( $pattern, $url, $matches ) ? $matches['lang'] : ''; // $matches['lang'] is the slug of the requested language.
 	}
 
 	/**

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -59,9 +59,13 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_get_language_from_url() {
-		$_SERVER['HTTP_HOST'] = wp_parse_url( $this->host, PHP_URL_HOST );
+		$_SERVER['HTTP_HOST']   = wp_parse_url( $this->host, PHP_URL_HOST );
 		$_SERVER['REQUEST_URI'] = '/?p=test&lang=fr';
-		$this->assertEquals( 'fr', $this->links_model->get_language_from_url() );
+		$this->assertSame( 'fr', $this->links_model->get_language_from_url() );
+		$_SERVER['REQUEST_URI'] = '/?p=test&lang=fra';
+		$this->assertSame( '', $this->links_model->get_language_from_url() );
+		$_SERVER['REQUEST_URI'] = '/?p=test&lang=fr%2F';
+		$this->assertSame( '', $this->links_model->get_language_from_url() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1583.

## Problem

A php warning "Attempt to read property `slug` on bool" [here](https://github.com/polylang/polylang/blob/100883399d35b28cbcf8096483f9cea72ae54131/include/crud-terms.php#L197).

## Why this is happening

The language slug in `$args['lang']` is invalid, due to a wrong extraction of it from the current URL.

## Proposed solution

Fix the regex pattern in `PLL_Links_Default::get_language_from_url()`.
The following values will now be considered invalid: `fra`, `fr/`. Previously, those values were considered valid (`fr`).
[Test of the pattern](https://regex101.com/r/fS5mhm/2).