### PR TITLE
Move PLL_Table_String instanciation before running mlang_action_{$action}

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -334,12 +334,13 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function languages_page() {
+		// Displays the page.
+		include __DIR__ . '/view-languages.php';
+
 		// Handle user input.
 		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		$this->handle_actions( $action );
 
-		// Displays the page.
-		include __DIR__ . '/view-languages.php';
 	}
 
 	/**

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -30,6 +30,16 @@ class PLL_Settings extends PLL_Admin_Base {
 	protected $modules;
 
 	/**
+	 * @var PLL_Table_Languages|null
+	 */
+	protected $list_table;
+
+	/**
+	 * @var PLL_Table_String|null
+	 */
+	protected $string_table;
+
+	/**
 	 * Constructor
 	 *
 	 * @since 1.2
@@ -291,13 +301,16 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function display_languages_form() {
+		if ( empty( $this->list_table ) ) {
+			return;
+		}
 		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
 		}
 
-		$list_table = new PLL_Table_Languages();
+		$list_table = $this->list_table;
 		$list_table->prepare_items( $this->model->get_languages_list() );
 		include __DIR__ . '/view-tab-lang.php';
 	}
@@ -310,7 +323,10 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function display_strings_form() {
-		$string_table = new PLL_Table_String( $this->model->get_languages_list() );
+		if ( empty( $this->string_table ) ) {
+			return;
+		}
+		$string_table = $this->string_table;
 		$string_table->prepare_items();
 		include __DIR__ . '/view-tab-strings.php';
 	}
@@ -334,12 +350,15 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function languages_page() {
-		// Displays the page.
-		include __DIR__ . '/view-languages.php';
+		$this->list_table = new PLL_Table_Languages();
+		$this->string_table = new PLL_Table_String( $this->model->get_languages_list() );
 
 		// Handle user input.
 		$action = isset( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		$this->handle_actions( $action );
+
+		// Displays the page.
+		include __DIR__ . '/view-languages.php';
 
 	}
 


### PR DESCRIPTION
fixes https://github.com/polylang/polylang-pro/issues/1668

The issue was introduced by the PR #1263  reported in the issue.

The languages list page isn't concerned because the all actions process is handled in the `PLL_Settings` class.
The settings page isn't concerned because the activate/deactivate module actions are also handled in the `PLL_Settings` class. Save actions are handled with Ajax request.

⚠The first solution considered didn't solve the issue on the translations page. 
It also broke the all actions on the languages list page.
See the all tests in the @Chrystll [comment](https://github.com/polylang/polylang/pull/1274#issuecomment-1543558614) below.
Include `settings/view-languages.php` before `PLL_Settings::handle_actions()` works because we instanciate in time `PLL_Table_String` or `PLL_Table_Languages` classes. However the content of the page is sent before the redirection is done in `PLL_Settings::handle_actions()`. So the PHP header instructions done in `wp_redirect()` WordPress function trigger warnings.

```
PHP Warning:  Cannot modify header information - headers already sent by ....
```
See https://github.com/WordPress/WordPress/blob/6.2/wp-includes/pluggable.php#L1426-L1430
⚠with PHP 7.4.33 it seems that no redirection is done due to this warning.

## What happens?
Actions in translations page are handled in [PLL_Table_String](https://github.com/polylang/polylang/blob/3.3.3/settings/table-string.php) class by hooking to `mlang_action_string-translation` which is triggered in [PLL_Settings::handle_actions()](https://github.com/polylang/polylang/blob/3.3.3/settings/settings.php#L283).

In the new code, `PLL_Table_String` is instanciate too late in `PLL_Settings::display_strings_form()` hooked in [settings/view-languages.php](https://github.com/polylang/polylang/blob/3.3.3/settings/view-languages.php#L31).
So because `PLL_Settings::handle_actions()` is run just before including the `settings/view-languages.php` file and `PLL_Table_String` isn't instanciated yet at this moment, the `PLL_Table_String::save_translations()` hooked to `mlang_action_string-translation` is never run because this hook doesn't exist and, at the end, no redirection is done as expected.
As the form action has the `noheader` parameter in its URL, WordPress doesn't generate the HTML admin header of the page.
https://github.com/WordPress/WordPress/blob/6.2/wp-admin/admin.php#L238-L240.
This is why the page layout is broken (no WordPress admin content is loaded) and explain `Undefined index: title` notice because the title global variable doesn't exist (created in the admin-header.php file not loaded).

## Changes
- Instanciate `PLL_Table_String` and `PLL_Table_Languages` in `PLL_Settings::languages_page()` method like in the previous code.
- Store these instances in `PLL_Settings` properties to be able to use them later in `display_strings_form()` and `display_languages_form()` to assign them to the local variable required by the views.

⚠Instanciate `PLL_Table_Languages` earlier isn't required because all the form submit process is inside the `PLL_Settings::handle_actions()` method. I did it only for consistency with what is done for `PLL_Table_String`.