### PR TITLE
Fix warning on term_props

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -147,7 +147,7 @@ class PLL_Model {
 			} else {
 				$languages = get_transient( 'pll_languages_list' );
 
-				if ( empty( $languages ) || ! is_array( $languages ) ) {
+				if ( empty( $languages ) || ! is_array( $languages ) || empty( reset( $languages )['term_props'] ) ) {
 					// Create the languages from taxonomies.
 					$languages = $this->get_languages_from_taxonomies();
 				} else {

--- a/include/model.php
+++ b/include/model.php
@@ -147,7 +147,7 @@ class PLL_Model {
 			} else {
 				$languages = get_transient( 'pll_languages_list' );
 
-				if ( empty( $languages ) || ! is_array( $languages ) || empty( reset( $languages )['term_props'] ) ) {
+				if ( empty( $languages ) || ! is_array( $languages ) || empty( reset( $languages )['term_props'] ) ) { // Test `term_props` in case we got a transient older than 3.4.
 					// Create the languages from taxonomies.
 					$languages = $this->get_languages_from_taxonomies();
 				} else {

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -270,5 +270,30 @@ class Model_Test extends PLL_UnitTestCase {
 		);
 		$this->assertSameSetsWithIndex( $slugs, $terms );
 	}
+
+	public function test_dont_use_old_format_languages_list() {
+		// Build cache.
+		self::$model->set_languages_ready();
+		self::$model->get_languages_list();
+		// Modify the transient.
+		$languages = get_transient( 'pll_languages_list' );
+		foreach ( $languages as &$language ) {
+			unset( $language['term_props'] );
+		}
+		// Inject our transient.
+		self::$model->clean_languages_cache();
+		set_transient( 'pll_languages_list', $languages );
+
+		// Test the list.
+		$languages = self::$model->get_languages_list();
+
+		$this->assertCount( 2, $languages, 'There should be 2 languages.' );
+
+		foreach ( $languages as $language ) {
+			$this->assertIsInt( $language->term_id, 'The language term_id should be an integer.' );
+			$this->assertGreaterThan( 0, $language->term_id, 'The language term_id should be a positive integer.' );
+			$this->assertSame( $language->term_id, $language->get_tax_prop( 'language', 'term_id' ), 'The tax prop term_id should contain the language term_id' );
+		}
+	}
 }
 

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -271,7 +271,11 @@ class Model_Test extends PLL_UnitTestCase {
 		$this->assertSameSetsWithIndex( $slugs, $terms );
 	}
 
-	public function test_dont_use_old_format_languages_list() {
+	/**
+	 * @ticket #1689
+	 * @see https://github.com/polylang/polylang-pro/issues/1689
+	 */
+	public function test_dont_use_languages_list_format_older_than_3_4() {
 		// Build cache.
 		self::$model->set_languages_ready();
 		self::$model->get_languages_list();

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -276,15 +276,17 @@ class Model_Test extends PLL_UnitTestCase {
 	 * @see https://github.com/polylang/polylang-pro/issues/1689
 	 */
 	public function test_dont_use_languages_list_format_older_than_3_4() {
-		// Build cache.
+		// Build the cache, so `get_transient()` will contain a valid value.
 		self::$model->set_languages_ready();
 		self::$model->get_languages_list();
-		// Modify the transient.
+
+		// Get the transient and break it.
 		$languages = get_transient( 'pll_languages_list' );
 		foreach ( $languages as &$language ) {
 			unset( $language['term_props'] );
 		}
-		// Inject our transient.
+
+		// Clear the cache then insert the broken transient.
 		self::$model->clean_languages_cache();
 		set_transient( 'pll_languages_list', $languages );
 
@@ -296,7 +298,7 @@ class Model_Test extends PLL_UnitTestCase {
 		foreach ( $languages as $language ) {
 			$this->assertIsInt( $language->term_id, 'The language term_id should be an integer.' );
 			$this->assertGreaterThan( 0, $language->term_id, 'The language term_id should be a positive integer.' );
-			$this->assertSame( $language->term_id, $language->get_tax_prop( 'language', 'term_id' ), 'The tax prop term_id should contain the language term_id' );
+			$this->assertSame( $language->term_id, $language->get_tax_prop( 'language', 'term_id' ), 'The tax prop term_id should contain the language term_id.' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1689.

After upgrading to Polylang 3.4, some users have a `Undefined array key "term_props"` php warning:
```
Warning: Undefined array key "term_props" in include/language-factory.php on line 161
Warning: foreach() argument must be of type array|object, null given in include/language-factory.php on line 161
Warning: Trying to access array offset on value of type null in include/language.php on line 300
Warning: Undefined array key "term_props" in include/language-factory.php on line 161
Warning: foreach() argument must be of type array|object, null given in include/language-factory.php on line 161
Warning: Trying to access array offset on value of type null in include/language.php on line 300
Warning: foreach() argument must be of type array|object, null given in include/model.php on line 283
```

For some reason, the data sent to `PLL_Language` is incorrect. The only possibility we can think of is the cache transient not being cleared during the upgrade process.

This PR does a quick test to make sure the languages data in the transient is in the new format before using it.