### PR TITLE
Don't reset the"static front page" option on deletion of a home page translation

### DIFF
--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -36,13 +36,6 @@ class PLL_Static_Pages {
 	protected $curlang;
 
 	/**
-	 * Used to temporarilly disable the static page translation.
-	 *
-	 * @var bool
-	 */
-	protected $page_translation_disabled = false;
-
-	/**
 	 * Constructor: setups filters and actions.
 	 *
 	 * @since 1.8
@@ -168,16 +161,6 @@ class PLL_Static_Pages {
 		// Translates page for posts and page on front.
 		add_filter( 'option_page_on_front', array( $this, 'translate_page_on_front' ) );
 		add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
-
-		/*
-		 * Disables the page translation when deleting the page for posts, page on front, or one of their translations.
-		 * The idea is to disable the translation when `_reset_front_page_settings_for_post()` is used, which is hooked
-		 * to `before_delete_post` and `wp_trash_post` at priority 10.
-		 */
-		add_action( 'before_delete_post', array( $this, 'maybe_disable_page_on_front_and_page_for_posts_translation' ), -10000 );
-		add_action( 'before_delete_post', array( $this, 'enable_page_on_front_and_page_for_posts_translation' ), 10000 );
-		add_action( 'wp_trash_post', array( $this, 'maybe_disable_page_on_front_and_page_for_posts_translation' ), -10000 );
-		add_action( 'wp_trash_post', array( $this, 'enable_page_on_front_and_page_for_posts_translation' ), 10000 );
 	}
 
 	/**
@@ -190,12 +173,15 @@ class PLL_Static_Pages {
 	 * @return int
 	 */
 	public function translate_page_on_front( $page_id ) {
-		if ( $this->page_translation_disabled || empty( $this->curlang->page_on_front ) ) {
+		if ( empty( $this->curlang->page_on_front ) ) {
 			return $page_id;
 		}
 
-		if ( doing_action( 'switch_blog' ) ) {
-			// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+		if ( doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
+			/*
+			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
+			 */
 			return $page_id;
 		}
 
@@ -211,62 +197,19 @@ class PLL_Static_Pages {
 	 * @return int
 	 */
 	public function translate_page_for_posts( $page_id ) {
-		if ( $this->page_translation_disabled || empty( $this->curlang->page_for_posts ) ) {
+		if ( empty( $this->curlang->page_for_posts ) ) {
 			return $page_id;
 		}
 
-		if ( doing_action( 'switch_blog' ) ) {
-			// Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+		if ( doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
+			/*
+			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
+			 */
 			return $page_id;
 		}
 
 		return $this->curlang->page_for_posts;
-	}
-
-	/**
-	 * Disables the translation of the "page on front" and "page for posts" if the given post is one of them and their
-	 * translations.
-	 * Hooked to `before_delete_post` at priority -10000.
-	 * Hooked to `wp_trash_post` at priority -10000.
-	 *
-	 * @see _reset_front_page_settings_for_post()
-	 *
-	 * @since 3.4.4
-	 *
-	 * @param int $post_id Post ID.
-	 * @return void
-	 */
-	public function maybe_disable_page_on_front_and_page_for_posts_translation( $post_id ) {
-		foreach ( $this->model->get_languages_list() as $language ) {
-			if ( $post_id === $language->page_on_front || $post_id === $language->page_for_posts ) {
-				$this->disable_page_on_front_and_page_for_posts_translation();
-				return;
-			}
-		}
-	}
-
-	/**
-	 * Disables the translation of the "page on front" and "page for posts".
-	 *
-	 * @since 3.4.4
-	 *
-	 * @return void
-	 */
-	public function disable_page_on_front_and_page_for_posts_translation() {
-		$this->page_translation_disabled = true;
-	}
-
-	/**
-	 * Enables the translation of the "page on front" and "page for posts".
-	 * Hooked to `before_delete_post` at priority -10000.
-	 * Hooked to `wp_trash_post` at priority -10000.
-	 *
-	 * @since 3.4.4
-	 *
-	 * @return void
-	 */
-	public function enable_page_on_front_and_page_for_posts_translation() {
-		$this->page_translation_disabled = false;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -94,23 +94,21 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		if ( 'frontend' === $env ) {
 			// Go to frontend.
 			$this->pll_env = new PLL_Frontend( $this->links_model );
-			$this->pll_env->init();
-
-			$this->pll_env->static_pages->pll_language_defined();
 		} else {
 			// Go to admin.
 			$this->pll_env = $pll_admin;
-			$this->pll_env->init();
-			$this->pll_env->static_pages->pll_language_defined();
 		}
+
+		$this->pll_env->init();
+		$this->pll_env->static_pages->pll_language_defined();
 	}
 
 	public static function wpTearDownAfterClass() {
-		wp_delete_post( self::$home_en );
-		wp_delete_post( self::$home_fr );
-		wp_delete_post( self::$home_de );
-		wp_delete_post( self::$posts_en );
-		wp_delete_post( self::$posts_fr );
+		wp_delete_post( self::$home_en, true );
+		wp_delete_post( self::$home_fr, true );
+		wp_delete_post( self::$home_de, true );
+		wp_delete_post( self::$posts_en, true );
+		wp_delete_post( self::$posts_fr, true );
 
 		parent::wpTearDownAfterClass();
 	}
@@ -656,5 +654,93 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
 		$this->assertEquals( home_url( '/en/home/' ), $this->pll_env->links->get_translation_url( self::$model->get_language( 'en' ) ) );
 		$this->assertEquals( array( get_post( $es ) ), $GLOBALS['wp_query']->posts );
+	}
+
+	/**
+	 * @dataProvider page_deletion_provider
+	 * @ticket 1701
+	 * @see https://github.com/polylang/polylang-pro/issues/1701
+	 *
+	 * @param string $delete   Name of the class property that stores the ID of the page to delete.
+	 * @param bool   $trash    Either the page should be deleted or trashed.
+	 * @param string $lang     Code of the current language.
+	 * @param array  $expected {
+	 *     Values to expect.
+	 *
+	 *     @var string $show_on_front  Value of the option `show_on_front`.
+	 *     @var int    $page_on_front  Value of the option `page_on_front`.
+	 *     @var string $page_for_posts Value of the option `page_for_posts`.
+	 * }
+	 * @return void
+	 */
+	public function test_page_deletion( $delete, $trash, $lang, $expected ) {
+		$this->init_test( 'admin' );
+
+		$this->pll_env->curlang = self::$model->get_language( $lang );
+		wp_delete_post( self::$$delete, ! $trash );
+
+		$expected_page_on_front  = is_string( $expected['page_on_front'] ) ? self::${$expected['page_on_front']} : $expected['page_on_front'];
+		$expected_page_for_posts = is_string( $expected['page_for_posts'] ) ? self::${$expected['page_for_posts']} : $expected['page_for_posts'];
+
+		$this->pll_env->static_pages->disable_page_on_front_and_page_for_posts_translation();
+		$this->assertSame( $expected['show_on_front'], get_option( 'show_on_front' ) );
+		$this->assertSame( $expected_page_on_front, get_option( 'page_on_front' ) );
+		$this->assertSame( $expected_page_for_posts, get_option( 'page_for_posts' ) );
+		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
+	}
+
+	public function page_deletion_provider() {
+		return array(
+			'Delete page on front not in option'  => array(
+				'delete'   => 'home_de',
+				'trash'    => false,
+				'lang'     => 'de',
+				'expected' => array(
+					'show_on_front'  => 'page',
+					'page_on_front'  => 'home_fr',
+					'page_for_posts' => 'posts_fr',
+				),
+			),
+			'Trash page on front not in option'   => array(
+				'delete'   => 'home_en',
+				'trash'    => true,
+				'lang'     => 'en',
+				'expected' => array(
+					'show_on_front'  => 'page',
+					'page_on_front'  => 'home_fr',
+					'page_for_posts' => 'posts_fr',
+				),
+			),
+			'Delete page on front in option'      => array(
+				'delete'   => 'home_fr',
+				'trash'    => false,
+				'lang'     => 'fr',
+				'expected' => array(
+					'show_on_front'  => 'posts',
+					'page_on_front'  => 0,
+					'page_for_posts' => 'posts_fr',
+				),
+			),
+			'Delete page for posts not in option' => array(
+				'delete'   => 'posts_en',
+				'trash'    => false,
+				'lang'     => 'en',
+				'expected' => array(
+					'show_on_front'  => 'page',
+					'page_on_front'  => 'home_fr',
+					'page_for_posts' => 'posts_fr',
+				),
+			),
+			'Delete page for posts in option'     => array(
+				'delete'   => 'posts_fr',
+				'trash'    => false,
+				'lang'     => 'fr',
+				'expected' => array(
+					'show_on_front'  => 'page',
+					'page_on_front'  => 'home_fr',
+					'page_for_posts' => 0,
+				),
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -667,9 +667,9 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	 * @param array  $expected {
 	 *     Values to expect.
 	 *
-	 *     @var string $show_on_front  Value of the option `show_on_front`.
-	 *     @var int    $page_on_front  Value of the option `page_on_front`.
-	 *     @var string $page_for_posts Value of the option `page_for_posts`.
+	 *     @var string     $show_on_front  Value of the option `show_on_front`.
+	 *     @var string|int $page_on_front  Name of the class property holding the value of the option `page_on_front`. Can also be `0`.
+	 *     @var string|int $page_for_posts Name of the class property holding the value of the option `page_for_posts`. Can also be `0`.
 	 * }
 	 * @return void
 	 */
@@ -682,11 +682,12 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$expected_page_on_front  = is_string( $expected['page_on_front'] ) ? self::${$expected['page_on_front']} : $expected['page_on_front'];
 		$expected_page_for_posts = is_string( $expected['page_for_posts'] ) ? self::${$expected['page_for_posts']} : $expected['page_for_posts'];
 
-		$this->pll_env->static_pages->disable_page_on_front_and_page_for_posts_translation();
+		// Assert the real values by shunting `translate_page_for_posts()` and `translate_page_on_front()`.
+		$GLOBALS['wp_current_filter']['test'] = 'before_delete_post';
 		$this->assertSame( $expected['show_on_front'], get_option( 'show_on_front' ) );
 		$this->assertSame( $expected_page_on_front, get_option( 'page_on_front' ) );
 		$this->assertSame( $expected_page_for_posts, get_option( 'page_for_posts' ) );
-		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
+		unset( $GLOBALS['wp_current_filter']['test'] );
 	}
 
 	/**
@@ -706,19 +707,21 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->pll_env->curlang = self::$model->get_language( 'fr' );
 		wp_delete_post( self::$home_fr, true );
 
-		$this->pll_env->static_pages->disable_page_on_front_and_page_for_posts_translation();
+		// Assert the real values by shunting `translate_page_for_posts()` and `translate_page_on_front()`.
+		$GLOBALS['wp_current_filter']['test'] = 'before_delete_post';
 		$this->assertSame( 'posts', get_option( 'show_on_front' ) );
 		$this->assertSame( 0, get_option( 'page_on_front' ) );
 		$this->assertSame( self::$posts_fr, get_option( 'page_for_posts' ) );
-		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
+		unset( $GLOBALS['wp_current_filter']['test'] );
 
 		wp_delete_post( self::$posts_fr, true );
 
-		$this->pll_env->static_pages->disable_page_on_front_and_page_for_posts_translation();
+		// Assert the real values by shunting `translate_page_for_posts()` and `translate_page_on_front()`.
+		$GLOBALS['wp_current_filter']['test'] = 'before_delete_post';
 		$this->assertSame( 'posts', get_option( 'show_on_front' ) );
 		$this->assertSame( 0, get_option( 'page_on_front' ) );
 		$this->assertSame( 0, get_option( 'page_for_posts' ) );
-		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
+		unset( $GLOBALS['wp_current_filter']['test'] );
 	}
 
 	public function page_deletion_provider() {

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -689,6 +689,38 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
 	}
 
+	/**
+	 * @ticket 1701
+	 * @see https://github.com/polylang/polylang-pro/issues/1701
+	 *
+	 * @return void
+	 */
+	public function test_page_deletion_without_translations() {
+		// Delete translations.
+		self::$model->post->delete_translation( self::$home_en );
+		self::$model->post->delete_translation( self::$home_de, true );
+		self::$model->post->delete_translation( self::$posts_en, true );
+
+		$this->init_test( 'admin' );
+
+		$this->pll_env->curlang = self::$model->get_language( 'fr' );
+		wp_delete_post( self::$home_fr, true );
+
+		$this->pll_env->static_pages->disable_page_on_front_and_page_for_posts_translation();
+		$this->assertSame( 'posts', get_option( 'show_on_front' ) );
+		$this->assertSame( 0, get_option( 'page_on_front' ) );
+		$this->assertSame( self::$posts_fr, get_option( 'page_for_posts' ) );
+		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
+
+		wp_delete_post( self::$posts_fr, true );
+
+		$this->pll_env->static_pages->disable_page_on_front_and_page_for_posts_translation();
+		$this->assertSame( 'posts', get_option( 'show_on_front' ) );
+		$this->assertSame( 0, get_option( 'page_on_front' ) );
+		$this->assertSame( 0, get_option( 'page_for_posts' ) );
+		$this->pll_env->static_pages->enable_page_on_front_and_page_for_posts_translation();
+	}
+
 	public function page_deletion_provider() {
 		return array(
 			'Delete page on front not in option'  => array(


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1701.

This PR allows to disable/enable the translation of the options `page_for_posts` and `page_on_front` whenever we want. This is done with the methods `PLL_Static_Pages::disable_page_on_front_and_page_for_posts_translation()` and `PLL_Static_Pages::enable_page_on_front_and_page_for_posts_translation()`.

This PR also disables these translations automatically when deleting the page for posts, page on front, or one of their translations. This is done by "surrounding" `_reset_front_page_settings_for_post()`, which is hooked to `before_delete_post` and `wp_trash_post`.

Note: maybe `disable_page_on_front_and_page_for_posts_translation()` could be used directly in place of `maybe_disable_page_on_front_and_page_for_posts_translation()`, but it feels safer (at least to me) to keep it.