### PR TITLE
Assign static pages to `PLL_Language` even if no translation exist.

### DIFF
--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -105,6 +105,21 @@ class PLL_Static_Pages {
 	 */
 	protected function get_translation( $static_page, $language ) {
 		$translations = $this->model->post->get_raw_translations( $this->$static_page );
+
+		if ( empty( $translations ) ) {
+			$page_lang = $this->model->post->get_object_term( $this->$static_page, $this->model->post->get_tax_language() );
+
+			if ( empty( $page_lang ) || $page_lang->slug !== $language['slug'] ) {
+				return 0;
+			}
+
+			/*
+			 * Current page doesn't have any translation,
+			 * but has a language defined corresponding to the current one.
+			 */
+			return $this->$static_page;
+		}
+
 		if ( ! isset( $translations[ $language['slug'] ] ) ) {
 			return 0;
 		}

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -106,18 +106,13 @@ class PLL_Static_Pages {
 	protected function get_translation( $static_page, $language ) {
 		$translations = $this->model->post->get_raw_translations( $this->$static_page );
 
+		// When the current static page doesn't have any translation, we must return itself for its language.
 		if ( empty( $translations ) ) {
 			$page_lang = $this->model->post->get_object_term( $this->$static_page, $this->model->post->get_tax_language() );
 
-			if ( empty( $page_lang ) || $page_lang->slug !== $language['slug'] ) {
-				return 0;
+			if ( ! empty( $page_lang ) && $page_lang->slug === $language['slug'] ) {
+				return $this->$static_page;
 			}
-
-			/*
-			 * Current page doesn't have any translation,
-			 * but has a language defined corresponding to the current one.
-			 */
-			return $this->$static_page;
 		}
 
 		if ( ! isset( $translations[ $language['slug'] ] ) ) {

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -20,12 +20,14 @@ class Single_Language_Test extends PLL_UnitTestCase {
 				'post_title' => 'Front Page EN',
 			)
 		);
+		self::$model->post->set_language( $this->home_en, 'en' );
 		$this->posts_en = $this->factory()->post->create(
 			array(
 				'post_type'  => 'page',
 				'post_title' => 'Blog Page EN',
 			)
 		);
+		self::$model->post->set_language( $this->posts_en, 'en' );
 	}
 
 	/**
@@ -36,7 +38,7 @@ class Single_Language_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		$options                  = PLL_Install::get_default_options();
-		$options['redirect_lang'] = 0;
+		$options['redirect_lang'] = 1;
 		$options['hide_default']  = 0;
 		$options['force_lang']    = 1;
 		$options['rewrite']       = 1;
@@ -57,8 +59,10 @@ class Single_Language_Test extends PLL_UnitTestCase {
 		$links_model->init();
 		$pll = new PLL_Frontend( $links_model );
 		$pll->init();
+		$pll->model->clean_languages_cache();
 
-		$this->go_to( home_url() );
+		// $this->go_to( home_url() );
+		$this->go_to( home_url( '/en' ) );
 
 		$this->assertTrue( is_front_page() );
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -11,7 +11,7 @@ class Single_Language_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 	}
 
-	public function FunctionName() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->home_en = $this->factory()->post->create(

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -1,0 +1,66 @@
+<?php
+
+class Single_Language_Test extends PLL_UnitTestCase {
+	protected $structure = '/%postname%/';
+	protected $home_en;
+	protected $posts_en;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+	}
+
+	public function FunctionName() {
+		parent::set_up();
+
+		$this->home_en = $this->factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Front Page EN',
+			)
+		);
+		$this->posts_en = $this->factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Blog Page EN',
+			)
+		);
+	}
+
+	/**
+	 * @ticket #1697
+	 * @see https://github.com/polylang/polylang-pro/issues/1697.
+	 */
+	public function test_front_page() {
+		global $wp_rewrite;
+
+		$options                  = PLL_Install::get_default_options();
+		$options['redirect_lang'] = 0;
+		$options['hide_default']  = 0;
+		$options['force_lang']    = 1;
+		$options['rewrite']       = 1;
+		$options['default_lang']  = 'en';
+		$model                    = new PLL_Model( $options );
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $this->home_en );
+		update_option( 'page_for_posts', $this->posts_en );
+
+		// Switch to pretty permalinks.
+		$wp_rewrite->init();
+		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
+		$wp_rewrite->set_permalink_structure( $this->structure );
+
+		$model->post->register_taxonomy(); // needs this for 'lang' query var
+		$links_model = $model->get_links_model();
+		$links_model->init();
+		$pll = new PLL_Frontend( $links_model );
+		$pll->init();
+
+		$this->go_to( home_url() );
+
+		$this->assertTrue( is_front_page() );
+		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_front_page' );
+	}
+}

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -61,7 +61,6 @@ class Single_Language_Test extends PLL_UnitTestCase {
 		$pll->init();
 		$pll->model->clean_languages_cache();
 
-		// $this->go_to( home_url() );
 		$this->go_to( home_url( '/en' ) );
 
 		$this->assertTrue( is_front_page() );


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/1697
Fixes #1291 

## Why?
When a static page has no translation, trying to translate it before assigning it to a `PLL_Language` object forces the value to `0`.

## How?
If a static page hasn't any translation, check if it's language correspond to the currently created language.