### PR TITLE
Fix incorrect DB table and alias in multisite

### DIFF
--- a/include/translatable-object-with-types-interface.php
+++ b/include/translatable-object-with-types-interface.php
@@ -9,6 +9,13 @@ defined( 'ABSPATH' ) || exit;
  * Interface to use for objects that can have one or more types.
  *
  * @since 3.4
+ *
+ * @phpstan-type DBInfo array{
+ *     table: non-empty-string,
+ *     id_column: non-empty-string,
+ *     type_column: non-empty-string,
+ *     default_alias: non-empty-string
+ * }
  */
 interface PLL_Translatable_Object_With_Types_Interface {
 

--- a/include/translatable-object-with-types-trait.php
+++ b/include/translatable-object-with-types-trait.php
@@ -10,20 +10,6 @@ defined( 'ABSPATH' ) || exit;
  * This must be used with {@see PLL_Translatable_Object_With_Types_Interface}.
  *
  * @since 3.4
- *
- * @property string[] $db {
- *     @type string $table         Name of the table.
- *     @type string $id_column     Name of the column containing the object's ID.
- *     @type string $type_column   Name of the column containing the object's type.
- *     @type string $default_alias Default alias corresponding to the object's table.
- * }
- *
- * @phpstan-property array{
- *     table: non-empty-string,
- *     id_column: non-empty-string,
- *     type_column: non-empty-string,
- *     default_alias: non-empty-string
- * } $db
  */
 trait PLL_Translatable_Object_With_Types_Trait {
 
@@ -46,12 +32,14 @@ trait PLL_Translatable_Object_With_Types_Trait {
 			$args = $this->get_translated_object_types();
 		}
 
+		$db = $this->get_db_infos();
+
 		return sprintf(
-			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
-			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (
+			"SELECT {$db['table']}.{$db['id_column']} FROM {$db['table']}
+			WHERE {$db['table']}.{$db['id_column']} NOT IN (
 				SELECT object_id FROM {$GLOBALS['wpdb']->term_relationships} WHERE term_taxonomy_id IN (%s)
 			)
-			AND {$this->db['type_column']} IN (%s)
+			AND {$db['type_column']} IN (%s)
 			%s",
 			PLL_Db_Tools::prepare_values_list( $language_ids ),
 			PLL_Db_Tools::prepare_values_list( $args ),

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -9,6 +9,12 @@ defined( 'ABSPATH' ) || exit;
  * Abstract class to use for object types that support at least one language.
  *
  * @since 3.4
+ *
+ * @phpstan-type DBInfo array{
+ *     table: non-empty-string,
+ *     id_column: non-empty-string,
+ *     default_alias: non-empty-string
+ * }
  */
 abstract class PLL_Translatable_Object {
 
@@ -64,26 +70,6 @@ abstract class PLL_Translatable_Object {
 	 * @phpstan-var non-empty-string|null
 	 */
 	protected $object_type = null;
-
-	/**
-	 * Contains database-related informations that can be used in some of this class methods.
-	 * These are specific to the table containing the objects.
-	 *
-	 * @var string[] {
-	 *     @type string $table         Name of the table.
-	 *     @type string $id_column     Name of the column containing the object's ID.
-	 *     @type string $default_alias Default alias corresponding to the object's table.
-	 * }
-	 * @see PLL_Translatable_Object::join_clause()
-	 * @see PLL_Translatable_Object::get_objects_with_no_lang_sql()
-	 *
-	 * @phpstan-var array{
-	 *     table: non-empty-string,
-	 *     id_column: non-empty-string,
-	 *     default_alias: non-empty-string
-	 * }
-	 */
-	protected $db;
 
 	/**
 	 * Constructor.
@@ -300,11 +286,13 @@ abstract class PLL_Translatable_Object {
 	public function join_clause( $alias = '' ) {
 		global $wpdb;
 
+		$db = $this->get_db_infos();
+
 		if ( empty( $alias ) ) {
-			$alias = $this->db['default_alias'];
+			$alias = $db['default_alias'];
 		}
 
-		return " INNER JOIN {$wpdb->term_relationships} AS pll_tr ON pll_tr.object_id = {$alias}.{$this->db['id_column']}";
+		return " INNER JOIN {$wpdb->term_relationships} AS pll_tr ON pll_tr.object_id = {$alias}.{$db['id_column']}";
 	}
 
 	/**
@@ -456,9 +444,11 @@ abstract class PLL_Translatable_Object {
 	 * @phpstan-param array<empty> $args
 	 */
 	protected function get_objects_with_no_lang_sql( array $language_ids, $limit, array $args = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$db = $this->get_db_infos();
+
 		return sprintf(
-			"SELECT {$this->db['table']}.{$this->db['id_column']} FROM {$this->db['table']}
-			WHERE {$this->db['table']}.{$this->db['id_column']} NOT IN (
+			"SELECT {$db['table']}.{$db['id_column']} FROM {$db['table']}
+			WHERE {$db['table']}.{$db['id_column']} NOT IN (
 				SELECT object_id FROM {$GLOBALS['wpdb']->term_relationships} WHERE term_taxonomy_id IN (%s)
 			)
 			%s",
@@ -508,4 +498,21 @@ abstract class PLL_Translatable_Object {
 		// Invalidate our cache.
 		wp_cache_set( 'last_changed', microtime(), $this->cache_type );
 	}
+
+	/**
+	 * Returns database-related informations that can be used in some of this class methods.
+	 * These are specific to the table containing the objects.
+	 *
+	 * @since 3.4.3
+	 * @see PLL_Translatable_Object::join_clause()
+	 * @see PLL_Translatable_Object::get_objects_with_no_lang_sql()
+	 *
+	 * @return string[] {
+	 *     @type string $table         Name of the table.
+	 *     @type string $id_column     Name of the column containing the object's ID.
+	 *     @type string $default_alias Default alias corresponding to the object's table.
+	 * }
+	 * @phpstan-return DBInfo
+	 */
+	abstract protected function get_db_infos();
 }

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -9,6 +9,8 @@ defined( 'ABSPATH' ) || exit;
  * Sets the posts languages and translations model up.
  *
  * @since 1.8
+ *
+ * @phpstan-import-type DBInfo from PLL_Translatable_Object_With_Types_Interface
  */
 class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
 
@@ -59,13 +61,6 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @param PLL_Model $model Instance of `PLL_Model`.
 	 */
 	public function __construct( PLL_Model &$model ) {
-		$this->db = array(
-			'table'         => $GLOBALS['wpdb']->posts,
-			'id_column'     => 'ID',
-			'type_column'   => 'post_type',
-			'default_alias' => $GLOBALS['wpdb']->posts,
-		);
-
 		parent::__construct( $model );
 
 		// Keep hooks in constructor for backward compatibility.
@@ -377,5 +372,30 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 		}
 
 		return $posts;
+	}
+
+	/**
+	 * Returns database-related informations that can be used in some of this class methods.
+	 * These are specific to the table containing the objects.
+	 *
+	 * @since 3.4.3
+	 * @see PLL_Translatable_Object::join_clause()
+	 * @see PLL_Translatable_Object::get_objects_with_no_lang_sql()
+	 *
+	 * @return string[] {
+	 *     @type string $table         Name of the table.
+	 *     @type string $id_column     Name of the column containing the object's ID.
+	 *     @type string $type_column   Name of the column containing the object's type.
+	 *     @type string $default_alias Default alias corresponding to the object's table.
+	 * }
+	 * @phpstan-return DBInfo
+	 */
+	protected function get_db_infos() {
+		return array(
+			'table'         => $GLOBALS['wpdb']->posts,
+			'id_column'     => 'ID',
+			'type_column'   => 'post_type',
+			'default_alias' => $GLOBALS['wpdb']->posts,
+		);
 	}
 }

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -9,6 +9,8 @@ defined( 'ABSPATH' ) || exit;
  * Sets the taxonomies languages and translations model up.
  *
  * @since 1.8
+ *
+ * @phpstan-import-type DBInfo from PLL_Translatable_Object_With_Types_Interface
  */
 class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translatable_Object_With_Types_Interface {
 
@@ -69,13 +71,6 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param PLL_Model $model Instance of `PLL_Model`.
 	 */
 	public function __construct( PLL_Model &$model ) {
-		$this->db = array(
-			'table'         => $GLOBALS['wpdb']->term_taxonomy,
-			'id_column'     => 'term_id',
-			'type_column'   => 'taxonomy',
-			'default_alias' => 't',
-		);
-
 		parent::__construct( $model );
 
 		// Keep hooks in constructor for backward compatibility.
@@ -317,5 +312,30 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		if ( ! empty( $translations ) ) {
 			$this->set_translation_in_mass( $translations );
 		}
+	}
+
+	/**
+	 * Returns database-related informations that can be used in some of this class methods.
+	 * These are specific to the table containing the objects.
+	 *
+	 * @since 3.4.3
+	 * @see PLL_Translatable_Object::join_clause()
+	 * @see PLL_Translatable_Object::get_objects_with_no_lang_sql()
+	 *
+	 * @return string[] {
+	 *     @type string $table         Name of the table.
+	 *     @type string $id_column     Name of the column containing the object's ID.
+	 *     @type string $type_column   Name of the column containing the object's type.
+	 *     @type string $default_alias Default alias corresponding to the object's table.
+	 * }
+	 * @phpstan-return DBInfo
+	 */
+	protected function get_db_infos() {
+		return array(
+			'table'         => $GLOBALS['wpdb']->term_taxonomy,
+			'id_column'     => 'term_id',
+			'type_column'   => 'taxonomy',
+			'default_alias' => 't',
+		);
 	}
 }

--- a/tests/phpunit/data/translatable-foo.php
+++ b/tests/phpunit/data/translatable-foo.php
@@ -12,19 +12,23 @@ class PLLTest_Translatable_Foo extends PLL_Translatable_Object {
 	protected $cache_type = 'foos';
 
 	/**
-	 * Constructor.
+	 * Returns database-related informations that can be used in some of this class methods.
+	 * These are specific to the table containing the objects.
 	 *
-	 * @since 1.8
+	 * @since 3.4.3
 	 *
-	 * @param PLL_Model $model Instance of `PLL_Model`.
+	 * @return string[] {
+	 *     @type string $table         Name of the table.
+	 *     @type string $id_column     Name of the column containing the object's ID.
+	 *     @type string $default_alias Default alias corresponding to the object's table.
+	 * }
+	 * @phpstan-return DBInfo
 	 */
-	public function __construct( PLL_Model &$model ) {
-		$this->db = array(
+	protected function get_db_infos() {
+		return array(
 			'table'         => $GLOBALS['wpdb']->prefix . 'foo',
 			'id_column'     => 'id',
 			'default_alias' => $GLOBALS['wpdb']->prefix . 'foo',
 		);
-
-		parent::__construct( $model );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1698.

This PR replaces the class property `PLL_Translatable_Object::$db` by the method `get_db_infos()`. This is necessary in multisite when `switch_blog()` is used, so the table name and the alias are up-to-date for the "switched" blog.