### PR TITLE
Add pll_admin_ajax_params filter

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -302,6 +302,15 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			$params = array_merge( $params, array( 'pll_term_id' => (int) $tag_ID ) );
 		}
 
+		/**
+		 * Filters the list of parameters to add to ajax request.
+		 *
+		 * @since 3.5
+		 *
+		 * @param array $params List of parameters.
+		 */
+		$params = apply_filters( 'pll_ajax_params', $params );
+
 		$str = http_build_query( $params );
 		$arr = wp_json_encode( $params );
 		?>

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -303,13 +303,13 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		}
 
 		/**
-		 * Filters the list of parameters to add to ajax request.
+		 * Filters the list of parameters to add to the admin ajax request.
 		 *
-		 * @since 3.5
+		 * @since 3.4.5
 		 *
-		 * @param array $params List of parameters.
+		 * @param array $params List of parameters to add to the admin ajax request.
 		 */
-		$params = apply_filters( 'pll_ajax_params', $params );
+		$params = apply_filters( 'pll_admin_ajax_params', $params );
 
 		$str = http_build_query( $params );
 		$arr = wp_json_encode( $params );


### PR DESCRIPTION
To fix the Polylang for WooCommerce PR https://github.com/polylang/polylang-wc/issues/667 we need to introduce this filter to be able to set the order id in any ajax request and thus filter correctly by the order language.

Related to a Polylang for WooCommerce PR https://github.com/polylang/polylang-wc/pull/672