### PR TITLE
Prevent Patchwork to print text during init

### DIFF
--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -91,8 +91,6 @@ install_wp() {
 		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
-
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -4,6 +4,22 @@ $_root_dir = dirname( dirname( dirname( __DIR__ ) ) );
 $_tests_dir = ! empty( getenv( 'WP_TESTS_DIR' ) ) ? getenv( 'WP_TESTS_DIR' ) : $_root_dir . '/tmp/wordpress-tests-lib';
 require_once $_tests_dir . '/includes/functions.php';
 
+// Temporary fix: prevent Patchwork to print `;\Patchwork\CodeManipulation\Stream::reinstateWrapper();` in CLI.
+$db_file_path = $_root_dir . '/tmp/wordpress/wp-content/db.php';
+
+if ( is_readable( $db_file_path ) && is_writable( $db_file_path ) ) {
+	$db_file_content = file_get_contents( $db_file_path );
+
+	if ( is_string( $db_file_content ) && trim( $db_file_content ) === '' ) {
+		$fp = @fopen( $db_file_path, 'wb' );
+
+		if ( $fp ) {
+			fwrite( $fp, '<?php' );
+			fclose( $fp );
+		}
+	}
+}
+
 // load the plugin however *no* Polylang instance is created as no languages exist in DB
 tests_add_filter(
 	'muplugins_loaded',

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -4,22 +4,6 @@ $_root_dir = dirname( dirname( dirname( __DIR__ ) ) );
 $_tests_dir = ! empty( getenv( 'WP_TESTS_DIR' ) ) ? getenv( 'WP_TESTS_DIR' ) : $_root_dir . '/tmp/wordpress-tests-lib';
 require_once $_tests_dir . '/includes/functions.php';
 
-// Temporary fix: prevent Patchwork to print `;\Patchwork\CodeManipulation\Stream::reinstateWrapper();` in CLI.
-$db_file_path = $_root_dir . '/tmp/wordpress/wp-content/db.php';
-
-if ( is_readable( $db_file_path ) && is_writable( $db_file_path ) ) {
-	$db_file_content = file_get_contents( $db_file_path );
-
-	if ( is_string( $db_file_content ) && trim( $db_file_content ) === '' ) {
-		$fp = @fopen( $db_file_path, 'wb' );
-
-		if ( $fp ) {
-			fwrite( $fp, '<?php' );
-			fclose( $fp );
-		}
-	}
-}
-
 // load the plugin however *no* Polylang instance is created as no languages exist in DB
 tests_add_filter(
 	'muplugins_loaded',


### PR DESCRIPTION
This is a quick and durty patch to prevent Patchwork to print `;\Patchwork\CodeManipulation\Stream::reinstateWrapper();` in CLI during the tests init.

It seems that requiring the empty file `wp-content/db.php` triggers the issue. I couldn't find any ticket about it on Patchwork's side. So, since it isn't a big issue and since we may someday rework the bootstrap (like we did in Polylang Pro), I opted for a quick and dirty fix.

Note: the issue is not triggered with Polylang Pro.