### PR TITLE
Prevent importing/exporting empty strings

### DIFF
--- a/include/mo.php
+++ b/include/mo.php
@@ -29,7 +29,9 @@ class PLL_MO extends MO {
 		 */
 		$strings = array();
 		foreach ( $this->entries as $entry ) {
-			$strings[] = wp_slash( array( $entry->singular, $this->translate( $entry->singular ) ) );
+			if ( '' !== $entry->singular ) {
+				$strings[] = wp_slash( array( $entry->singular, $this->translate( $entry->singular ) ) );
+			}
 		}
 
 		update_term_meta( $lang->term_id, '_pll_strings_translations', $strings );
@@ -53,7 +55,11 @@ class PLL_MO extends MO {
 		}
 
 		foreach ( $strings as $msg ) {
-			$this->add_entry( $this->make_entry( $msg[0], $msg[1] ) );
+			$entry = $this->make_entry( $msg[0], $msg[1] );
+
+			if ( '' !== $entry->singular ) {
+				$this->add_entry( $entry );
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -256,4 +256,37 @@ class Strings_Test extends PLL_UnitTestCase {
 
 		$GLOBALS['wp_locale_switcher'] = $old_locale_switcher; // Reset the original global var
 	}
+
+	public function test_export_empty_string() {
+		$lang = self::$model->get_language( 'fr' );
+		$mo   = new PLL_MO();
+
+		$mo->add_entry( $mo->make_entry( 'test', 'test fr' ) );
+		$mo->add_entry( $mo->make_entry( '', 'empty string fr' ) );
+		$mo->add_entry( $mo->make_entry( 'test 2', 'test 2 fr' ) );
+		$mo->export_to_db( $lang );
+
+		$strings  = get_term_meta( $lang->term_id, '_pll_strings_translations', true );
+		$expected = array(
+			array( 'test', 'test fr' ),
+			array( 'test 2', 'test 2 fr' ),
+		);
+
+		$this->assertSame( $expected, $strings );
+	}
+
+	public function test_import_empty_string() {
+		$lang = self::$model->get_language( 'fr' );
+		$mo   = new PLL_MO();
+
+		$strings = array(
+			array( 'test', 'test fr' ),
+			array( '', 'empty string fr' ),
+			array( 'test 2', 'test 2 fr' ),
+		);
+		update_term_meta( $lang->term_id, '_pll_strings_translations', $strings );
+
+		$mo->import_from_db( $lang );
+		$this->assertSame( array( 'test', 'test 2' ), array_keys( $mo->entries ) );
+	}
 }


### PR DESCRIPTION
This PR prevents `PLL_MO::export_to_db()` from exporting to the DB a translation whose original text is an empty string.
This does the same for `PLL_MO::import_from_db()`, by preventing it from importing from the DB a translation whose original text is an empty string.