### PR TITLE
Fix tags translation during post update.

### DIFF
--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -337,26 +337,11 @@ class PLL_CRUD_Posts {
 	 * @return void
 	 */
 	public function force_tags_translation( $post_id, $post_after, $post_before ) {
-		static $avoid_recursion = false;
-
-		if ( $avoid_recursion ) {
-			return;
-		}
-
-		$avoid_recursion = true;
-
 		$post_before = $post_before->to_array();
 
-		if ( empty( $post_before['tags_input'] ) ) {
-			$avoid_recursion = false;
-			return;
+		if ( ! empty( $post_before['tags_input'] ) ) {
+			// Let's ensure that  `PLL_CRUD_Posts::set_object_terms()` will do its job.
+			wp_set_post_tags( $post_id, $post_before['tags_input'] );
 		}
-
-		$post_after               = $post_after->to_array();
-		$post_after['tags_input'] = $post_before['tags_input'];  // Will force `PLL_CRUD_Posts::set_object_terms()` to do its job.
-
-		wp_insert_post( $post_after );
-
-		$avoid_recursion = false;
 	}
 }

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -337,12 +337,18 @@ class PLL_CRUD_Posts {
 	 * @return void
 	 */
 	public function force_tags_translation( $post_id, $post_after, $post_before ) {
-		remove_action( 'post_updated', array( $this, 'force_tags_translation' ) );
+		static $avoid_recursion = false;
+
+		if ( $avoid_recursion ) {
+			return;
+		}
+
+		$avoid_recursion = true;
 
 		$post_before = $post_before->to_array();
 
 		if ( empty( $post_before['tags_input'] ) ) {
-			add_action( 'post_updated', array( $this, 'force_tags_translation' ), 10, 3 );
+			$avoid_recursion = false;
 			return;
 		}
 
@@ -351,6 +357,6 @@ class PLL_CRUD_Posts {
 
 		wp_insert_post( $post_after );
 
-		add_action( 'post_updated', array( $this, 'force_tags_translation' ), 10, 3 );
+		$avoid_recursion = false;
 	}
 }

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -45,6 +45,7 @@ class PLL_CRUD_Posts {
 		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 4 );
 		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 2 );
 		add_action( 'before_delete_post', array( $this, 'delete_post' ) );
+		add_action( 'post_updated', array( $this, 'force_tags_translation' ), 10, 3 );
 
 		// Specific for media
 		if ( $polylang->options['media_support'] ) {
@@ -323,5 +324,33 @@ class PLL_CRUD_Posts {
 		 */
 		do_action( 'pll_translate_media', $post_id, $tr_id, $lang->slug );
 		return $tr_id;
+	}
+
+	/**
+	 * Forces tags translation when a post is updated, due to `tags_input` paramter being removed in `wp_update_post()`.
+	 *
+	 * @since 3.4.4
+	 *
+	 * @param int     $post_id      Post ID, unused.
+	 * @param WP_Post $post_after   Post object following the update.
+	 * @param WP_Post $post_before  Post object before the update.
+	 * @return void
+	 */
+	public function force_tags_translation( $post_id, $post_after, $post_before ) {
+		remove_action( 'post_updated', array( $this, 'force_tags_translation' ) );
+
+		$post_before = $post_before->to_array();
+
+		if ( empty( $post_before['tags_input'] ) ) {
+			add_action( 'post_updated', array( $this, 'force_tags_translation' ), 10, 3 );
+			return;
+		}
+
+		$post_after               = $post_after->to_array();
+		$post_after['tags_input'] = $post_before['tags_input'];  // Will force `PLL_CRUD_Posts::set_object_terms()` to do its job.
+
+		wp_insert_post( $post_after );
+
+		add_action( 'post_updated', array( $this, 'force_tags_translation' ), 10, 3 );
 	}
 }

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -327,9 +327,9 @@ class PLL_CRUD_Posts {
 	}
 
 	/**
-	 * Forces tags translation when a post is updated, due to `tags_input` paramter being removed in `wp_update_post()`.
+	 * Ensure that tags are in the correct language when a post is updated, due to `tags_input` parameter being removed in `wp_update_post()`.
 	 *
-	 * @since 3.4.4
+	 * @since 3.4.5
 	 *
 	 * @param int     $post_id      Post ID, unused.
 	 * @param WP_Post $post_after   Post object following the update.

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -13,4 +13,25 @@ class PLL_UnitTestCase extends WP_UnitTestCase {
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.
 		add_filter( 'wp_doing_ajax', '__return_false' );
 	}
+
+	/**
+	 * Asserts an object has the correct language set.
+	 *
+	 * @param WP_Post|WP_Term $object   Object to check, only post and term supported.
+	 * @param string          $language Language slug to check.
+	 * @param string          $message  Error message.
+	 * @return void
+	 */
+	protected function assert_has_language( $object, $language, $message = '' ) {
+		$object_language = false;
+
+		if ( $object instanceof WP_Post ) {
+			$object_language = self::$model->post->get_language( $object->ID );
+		} elseif ( $object instanceof WP_Term ) {
+			$object_language = self::$model->term->get_language( $object->term_id );
+		}
+
+		$this->assertNotFalse( $object_language, $message );
+		$this->assertSame( $language, $object_language->slug, $message );
+	}
 }

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -1,0 +1,88 @@
+<?php
+
+class CRUD_Posts_Test extends PLL_UnitTestCase {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::create_language( 'en_US' );
+		self::create_language( 'fr_FR' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		register_taxonomy( 'custom_tax', 'post' );
+
+		$options                = array_merge(
+			PLL_Install::get_default_options(),
+			array(
+				'default_lang' => 'en',
+				'taxonomies'   => array( 'custom_tax' => 'custom_tax' ),
+			)
+		);
+		$model                  = new PLL_Admin_Model( $options );
+		$links_model            = new PLL_Links_Default( $model );
+		$this->pll_admin        = new PLL_Admin( $links_model );
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		_unregister_taxonomy( 'custom_tax' );
+	}
+
+	/**
+	 * @testWith ["post_tag", "tags_input"]
+	 *           ["category", "post_category"]
+	 *           ["custom_tax", "tax_input"]
+	 *
+	 * @param string $taxonomy     Taxonomy to test.
+	 * @param string $post_tax_arg Post argument key used regarding the taxonomy in `wp_update_post()`.
+	 */
+	public function test_language_change_with_taxonomy( $taxonomy, $post_tax_arg ) {
+		// Fixtures.
+		$term_en = self::factory()->term->create( array( 'taxonomy' => $taxonomy ) );
+		$this->pll_admin->model->term->set_language( $term_en, 'en' );
+		$term_fr = self::factory()->term->create( array( 'taxonomy' => $taxonomy ) );
+		$this->pll_admin->model->term->set_language( $term_fr, 'fr' );
+		$this->pll_admin->model->term->save_translations(
+			$term_en,
+			array(
+				'en' => $term_en,
+				'fr' => $term_fr,
+			)
+		);
+
+		$term_input = in_array( $taxonomy, array( 'category', 'post_tag' ), true ) ? array( $term_en ) : array( $taxonomy => array( $term_en ) );  // Special case fo custom taxonomies.
+		$post       = self::factory()->post->create_and_get( array( $post_tax_arg => $term_input ) );
+		$this->pll_admin->model->post->set_language( $post->ID, 'en' );
+
+		// Change post language and update it.
+		$this->pll_admin->model->post->set_language( $post->ID, 'fr' );
+		$postarr = $post->to_array();
+
+		// Pass the term in previous language on purpose.
+		if ( ! in_array( $taxonomy, array( 'category', 'post_tag' ), true ) ) {
+			wp_set_current_user( 1 ); // Current user should have the proper capability to set custom taxonomy terms.
+			$postarr[ $post_tax_arg ] = array( $taxonomy => array( $term_en ) ); // Special case fo custom taxonomies wich expects an array of array.
+		} elseif ( 'post_tag' === $taxonomy ) {
+			$postarr[ $post_tax_arg ] = array( get_term( $term_en, $taxonomy )->name ); // Special case for tags where `wp_update_post()` removes existing one by names.
+		} else {
+			$postarr[ $post_tax_arg ] = array( $term_en ); // Pass the term in previous language on purpose.
+		}
+
+		$result = wp_update_post( $postarr );
+
+		$this->assertSame( $post->ID, $result, 'The post should be well updated.' );
+		$this->assert_has_language( $post, 'fr', 'The post language should be French.' );
+
+		$post  = get_post( $post->ID );
+		$terms = wp_get_object_terms( $post->ID, $taxonomy, array( 'fields' => 'ids' ) );
+
+		$this->assertNotWPError( $terms );
+		$this->assertCount( 1, $terms, "The post should have only one {$taxonomy}." );
+		$this->assertSame( $term_fr, reset( $terms ), "The {$taxonomy} should have been translated." );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1712

## What?
`wp_update_post()` is removing `tags_input` param when there is no change. But in our case we do need it so `PLL_CRUD_Posts::set_object_terms()` can update the post tags according to the new language.

## How?
- Hook to `post_updated` and force `wp_insert_post()` with the `tags_input` parameter.

## And?
- Add tests for tag, category and custom taxonomy just for safety.

*Note: I previously wanted to use `wp_insert_post_data` to filter the arguments but it can't be done since the first parameter is a post data array containing only DB columns. As I see it there is no way to filter `$postarr` in `wp_insert_post()`...*