### PR TITLE
Override `set_language_home_urls()` for domains and subdomains

### DIFF
--- a/include/links-abstract-domain.php
+++ b/include/links-abstract-domain.php
@@ -81,7 +81,7 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 	/**
 	 * Adds home and search URLs to language data before the object is created.
 	 *
-	 * @since 3.4
+	 * @since 3.4.1
 	 *
 	 * @param array $additional_data Array of language additional data.
 	 * @param array $language        Language data.

--- a/include/links-abstract-domain.php
+++ b/include/links-abstract-domain.php
@@ -77,4 +77,20 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 		$uploads['baseurl'] = $this->add_language_to_link( $uploads['baseurl'], $lang );
 		return $uploads;
 	}
+
+	/**
+	 * Adds home and search URLs to language data before the object is created.
+	 *
+	 * @since 3.4
+	 *
+	 * @param array $additional_data Array of language additional data.
+	 * @param array $language        Language data.
+	 * @return array Language data with home and search URLs added.
+	 */
+	public function set_language_home_urls( $additional_data, $language ) {
+		$language = array_merge( $language, $additional_data );
+		$additional_data['search_url'] = $this->home_url( $language['slug'] );
+		$additional_data['home_url']   = $additional_data['search_url'];
+		return $additional_data;
+	}
 }

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -175,8 +175,8 @@ abstract class PLL_Links_Model {
 	 */
 	public function set_language_home_urls( $additional_data, $language ) {
 		$language = array_merge( $language, $additional_data );
-		$additional_data['search_url']  = $this->home_url( $language['slug'] );
-		$additional_data['home_url']    = empty( $language['page_on_front'] ) || $this->options['redirect_lang'] ? $additional_data['search_url'] : $this->front_page_url( $language );
+		$additional_data['search_url'] = $this->home_url( $language['slug'] );
+		$additional_data['home_url']   = empty( $language['page_on_front'] ) || $this->options['redirect_lang'] ? $additional_data['search_url'] : $this->front_page_url( $language );
 
 		return $additional_data;
 	}

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -78,4 +78,52 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$this->assertEquals( 'http://example.fr/essai/', get_permalink( $post_id ) );
 		$this->assertEquals( 'http://example.fr/?p=' . $post_id, wp_get_shortlink( $post_id ) );
 	}
+
+	public function test_home_url_static_page() {
+		// Create static pages.
+		$home_en = self::factory()->post->create(
+			array(
+				'post_title'   => 'home',
+				'post_type'    => 'page',
+				'post_content' => 'en1<!--nextpage-->en2',
+			)
+		);
+		self::$model->post->set_language( $home_en, 'en' );
+
+		$home_fr = self::factory()->post->create(
+			array(
+				'post_title'   => 'accueil',
+				'post_type'    => 'page',
+				'post_content' => 'fr1<!--nextpage-->fr2',
+			)
+		);
+		self::$model->post->set_language( $home_fr, 'fr' );
+
+		$home_de = self::factory()->post->create(
+			array(
+				'post_title'   => 'willkommen',
+				'post_type'    => 'page',
+				'post_content' => 'fr1<!--nextpage-->fr2',
+			)
+		);
+		self::$model->post->set_language( $home_de, 'de' );
+		self::$model->post->save_translations(
+			$home_en,
+			array(
+				'en' => $home_en,
+				'fr' => $home_fr,
+				'de' => $home_de,
+			)
+		);
+
+		$pll_admin        = new PLL_Admin( $this->links_model );
+		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $home_en );
+
+		$this->assertSame( 'http://example.org/', get_permalink( $home_en ) );
+		$this->assertSame( 'http://example.fr/', get_permalink( $home_fr ) );
+		$this->assertSame( 'http://example.de/', get_permalink( $home_de ) );
+	}
 }

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -123,7 +123,10 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		update_option( 'page_on_front', $home_en );
 
 		$this->assertSame( 'http://example.org/', get_permalink( $home_en ) );
+		$this->assertSame( 'http://example.org/', $pll_admin->links_model->home_url( 'en' ) );
 		$this->assertSame( 'http://example.fr/', get_permalink( $home_fr ) );
+		$this->assertSame( 'http://example.fr/', $pll_admin->links_model->home_url( 'fr' ) );
 		$this->assertSame( 'http://example.de/', get_permalink( $home_de ) );
+		$this->assertSame( 'http://example.de/', $pll_admin->links_model->home_url( 'de' ) );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1688

This PR fixes a regresion introduced in version 3.4.

We used to have a [`PLL_Links_Model::set_home_urls()`](https://github.com/polylang/polylang/blob/3.3.3/include/links-model.php#L167-L170) method calling `front_page_url()` when using a static front page. It used to be overriden in [`PLL_Links_Abstract_Domain`](https://github.com/polylang/polylang/blob/3.3.3/include/links-abstract-domain.php#L56-L59) to avoid calling `front_page_url()` in this specific case.

In version 3.4, we replaced `set_home_urls()` by `set_language_home_urls()` but we forgot to override the method in `PLL_Links_Abstract_Domain`.