### PR TITLE
Prevent an error when updating a translated option while the blog is switched

### DIFF
--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -262,8 +262,17 @@ class PLL_Translate_Option {
 			$this->translations[ $language->slug ]->import_from_db( $language );
 		}
 
+		$lang = pll_current_language();
+		if ( empty( $lang ) ) {
+			$lang = pll_default_language();
+		}
+
+		if ( empty( $lang ) ) {
+			return $value; // Something's wrong.
+		}
+
 		// Filters out the strings which would be updated to their translations and stores the updated strings.
-		$value = $this->check_value_recursive( $unfiltered_old_value, $value, $this->keys );
+		$value = $this->check_value_recursive( $unfiltered_old_value, $value, $this->keys, $this->translations[ $lang ] );
 
 		return $value;
 	}
@@ -314,32 +323,27 @@ class PLL_Translate_Option {
 	 * later assign the translations to the new value in {@see PLL_Translate_Option::update_option()}.
 	 *
 	 * @since 2.9
+	 * @since 3.5 Added $mo parameter.
 	 *
 	 * @param mixed      $old_values The old option value.
-	 * @param mixed      $values     The new option value..
+	 * @param mixed      $values     The new option value.
 	 * @param array|bool $key        Array of option keys to translate.
+	 * @param PLL_MO     $mo         Translations used to compare the updated string to the translated old string.
 	 * @return mixed
 	 */
-	protected function check_value_recursive( $old_values, $values, $key ) {
+	protected function check_value_recursive( $old_values, $values, $key, $mo ) {
 		$children = is_array( $key ) ? $key : array();
-
-		$lang = pll_current_language();
-		if ( empty( $lang ) ) {
-			$lang = pll_default_language();
-		}
-
-		$mo = &$this->translations[ $lang ];
 
 		if ( is_array( $values ) || is_object( $values ) ) {
 			if ( count( $children ) ) {
 				foreach ( $children as $name => $child ) {
 					if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $name ], $values[ $name ] ) ) {
-						$values[ $name ] = $this->check_value_recursive( $old_values[ $name ], $values[ $name ], $child );
+						$values[ $name ] = $this->check_value_recursive( $old_values[ $name ], $values[ $name ], $child, $mo );
 						continue;
 					}
 
 					if ( is_object( $values ) && is_object( $old_values ) && isset( $old_values->$name, $values->$name ) ) {
-						$values->$name = $this->check_value_recursive( $old_values->$name, $values->$name, $child );
+						$values->$name = $this->check_value_recursive( $old_values->$name, $values->$name, $child, $mo );
 						continue;
 					}
 
@@ -349,11 +353,11 @@ class PLL_Translate_Option {
 						// The first case could be handled by the next one, but we avoid calls to preg_match here.
 						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
 							if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $n ] ) ) {
-								$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $value, $child );
+								$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $value, $child, $mo );
 							}
 
 							if ( is_object( $values ) && is_object( $old_values ) && isset( $old_values->$n ) ) {
-								$values->$n = $this->check_value_recursive( $old_values->$n, $value, $child );
+								$values->$n = $this->check_value_recursive( $old_values->$n, $value, $child, $mo );
 							}
 						}
 					}
@@ -362,11 +366,11 @@ class PLL_Translate_Option {
 				// Parent key is a wildcard and no sub-key has been whitelisted.
 				foreach ( $values as $n => $value ) {
 					if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $n ] ) ) {
-						$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $value, $key );
+						$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $value, $key, $mo );
 					}
 
 					if ( is_object( $values ) && is_object( $old_values ) && isset( $old_values->$n ) ) {
-						$values->$n = $this->check_value_recursive( $old_values->$n, $value, $key );
+						$values->$n = $this->check_value_recursive( $old_values->$n, $value, $key, $mo );
 					}
 				}
 			}

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -257,10 +257,9 @@ class PLL_Translate_Option {
 		}
 
 		// Load translations in all languages.
