### PR TITLE
Replaces pre_get_posts by parse_query in PLL_Frontend_Auto_Translate

### DIFF
--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -33,7 +33,7 @@ class PLL_Frontend_Auto_Translate {
 		$this->model = &$polylang->model;
 		$this->curlang = &$polylang->curlang;
 
-		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) ); // after main Polylang filter
+		add_action( 'parse_query', array( $this, 'pre_get_posts' ), 20 ); // after main Polylang filter
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ), 20, 2 );
 	}
 

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -33,7 +33,7 @@ class PLL_Frontend_Auto_Translate {
 		$this->model = &$polylang->model;
 		$this->curlang = &$polylang->curlang;
 
-		add_action( 'parse_query', array( $this, 'pre_get_posts' ), 100 ); // After all Polylang filters.
+		add_action( 'parse_query', array( $this, 'translate_included_ids_in_query' ), 100 ); // After all Polylang filters.
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ), 20, 2 );
 	}
 
@@ -73,7 +73,7 @@ class PLL_Frontend_Auto_Translate {
 	 * @param WP_Query $query WP_Query object
 	 * @return void
 	 */
-	public function pre_get_posts( $query ) {
+	public function translate_included_ids_in_query( $query ) {
 		global $wpdb;
 		$qv = &$query->query_vars;
 

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -33,7 +33,7 @@ class PLL_Frontend_Auto_Translate {
 		$this->model = &$polylang->model;
 		$this->curlang = &$polylang->curlang;
 
-		add_action( 'parse_query', array( $this, 'pre_get_posts' ), 20 ); // after main Polylang filter
+		add_action( 'parse_query', array( $this, 'pre_get_posts' ), 100 ); // After all Polylang filters.
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ), 20, 2 );
 	}
 


### PR DESCRIPTION
In some cases, we don't pass through `pre_get_posts` but through `parse_query`, so the query was not filtered.

By passing through `parse_query`, we can always filter the query.

For instance, for WooCommerce blocks of type `AbstractProductGrid`, we passed through a method that creates a `BlocksWpQuery` and therefore passes through `parse_query()` without passing through a `get_posts()`, which meant that our query wasn't filtered ( since we didn't pass through the `pre_get_posts` hook).
So the products in the block were not filtered in the right language.

