### PR TITLE
Use `sanitize_locale_name()` when available

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -91,3 +91,20 @@ function pll_use_block_editor_plugin() {
 	 */
 	return class_exists( 'PLL_Block_Editor_Plugin' ) && apply_filters( 'pll_use_block_editor_plugin', ! defined( 'PLL_USE_BLOCK_EDITOR_PLUGIN' ) || PLL_USE_BLOCK_EDITOR_PLUGIN );
 }
+
+/**
+ * Strips out all characters not allowed in a locale code.
+ *
+ * @since 3.5
+ *
+ * @param string $locale_code The locale code to be sanitized.
+ * @return string The sanitized value.
+ */
+function pll_sanitize_locale_code( $locale_code ) {
+	if ( function_exists( 'sanitize_locale_name' ) ) {
+		return (string) sanitize_locale_name( $locale_code );
+	}
+
+	// Limit to A-Z, a-z, 0-9, '_', '-'.
+	return (string) preg_replace( '/[^A-Za-z0-9_-]/', '', $locale_code );
+}

--- a/include/functions.php
+++ b/include/functions.php
@@ -29,9 +29,9 @@ if ( ! function_exists( 'wpcom_vip_get_page_by_path' ) ) {
 if ( ! function_exists( 'sanitize_locale_name' ) ) {
 	/**
 	 * Strips out all characters not allowed in a locale code.
+	 * Backward compatibility with WP < 6.2.1.
 	 *
 	 * @since 3.5
-	 * @since WP 6.2.1
 	 *
 	 * @param string $locale_name The locale name to be sanitized.
 	 * @return string The sanitized value.
@@ -42,9 +42,9 @@ if ( ! function_exists( 'sanitize_locale_name' ) ) {
 
 		/**
 		 * Filters a sanitized locale name string.
+		 * Backward compatibility with WP < 6.2.1.
 		 *
 		 * @since 3.5
-		 * @since WP 6.2.1
 		 *
 		 * @param string $sanitized   The sanitized locale name.
 		 * @param string $locale_name The locale name before sanitization.

--- a/include/functions.php
+++ b/include/functions.php
@@ -26,6 +26,33 @@ if ( ! function_exists( 'wpcom_vip_get_page_by_path' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_locale_name' ) ) {
+	/**
+	 * Strips out all characters not allowed in a locale code.
+	 *
+	 * @since 3.5
+	 * @since WP 6.2.1
+	 *
+	 * @param string $locale_name The locale name to be sanitized.
+	 * @return string The sanitized value.
+	 */
+	function sanitize_locale_name( $locale_name ) {
+		// Limit to A-Z, a-z, 0-9, '_', '-'.
+		$sanitized = (string) preg_replace( '/[^A-Za-z0-9_-]/', '', $locale_name );
+
+		/**
+		 * Filters a sanitized locale name string.
+		 *
+		 * @since 3.5
+		 * @since WP 6.2.1
+		 *
+		 * @param string $sanitized   The sanitized locale name.
+		 * @param string $locale_name The locale name before sanitization.
+		 */
+		return apply_filters( 'sanitize_locale_name', $sanitized, $locale_name );
+	}
+}
+
 /**
  * Determines whether we should load the cache compatibility
  *
@@ -90,21 +117,4 @@ function pll_use_block_editor_plugin() {
 	 * @param bool $use_plugin True when loading the block editor plugin.
 	 */
 	return class_exists( 'PLL_Block_Editor_Plugin' ) && apply_filters( 'pll_use_block_editor_plugin', ! defined( 'PLL_USE_BLOCK_EDITOR_PLUGIN' ) || PLL_USE_BLOCK_EDITOR_PLUGIN );
-}
-
-/**
- * Strips out all characters not allowed in a locale code.
- *
- * @since 3.5
- *
- * @param string $locale_code The locale code to be sanitized.
- * @return string The sanitized value.
- */
-function pll_sanitize_locale_code( $locale_code ) {
-	if ( function_exists( 'sanitize_locale_name' ) ) {
-		return (string) sanitize_locale_name( $locale_code );
-	}
-
-	// Limit to A-Z, a-z, 0-9, '_', '-'.
-	return (string) preg_replace( '/[^A-Za-z0-9_-]/', '', $locale_code );
 }

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -525,8 +525,8 @@ class PLL_Wizard {
 	public function save_step_languages() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
-		$all_languages = include POLYLANG_DIR . '/settings/languages.php';
-		$languages = isset( $_POST['languages'] ) && is_array( $_POST['languages'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['languages'] ) ) : false;
+		$all_languages   = include POLYLANG_DIR . '/settings/languages.php';
+		$languages       = isset( $_POST['languages'] ) && is_array( $_POST['languages'] ) ? array_map( 'pll_sanitize_locale_code', $_POST['languages'] ) : false;
 		$saved_languages = array();
 
 		// If there is no language added or defined.
@@ -692,7 +692,7 @@ class PLL_Wizard {
 	public function save_step_untranslated_contents() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
-		$lang = isset( $_POST['language'] ) ? sanitize_text_field( wp_unslash( $_POST['language'] ) ) : false;
+		$lang = ! empty( $_POST['language'] ) && is_string( $_POST['language'] ) ? pll_sanitize_locale_code( $_POST['language'] ) : false;
 
 		if ( empty( $lang ) ) {
 			$lang = $this->options['default_lang'];

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -526,7 +526,7 @@ class PLL_Wizard {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
 		$all_languages   = include POLYLANG_DIR . '/settings/languages.php';
-		$languages       = isset( $_POST['languages'] ) && is_array( $_POST['languages'] ) ? array_map( 'pll_sanitize_locale_code', $_POST['languages'] ) : false;
+		$languages       = isset( $_POST['languages'] ) && is_array( $_POST['languages'] ) ? array_map( 'sanitize_locale_name', $_POST['languages'] ) : false;
 		$saved_languages = array();
 
 		// If there is no language added or defined.
@@ -692,7 +692,7 @@ class PLL_Wizard {
 	public function save_step_untranslated_contents() {
 		check_admin_referer( 'pll-wizard', '_pll_nonce' );
 
-		$lang = ! empty( $_POST['language'] ) && is_string( $_POST['language'] ) ? pll_sanitize_locale_code( $_POST['language'] ) : false;
+		$lang = ! empty( $_POST['language'] ) && is_string( $_POST['language'] ) ? sanitize_locale_name( $_POST['language'] ) : false;
 
 		if ( empty( $lang ) ) {
 			$lang = $this->options['default_lang'];

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -87,10 +87,10 @@
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
 			<property name="customSanitizingFunctions" type="array">
-				<element value="pll_sanitize_locale_code"/>
+				<element value="sanitize_locale_name"/>
 			</property>
 			<property name="customUnslashingSanitizingFunctions" type="array">
-				<element value="pll_sanitize_locale_code"/>
+				<element value="sanitize_locale_name"/>
 			</property>
 		</properties>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -84,6 +84,17 @@
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customSanitizingFunctions" type="array">
+				<element value="pll_sanitize_locale_code"/>
+			</property>
+			<property name="customUnslashingSanitizingFunctions" type="array">
+				<element value="pll_sanitize_locale_code"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="Generic.Commenting.Fixme.CommentFound" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -185,7 +185,7 @@ class PLL_Settings extends PLL_Admin_Base {
 					}
 				} else {
 					add_settings_error( 'general', 'pll_languages_created', __( 'Language added.', 'polylang' ), 'updated' );
-					$locale = sanitize_text_field( wp_unslash( $_POST['locale'] ) ); // phpcs:ignore WordPress.Security
+					$locale = pll_sanitize_locale_code( $_POST['locale'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 					if ( 'en_US' !== $locale && current_user_can( 'install_languages' ) ) {
 						// Attempts to install the language pack

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -185,7 +185,7 @@ class PLL_Settings extends PLL_Admin_Base {
 					}
 				} else {
 					add_settings_error( 'general', 'pll_languages_created', __( 'Language added.', 'polylang' ), 'updated' );
-					$locale = pll_sanitize_locale_code( $_POST['locale'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+					$locale = sanitize_locale_name( $_POST['locale'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 					if ( 'en_US' !== $locale && current_user_can( 'install_languages' ) ) {
 						// Attempts to install the language pack

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -14,4 +14,8 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	public function test_wp_admin_bar() {
 		$this->check_method( 'cc6308276c4e0553f75da06592f881cb', '6.2', 'wp_admin_bar_search_menu' );
 	}
+
+	public function test_sanitize_locale_name() {
+		$this->check_method( 'c095fac87bb4632618334ab540b9e87d', '6.2.1', 'sanitize_locale_name' );
+	}
 }


### PR DESCRIPTION
WP 6.2.1 introduced `sanitize_locale_name()` to sanitize a locale code. This PR uses it if it is available.

This PR introduces the function `pll_sanitize_locale_code()`.
This function uses `sanitize_locale_name()` if available. However, the filter `'sanitize_locale_name'` is not polyfilled because it didn't exist before the introduction of the function, so it wouldn't make sense to have it before WP 6.2.1.
This function uses a regex pattern that removes slashes, so it is considered as a sanitization AND an unslashing function.
It is a function instead of a method so it can be liste in PHPCS (see next point).

- Tell PHPCS that `pll_sanitize_locale_code()` is a sanitization + unslashing function.
- Watch `sanitize_locale_name()` for changes.
- `wp_unslash()` is not needed anymore.
- In `PLL_Settings::handle_actions()`, ignore only this specific sniff:

```
Detected usage of a possibly undefined superglobal array index: $_POST['locale']. Use isset() or empty() to check the index exists before using it
```