### PR TITLE
Fix get_calendar() test

### DIFF
--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -133,16 +133,16 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 			FROM $wpdb->posts $join_clause
 			WHERE post_date < '$thisyear-$thismonth-01'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
-				ORDER BY post_date DESC
-				LIMIT 1"
+			ORDER BY post_date DESC
+			LIMIT 1"
 		);  #modified#
 		$next     = $wpdb->get_row(
 			"SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
 			FROM $wpdb->posts $join_clause
 			WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
 			AND post_type = 'post' AND post_status = 'publish' $where_clause
-				ORDER BY post_date ASC
-				LIMIT 1"
+			ORDER BY post_date ASC
+			LIMIT 1"
 		);  #modified#
 
 		/* translators: Calendar caption: 1: Month name, 2: 4-digit year. */

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -8,7 +8,7 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_calendar() {
-		$this->check_method( '91861c7d8b70cb3e4d2b6d0b9deae2fe', '6.2', 'get_calendar' );
+		$this->check_method( '01b136c86d6837211ada6651fba90e28', '6.3', 'get_calendar' );
 	}
 
 	public function test_wp_admin_bar() {


### PR DESCRIPTION
A formatting and alignment check has been done on SQL queries, see [here](https://core.trac.wordpress.org/changeset/55857).

The change about `get_calendar()` is only an alignment change, I've added it for better readability, and adapted the tests.