### PR TITLE
Fix PHP 8.2 deprecated notice in tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="install">

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -15,7 +15,7 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	public function init( $pagename ) {
 		wp_set_current_user( 1 );
 
-		$_GET['page'] = $pagename;
+		$GLOBALS['plugin_page'] = $_GET['page'] = $pagename;
 
 		$links_model = self::$model->get_links_model();
 		return new PLL_Settings( $links_model );


### PR DESCRIPTION
This fixes deprecated notices in PHP 8.2 introduced by new tests from #1307.
```
PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /home/travis/build/polylang/polylang/tmp/wordpress/wp-admin/includes/plugin.php on line 2088
```
It was due to a missing global in test setup.

Additionnally the PR sets `convertDeprecationsToExceptions` to true to improve the deprecated notices visibility.