### PR TITLE
Don't set $_column_headers in list tables

### DIFF
--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -259,7 +259,6 @@ class PLL_Table_Languages extends WP_List_Table {
 	 */
 	public function prepare_items( $data = array() ) {
 		$per_page = $this->get_items_per_page( 'pll_lang_per_page' );
-		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
 
 		usort( $data, array( $this, 'usort_reorder' ) );
 

--- a/settings/table-settings.php
+++ b/settings/table-settings.php
@@ -170,8 +170,6 @@ class PLL_Table_Settings extends WP_List_Table {
 	 * @return void
 	 */
 	public function prepare_items( $items = array() ) {
-		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns(), $this->get_primary_column_name() );
-
 		// Sort rows, lowest priority on top.
 		usort(
 			$items,

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -283,7 +283,6 @@ class PLL_Table_String extends WP_List_Table {
 
 		// Paging
 		$per_page = $this->get_items_per_page( 'pll_strings_per_page' );
-		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
 
 		$total_items = count( $data );
 		$this->items = array_slice( $data, ( $this->get_pagenum() - 1 ) * $per_page, $per_page, true );


### PR DESCRIPTION
This fixes the error `Undefined array key 2` reported by our [PHPUnit tests](https://app.travis-ci.com/github/polylang/polylang/jobs/604689796) 

See https://core.trac.wordpress.org/ticket/32170#comment:65 for the context
Maybe the backward compatibility issue will be fixed by WordPress before the final release. However, there is no point to keep the legacy way to define column headers.