-		foreach ( pll_languages_list() as $lang ) {
-			$language = PLL()->model->get_language( $lang );
-			$this->translations[ $lang ] = new PLL_MO();
-			$this->translations[ $lang ]->import_from_db( $language );
+		foreach ( $languages as $language ) {
+			$this->translations[ $language->slug ] = new PLL_MO();
+			$this->translations[ $language->slug ]->import_from_db( $language );
 		}
 
 		// Filters out the strings which would be updated to their translations and stores the updated strings.
@@ -284,20 +283,20 @@ class PLL_Translate_Option {
 		$curlang = pll_current_language();
 
 		if ( ! empty( $this->updated_strings ) ) {
-			foreach ( pll_languages_list() as $lang ) {
+			foreach ( PLL()->model->get_languages_list() as $language ) {
 
-				$mo = &$this->translations[ $lang ];
+				$mo = &$this->translations[ $language->slug ];
 
 				foreach ( $this->updated_strings as $old_string => $string ) {
 					$translation = $mo->translate( $old_string );
-					if ( ( empty( $curlang ) && $translation === $old_string ) || $lang === $curlang ) {
+					if ( ( empty( $curlang ) && $translation === $old_string ) || $language->slug === $curlang ) {
 						$translation = $string;
 					}
 
 					// Add new entry with new string and old translation.
 					$mo->add_entry( $mo->make_entry( $string, $translation ) );
 				}
-				$language = PLL()->model->get_language( $lang );
+
 				$mo->export_to_db( $language );
 			}
 		}

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -250,6 +250,12 @@ class PLL_Translate_Option {
 		// Stores the unfiltered old option value before it is updated in DB.
 		$unfiltered_old_value = $this->get_raw_option( $name );
 
+		$languages = PLL()->model->get_languages_list();
+
+		if ( empty( $languages ) ) {
+			return $value;
+		}
+
 		// Load translations in all languages.
 		foreach ( pll_languages_list() as $lang ) {
 			$language = PLL()->model->get_language( $lang );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -786,16 +786,6 @@ parameters:
 			path: include/translate-option.php
 
 		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_MO\\:\\:export_to_db\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
-			count: 1
-			path: include/translate-option.php
-
-		-
-			message: "#^Parameter \\#1 \\$lang of method PLL_MO\\:\\:import_from_db\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
-			count: 1
-			path: include/translate-option.php
-
-		-
 			message: "#^Parameter \\#1 \\$singular of method Translations\\:\\:translate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: include/translate-option.php

--- a/tests/phpunit/tests/test-multisite-option.php
+++ b/tests/phpunit/tests/test-multisite-option.php
@@ -22,6 +22,8 @@ if ( is_multisite() ) :
 		public function tear_down() {
 			parent::tear_down();
 
+			restore_current_blog();
+
 			unset( $GLOBALS['polylang'] );
 		}
 
@@ -40,6 +42,24 @@ if ( is_multisite() ) :
 
 			$this->assertSame( 'Test Blog', get_site( 1 )->blogname ); // The default blog.
 			$this->assertSame( 'The new blog to test', get_site( $blog_id )->blogname ); // The blog that we have created.
+		}
+
+		/**
+		 * @ticket #1727
+		 * @see https://github.com/polylang/polylang-pro/issues/1685
+		 */
+		 public function test_update_option_when_blog_is_switched() {
+			$blog_id = self::factory()->blog->create( array( 'title' => 'Another blog' ) );
+
+			$GLOBALS['l10n']['pll_string'] = new PLL_MO(); // Required to pass an internal test of PLL_Translate_Option::translate().
+
+			new PLL_Translate_Option( 'blogname', array(), array( 'context' => 'WordPress' ) );
+
+			switch_to_blog( $blog_id );
+			update_option( 'blogname', 'The new blogname' );
+
+			$this->assertSame( 'Test Blog', get_site( 1 )->blogname ); // The default blog.
+			$this->assertSame( 'The new blogname', get_site( $blog_id )->blogname );
 		}
 	}
 

--- a/tests/phpunit/tests/test-multisite-option.php
+++ b/tests/phpunit/tests/test-multisite-option.php
@@ -48,7 +48,7 @@ if ( is_multisite() ) :
 		 * @ticket #1727
 		 * @see https://github.com/polylang/polylang-pro/issues/1685
 		 */
-		 public function test_update_option_when_blog_is_switched() {
+		public function test_update_option_when_blog_is_switched() {
 			$blog_id = self::factory()->blog->create( array( 'title' => 'Another blog' ) );
 
 			$GLOBALS['l10n']['pll_string'] = new PLL_MO(); // Required to pass an internal test of PLL_Translate_Option::translate().


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1727

To reproduce the bug:
- Start the process on a site where Polylang is installed.
- Switch to a site where Polylang is **not** installed. 
- Update a translated option (typically the site title).

These steps are reproduced in a new test.

The bug itself is fixed by a3de44fd0fbdff515a71fe7106d1eac614c79289.

the PR goes a bit beyond and:
- Moves the evaluation for translations to use in `check_value_recursive()` to the calling method to avoid to do the same operations multiple times.
- Removes calls to `PLL()->model->get_language()` by getting directly a list of objects instead of language slugs.