### PR TITLE
Cast wp_parse_url() return value to string

### DIFF
--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -45,11 +45,11 @@ class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
 	 * @return void
 	 */
 	public function set_language_from_url() {
-		$host      = str_replace( 'www.', '', wp_parse_url( $this->links_model->home, PHP_URL_HOST ) ); // Remove www. for the comparison
+		$host      = str_replace( 'www.', '', (string) wp_parse_url( $this->links_model->home, PHP_URL_HOST ) ); // Remove www. for the comparison
 		$home_path = (string) wp_parse_url( $this->links_model->home, PHP_URL_PATH );
 
 		$requested_url   = pll_get_requested_url();
-		$requested_host  = str_replace( 'www.', '', wp_parse_url( $requested_url, PHP_URL_HOST ) ); // Remove www. for the comparison
+		$requested_host  = str_replace( 'www.', '', (string) wp_parse_url( $requested_url, PHP_URL_HOST ) ); // Remove www. for the comparison
 		$requested_path  = rtrim( str_replace( $this->index, '', (string) wp_parse_url( $requested_url, PHP_URL_PATH ) ), '/' ); // Some PHP setups turn requests for / into /index.php in REQUEST_URI
 		$requested_query = wp_parse_url( $requested_url, PHP_URL_QUERY );
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -356,11 +356,6 @@ parameters:
 			path: frontend/choose-lang-domain.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false\\|null given\\.$#"
-			count: 2
-			path: frontend/choose-lang-url.php
-
-		-
 			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
 			count: 2
 			path: frontend/choose-lang.php


### PR DESCRIPTION
If a server is misconfigured and `pll_get_requested_url()` returns an empty string, `wp_parse_url()` returns null and we  get a deprecated notice:
```
PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /frontend/choose-lang-url.php on line 52
```
Casting wp_parse_url() return value to string should avoid this.