### PR TITLE
Make testcase classes abstract and autoloaded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,11 @@
 			"settings/"
 		]
 	},
+	"autoload-dev": {
+		"classmap": [
+			"tests/phpunit/includes/"
+		]
+	},
 	"scripts": {
 		"test":"vendor/bin/phpunit",
 		"cs":"vendor/bin/phpcs",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	},
 	"autoload-dev": {
 		"classmap": [
-			"tests/phpunit/includes/"
+			"tests/phpunit/"
 		]
 	},
 	"scripts": {

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -28,17 +28,6 @@ if ( ! defined( 'PLL_TEST_DATA_DIR' ) ) {
 }
 
 require_once __DIR__ . '/polyfills.php';
-require_once __DIR__ . '/doing-it-wrong-trait.php';
-require_once __DIR__ . '/links-trait.php';
-require_once __DIR__ . '/testcase-trait.php';
-require_once __DIR__ . '/testcase.php';
-require_once __DIR__ . '/testcase-ajax.php';
-require_once __DIR__ . '/testcase-assets.php';
-require_once __DIR__ . '/testcase-canonical.php';
-require_once __DIR__ . '/testcase-domain.php';
-require_once __DIR__ . '/testcase-translated-object.php';
-require_once __DIR__ . '/wp-screen-mock.php';
-require_once __DIR__ . '/check-wp-functions-trait.php';
 
 printf(
 	'Testing Polylang%1$s %2$s with WordPress %3$s...' . PHP_EOL,

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -3,7 +3,7 @@
 /**
  * A test case class for Polylang ajax tests
  */
-class PLL_Ajax_UnitTestCase extends WP_Ajax_UnitTestCase {
+abstract class PLL_Ajax_UnitTestCase extends WP_Ajax_UnitTestCase {
 
 	use PLL_UnitTestCase_Trait;
 

--- a/tests/phpunit/includes/testcase-assets.php
+++ b/tests/phpunit/includes/testcase-assets.php
@@ -1,7 +1,7 @@
 <?php
 require POLYLANG_DIR . '/include/api.php';
 
-class PLL_Assets_UnitTestCase extends PLL_UnitTestCase {
+abstract class PLL_Assets_UnitTestCase extends PLL_UnitTestCase {
 	/**
 	 * The Polylang assets identifiers (those rendered by WordPress in HTML tags).
 	 *

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -1,6 +1,6 @@
 <?php
 
-class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
+abstract class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 
 	use PLL_UnitTestCase_Trait;
 

--- a/tests/phpunit/includes/testcase-domain.php
+++ b/tests/phpunit/includes/testcase-domain.php
@@ -1,6 +1,6 @@
 <?php
 
-class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
+abstract class PLL_Domain_UnitTestCase extends PLL_UnitTestCase {
 	use PLL_Test_Links_Trait;
 
 	protected $hosts;

--- a/tests/phpunit/includes/testcase-translated-object.php
+++ b/tests/phpunit/includes/testcase-translated-object.php
@@ -8,7 +8,7 @@
  *
  * Testes PLL_Translated_Object methods tha are common to PLL_Translated_Post and PLL_Translated_Term.
  */
-class PLL_Translated_Object_UnitTestCase extends PLL_UnitTestCase {
+abstract class PLL_Translated_Object_UnitTestCase extends PLL_UnitTestCase {
 	/**
 	 * @covers PLL_Translated_Object::save_translations()
 	 *

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -3,7 +3,7 @@
 /**
  * A test case class for Polylang standard tests
  */
-class PLL_UnitTestCase extends WP_UnitTestCase {
+abstract class PLL_UnitTestCase extends WP_UnitTestCase {
 
 	use PLL_UnitTestCase_Trait;
 


### PR DESCRIPTION
Making those classes abstract allows us to autoload them here and in other plugins like Polylang Pro.

This PR also autoloads all test classes, it could be useful in the future.