### PR TITLE
Use of optional chaining operator to prevent javascript error when excerpt field doesn't exist

### DIFF
--- a/js/src/block-editor.js
+++ b/js/src/block-editor.js
@@ -125,12 +125,9 @@ jQuery(
 				);
 
 				function isEmptyPost() {
-					const editor  = select( 'core/editor' );
-					const title   = editor.getEditedPostAttribute( 'title' ).trim();
-					const content = editor.getEditedPostAttribute( 'content' ).trim();
-					const excerpt = editor.getEditedPostAttribute( 'excerpt' ).trim();
+					const editor = select( 'core/editor' );
 
-					return ! title && ! content && ! excerpt;
+					return ! editor.getEditedPostAttribute( 'title' )?.trim() && ! editor.getEditedPostContent() && ! editor.getEditedPostAttribute( 'excerpt' )?.trim();
 				}
 
 				/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -144,6 +144,23 @@
 		<exclude-pattern>*/*.js</exclude-pattern>
 	</rule>
 
+	<!-- PHPCS cannot correctly parse JavaScript syntax -->
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<exclude-pattern>*/*.js</exclude-pattern>
+	</rule>
+
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<exclude-pattern>*/*.js</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.WhiteSpace.OperatorSpacing">
+		<exclude-pattern>*/*./js</exclude-pattern>
+	</rule>
+
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<exclude-pattern>*/*.js</exclude-pattern>
+	</rule>
+
 	<exclude-pattern>js/*.min.js</exclude-pattern>
 	<exclude-pattern>js/build</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1724

- use of optional chaining operator to prevent unsing `trim()` function on an undefined value.
- use `getEditedPostContent()` for Polylang Pro for consistency and don't trim it because the content can't be empty even if we type  a space in the block.
Indeed, while we type one character - like a space for example - in the block, by default the block editor always generate block comment.
- format the code as in Polylang Pro for consistency
- Do the same with the title field even if it always exists and required

See https://github.com/polylang/polylang-pro/blob/3.4.4/modules/block-editor/js/sidebar/components/switcher/index.js#L26

~~_Maybe need to ignore some PHPCS rules for javascript code like for Polylang Pro_~~
https://github.com/polylang/polylang-pro/blob/3.4.4/phpcs.xml.dist#L107-L123