### PR TITLE
Javascript type is not required for HTML5

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -314,7 +314,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		$str = http_build_query( $params );
 		$arr = wp_json_encode( $params );
 		?>
-		<script type="text/javascript">
+		<script>
 			if (typeof jQuery != 'undefined') {
 				jQuery(
 					function( $ ){

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -132,20 +132,21 @@ class PLL_Frontend_Filters_Search {
 	}
 
 	/**
-	 * Allows modifying the search form if it does not pass get_search_form
+	 * Allows modifying the search form if it does not pass get_search_form.
 	 *
 	 * @since 0.1
 	 *
 	 * @return void
 	 */
 	public function wp_print_footer_scripts() {
-		// Don't use directly e[0] just in case there is somewhere else an element named 's'
-		// Check before if the hidden input has not already been introduced by get_search_form ( FIXME: is there a way to improve this ) ?
-		// Thanks to AndyDeGroo for improving the code for compatibility with old browsers
-		// http://wordpress.org/support/topic/development-of-polylang-version-08?replies=6#post-2645559
+		/*
+		 * Don't use directly e[0] just in case there is somewhere else an element named 's'
+		 * Check before if the hidden input has not already been introduced by get_search_form ( FIXME: is there a way to improve this ) ?
+		 * Thanks to AndyDeGroo for improving the code for compatibility with old browsers
+		 * http://wordpress.org/support/topic/development-of-polylang-version-08?replies=6#post-2645559
+		 */
 		$lang = esc_js( $this->curlang->slug );
-		$js = "//<![CDATA[
-		e = document.getElementsByName( 's' );
+		$js = "e = document.getElementsByName( 's' );
 		for ( i = 0; i < e.length; i++ ) {
 			if ( e[i].tagName.toUpperCase() == 'INPUT' ) {
 				s = e[i].parentNode.parentNode.children;
@@ -159,12 +160,18 @@ class PLL_Frontend_Filters_Search {
 					var ih = document.createElement( 'input' );
 					ih.type = 'hidden';
 					ih.name = 'lang';
-					ih.value = '$lang';
+					ih.value = '{$lang}';
 					e[i].parentNode.appendChild( ih );
 				}
 			}
+		}";
+
+		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
+
+		if ( $type_attr ) {
+			$js = "/* <![CDATA[ */\n{$js}\n/* ]]> */";
 		}
-		//]]>";
-		echo '<script type="text/javascript">' . $js . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput
+
+		echo "<script{$type_attr}>\n{$js}\n</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -266,15 +266,14 @@ class PLL_Switcher {
 		 */
 		$out = apply_filters( 'pll_the_languages', $walker->walk( $elements, -1, $args ), $args );
 
-		// Javascript to switch the language when using a dropdown list
+		// Javascript to switch the language when using a dropdown list.
 		if ( $args['dropdown'] && 0 === $args['admin_render'] ) {
-			// Accept only few valid characters for the urls_x variable name ( as the widget id includes '-' which is invalid )
+			// Accept only few valid characters for the urls_x variable name (as the widget id includes '-' which is invalid).
 			$out .= sprintf(
-				'<script type="text/javascript">
-					//<![CDATA[
-					document.getElementById( "%1$s" ).addEventListener( "change", function ( event ) { location.href = event.currentTarget.value; } )
-					//]]>
+				'<script type="%1$s">
+					document.getElementById( "%2$s" ).addEventListener( "change", function ( event ) { location.href = event.currentTarget.value; } )
 				</script>',
+				current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"',
 				esc_js( $args['name'] )
 			);
 		}

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -270,7 +270,7 @@ class PLL_Switcher {
 		if ( $args['dropdown'] && 0 === $args['admin_render'] ) {
 			// Accept only few valid characters for the urls_x variable name (as the widget id includes '-' which is invalid).
 			$out .= sprintf(
-				'<script type="%1$s">
+				'<script%1$s>
 					document.getElementById( "%2$s" ).addEventListener( "change", function ( event ) { location.href = event.currentTarget.value; } )
 				</script>',
 				current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"',

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -70,7 +70,7 @@ class PLL_Cache_Compat {
 
 		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
 
-		echo "<script{$type_attr}>\n{$js}</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+		echo "<script{$type_attr}>\n{$js}\n</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
 	/**

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -67,7 +67,10 @@ class PLL_Cache_Compat {
 			'; SameSite=' . $samesite,
 			esc_js( $expiration )
 		);
-		echo "<script type='text/javascript'>\n" . $js . "</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+
+		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
+
+		echo "<script{$type_attr}>\n{$js}</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
 	/**

--- a/modules/wizard/view-wizard-page.php
+++ b/modules/wizard/view-wizard-page.php
@@ -29,7 +29,7 @@ if ( is_rtl() ) {
 		);
 		?>
 		</title>
-		<script type="text/javascript">
+		<script>
 			var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php', 'relative' ) ); ?>';
 		</script>
 		<?php do_action( 'admin_enqueue_scripts' ); ?>

--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -87,8 +87,7 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 		$deactivated = sprintf( '<span class="deactivated">%s</span>', $this->action_links['deactivated'] );
 
 		?>
-		<script type='text/javascript'>
-			//<![CDATA[
+		<script>
 			jQuery(
 				function( $ ){
 					$( "input[name='force_lang']" ).on( 'change', function() {
@@ -102,7 +101,6 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 					} );
 				}
 			);
-			// ]]>
 		</script>
 		<?php
 	}


### PR DESCRIPTION
For the context: https://wordpress.org/support/topic/the-type-attribute-is-unnecessary-for-javascript-resources-3/

This PR handles two cases:
- On front, it honors `current_theme_support( 'html5', 'script' )` to output javascript type (and optionally `CDATA`) or not for inline scripts, as done by WP since the verson 5.3. See:  https://core.trac.wordpress.org/ticket/42804
- On admin, the javascript type and CDATA are removed as the doctype was switched to html5 since WP 3.3. See https://core.trac.wordpress.org/ticket/18202