### PR TITLE
Require PHP 7 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"homepage": "https://polylang.pro",
 	"type": "wordpress-plugin",
 	"require": {
-		"php": ">=5.6"
+		"php": ">=7.0"
 	},
 	"require-dev": {
 		"wpsyntex/polylang-phpstan": "^1.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<config name="minimum_supported_wp_version" value="5.8"/>
 
 	<rule ref="PHPCompatibilityWP">
-		<config name="testVersion" value="5.6-"/>
+		<config name="testVersion" value="7.0-"/>
 	</rule>
 
 	<rule ref="WordPressVIPMinimum">

--- a/polylang.php
+++ b/polylang.php
@@ -12,7 +12,7 @@
  * Description:       Adds multilingual capability to WordPress
  * Version:           3.5-dev
  * Requires at least: 5.8
- * Requires PHP:      5.6
+ * Requires PHP:      7.0
  * Author:            WP SYNTEX
  * Author URI:        https://polylang.pro
  * Text Domain:       polylang
@@ -55,7 +55,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 	// Go on loading the plugin
 	define( 'POLYLANG_VERSION', '3.5-dev' );
 	define( 'PLL_MIN_WP_VERSION', '5.8' );
-	define( 'PLL_MIN_PHP_VERSION', '5.6' );
+	define( 'PLL_MIN_PHP_VERSION', '7.0' );
 
 	define( 'POLYLANG_FILE', __FILE__ );
 	define( 'POLYLANG_DIR', __DIR__ );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://polylang.pro
 Tags: multilingual, bilingual, translate, translation, language, multilanguage, international, localization
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.6
+Requires PHP: 7.0
 Stable tag: 3.4.4
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -75,7 +75,7 @@ Wherever third party code has been used, credit has been given in the code’s c
 
 == Installation ==
 
-1. Make sure you are using WordPress 5.8 or later and that your server is running PHP 5.6 or later (same requirement as WordPress itself).
+1. Make sure you are using WordPress 5.8 or later and that your server is running PHP 7.0 or later (same requirement as WordPress itself).
 1. If you tried other multilingual plugins, deactivate them before activating Polylang, otherwise, you may get unexpected results!
 1. Install and activate the plugin as usual from the 'Plugins' menu in WordPress.
 1. The [setup wizard](https://polylang.pro/doc/setup-wizard/) is automatically launched to help you get started more easily with Polylang by configuring the main features.


### PR DESCRIPTION
[WP 6.3 will drop the support of PHP 5.6](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/). To potentially avoid a drama similar to #415 planned for 2.7 and moved to 2.6.7 in urgence, I propose to move to PHP 7 more or less at the same time as WP. Even if we still support WP 5.8. 