### PR TITLE
Use PLL_Cache to cache translated options

### DIFF
--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -111,7 +111,7 @@ class PLL_Translate_Option {
 		$lang = $GLOBALS['l10n']['pll_string']->get_header( 'Language' );
 
 		$cache = $this->cache->get( $lang );
-		if ( empty( $cache ) ) {
+		if ( false === $cache ) {
 			$cache = $this->translate_string_recursive( $value, $this->keys );
 			$this->cache->set( $lang, $cache );
 		}

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -40,9 +40,9 @@ class PLL_Translate_Option {
 	/**
 	 * Cache for the translated values.
 	 *
-	 * @var array
+	 * @var PLL_Cache
 	 */
-	private $translated_values;
+	private $cache;
 
 	/**
 	 * Constructor
@@ -69,6 +69,8 @@ class PLL_Translate_Option {
 	 * }
 	 */
 	public function __construct( $name, $keys = array(), $args = array() ) {
+		$this->cache = new PLL_Cache();
+
 		// Registers the strings.
 		$context = isset( $args['context'] ) ? $args['context'] : 'Polylang';
 		$this->register_string_recursive( $context, $name, get_option( $name ), $keys );
@@ -108,11 +110,13 @@ class PLL_Translate_Option {
 
 		$lang = $GLOBALS['l10n']['pll_string']->get_header( 'Language' );
 
-		if ( ! isset( $this->translated_values[ $lang ] ) ) {
-			$this->translated_values[ $lang ] = $this->translate_string_recursive( $value, $this->keys );
+		$cache = $this->cache->get( $lang );
+		if ( empty( $cache ) ) {
+			$cache = $this->translate_string_recursive( $value, $this->keys );
+			$this->cache->set( $lang, $cache );
 		}
 
-		return $this->translated_values[ $lang ];
+		return $cache;
 	}
 
 	/**
@@ -292,7 +296,7 @@ class PLL_Translate_Option {
 			}
 		}
 
-		unset( $this->translated_values );
+		$this->cache->clean();
 	}
 
 	/**

--- a/tests/phpunit/tests/test-multisite-option.php
+++ b/tests/phpunit/tests/test-multisite-option.php
@@ -1,0 +1,50 @@
+<?php
+
+if ( is_multisite() ) :
+
+	class Multisite_Option_Test extends PLL_UnitTestCase {
+
+		public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+			parent::wpSetUpBeforeClass( $factory );
+
+			self::create_language( 'en_US' );
+
+			require_once POLYLANG_DIR . '/include/api.php';
+		}
+
+		public function set_up() {
+			parent::set_up();
+
+			$links_model = self::$model->get_links_model();
+			$GLOBALS['polylang'] = new PLL_Admin( $links_model );
+		}
+
+		public function tear_down() {
+			parent::tear_down();
+
+			unset( $GLOBALS['polylang'] );
+		}
+
+		/**
+		 * @ticket #1685
+		 * @see https://github.com/polylang/polylang-pro/issues/1685
+		 */
+		public function test_translate_blogname() {
+			$blog_id = self::factory()->blog->create( array( 'title' => 'The new blog to test' ) );
+
+			$language = self::$model->get_language( 'en' );
+
+			$mo = new PLL_MO();
+			$mo->add_entry( $mo->make_entry( 'Some string', 'Some translation' ) );
+			$GLOBALS['l10n']['pll_string'] = &$mo;
+
+			PLL()->curlang = $language;
+
+			new PLL_Translate_Option( 'blogname', array(), array( 'context' => 'WordPress' ) );
+
+			$this->assertSame( 'Test Blog', get_site( 1 )->blogname ); // The default blog.
+			$this->assertSame( 'The new blog to test', get_site( $blog_id )->blogname ); // The blog that we have created.
+		}
+	}
+
+endif;

--- a/tests/phpunit/tests/test-multisite-option.php
+++ b/tests/phpunit/tests/test-multisite-option.php
@@ -29,16 +29,12 @@ if ( is_multisite() ) :
 		 * @ticket #1685
 		 * @see https://github.com/polylang/polylang-pro/issues/1685
 		 */
-		public function test_translate_blogname() {
+		public function test_blogname() {
 			$blog_id = self::factory()->blog->create( array( 'title' => 'The new blog to test' ) );
 
-			$language = self::$model->get_language( 'en' );
+			$GLOBALS['l10n']['pll_string'] = new PLL_MO(); // Required to pass an internal test of PLL_Translate_Option::translate().
 
-			$mo = new PLL_MO();
-			$mo->add_entry( $mo->make_entry( 'Some string', 'Some translation' ) );
-			$GLOBALS['l10n']['pll_string'] = &$mo;
-
-			PLL()->curlang = $language;
+			PLL()->curlang = self::$model->get_language( 'en' );
 
 			new PLL_Translate_Option( 'blogname', array(), array( 'context' => 'WordPress' ) );
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1685

In #1196, I introduced a cache for translated options. This causes a bug as the cache is the same for all sites on a multisite.

In this PR, I use `PLL_Cache` (which is natively site dependent) to handle the cache instead of a simple array.