### PR TITLE
Init `PLL_Frontend` once main query in tests.

### DIFF
--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -95,13 +95,14 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		unset( $GLOBALS['wp_actions']['pll_language_defined'] );
 		unset( $this->frontend->curlang );
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $url, PHP_URL_HOST );
-		$this->frontend->init();
 
 		// restart copy paste of WP_UnitTestCase::go_to
 		$GLOBALS['wp_the_query'] = new WP_Query();
 		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
 		$GLOBALS['wp'] = new WP();
 		_cleanup_query_vars();
+
+		$this->frontend->init();
 
 		$GLOBALS['wp']->main( $parts['query'] );
 	}


### PR DESCRIPTION
## What?
Fixes these [errors](https://app.travis-ci.com/github/polylang/polylang/jobs/604959404) occurring with WP nightly (6.3-alpha-56055).

## Why?
Didn't find the why 😭
But where the error is triggered I found.
In `Choose_Lang_Domain_Test::go_to()`, `PLL_Frontend::init()` is called before the main query is set.
This is calling `PLL_Choose_Lang::set_language()` then `wp_styles()` which creates a new instance and fires `wp_default_styles` action.
After that `wp_default_styles()` function callback calls `wp_should_load_separate_core_block_assets()` finally calling `is_feed()` which trigger an error because `global $wp_query` is empty (for an unknown reason...).

## How?
Move `PLL_Frontend::init()` after we set the main query in `Choose_Lang_Domain_Test::go_to()`.