### PR TITLE
wp_list_filter() now uses strict comparison

### DIFF
--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -359,7 +359,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		// Register
 		do_action( 'wpml_register_single_string', 'wpml_string_context', 'wpml_string_name', 'wpml_string_test' );
 
-		$str = wp_list_filter( PLL_Admin_Strings::get_strings(), array( 'icl' => 1 ) );
+		$str = wp_list_filter( PLL_Admin_Strings::get_strings(), array( 'icl' => true ) );
 		$str = reset( $str );
 
 		$this->assertEquals( 'wpml_string_context', $str['context'] );


### PR DESCRIPTION
Fixes the error  `Failed asserting that null matches expected 'wpml_string_context'.` reported in our PHPUnit tests in https://app.travis-ci.com/github/polylang/polylang/jobs/604689795
See https://core.trac.wordpress.org/ticket/57839#comment:61 for the context.