### PR TITLE
Fix customizer switching from the static front page to the blog

### DIFF
--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -29,7 +29,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	protected $options;
 
 	/**
-	 * Constructor: setups filters and actions
+	 * Constructor: setups filters and actions.
 	 *
 	 * @since 1.8
 	 *
@@ -44,7 +44,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 
 		add_action( 'pll_home_requested', array( $this, 'pll_home_requested' ) );
 
-		// Manages the redirection of the homepage
+		// Manages the redirection of the homepage.
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
 
 		add_filter( 'pll_pre_translation_url', array( $this, 'pll_pre_translation_url' ), 10, 3 );
@@ -52,23 +52,9 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 
 		add_filter( 'pll_set_language_from_query', array( $this, 'page_on_front_query' ), 10, 2 );
 		add_filter( 'pll_set_language_from_query', array( $this, 'page_for_posts_query' ), 10, 2 );
-	}
 
-	/**
-	 * Init the filters
-	 *
-	 * @since 1.8
-	 *
-	 * @return void
-	 */
-	public function pll_language_defined() {
-		parent::pll_language_defined();
-
-		// Support theme customizer
-		if ( isset( $_POST['wp_customize'], $_POST['customized'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			add_filter( 'pre_option_page_on_front', 'pll_get_post', 20 );
-			add_filter( 'pre_option_page_for_post', 'pll_get_post', 20 );
-		}
+		// Specific cases for the customizer.
+		add_action( 'customize_register', array( $this, 'filter_customizer' ) );
 	}
 
 	/**
@@ -277,5 +263,29 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 		}
 
 		return 0; // No page queried.
+	}
+
+	/**
+	 * Add support for the theme customizer.
+	 *
+	 * @since 3.4.2
+	 *
+	 * @return void
+	 */
+	public function filter_customizer() {
+		add_filter( 'pre_option_page_on_front', array( $this, 'customize_page' ), 20 ); // After the customizer.
+		add_filter( 'pre_option_page_for_post', array( $this, 'customize_page' ), 20 );
+	}
+
+	/**
+	 * Translate the page id when customized
+	 *
+	 * @since 3.4.2
+	 *
+	 * @param int|false $pre A page id if the setting is customized, false otherwise.
+	 * @return int|false
+	 */
+	public function customize_page( $pre ) {
+		return is_numeric( $pre ) ? pll_get_post( (int) $pre ) : $pre;
 	}
 }

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -266,7 +266,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Add support for the theme customizer.
+	 * Adds support for the theme customizer.
 	 *
 	 * @since 3.4.2
 	 *
@@ -280,11 +280,11 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Translate the page id when customized.
+	 * Translates the page ID when customized.
 	 *
 	 * @since 3.4.2
 	 *
-	 * @param int|false $pre A page id if the setting is customized, false otherwise.
+	 * @param int|false $pre A page ID if the setting is customized, false otherwise.
 	 * @return int|false
 	 */
 	public function customize_page( $pre ) {
@@ -292,18 +292,18 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Fix the translation url the option 'show_on_front' is customized.
+	 * Fixes the translation URL if the option 'show_on_front' is customized.
 	 *
 	 * @since 3.4.2
 	 *
-	 * @param string       $url      An empty string or the url of the translation of the current page.
+	 * @param string       $url      An empty string or the URL of the translation of the current page.
 	 * @param PLL_Language $language The language of the translation.
 	 * @return string
 	 */
 	public function customize_translation_url( $url, $language ) {
 		if ( 'posts' === get_option( 'show_on_front' ) && is_front_page() ) {
-			// When the page on front displays posts, the home url is the same as the search url.
-			$url = $language->get_search_url();
+			// When the page on front displays posts, the home URL is the same as the search URL.
+			return $language->get_search_url();
 		}
 		return $url;
 	}

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -275,10 +275,12 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	public function filter_customizer() {
 		add_filter( 'pre_option_page_on_front', array( $this, 'customize_page' ), 20 ); // After the customizer.
 		add_filter( 'pre_option_page_for_post', array( $this, 'customize_page' ), 20 );
+
+		add_filter( 'pll_pre_translation_url', array( $this, 'customize_translation_url' ), 20, 2 ); // After the generic hook in this class.
 	}
 
 	/**
-	 * Translate the page id when customized
+	 * Translate the page id when customized.
 	 *
 	 * @since 3.4.2
 	 *
@@ -287,5 +289,22 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 */
 	public function customize_page( $pre ) {
 		return is_numeric( $pre ) ? pll_get_post( (int) $pre ) : $pre;
+	}
+
+	/**
+	 * Fix the translation url the option 'show_on_front' is customized.
+	 *
+	 * @since 3.4.2
+	 *
+	 * @param string       $url      An empty string or the url of the translation of the current page.
+	 * @param PLL_Language $language The language of the translation.
+	 * @return string
+	 */
+	public function customize_translation_url( $url, $language ) {
+		if ( 'posts' === get_option( 'show_on_front' ) && is_front_page() ) {
+			// When the page on front displays posts, the home url is the same as the search url.
+			$url = $language->get_search_url();
+		}
+		return $url;
 	}
 }

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -172,7 +172,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 		// Redirect the language page to the homepage when using a static front page
 		if ( ( $this->options['redirect_lang'] || $this->options['hide_default'] ) && $this->is_front_page( $query ) && $lang = $this->model->get_language( get_query_var( 'lang' ) ) ) {
 			$query->is_archive = $query->is_tax = false;
-			if ( ! empty( $lang->page_on_front ) ) {
+			if ( 'page' === get_option( 'show_on_front' ) && ! empty( $lang->page_on_front ) ) {
 				$query->set( 'page_id', $lang->page_on_front );
 				$query->is_singular = $query->is_page = true;
 				unset( $query->query_vars['lang'], $query->queried_object ); // Reset queried object

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -88,9 +88,13 @@ class PLL_Frontend extends PLL_Base {
 
 		add_action( 'admin_bar_menu', array( $this, 'remove_customize_admin_bar' ), 41 ); // After WP_Admin_Bar::add_menus
 
-		// Static front page and page for posts.
-		// Early instantiated to be able to correctly initialize language properties.
-		if ( 'page' === get_option( 'show_on_front' ) ) {
+		/*
+		 * Static front page and page for posts.
+		 *
+		 * Early instantiated to be able to correctly initialize language properties.
+		 * Also loaded in customizer preview, directly reading the request as we act before WP.
+		 */
+		if ( 'page' === get_option( 'show_on_front' ) || ( isset( $_REQUEST['wp_customize'] ) && 'on' === $_REQUEST['wp_customize'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->static_pages = new PLL_Frontend_Static_Pages( $this );
 		}
 

--- a/include/base.php
+++ b/include/base.php
@@ -188,6 +188,11 @@ abstract class PLL_Base {
 		}
 
 		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
+		/*
+		 * 'customize_register' is hooked by:
+		 * @see PLL_Nav_Menu::create_nav_menu_locations()
+		 * @see PLL_Frontend_Static_Pages::filter_customizer()
+		 */
 		if ( $customize_register_hooks > 1 + (int) ( 'page' === get_option( 'show_on_front' ) ) ) { // Are there other hooks than our own?
 			return false;
 		}

--- a/include/base.php
+++ b/include/base.php
@@ -188,6 +188,7 @@ abstract class PLL_Base {
 		}
 
 		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
+
 		/*
 		 * 'customize_register' is hooked by:
 		 * @see PLL_Nav_Menu::create_nav_menu_locations()

--- a/include/base.php
+++ b/include/base.php
@@ -188,7 +188,7 @@ abstract class PLL_Base {
 		}
 
 		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
-		if ( $customize_register_hooks > 1 ) {
+		if ( $customize_register_hooks > 1 + (int) ( 'page' === get_option( 'show_on_front' ) ) ) { // Are there other hooks than our own?
 			return false;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1692
See also https://wordpress.org/support/topic/cant-make-changes-refresh-redirects-to-latest-posts/

NB: While doing tests for this PR, I noticed that the Homepage Settings panel was removed from the customizer with Polylang versions < 3.4. The correct behavior was restored in Polylang 3.4.

The reported issue was due to an incorrect usage of the filter `pre_option_page_on_front`. If this setting is not modified, then the filter param is `false` which was transformed to `0` by `pll_get_post()` and thus WP always displayed the blog page.

In the bug fix (f054942768c96330b90f89d6923a0ca7d70a1bb2), I preferred to use the `customize_register` action instead of reading directly the data passed to the HTTP request. This required to (conditionnally) increase our counter of our `customize_register` actions (00b51046489a81467d103b65ac43d0dfe375a5b7).

Once done, I fixed several other issues:
- If the setting was set to a static front page and we switched to the blog page in the customizer, the language switcher url remained to the static front page (visible when the page slug is in the url). See d71ffbf5d354b24275436e05dce2a37804e4bc9b
- Then the page displayed after the click in the language switcher was the translation of the previous static front page page instead of the translated list of posts. See 0926e21d7b96cb3d39769711ae0b4cd54108d423
- On the opposite, if the setting was set to the blog page and switched to a static front page in the customizer, the translation mechanism did not work at all. See ae3a0c13d4959fbde54a1c6059737c3a545ecb89

