### PR TITLE
E2E tests for Polylang Wizard and languages creation as well as settings panel.

### DIFF
--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -33,8 +33,14 @@ export default defineConfig( {
 	// Configure projects only for Chrome for the moment.
 	projects: [
 		{
+			name: 'env-setup',
+			testMatch: 'env-set-up.spec.js',
+		},
+		{
 			name: 'chromium',
 			use: { ...devices['Desktop Chrome'] },
+			dependencies: ['env-setup'],
+			testIgnore: 'env-set-up.spec.js',
 		},
 	],
 

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
-// import { test, expect } from '@playwright/test';
 
 /**
  * Internal dependencies.

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -28,18 +28,18 @@ test.describe( 'Launch Polylang', () => {
 		await page.getByRole('button', { name: 'Continue ' }).click();
 		await page.getByRole('link', { name: 'Return to the Dashboard' }).click();
 
-		// Go to languages panel.
+		// Go to languages panel and check that English is in the list.
 		await page.getByRole('link', { name: 'Languages' }).first().click();
 		await expect( page.getByRole('cell', { name: 'English Edit | Delete' }) ).toBeVisible();
-		await expect(page.locator('table.languages > tbody > tr > td').nth(3), 'English sould be visible in the table and be set to default language.').toContainText('Default language');
+		await expect(page.locator('table.languages > tbody > tr > td').nth(3), 'English should be visible in the list table and be set to default language.').toContainText('Default language');
 	});
 
-	test('Test add language through settings', async ({ page }) => {
+	test('Test add language through languages panel', async ({ page }) => {
 		// Navigate to the dashboard and click on "Languages" to go to the languages panel.
 		await page.goto('/wp-admin');
 		await page.getByRole('link', { name: 'Languages' }).first().click();
 
-		// Select French and add it.
+		// Select French, add it and check it is added to the list table.
 		await page.locator('#lang_list-button span').nth(1).click();
 		await page.getByRole('option', { name: 'Français - fr_FR' }).click();
 		await page.getByRole('button', { name: 'Add new language' }).click();

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -44,5 +44,6 @@ test.describe( 'Launch Polylang', () => {
 		await page.getByRole('option', { name: 'Français - fr_FR' }).click();
 		await page.getByRole('button', { name: 'Add new language' }).click();
 		await expect( page.getByRole('cell', { name: 'Français Edit | Delete' }), 'French should be visible in the table.').toBeVisible();
+		await expect(page.locator('table.languages > tbody > tr > td').nth(3), 'English should still be visible in the list table and be set to default language.').toContainText('Default language');
 	});
 });

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -7,50 +7,42 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
  */
 import { deleteAllLanguages } from '../../tools';
 
-/** @type {import('@playwright/test').Page} */
-let page;
-
 test.describe( 'Launch Polylang', () => {
-	test.beforeAll(async ({ browser }) => {
-		page = await browser.newPage();
-		await page.goto('/wp-login.php');
-		await page.getByLabel('Username or Email Address').click();
-		await page.getByLabel('Username or Email Address').fill('admin');
-		await page.getByLabel('Username or Email Address').press('Tab');
-		await page.getByLabel('Password', { exact: true }).fill('password');
-		await page.getByLabel('Password', { exact: true }).press('Tab');
-		await page.getByRole('button', { name: 'Show password' }).press('Tab');
-		await page.getByLabel('Remember Me').check();
-		await page.getByLabel('Remember Me').press('Tab');
-		await page.getByRole('button', { name: 'Log In' }).press('Enter');
-	})
-
 	test.afterAll(async ({ requestUtils }) => {
 		await deleteAllLanguages( requestUtils );
-		await page.close();
 	});
 
 	test('Test add language through Wizard', async ({ page }) => {
+		// Display the Wizard.
 		await page.goto('/wp-admin/admin.php?page=mlang_wizard');
+
+		// Select American English language to add.
 		await page.locator('#lang_list-button span').nth(1).click();
 		await page.getByRole('option', { name: 'English - en_US' }).click();
 		await page.getByRole('button', { name: ' Add new language' }).click();
-		await expect(page.getByRole('cell', { name: 'English - en_US' })).toBeVisible();
+		await expect(page.getByRole('cell', { name: 'English - en_US' }), 'English should be displayed in the languages to add list. ').toBeVisible();
+
+		// Validate steps and navigate to the dashboard.
 		await page.getByRole('button', { name: 'Continue ' }).click();
 		await page.getByRole('button', { name: 'Continue ' }).click();
 		await page.getByRole('button', { name: 'Continue ' }).click();
 		await page.getByRole('link', { name: 'Return to the Dashboard' }).click();
+
+		// Go to languages panel.
 		await page.getByRole('link', { name: 'Languages' }).first().click();
 		await expect( page.getByRole('cell', { name: 'English Edit | Delete' }) ).toBeVisible();
-		await expect(page.locator('table.languages > tbody > tr > td').nth(3)).toContainText('Default language');
+		await expect(page.locator('table.languages > tbody > tr > td').nth(3), 'English sould be visible in the table and be set to default language.').toContainText('Default language');
 	});
 
 	test('Test add language through settings', async ({ page }) => {
+		// Navigate to the dashboard and click on "Languages" to go to the languages panel.
 		await page.goto('/wp-admin');
 		await page.getByRole('link', { name: 'Languages' }).first().click();
+
+		// Select French and add it.
 		await page.locator('#lang_list-button span').nth(1).click();
 		await page.getByRole('option', { name: 'Français - fr_FR' }).click();
 		await page.getByRole('button', { name: 'Add new language' }).click();
-		await expect( page.getByRole('cell', { name: 'Français Edit | Delete' }) ).toBeVisible();
+		await expect( page.getByRole('cell', { name: 'Français Edit | Delete' }), 'French should be visible in the table.').toBeVisible();
 	});
 });

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -8,7 +8,7 @@ let page;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await page.goto('http://localhost:8889/wp-login.php');
+	await page.goto('/wp-login.php');
 	await page.getByLabel('Username or Email Address').click();
 	await page.getByLabel('Username or Email Address').fill('admin');
 	await page.getByLabel('Username or Email Address').press('Tab');
@@ -26,7 +26,7 @@ test.afterAll(async () => {
 
 test.describe( 'Launch Polylang', () => {
 	test('Test add language through Wizard', async ({ page }) => {
-		await page.goto('http://localhost:8889/wp-admin/admin.php?page=mlang_wizard');
+		await page.goto('/wp-admin/admin.php?page=mlang_wizard');
 		await page.locator('#lang_list-button span').nth(1).click();
 		await page.getByRole('option', { name: 'English - en_US' }).click();
 		await page.getByRole('button', { name: ' Add new language' }).click();
@@ -43,7 +43,7 @@ test.describe( 'Launch Polylang', () => {
 	});
 
 	test('Test add language through settings', async ({ page }) => {
-		await page.goto('http://localhost:8889/wp-admin');
+		await page.goto('/wp-admin');
 		await page.getByRole('link', { name: 'Languages' }).first().click();
 		await page.locator('#lang_list-button span').nth(1).click();
 		await page.getByRole('option', { name: 'Français - fr_FR' }).click();

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -1,30 +1,36 @@
 // @ts-check
 
-// import { test, expect } from '@wordpress/e2e-test-utils-playwright';
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+// import { test, expect } from '@playwright/test';
+
+/**
+ * Internal dependencies.
+ */
+import { deleteAllLanguages } from '../../tools';
 
 /** @type {import('@playwright/test').Page} */
 let page;
 
-test.beforeAll(async ({ browser }) => {
-	page = await browser.newPage();
-	await page.goto('/wp-login.php');
-	await page.getByLabel('Username or Email Address').click();
-	await page.getByLabel('Username or Email Address').fill('admin');
-	await page.getByLabel('Username or Email Address').press('Tab');
-	await page.getByLabel('Password', { exact: true }).fill('password');
-	await page.getByLabel('Password', { exact: true }).press('Tab');
-	await page.getByRole('button', { name: 'Show password' }).press('Tab');
-	await page.getByLabel('Remember Me').check();
-	await page.getByLabel('Remember Me').press('Tab');
-	await page.getByRole('button', { name: 'Log In' }).press('Enter');
-})
-
-test.afterAll(async () => {
-	await page.close();
-});
-
 test.describe( 'Launch Polylang', () => {
+	test.beforeAll(async ({ browser }) => {
+		page = await browser.newPage();
+		await page.goto('/wp-login.php');
+		await page.getByLabel('Username or Email Address').click();
+		await page.getByLabel('Username or Email Address').fill('admin');
+		await page.getByLabel('Username or Email Address').press('Tab');
+		await page.getByLabel('Password', { exact: true }).fill('password');
+		await page.getByLabel('Password', { exact: true }).press('Tab');
+		await page.getByRole('button', { name: 'Show password' }).press('Tab');
+		await page.getByLabel('Remember Me').check();
+		await page.getByLabel('Remember Me').press('Tab');
+		await page.getByRole('button', { name: 'Log In' }).press('Enter');
+	})
+
+	test.afterAll(async ({ requestUtils }) => {
+		await deleteAllLanguages( requestUtils );
+		await page.close();
+	});
+
 	test('Test add language through Wizard', async ({ page }) => {
 		await page.goto('/wp-admin/admin.php?page=mlang_wizard');
 		await page.locator('#lang_list-button span').nth(1).click();

--- a/tests/e2e/specs/create-languages/create-languages.spec.js
+++ b/tests/e2e/specs/create-languages/create-languages.spec.js
@@ -41,9 +41,7 @@ test.describe( 'Launch Polylang', () => {
 		await page.getByRole('button', { name: 'Continue ' }).click();
 		await page.getByRole('link', { name: 'Return to the Dashboard' }).click();
 		await page.getByRole('link', { name: 'Languages' }).first().click();
-		await page.getByRole('link', { name: 'Languages' }).first().click();
 		await expect( page.getByRole('cell', { name: 'English Edit | Delete' }) ).toBeVisible();
-		await page.getByRole('link', { name: 'Languages' }).first().click();
 		await expect(page.locator('table.languages > tbody > tr > td').nth(3)).toContainText('Default language');
 	});
 

--- a/tests/e2e/specs/env-set-up.spec.js
+++ b/tests/e2e/specs/env-set-up.spec.js
@@ -30,12 +30,12 @@ test.describe( 'Environment Setup Test', () => {
 
 	test( 'Polylang test plugin manages languages properly', async ( { requestUtils } ) => {
 		const english = await createLanguage( requestUtils, 'en_US' );
-		expect( english ).toStrictEqual(
+		expect( english, 'English should be created and returned.' ).toStrictEqual(
 			{"active": true, "custom_flag": "", "custom_flag_url": "", "facebook": "en_US", "fallbacks": [], "flag": "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAALCAMAAABBPP0LAAAAmVBMVEViZsViZMJiYrf9gnL8eWrlYkjgYkjZYkj8/PujwPybvPz4+PetraBEgfo+fvo3efkydfkqcvj8Y2T8UlL8Q0P8MzP9k4Hz8/Lu7u4DdPj9/VrKysI9fPoDc/EAZ7z7IiLHYkjp6ekCcOTk5OIASbfY/v21takAJrT5Dg6sYkjc3Nn94t2RkYD+y8KeYkjs/v7l5fz0dF22YkjWvcOLAAAAgElEQVR4AR2KNULFQBgGZ5J13KGGKvc/Cw1uPe62eb9+Jr1EUBFHSgxxjP2Eca6AfUSfVlUfBvm1Ui1bqafctqMndNkXpb01h5TLx4b6TIXgwOCHfjv+/Pz+5vPRw7txGWT2h6yO0/GaYltIp5PT1dEpLNPL/SdWjYjAAZtvRPgHJX4Xio+DSrkAAAAASUVORK5CYII=\" alt=\"English\" width=\"16\" height=\"11\" style=\"width: 16px; height: 11px;\" />", "flag_code": "us", "flag_url": "http://localhost:8889/wp-content/plugins/polylang/flags/us.png", "host": null, "is_default": true, "is_rtl": 0, "locale": "en_US", "name": "English", "page_for_posts": 0, "page_on_front": 0, "slug": "en", "term_group": 0, "term_id": 2, "w3c": "en-US"}
 		);
 
 		const french = await createLanguage( requestUtils, 'fr_FR' );
-		expect( french ).toStrictEqual(
+		expect( french, 'French should be created and returned.' ).toStrictEqual(
 			{"active": true, "custom_flag": "", "custom_flag_url": "", "facebook": "fr_FR", "fallbacks": [], "flag": "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAALCAMAAABBPP0LAAAAbFBMVEVzldTg4ODS0tLxDwDtAwDjAADD0uz39/fy8vL3k4nzgna4yOixwuXu7u7s6+zn5+fyd2rvcGPtZljYAABrjNCpvOHrWkxegsqfs93NAADpUUFRd8THAABBa7wnVbERRKa8vLyxsLCoqKigoKClCvcsAAAAXklEQVR4AS3JxUEAQQAEwZo13Mk/R9w5/7UERJCIGIgj5qfRJZEpPyNfCgJTjMR1eRRnJiExFJz5Mf1PokWr/UztIjRGQ3V486u0HO55m634U6dMcf0RNPfkVCTvKjO16xHA8miowAAAAABJRU5ErkJggg==\" alt=\"Français\" width=\"16\" height=\"11\" style=\"width: 16px; height: 11px;\" />", "flag_code": "fr", "flag_url": "http://localhost:8889/wp-content/plugins/polylang/flags/fr.png", "host": null, "is_default": false, "is_rtl": 0, "locale": "fr_FR", "name": "Français", "page_for_posts": 0, "page_on_front": 0, "slug": "fr", "term_group": 0, "term_id": 4, "w3c": "fr-FR",}
 		);
 
@@ -48,22 +48,23 @@ test.describe( 'Environment Setup Test', () => {
 		);
 
 		const isFrenchDeleted = await deleteLanguage( requestUtils, 'fr' );
-		expect( isFrenchDeleted ).toBeTruthy();
+		expect( isFrenchDeleted, 'French should be deleted.' ).toBeTruthy();
 
 		const isAllLanguagesDeleted = await deleteAllLanguages( requestUtils );
-		expect( isAllLanguagesDeleted ).toBeTruthy();
+	expect( isAllLanguagesDeleted, 'All languages should be deleted.' ).toBeTruthy();
 
 		const noMoreLanguages = await getAllLanguages( requestUtils );
-		expect( noMoreLanguages ).toStrictEqual([]);
+		expect( noMoreLanguages, 'Languages list should be empty.' ).toStrictEqual([]);
 	} );
 
 	test( 'Polylang test plugin manages options properly', async ( { requestUtils } ) => {
 		const supportMedia = await setOption( requestUtils, 'media_support', '1' );
-		expect( supportMedia ).toBeTruthy();
+		expect( supportMedia, 'media_support option should be updated.' ).toBeTruthy();
 
 		const resetOptions = await deleteOptions( requestUtils );
-		expect( resetOptions ).toBeTruthy();
+		expect( resetOptions, 'Options should be set to default values.' ).toBeTruthy();
 
+		// Test all default options values.
 		const options = await getOptions( requestUtils );
 		expect( options.browser ).toStrictEqual( 0 );
 		expect( options.domains ).toStrictEqual( [] );

--- a/tests/e2e/specs/settings/settings-table.spec.js
+++ b/tests/e2e/specs/settings/settings-table.spec.js
@@ -24,7 +24,7 @@ test.describe( 'Plugin Settings UI Test', () => {
 	} );
 
 	test( 'URL modification module', async ( { page } ) => {
-		// Open URL modifications settings panel and test default options are visible.
+		// Open URL modifications settings panel and test default options are visible (i.e. when plain permalink is enabled).
 		await page.getByRole('cell', { name: 'URL modifications Settings' }).getByTitle('Configure this module').click();
 		await expect( page.getByText('The language is set from content') ).toBeVisible();
 		await expect( page.getByText('The language is set from the code in the URL') ).toBeVisible();

--- a/tests/e2e/specs/settings/settings-table.spec.js
+++ b/tests/e2e/specs/settings/settings-table.spec.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Plugin Settings UI Test', () => {
+	test( 'URL modification module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await page.getByRole('cell', { name: 'URL modifications Settings' }).getByTitle('Configure this module').click();
+		await expect( page.getByText('The language is set from content') ).toBeVisible();
+		await expect( page.getByText('The language is set from the code in the URL') ).toBeVisible();
+		await expect( page.getByText('The language is set from the subdomain name in pretty permalinks') ).toBeVisible();
+		await expect( page.getByText('The language is set from different domains') ).toBeVisible();
+		await expect( page.getByText('Hide URL language information for default language') ).toBeVisible();
+	});
+});

--- a/tests/e2e/specs/settings/settings-table.spec.js
+++ b/tests/e2e/specs/settings/settings-table.spec.js
@@ -2,9 +2,27 @@
 
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
+/**
+ * Internal dependencies.
+ */
+import { deleteOptions, createLanguage, deleteAllLanguages } from '../../tools';
+
+
 test.describe( 'Plugin Settings UI Test', () => {
-	test( 'URL modification module', async ( { page } ) => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await createLanguage( requestUtils, 'en_US' );
+	});
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await deleteOptions( requestUtils );
+		await deleteAllLanguages( requestUtils );
+	});
+
+	test.beforeEach( async ( { page } ) => {
 		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+	} );
+
+	test( 'URL modification module', async ( { page } ) => {
 		await page.getByRole('cell', { name: 'URL modifications Settings' }).getByTitle('Configure this module').click();
 		await expect( page.getByText('The language is set from content') ).toBeVisible();
 		await expect( page.getByText('The language is set from the code in the URL') ).toBeVisible();
@@ -14,39 +32,33 @@ test.describe( 'Plugin Settings UI Test', () => {
 	});
 
 	test( 'Detect browser language module', async ( { page } ) => {
-		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 		await page.getByRole('cell', { name: 'Detect browser language Activate' }).getByTitle('Activate this module').click();
 		await expect( page.locator('#pll-module-browser').getByText('Deactivate') ).toBeVisible();
 	});
 
 	test( 'Media module', async ( { page } ) => {
-		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 		await page.getByRole('cell', { name: 'Media Activate' }).getByTitle('Activate this module').click();
 		await expect( page.locator('#pll-module-media').getByText('Deactivate') ).toBeVisible();
 	});
 
 	test( 'Custom post types and Taxonomies module', async ( { page } ) => {
-		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 		await expect( page.getByText('Custom post types and Taxonomies', { exact: true }) ).toBeVisible();
 		await expect( page.locator('#pll-module-cpt').getByText('Deactivated') ).toBeVisible();
 	});
 
 	test( 'Share slugs module', async ( { page } ) => {
-		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 		await expect( page.getByText('Share slugs') ).toBeVisible();
 		await expect( page.locator('#pll-module-share-slugs').getByText('Deactivated') ).toBeVisible();
 		await expect( page.locator('div').filter({ hasText: /^To enable this feature, you need Polylang Pro\. Upgrade now\.$/ }).first() ).toBeVisible();
 	});
 
 	test( 'Translate slugs module', async ( { page } ) => {
-		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 		await expect( page.getByText('Translate slugs') ).toBeVisible();
 		await expect( page.locator('#pll-module-translate-slugs').getByText('Deactivated') ).toBeVisible();
 		await expect( page.locator('div').filter({ hasText: /^To enable this feature, you need Polylang Pro\. Upgrade now\.$/ }).nth(1) ).toBeVisible();
 	});
 
 	test( 'License keys module', async ( { page } ) => {
-		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 		await expect( page.getByText('License keys') ).toBeVisible();
 		await expect( page.locator('#pll-module-licenses').getByText('Deactivated') ).toBeVisible();
 	});

--- a/tests/e2e/specs/settings/settings-table.spec.js
+++ b/tests/e2e/specs/settings/settings-table.spec.js
@@ -19,10 +19,12 @@ test.describe( 'Plugin Settings UI Test', () => {
 	});
 
 	test.beforeEach( async ( { page } ) => {
+		// Each tests are made by navigating to Polylang settings.
 		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 	} );
 
 	test( 'URL modification module', async ( { page } ) => {
+		// Open URL modifications options panel and test each ones are accessible.
 		await page.getByRole('cell', { name: 'URL modifications Settings' }).getByTitle('Configure this module').click();
 		await expect( page.getByText('The language is set from content') ).toBeVisible();
 		await expect( page.getByText('The language is set from the code in the URL') ).toBeVisible();
@@ -32,33 +34,39 @@ test.describe( 'Plugin Settings UI Test', () => {
 	});
 
 	test( 'Detect browser language module', async ( { page } ) => {
+		// Active "Detect browser language" module then test it can be deactivated.
 		await page.getByRole('cell', { name: 'Detect browser language Activate' }).getByTitle('Activate this module').click();
 		await expect( page.locator('#pll-module-browser').getByText('Deactivate') ).toBeVisible();
 	});
 
 	test( 'Media module', async ( { page } ) => {
+		// Active "Media translation" module then test it can be deactivated.
 		await page.getByRole('cell', { name: 'Media Activate' }).getByTitle('Activate this module').click();
 		await expect( page.locator('#pll-module-media').getByText('Deactivate') ).toBeVisible();
 	});
 
 	test( 'Custom post types and Taxonomies module', async ( { page } ) => {
+		// Test "Custom post types and Taxonomies" module is display and can be deactivated.
 		await expect( page.getByText('Custom post types and Taxonomies', { exact: true }) ).toBeVisible();
 		await expect( page.locator('#pll-module-cpt').getByText('Deactivated') ).toBeVisible();
 	});
 
 	test( 'Share slugs module', async ( { page } ) => {
+		// Test "Share slugs" module is unavailable and Polylang Pro purchase link is accessible.
 		await expect( page.getByText('Share slugs') ).toBeVisible();
 		await expect( page.locator('#pll-module-share-slugs').getByText('Deactivated') ).toBeVisible();
 		await expect( page.locator('div').filter({ hasText: /^To enable this feature, you need Polylang Pro\. Upgrade now\.$/ }).first() ).toBeVisible();
 	});
 
 	test( 'Translate slugs module', async ( { page } ) => {
+		// Test "Translate slugs" module is unavailable and Polylang Pro purchase link is accessible.
 		await expect( page.getByText('Translate slugs') ).toBeVisible();
 		await expect( page.locator('#pll-module-translate-slugs').getByText('Deactivated') ).toBeVisible();
 		await expect( page.locator('div').filter({ hasText: /^To enable this feature, you need Polylang Pro\. Upgrade now\.$/ }).nth(1) ).toBeVisible();
 	});
 
 	test( 'License keys module', async ( { page } ) => {
+		// Test "License" is deactivated.
 		await expect( page.getByText('License keys') ).toBeVisible();
 		await expect( page.locator('#pll-module-licenses').getByText('Deactivated') ).toBeVisible();
 	});

--- a/tests/e2e/specs/settings/settings-table.spec.js
+++ b/tests/e2e/specs/settings/settings-table.spec.js
@@ -19,12 +19,12 @@ test.describe( 'Plugin Settings UI Test', () => {
 	});
 
 	test.beforeEach( async ( { page } ) => {
-		// Each tests are made by navigating to Polylang settings.
+		// Go to settings.
 		await page.goto('/wp-admin/admin.php?page=mlang_settings');
 	} );
 
 	test( 'URL modification module', async ( { page } ) => {
-		// Open URL modifications options panel and test each ones are accessible.
+		// Open URL modifications settings panel and test default options are visible.
 		await page.getByRole('cell', { name: 'URL modifications Settings' }).getByTitle('Configure this module').click();
 		await expect( page.getByText('The language is set from content') ).toBeVisible();
 		await expect( page.getByText('The language is set from the code in the URL') ).toBeVisible();
@@ -34,19 +34,19 @@ test.describe( 'Plugin Settings UI Test', () => {
 	});
 
 	test( 'Detect browser language module', async ( { page } ) => {
-		// Active "Detect browser language" module then test it can be deactivated.
+		// Activate "Detect browser language" module then test it can be deactivated.
 		await page.getByRole('cell', { name: 'Detect browser language Activate' }).getByTitle('Activate this module').click();
 		await expect( page.locator('#pll-module-browser').getByText('Deactivate') ).toBeVisible();
 	});
 
 	test( 'Media module', async ( { page } ) => {
-		// Active "Media translation" module then test it can be deactivated.
+		// Activate "Media translation" module then test it can be deactivated.
 		await page.getByRole('cell', { name: 'Media Activate' }).getByTitle('Activate this module').click();
 		await expect( page.locator('#pll-module-media').getByText('Deactivate') ).toBeVisible();
 	});
 
 	test( 'Custom post types and Taxonomies module', async ( { page } ) => {
-		// Test "Custom post types and Taxonomies" module is display and can be deactivated.
+		// Test "Custom post types and Taxonomies" module is displayed and can be deactivated.
 		await expect( page.getByText('Custom post types and Taxonomies', { exact: true }) ).toBeVisible();
 		await expect( page.locator('#pll-module-cpt').getByText('Deactivated') ).toBeVisible();
 	});

--- a/tests/e2e/specs/settings/settings-table.spec.js
+++ b/tests/e2e/specs/settings/settings-table.spec.js
@@ -12,4 +12,42 @@ test.describe( 'Plugin Settings UI Test', () => {
 		await expect( page.getByText('The language is set from different domains') ).toBeVisible();
 		await expect( page.getByText('Hide URL language information for default language') ).toBeVisible();
 	});
+
+	test( 'Detect browser language module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await page.getByRole('cell', { name: 'Detect browser language Activate' }).getByTitle('Activate this module').click();
+		await expect( page.locator('#pll-module-browser').getByText('Deactivate') ).toBeVisible();
+	});
+
+	test( 'Media module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await page.getByRole('cell', { name: 'Media Activate' }).getByTitle('Activate this module').click();
+		await expect( page.locator('#pll-module-media').getByText('Deactivate') ).toBeVisible();
+	});
+
+	test( 'Custom post types and Taxonomies module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await expect( page.getByText('Custom post types and Taxonomies', { exact: true }) ).toBeVisible();
+		await expect( page.locator('#pll-module-cpt').getByText('Deactivated') ).toBeVisible();
+	});
+
+	test( 'Share slugs module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await expect( page.getByText('Share slugs') ).toBeVisible();
+		await expect( page.locator('#pll-module-share-slugs').getByText('Deactivated') ).toBeVisible();
+		await expect( page.locator('div').filter({ hasText: /^To enable this feature, you need Polylang Pro\. Upgrade now\.$/ }).first() ).toBeVisible();
+	});
+
+	test( 'Translate slugs module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await expect( page.getByText('Translate slugs') ).toBeVisible();
+		await expect( page.locator('#pll-module-translate-slugs').getByText('Deactivated') ).toBeVisible();
+		await expect( page.locator('div').filter({ hasText: /^To enable this feature, you need Polylang Pro\. Upgrade now\.$/ }).nth(1) ).toBeVisible();
+	});
+
+	test( 'License keys module', async ( { page } ) => {
+		await page.goto('/wp-admin/admin.php?page=mlang_settings');
+		await expect( page.getByText('License keys') ).toBeVisible();
+		await expect( page.locator('#pll-module-licenses').getByText('Deactivated') ).toBeVisible();
+	});
 });

--- a/tests/e2e/specs/wizard/create-languages.spec.js
+++ b/tests/e2e/specs/wizard/create-languages.spec.js
@@ -1,0 +1,53 @@
+// @ts-check
+
+// import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { test, expect } from '@playwright/test';
+
+/** @type {import('@playwright/test').Page} */
+let page;
+
+test.beforeAll(async ({ browser }) => {
+	page = await browser.newPage();
+	await page.goto('http://localhost:8889/wp-login.php');
+	await page.getByLabel('Username or Email Address').click();
+	await page.getByLabel('Username or Email Address').fill('admin');
+	await page.getByLabel('Username or Email Address').press('Tab');
+	await page.getByLabel('Password', { exact: true }).fill('password');
+	await page.getByLabel('Password', { exact: true }).press('Tab');
+	await page.getByRole('button', { name: 'Show password' }).press('Tab');
+	await page.getByLabel('Remember Me').check();
+	await page.getByLabel('Remember Me').press('Tab');
+	await page.getByRole('button', { name: 'Log In' }).press('Enter');
+})
+
+test.afterAll(async () => {
+	await page.close();
+});
+
+test.describe( 'Launch Polylang', () => {
+	test('Test add language through Wizard', async ({ page }) => {
+		await page.goto('http://localhost:8889/wp-admin/admin.php?page=mlang_wizard');
+		await page.locator('#lang_list-button span').nth(1).click();
+		await page.getByRole('option', { name: 'English - en_US' }).click();
+		await page.getByRole('button', { name: ' Add new language' }).click();
+		await expect(page.getByRole('cell', { name: 'English - en_US' })).toBeVisible();
+		await page.getByRole('button', { name: 'Continue ' }).click();
+		await page.getByRole('button', { name: 'Continue ' }).click();
+		await page.getByRole('button', { name: 'Continue ' }).click();
+		await page.getByRole('link', { name: 'Return to the Dashboard' }).click();
+		await page.getByRole('link', { name: 'Languages' }).first().click();
+		await page.getByRole('link', { name: 'Languages' }).first().click();
+		await expect( page.getByRole('cell', { name: 'English Edit | Delete' }) ).toBeVisible();
+		await page.getByRole('link', { name: 'Languages' }).first().click();
+		await expect(page.locator('table.languages > tbody > tr > td').nth(3)).toContainText('Default language');
+	});
+
+	test('Test add language through settings', async ({ page }) => {
+		await page.goto('http://localhost:8889/wp-admin');
+		await page.getByRole('link', { name: 'Languages' }).first().click();
+		await page.locator('#lang_list-button span').nth(1).click();
+		await page.getByRole('option', { name: 'Français - fr_FR' }).click();
+		await page.getByRole('button', { name: 'Add new language' }).click();
+		await expect( page.getByRole('cell', { name: 'Français Edit | Delete' }) ).toBeVisible();
+	});
+});


### PR DESCRIPTION
## How?
- Add test for language creation within the wizard and the languages panel.
- Add test for each modules within the settings panel.
- Make `env-set-up.spec.js` a dependency for all other tests.