### PR TITLE
[MS] Fix option creation on blog creation

### DIFF
--- a/install/install-base.php
+++ b/install/install-base.php
@@ -31,7 +31,7 @@ class PLL_Install_Base {
 		register_deactivation_hook( $plugin_basename, array( $this, 'deactivate' ) );
 
 		// Site creation on multisite.
-		add_action( 'wp_insert_site', array( $this, 'new_site' ) );
+		add_action( 'wp_initialize_site', array( $this, 'new_site' ), 50 ); // After WP (prio 10).
 	}
 
 	/**

--- a/tests/phpunit/tests/test-multisite.php
+++ b/tests/phpunit/tests/test-multisite.php
@@ -1,15 +1,20 @@
 <?php
 
-if ( is_multisite() ) :
+class Multisite_Test extends PLL_UnitTestCase {
 
-	class Multisite_Test extends PLL_UnitTestCase {
-		public function test_new_site() {
-			$site_id = self::factory()->blog->create();
-			switch_to_blog( $site_id );
-			$options = get_option( 'polylang' );
-			restore_current_blog();
-			$this->assertNotFalse( $options );
+	public function set_up() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires WordPress multisite.' );
 		}
+
+		parent::set_up();
 	}
 
-endif;
+	public function test_new_site() {
+		$site_id = self::factory()->blog->create();
+		switch_to_blog( $site_id );
+		$options = get_option( 'polylang' );
+		restore_current_blog();
+		$this->assertNotFalse( $options );
+	}
+}

--- a/tests/phpunit/tests/test-multisite.php
+++ b/tests/phpunit/tests/test-multisite.php
@@ -5,7 +5,9 @@ if ( is_multisite() ) :
 	class Multisite_Test extends PLL_UnitTestCase {
 		public function test_new_site() {
 			$site_id = self::factory()->blog->create();
+			switch_to_blog( $site_id );
 			$options = get_option( 'polylang' );
+			restore_current_blog();
 			$this->assertNotFalse( $options );
 		}
 	}

--- a/tests/phpunit/tests/test-multisite.php
+++ b/tests/phpunit/tests/test-multisite.php
@@ -1,20 +1,15 @@
 <?php
 
-class Multisite_Test extends PLL_UnitTestCase {
+if ( is_multisite() ) :
 
-	public function set_up() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test requires WordPress multisite.' );
+	class Multisite_Test extends PLL_UnitTestCase {
+		public function test_new_site() {
+			$site_id = self::factory()->blog->create();
+			switch_to_blog( $site_id );
+			$options = get_option( 'polylang' );
+			restore_current_blog();
+			$this->assertNotFalse( $options );
 		}
-
-		parent::set_up();
 	}
 
-	public function test_new_site() {
-		$site_id = self::factory()->blog->create();
-		switch_to_blog( $site_id );
-		$options = get_option( 'polylang' );
-		restore_current_blog();
-		$this->assertNotFalse( $options );
-	}
-}
+endif;


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1721.

Everything is explained in the issue. This PR:
1. Adds the missing `switch_to_blog()` and `restore_current_blog()` in `Multisite_Test::test_new_site()`, so the option tested is the one from the new blog.
2. Hooks `'wp_initialize_site'` instead of `'wp_insert_site'`, so the option is created after the DB tables are created when a new blog is created.