### PR TITLE
Prevent to create `PLL_Language` with orphan term_language term.

### DIFF
--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -47,7 +47,7 @@ class PLL_Language_Factory {
 	 * @param array $language_data Language object properties stored as an array. See `PLL_Language::__construct()`
 	 *                             for information on accepted properties.
 	 *
-	 * @return PLL_Language|null A language object if given data pass sanitization, null otherwise.
+	 * @return PLL_Language A language object if given data pass sanitization, null otherwise.
 	 *
 	 * @phpstan-param LanguageData $language_data
 	 */
@@ -61,13 +61,17 @@ class PLL_Language_Factory {
 	 * @since 3.4
 	 *
 	 * @param WP_Term[] $terms List of language terms, with the language taxonomy names as array keys.
-	 *                         `language` is a mandatory key, `term_language` should be too in a
-	 *                         fully operational environment.
-	 * @return PLL_Language
+	 *                         `language` is a mandatory key for the object to be created,
+	 *                         `term_language` should be too in a fully operational environment.
+	 * @return PLL_Language|null Language object on success, `null` on failure.
 	 *
-	 * @phpstan-param array{language:WP_Term}&array<string, WP_Term> $terms
+	 * @phpstan-param array{language?:WP_Term}&array<string, WP_Term> $terms
 	 */
 	public function get_from_terms( array $terms ) {
+		if ( ! isset( $terms['language'] ) ) {
+			return null;
+		}
+
 		$languages = $this->get_languages();
 		$data      = array(
 			'name'       => $terms['language']->name,

--- a/include/model.php
+++ b/include/model.php
@@ -978,9 +978,11 @@ class PLL_Model {
 		 *     }
 		 * ) $terms_by_slug
 		 */
-		$languages = array_map(
-			array( new PLL_Language_Factory( $this->options ), 'get_from_terms' ),
-			array_values( $terms_by_slug )
+		$languages = array_filter(
+			array_map(
+				array( new PLL_Language_Factory( $this->options ), 'get_from_terms' ),
+				array_values( $terms_by_slug )
+			)
 		);
 
 		/**

--- a/tests/phpunit/tests/test-languages-list.php
+++ b/tests/phpunit/tests/test-languages-list.php
@@ -1,0 +1,51 @@
+<?php
+
+class Languages_List_Test extends PLL_UnitTestCase {
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+	}
+
+	public function set_up() {
+		$options                 = PLL_Install::get_default_options();
+		$options['default_lang'] = 'en';
+		$this->pll_model         = new PLL_Admin_Model( $options );
+	}
+
+	/**
+	 * @ticket #1691
+	 * @see https://github.com/polylang/polylang-pro/issues/1691.
+	 */
+	public function test_ghost_language() {
+		// Create an ghost language.
+		wp_insert_term( 'Casper', 'term_language', array( 'slug' => 'falang_casp' ) );
+
+		$this->pll_model->clean_languages_cache();
+		$list = @$this->pll_model->get_languages_list(); // Supress notices to let the assertion do its job.
+
+		$this->assertCount( 1, $list, 'There should be only one language.' );
+
+		$list = wp_list_pluck( $list, 'slug' );
+
+		$this->assertSameSets( array( 'en' ), $list, 'The language should be English.' );
+	}
+
+	public function test_missing_term_language() {
+		// Delete the `term_language` term.
+		$en = $this->pll_model->get_language( 'en' );
+		wp_delete_term( $en->get_tax_prop( 'term_language', 'term_id' ), 'term_language' );
+
+		$this->pll_model->clean_languages_cache();
+		$list = $this->pll_model->get_languages_list(); // Supress notices to let the assertion do its job.
+
+		$this->assertCount( 1, $list, 'There should be only one language.' );
+
+		$list = wp_list_pluck( $list, 'slug' );
+
+		$this->assertSameSets( array( 'en' ), $list, 'The language should be English.' );
+	}
+}


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/1691

## Why?
`PLL_Language_factory::get_from_terms()` may receive a term from a `term_language` taxonomy not corresponding to any languages created with Polylang because no corresponding terms with the `language` taxonomy exist. Leading to all kinds of notices as well as an empty language in the list.

## How?
Return early from `PLL_Language_factory::get_from_terms()` if term with `language` taxonomy isn't set.