### PR TITLE
Fix PHPStan errors related to intval usage

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -634,46 +634,48 @@ class PLL_Admin_Filters_Term {
 			$lang_slug = sanitize_key( $_POST['term_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			if ( ! empty( $lang_slug ) ) {
 				$lang = $this->model->get_language( $lang_slug );
+				return $lang instanceof PLL_Language ? $lang : null;
 			}
 		}
 
-		elseif ( ! empty( $_POST['inline_lang_choice'] ) && is_string( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_POST['inline_lang_choice'] ) && is_string( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			if ( ! empty( $lang_slug ) ) {
 				$lang = $this->model->get_language( $lang_slug );
+				return $lang instanceof PLL_Language ? $lang : null;
 			}
 		}
 
 		// *Post* bulk edit, in case a new term is created
-		elseif ( isset( $_GET['bulk_edit'], $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_GET['bulk_edit'], $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// Bulk edit does not modify the language
 			if ( -1 === (int) $_GET['inline_lang_choice'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->post->get_language( $this->post_id );
+				return $lang instanceof PLL_Language ? $lang : null;
 			} elseif ( is_string( $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang_slug = sanitize_key( $_GET['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
 				if ( ! empty( $lang_slug ) ) {
 					$lang = $this->model->get_language( $lang_slug );
+					return $lang instanceof PLL_Language ? $lang : null;
 				}
 			}
 		}
 
 		// Special cases for default categories as the select is disabled.
-		elseif ( ! empty( $_POST['tag_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$default_term = get_option( 'default_category' );
-			if ( is_int( $default_term ) && in_array( $default_term, $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			}
+		$default_term = get_option( 'default_category' );
+
+		if ( ! is_numeric( $default_term ) ) {
+			return null;
 		}
 
-		elseif ( ! empty( $_POST['tax_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$default_term = get_option( 'default_category' );
-			if ( is_int( $default_term ) && in_array( $default_term, $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			}
+		if ( ! empty( $_POST['tag_ID'] ) && in_array( (int) $default_term, $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			return $lang instanceof PLL_Language ? $lang : null;
 		}
 
-		if ( $lang instanceof PLL_Language ) {
-			return $lang;
+		if ( ! empty( $_POST['tax_ID'] ) && in_array( (int) $default_term, $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			return $lang instanceof PLL_Language ? $lang : null;
 		}
 
 		return null;

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -658,12 +658,18 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Special cases for default categories as the select is disabled.
-		elseif ( ! empty( $_POST['tag_ID'] ) && in_array( intval( get_option( 'default_category' ) ), $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tag_ID'] ) ) {
+			$default_term = get_option( 'default_category' );
+			if ( is_int( $default_term ) && in_array( $default_term, $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			}
 		}
 
-		elseif ( ! empty( $_POST['tax_ID'] ) && in_array( intval( get_option( 'default_category' ) ), $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		elseif ( ! empty( $_POST['tax_ID'] ) ) {
+			$default_term = get_option( 'default_category' );
+			if ( is_int( $default_term ) && in_array( $default_term, $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			}
 		}
 
 		if ( $lang instanceof PLL_Language ) {

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -632,18 +632,14 @@ class PLL_Admin_Filters_Term {
 
 		if ( ! empty( $_POST['term_lang_choice'] ) && is_string( $_POST['term_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang_slug = sanitize_key( $_POST['term_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			if ( ! empty( $lang_slug ) ) {
-				$lang = $this->model->get_language( $lang_slug );
-				return $lang instanceof PLL_Language ? $lang : null;
-			}
+			$lang = $this->model->get_language( $lang_slug );
+			return $lang instanceof PLL_Language ? $lang : null;
 		}
 
 		if ( ! empty( $_POST['inline_lang_choice'] ) && is_string( $_POST['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$lang_slug = sanitize_key( $_POST['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			if ( ! empty( $lang_slug ) ) {
-				$lang = $this->model->get_language( $lang_slug );
-				return $lang instanceof PLL_Language ? $lang : null;
-			}
+			$lang = $this->model->get_language( $lang_slug );
+			return $lang instanceof PLL_Language ? $lang : null;
 		}
 
 		// *Post* bulk edit, in case a new term is created
@@ -654,10 +650,8 @@ class PLL_Admin_Filters_Term {
 				return $lang instanceof PLL_Language ? $lang : null;
 			} elseif ( is_string( $_GET['inline_lang_choice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang_slug = sanitize_key( $_GET['inline_lang_choice'] ); // phpcs:ignore WordPress.Security.NonceVerification
-				if ( ! empty( $lang_slug ) ) {
-					$lang = $this->model->get_language( $lang_slug );
-					return $lang instanceof PLL_Language ? $lang : null;
-				}
+				$lang = $this->model->get_language( $lang_slug );
+				return $lang instanceof PLL_Language ? $lang : null;
 			}
 		}
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -658,14 +658,14 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Special cases for default categories as the select is disabled.
-		elseif ( ! empty( $_POST['tag_ID'] ) ) {
+		elseif ( ! empty( $_POST['tag_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$default_term = get_option( 'default_category' );
 			if ( is_int( $default_term ) && in_array( $default_term, $this->model->term->get_translations( (int) $_POST['tag_ID'] ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->term->get_language( (int) $_POST['tag_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			}
 		}
 
-		elseif ( ! empty( $_POST['tax_ID'] ) ) {
+		elseif ( ! empty( $_POST['tax_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$default_term = get_option( 'default_category' );
 			if ( is_int( $default_term ) && in_array( $default_term, $this->model->term->get_translations( (int) $_POST['tax_ID'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$lang = $this->model->term->get_language( (int) $_POST['tax_ID'] ); // phpcs:ignore WordPress.Security.NonceVerification

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -76,12 +76,21 @@ class PLL_Static_Pages {
 	 * @return void
 	 */
 	public function init() {
-		if ( 'page' === get_option( 'show_on_front' ) ) {
-			$this->page_on_front  = intval( get_option( 'page_on_front' ) );
-			$this->page_for_posts = intval( get_option( 'page_for_posts' ) );
-		} else {
-			$this->page_on_front  = 0;
-			$this->page_for_posts = 0;
+		$this->page_on_front  = 0;
+		$this->page_for_posts = 0;
+
+		if ( 'page' !== get_option( 'show_on_front' ) ) {
+			return;
+		}
+
+		$page_on_front = get_option( 'page_on_front' );
+		if ( is_int( $page_on_front ) ) {
+			$this->page_on_front = $page_on_front;
+		}
+
+		$page_for_posts = get_option( 'page_for_posts' );
+		if ( is_int( $page_for_posts ) ) {
+			$this->page_for_posts = $page_for_posts;
 		}
 	}
 

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -84,13 +84,13 @@ class PLL_Static_Pages {
 		}
 
 		$page_on_front = get_option( 'page_on_front' );
-		if ( is_int( $page_on_front ) ) {
-			$this->page_on_front = $page_on_front;
+		if ( is_numeric( $page_on_front ) ) {
+			$this->page_on_front = (int) $page_on_front;
 		}
 
 		$page_for_posts = get_option( 'page_for_posts' );
-		if ( is_int( $page_for_posts ) ) {
-			$this->page_for_posts = $page_for_posts;
+		if ( is_numeric( $page_for_posts ) ) {
+			$this->page_for_posts = (int) $page_for_posts;
 		}
 	}
 


### PR DESCRIPTION
Since the version 1.10.15, PHPStan reports an error when passing `mixed` to `intval()`.
So this PR replaces this function by an explicit type check of th `get_option()` return value.