### PR TITLE
Revert "Don't set $_column_headers in list tables"

### DIFF
--- a/settings/table-languages.php
+++ b/settings/table-languages.php
@@ -259,6 +259,7 @@ class PLL_Table_Languages extends WP_List_Table {
 	 */
 	public function prepare_items( $data = array() ) {
 		$per_page = $this->get_items_per_page( 'pll_lang_per_page' );
+		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
 
 		usort( $data, array( $this, 'usort_reorder' ) );
 

--- a/settings/table-settings.php
+++ b/settings/table-settings.php
@@ -170,6 +170,8 @@ class PLL_Table_Settings extends WP_List_Table {
 	 * @return void
 	 */
 	public function prepare_items( $items = array() ) {
+		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns(), $this->get_primary_column_name() );
+
 		// Sort rows, lowest priority on top.
 		usort(
 			$items,

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -283,6 +283,7 @@ class PLL_Table_String extends WP_List_Table {
 
 		// Paging
 		$per_page = $this->get_items_per_page( 'pll_strings_per_page' );
+		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
 
 		$total_items = count( $data );
 		$this->items = array_slice( $data, ( $this->get_pagenum() - 1 ) * $per_page, $per_page, true );

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -12,10 +12,13 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	public function test_display_languages_table() {
-		wp_set_current_user( 1 );
+	public function set_up() {
+		parent::set_up();
 
-		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
+		wp_set_current_user( 1 );
+	}
+
+	public function test_display_languages_table() {
 		$_GET['page'] = 'mlang';
 
 		$links_model = self::$model->get_links_model();
@@ -67,9 +70,6 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_display_strings_table() {
-		wp_set_current_user( 1 );
-
-		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		$_GET['page'] = 'mlang_strings';
 
 		$links_model = self::$model->get_links_model();
@@ -113,9 +113,6 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_display_settings_table() {
-		wp_set_current_user( 1 );
-
-		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		$_GET['page'] = 'mlang_settings';
 
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -12,20 +12,20 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 	}
 
-	public function set_up() {
-		parent::set_up();
-
+	public function init( $pagename ) {
 		wp_set_current_user( 1 );
+
+		$_GET['page'] = $pagename;
+
+		$links_model = self::$model->get_links_model();
+		return new PLL_Settings( $links_model );
 	}
 
 	public function test_display_languages_table() {
 		// Avoid an API request triggered by wp_get_available_translations() called in languages_page().
 		add_filter( 'pre_site_transient_available_translations', '__return_empty_array' );
 
-		$_GET['page'] = 'mlang';
-
-		$links_model = self::$model->get_links_model();
-		$pll_env = new PLL_Settings( $links_model );
+		$this->init( 'mlang' );
 
 		ob_start();
 		do_action( 'admin_menu' );
@@ -73,10 +73,7 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_display_strings_table() {
-		$_GET['page'] = 'mlang_strings';
-
-		$links_model = self::$model->get_links_model();
-		$pll_env = new PLL_Settings( $links_model );
+		$this->init( 'mlang_strings' );
 
 		PLL_Admin_Strings::register_string( 'Test', 'Some string' );
 
@@ -116,10 +113,7 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_display_settings_table() {
-		$_GET['page'] = 'mlang_settings';
-
-		$links_model = self::$model->get_links_model();
-		$pll_env = new PLL_Settings( $links_model );
+		$pll_env = $this->init( 'mlang_settings' );
 		$pll_env->register_settings_modules(); // Manually register modules to avoid firing the 'admin_init' action.
 
 		ob_start();

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -19,6 +19,9 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_display_languages_table() {
+		// Avoid an API request triggered by wp_get_available_translations() called in languages_page().
+		add_filter( 'pre_site_transient_available_translations', '__return_empty_array' );
+
 		$_GET['page'] = 'mlang';
 
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -109,14 +109,7 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'Translations', $th->item( 0 )->nodeValue );
 
 		// The rows.
-		$this->assertSame( 1, $xpath->query( '//tbody/tr' )->length ); // 1 per string.
-
-		$td = $xpath->query( '//tbody/tr/td' );
-		// $this->assertSame( 'Some string', $td->item( 0 )->nodeValue ); // This cell displays a parasitic child button.
-		$this->assertSame( 'Test', $td->item( 1 )->nodeValue );
-		$this->assertSame( 'Polylang', $td->item( 2 )->nodeValue );
-
-		$this->assertSame( 2, $xpath->query( '//tbody/tr/td/div/input' )->length ); // 1 per language.
+		$this->assertSame( count( PLL_Admin_Strings::get_strings() ), $xpath->query( '//tbody/tr' )->length ); // 1 per string.
 	}
 
 	public function test_display_settings_table() {

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -1,0 +1,169 @@
+<?php
+
+class Settings_List_Tables_Test extends PLL_UnitTestCase {
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+	}
+
+	public function test_display_languages_table() {
+		wp_set_current_user( 1 );
+
+		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
+		$_GET['page'] = 'mlang';
+
+		$links_model = self::$model->get_links_model();
+		$pll_env = new PLL_Settings( $links_model );
+
+		ob_start();
+		do_action( 'admin_menu' );
+		set_current_screen();
+		do_action( 'load-toplevel_page_mlang' );
+		get_admin_page_title();
+		get_current_screen()->render_screen_meta();
+		do_action( 'toplevel_page_mlang' );
+		$out = ob_get_clean();
+
+		$doc = new DomDocument();
+		$doc->loadHTML( $out );
+		$xpath = new DOMXpath( $doc );
+
+		// All column headers.
+		$this->assertSame( 7, $xpath->query( '//thead/tr/th' )->length );
+
+		$th = $xpath->query( '//th[@id="name"]/a/span' );
+		$this->assertSame( 'Full name', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="locale"]/a/span' );
+		$this->assertSame( 'Locale', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="slug"]/a/span' );
+		$this->assertSame( 'Code', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="default_lang"]/span/span' );
+		$this->assertSame( 'Default language', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="term_group"]/a/span' );
+		$this->assertSame( 'Order', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="flag"]' );
+		$this->assertSame( 'Flag', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="count"]/a/span' );
+		$this->assertSame( 'Posts', $th->item( 0 )->nodeValue );
+
+		// The rows ( 1 per language ).
+		$this->assertSame( 2, $xpath->query( '//tbody/tr' )->length );
+
+		// Just check 1 language name.
+		$td = $xpath->query( '//tbody/tr/td/a' );
+		$this->assertSame( 'English', $td->item( 0 )->nodeValue );
+	}
+
+	public function test_display_strings_table() {
+		wp_set_current_user( 1 );
+
+		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
+		$_GET['page'] = 'mlang_strings';
+
+		$links_model = self::$model->get_links_model();
+		$pll_env = new PLL_Settings( $links_model );
+
+		PLL_Admin_Strings::register_string( 'Test', 'Some string' );
+
+		ob_start();
+		do_action( 'admin_menu' );
+		set_current_screen();
+		do_action( 'load-languages_page_mlang_strings' );
+		get_admin_page_title();
+		get_current_screen()->render_screen_meta();
+		do_action( 'languages_page_mlang_strings' );
+		$out = ob_get_clean();
+
+		$doc = new DomDocument();
+		$doc->loadHTML( $out );
+		$xpath = new DOMXpath( $doc );
+
+		// All column headers.
+		$this->assertSame( 4, $xpath->query( '//thead/tr/th' )->length ); // Doesn't count the checkbox.
+
+		$th = $xpath->query( '//thead/tr/td[@id="cb"]/input' ); // Curiously, this a <td>.
+		$this->assertSame( 'checkbox', $th->item( 0 )->getAttribute( 'type' ) );
+
+		$th = $xpath->query( '//th[@id="string"]/a/span' );
+		$this->assertSame( 'String', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="name"]/a/span' );
+		$this->assertSame( 'Name', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="context"]/a/span' );
+		$this->assertSame( 'Group', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="translations"]' );
+		$this->assertSame( 'Translations', $th->item( 0 )->nodeValue );
+
+		// The rows.
+		$this->assertSame( 1, $xpath->query( '//tbody/tr' )->length ); // 1 per string.
+
+		$td = $xpath->query( '//tbody/tr/td' );
+		// $this->assertSame( 'Some string', $td->item( 0 )->nodeValue ); // This cell displays a parasitic child button.
+		$this->assertSame( 'Test', $td->item( 1 )->nodeValue );
+		$this->assertSame( 'Polylang', $td->item( 2 )->nodeValue );
+
+		$this->assertSame( 2, $xpath->query( '//tbody/tr/td/div/input' )->length ); // 1 per language.
+	}
+
+	public function test_display_settings_table() {
+		wp_set_current_user( 1 );
+
+		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
+		$_GET['page'] = 'mlang_settings';
+
+		$links_model = self::$model->get_links_model();
+		$pll_env = new PLL_Settings( $links_model );
+		$pll_env->register_settings_modules(); // Manually register modules to avoid firing the 'admin_init' action.
+
+		ob_start();
+		do_action( 'admin_menu' );
+		set_current_screen();
+		do_action( 'load-languages_page_mlang_settings' );
+		get_admin_page_title();
+		get_current_screen()->render_screen_meta();
+		do_action( 'languages_page_mlang_settings' );
+		$out = ob_get_clean();
+
+		$doc = new DomDocument();
+		$doc->loadHTML( $out );
+		$xpath = new DOMXpath( $doc );
+
+		// All column headers.
+		$this->assertSame( 2, $xpath->query( '//thead/tr/th' )->length ); // Doesn't count the empty cb.
+
+		$th = $xpath->query( '//thead/tr/td[@id="cb"]' ); // Curiously, this a <td>.
+		$this->assertEmpty( $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="plugin-title"]' );
+		$this->assertSame( 'Module', $th->item( 0 )->nodeValue );
+
+		$th = $xpath->query( '//th[@id="description"]' );
+		$this->assertSame( 'Description', $th->item( 0 )->nodeValue );
+
+		// The rows.
+		$trs = $xpath->query( '//tbody/tr' );
+		$this->assertSame( 6, $trs->length ); // Only core modules (5 + Hidden URL modifications form).
+
+		$this->assertSame( 'pll-module-url', $trs->item( 0 )->getAttribute( 'id' ) );
+		$this->assertSame( 'pll-configure-url', $trs->item( 1 )->getAttribute( 'id' ) );
+		$this->assertSame( 'display: none;', $trs->item( 1 )->getAttribute( 'style' ) );
+		$this->assertSame( 'pll-module-browser', $trs->item( 2 )->getAttribute( 'id' ) );
+		$this->assertSame( 'pll-module-media', $trs->item( 3 )->getAttribute( 'id' ) );
+		$this->assertSame( 'pll-module-cpt', $trs->item( 4 )->getAttribute( 'id' ) );
+		$this->assertSame( 'pll-module-licenses', $trs->item( 5 )->getAttribute( 'id' ) );
+	}
+}

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -20,8 +20,8 @@ class Settings_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Avoid http call
-		add_filter( 'pre_transient_available_translations', '__return_empty_array' );
+		// Avoid an API request triggered by wp_get_available_translations() called in languages_page().
+		add_filter( 'pre_site_transient_available_translations', '__return_empty_array' );
 	}
 
 	/**
@@ -38,10 +38,6 @@ class Settings_Test extends PLL_UnitTestCase {
 		$GLOBALS['plugin_page'] = 'mlang';
 		get_admin_page_title();
 		set_current_screen();
-
-		// languages_pages() calls wp_get_available_translations() which triggers a wp.org api request
-		// if the transient 'available_translations' is empty, so let's fill it with a dummy value.
-		set_site_transient( 'available_translations', array( 'fr_FR' => '' ) );
 
 		ob_start();
 		$links_model = self::$model->get_links_model();


### PR DESCRIPTION
This reverts #1305, because:
- It is now useless since WP fixed the issue on its side.
- This totally breaks the tables.

Unfortunately, things are not as simple as I imagined.
The columns are added by `WP_List_Table` with `get_column_headers()` using the filter `manage_{$screen->id}_columns`. So there are several steps to make things happen the same was as in WP:
1. Pass the `screen` param to the `WP_List_Table` constructor.
2. Instantiate our `WP_List_Table` child class early enough (probably hooked to `load-{$screen->id}` otherwise `get_column_headers()` is called before the filter is added in the  the `WP_List_Table` constructor.

