### PR TITLE
Fix errors since PHPStan 1.10.22.

### DIFF
--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -48,7 +48,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	 *
 	 * @since 1.2
 	 *
-	 * @return object|bool detected language, false if none was found
+	 * @return PLL_Language|false detected language, false if none was found
 	 */
 	protected function get_language_from_content() {
 		// No language set for 404
@@ -158,7 +158,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	 * @since 0.9
 	 *
 	 * @param PLL_Language|false $lang Language found by {@see PLL_Choose_Lang_Content::get_language_from_content()}.
-	 * @return PLL_Language
+	 * @return PLL_Language|false
 	 */
 	public function pll_get_current_language( $lang ) {
 		return ! $lang ? $this->get_preferred_language() : $lang;

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -75,7 +75,7 @@ abstract class PLL_Choose_Lang {
 	 *
 	 * @since 1.2
 	 *
-	 * @param PLL_Language $curlang Current language.
+	 * @param PLL_Language|false $curlang Current language.
 	 * @return void
 	 */
 	protected function set_language( $curlang ) {
@@ -86,7 +86,15 @@ abstract class PLL_Choose_Lang {
 
 		// Final check in case $curlang has an unexpected value
 		// See https://wordpress.org/support/topic/detect-browser-language-sometimes-setting-null-language
-		$this->curlang = ( $curlang instanceof PLL_Language ) ? $curlang : $this->model->get_default_language();
+		if ( ! $curlang instanceof PLL_Language ) {
+			$default = $this->model->get_default_language();
+			$curlang = $default instanceof PLL_Language ? $default : null;
+		}
+		$this->curlang = $curlang;
+
+		if ( empty( $this->curlang ) ) {
+			return;
+		}
 
 		$GLOBALS['text_direction'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
 		if ( did_action( 'wp_default_styles' ) ) {
@@ -161,7 +169,7 @@ abstract class PLL_Choose_Lang {
 	 *
 	 * @since 0.1
 	 *
-	 * @return object browser preferred language or default language
+	 * @return PLL_Language|false browser preferred language or default language
 	 */
 	public function get_preferred_language() {
 		$language = false;

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -87,14 +87,14 @@ abstract class PLL_Choose_Lang {
 		// Final check in case $curlang has an unexpected value
 		// See https://wordpress.org/support/topic/detect-browser-language-sometimes-setting-null-language
 		if ( ! $curlang instanceof PLL_Language ) {
-			$default = $this->model->get_default_language();
-			$curlang = $default instanceof PLL_Language ? $default : null;
-		}
-		$this->curlang = $curlang;
+			$curlang = $this->model->get_default_language();
 
-		if ( empty( $this->curlang ) ) {
-			return;
+			if ( ! $curlang instanceof PLL_Language ) {
+				return;
+			}
 		}
+		
+		$this->curlang = $curlang;
 
 		$GLOBALS['text_direction'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
 		if ( did_action( 'wp_default_styles' ) ) {

--- a/include/links-abstract-domain.php
+++ b/include/links-abstract-domain.php
@@ -46,7 +46,9 @@ abstract class PLL_Links_Abstract_Domain extends PLL_Links_Permalinks {
 		}
 
 		$host = wp_parse_url( $url, PHP_URL_HOST );
-		return ( $lang = array_search( $host, $this->get_hosts() ) ) ? $lang : '';
+		$lang = array_search( $host, $this->get_hosts() );
+
+		return is_string( $lang ) ? $lang : '';
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -326,16 +326,6 @@ parameters:
 			path: frontend/accept-language.php
 
 		-
-			message: "#^Method PLL_Choose_Lang_Content\\:\\:pll_get_current_language\\(\\) should return PLL_Language but returns object\\.$#"
-			count: 1
-			path: frontend/choose-lang-content.php
-
-		-
-			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang\\:\\:set_language\\(\\) expects PLL_Language, object\\|true given\\.$#"
-			count: 1
-			path: frontend/choose-lang-content.php
-
-		-
 			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang_Content\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
 			count: 1
 			path: frontend/choose-lang-content.php
@@ -354,16 +344,6 @@ parameters:
 			message: "#^Method PLL_Choose_Lang_Domain\\:\\:get_preferred_language\\(\\) should return PLL_Language but returns PLL_Language\\|false\\.$#"
 			count: 1
 			path: frontend/choose-lang-domain.php
-
-		-
-			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
-			count: 2
-			path: frontend/choose-lang.php
-
-		-
-			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang\\:\\:set_language\\(\\) expects PLL_Language, object\\|false given\\.$#"
-			count: 2
-			path: frontend/choose-lang.php
 
 		-
 			message: "#^Parameter \\#1 \\$term_id of method PLL_Frontend_Auto_Translate\\:\\:get_term\\(\\) expects int, float\\|int\\<0, max\\> given\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,12 +32,6 @@ parameters:
 			count: 1
 			path: admin/admin-base.php
 
-		# Ignored because of https://wordpress.org/support/topic/detect-browser-language-sometimes-setting-null-language
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: frontend/choose-lang.php
-
 		# Ignored because the WordPress stubs doesn't know our added 'lang' parameter in get_posts() and PLL_Model::get_languages_list() seems not to always return int[] as expected by 'post__in' parameter
 		- "#^Parameter \\#1 \\$args of function get_posts expects array(.+)\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
 


### PR DESCRIPTION
## What?
New PHPStan errors since last [release](https://github.com/phpstan/phpstan/releases/tag/1.10.22).

## How?
- Add a correct return type for `get_preferred_language()`.
- Fix resulting errors all around the code base.