### PR TITLE
Check Polylang's callbacks are hooked before removing removing customize menu.

### DIFF
--- a/include/base.php
+++ b/include/base.php
@@ -182,22 +182,40 @@ abstract class PLL_Base {
 			return false;
 		}
 
+		return ! $this->is_customize_register_hooked();
+	}
+
+	/**
+	 * Tells whether or not Polylang's callbacks are hooked to `customize_register`.
+	 * Overridden by child classes.
+	 *
+	 * @since 3.4.3
+	 *
+	 * @global $wp_filter
+	 *
+	 * @return boolean True if Polylang's callbacks are hooked, false otherwise.
+	 */
+	protected function is_customize_register_hooked() {
 		global $wp_filter;
-		if ( empty( $wp_filter['customize_register'] ) ) {
+
+		if ( empty( $wp_filter['customize_register'] ) || ! $wp_filter['customize_register'] instanceof WP_Hook ) {
 			return false;
 		}
-
-		$customize_register_hooks = count( array_merge( ...array_values( $wp_filter['customize_register']->callbacks ) ) );
 
 		/*
 		 * 'customize_register' is hooked by:
 		 * @see PLL_Nav_Menu::create_nav_menu_locations()
 		 * @see PLL_Frontend_Static_Pages::filter_customizer()
 		 */
-		if ( $customize_register_hooks > 1 + (int) ( 'page' === get_option( 'show_on_front' ) ) ) { // Are there other hooks than our own?
-			return false;
+		$floor = 0;
+		if ( ! empty( $this->nav_menu ) && (bool) $wp_filter['customize_register']->has_filter( 'customize_register', array( $this->nav_menu, 'create_nav_menu_locations' ) ) ) {
+			$floor++;
 		}
 
-		return true;
+		if ( ! empty( $this->static_pages ) && (bool) $wp_filter['customize_register']->has_filter( 'customize_register', array( $this->static_pages, 'filter_customizer' ) ) ) {
+			$floor++;
+		}
+
+		return count( $wp_filter['customize_register']->callbacks ) > $floor;
 	}
 }

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -1,7 +1,5 @@
 <?php
 class Admin_Test extends PLL_UnitTestCase {
-
-	protected $nav_menu;
 	protected static $stylesheet;
 
 	/**
@@ -67,10 +65,9 @@ class Admin_Test extends PLL_UnitTestCase {
 		global $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
 
-
-		$links_model = self::$model->get_links_model();
-		$pll_admin = new PLL_Admin( $links_model );
-		$this->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
+		$links_model         = self::$model->get_links_model();
+		$pll_admin           = new PLL_Admin( $links_model );
+		$pll_admin->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
 
 		self::require_wp_menus();
 
@@ -83,9 +80,9 @@ class Admin_Test extends PLL_UnitTestCase {
 		global $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
 
-		$links_model = self::$model->get_links_model();
-		$pll_admin = new PLL_Admin( $links_model );
-		$this->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
+		$links_model         = self::$model->get_links_model();
+		$pll_admin           = new PLL_Admin( $links_model );
+		$pll_admin->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
 
 		self::require_wp_menus();
 
@@ -104,9 +101,9 @@ class Admin_Test extends PLL_UnitTestCase {
 		global $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
 
-		$links_model = self::$model->get_links_model();
-		$pll_admin = new PLL_Admin( $links_model );
-		$this->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
+		$links_model         = self::$model->get_links_model();
+		$pll_admin           = new PLL_Admin( $links_model );
+		$pll_admin->nav_menu = new PLL_Nav_Menu( $pll_admin ); // For auto added pages to menu.
 
 		add_action( 'customize_register', array( $this, 'whatever' ) );
 

--- a/tests/phpunit/tests/test-customizer.php
+++ b/tests/phpunit/tests/test-customizer.php
@@ -1,0 +1,102 @@
+<?php
+
+class Customizer_Test extends PLL_UnitTestCase {
+	/**
+	 * @var WP_Customize_Manager
+	 */
+	protected $wp_customize;
+
+	protected $page_en;
+	protected $page_fr;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		parent::wpTearDownAfterClass();
+
+		unset( $_POST );
+		unset( $GLOBALS['wp_customize'] );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->page_en = $this->factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Front Page EN',
+			)
+		);
+		self::$model->post->set_language( $this->page_en, 'en' );
+		$this->page_fr = $this->factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Front Page FR',
+			)
+		);
+		self::$model->post->set_language( $this->page_fr, 'fr' );
+		self::$model->post->save_translations(
+			$this->page_en,
+			array(
+				'en' => $this->page_en,
+				'fr' => $this->page_fr,
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
+	}
+
+	public function test_static_front_page_update() {
+		$_POST['customized'] = json_encode(
+			array(
+				'show_on_front' => 'page',
+				'page_on_front' => $this->page_fr,
+			)
+		);
+		$_POST['wp_customize'] = 'on';
+
+		$links_model             = self::$model->get_links_model();
+		$this->pll_env           = new PLL_Frontend( $links_model );
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
+		$this->wp_customize      = $GLOBALS['wp_customize'];
+		do_action( 'customize_register', $this->wp_customize );
+		$this->pll_env->curlang = self::$model->get_language( 'fr' );
+		do_action( 'pll_language_defined', $this->pll_env->curlang->slug, $this->pll_env->curlang );
+
+		$show_on_front = $this->wp_customize->get_setting( 'show_on_front' );
+		$show_on_front->save();
+		$page_on_front = $this->wp_customize->get_setting( 'page_on_front' );
+		$page_on_front->save();
+
+		$this->assertSame( 'page', $show_on_front->value() );
+		$this->assertSame( $this->page_fr, $page_on_front->value() );
+	}
+
+	public function test_static_front_page_display_secondary_language() {
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $this->page_en );
+		self::$model->clean_languages_cache();
+
+		$_POST['wp_customize'] = 'on';
+
+		$links_model             = self::$model->get_links_model();
+		$this->pll_env           = new PLL_Frontend( $links_model );
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
+		$this->wp_customize      = $GLOBALS['wp_customize'];
+		do_action( 'customize_register', $this->wp_customize );
+		$this->pll_env->curlang = self::$model->get_language( 'fr' );
+		do_action( 'pll_language_defined', $this->pll_env->curlang->slug, $this->pll_env->curlang );
+
+		$show_on_front = $this->wp_customize->get_setting( 'show_on_front' );
+		$page_on_front = $this->wp_customize->get_setting( 'page_on_front' );
+
+		$this->assertSame( 'page', $show_on_front->value() );
+		$this->assertSame( $this->page_fr, $page_on_front->value() );
+	}
+}


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/1696

## Why?
In some context (e.g. `PLL_Settings`) our callbacks might not be hooked.

## How?
By checking our callbacks are really hooked, we can count `customize_register` callbacks properly.

*Note: `Customize_Test` class being introduced by #1292, we should wait until it's merge before.*