### PR TITLE
Fix undefined variables in tests

### DIFF
--- a/tests/phpunit/tests/test-accept-languages-collection.php
+++ b/tests/phpunit/tests/test-accept-languages-collection.php
@@ -103,9 +103,8 @@ class Accept_Languages_Collection_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_pick_matching_language_and_region_with_custom_slug() {
-		$accept_languages    = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-HK' );
-		$zh_cn['slug']       = 'zh-cn'; // Custom slug.
-		self::create_language( 'zh_CN', $zh_cn );
+		$accept_languages = PLL_Accept_Languages_Collection::from_accept_language_header( 'zh-HK' );
+		self::create_language( 'zh_CN', array( 'slug' => 'zh-cn' ) ); // Custom slug.
 		$zh_cn = self::$model->get_language( 'zh_CN' );
 		$languages = array( $zh_cn );
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -421,11 +421,13 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$posts = get_posts( array( 'fields' => 'ids', 'tag__in' => array( $tag ) ) );
 		$this->assertEmpty( $posts );
 
-		$tax_query[] = array(
-			'taxonomy' => 'post_tag',
-			'field'    => 'term_id',
-			'terms'    => $tag,
-			'operator' => 'IN',
+		$tax_query = array(
+			array(
+				'taxonomy' => 'post_tag',
+				'field'    => 'term_id',
+				'terms'    => $tag,
+				'operator' => 'IN',
+			),
 		);
 
 		$posts = get_posts( array( 'fields' => 'ids', 'tax_query' => $tax_query ) );
@@ -451,8 +453,6 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		ob_start();
 		do_action( 'admin_print_footer_scripts' );
 		$footer = ob_get_clean();
-
-		$terms['fr'] = array( 'category' => array( self::$model->term->get( $term_id, 'fr' ) ) );
 
 		$this->assertEquals( 1, preg_match( '/var pll_term_languages = {"fr":{"category":\[(\d+),\d+\]}/', $footer, $matches ) );
 		$this->assertEquals( $term_id, $matches[1] );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -429,11 +429,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		self::$model->term->set_language( $en, 'en' );
 
 		require_once ABSPATH . 'wp-admin/includes/nav-menu.php';
-		$taxonomy['args'] = get_taxonomy( 'category' );
+		$box = array( 'args' => get_taxonomy( 'category' ) );
 		$this->pll_admin->set_current_language();
 
 		ob_start();
-		wp_nav_menu_item_taxonomy_meta_box( null, $taxonomy );
+		wp_nav_menu_item_taxonomy_meta_box( null, $box );
 		$out = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $out, 'test' ) );
@@ -444,7 +444,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->pll_admin->set_current_language();
 
 		ob_start();
-		wp_nav_menu_item_taxonomy_meta_box( null, $taxonomy );
+		wp_nav_menu_item_taxonomy_meta_box( null, $box );
 		$out = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $out, 'test' ) );

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -18,13 +18,19 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 	}
 
 	protected function update_language( $lang, $args ) {
-		foreach ( array( 'name', 'slug', 'locale', 'term_group' ) as $key ) {
-			$defaults[ $key ] = $lang->$key;
-		}
-		$args['rtl'] = $lang->is_rtl;
-		$args['flag'] = $lang->flag_code;
+		$defaults = array(
+			'name'       => $lang->name,
+			'slug'       => $lang->slug,
+			'locale'     => $lang->locale,
+			'term_group' => $lang->term_group,
+		);
+
+		$args['rtl']     = $lang->is_rtl;
+		$args['flag']    = $lang->flag_code;
 		$args['lang_id'] = $lang->term_id;
+
 		$args = wp_parse_args( $args, $defaults );
+
 		self::$model->update_language( $args );
 	}
 
@@ -64,9 +70,11 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		self::factory()->post->create( array( 'post_type' => 'nav_menu_item' ) );
 		self::factory()->post->create( array( 'post_type' => 'cpt' ) );
 
-		// 2 posts without language
-		$expected['posts'][] = self::factory()->post->create();
-		$expected['posts'][] = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		// 2 posts without language.
+		$expected_posts = array(
+			self::factory()->post->create(),
+			self::factory()->post->create( array( 'post_type' => 'page' ) ),
+		);
 
 		// 2 terms with language
 		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
@@ -79,15 +87,17 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 		self::factory()->term->create( array( 'taxonomy' => 'nav_menu' ) );
 		self::factory()->term->create( array( 'taxonomy' => 'tax' ) );
 
-		// 2 terms without language
-		$expected['terms'][] = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
-		$expected['terms'][] = self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) );
+		// 2 terms without language.
+		$expected_terms = array(
+			self::factory()->term->create( array( 'taxonomy' => 'category' ) ),
+			self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) ),
+		);
 
 		$nolang = self::$model->get_objects_with_no_lang();
 
-		// sort arrays as values don't have necessarily the same keys and order
-		$this->assertTrue( sort( $expected['posts'] ), sort( $nolang['posts'] ) );
-		$this->assertTrue( sort( $expected['terms'] ), sort( $nolang['terms'] ) );
+		// Sort arrays as values don't have necessarily the same keys and order.
+		$this->assertTrue( sort( $expected_posts ), sort( $nolang['posts'] ) );
+		$this->assertTrue( sort( $expected_terms ), sort( $nolang['terms'] ) );
 
 		_unregister_post_type( 'cpt' );
 		_unregister_taxonomy( 'tax' );

--- a/tests/phpunit/tests/test-admin-model.php
+++ b/tests/phpunit/tests/test-admin-model.php
@@ -95,9 +95,8 @@ class Admin_Model_Test extends PLL_UnitTestCase {
 
 		$nolang = self::$model->get_objects_with_no_lang();
 
-		// Sort arrays as values don't have necessarily the same keys and order.
-		$this->assertTrue( sort( $expected_posts ), sort( $nolang['posts'] ) );
-		$this->assertTrue( sort( $expected_terms ), sort( $nolang['terms'] ) );
+		$this->assertSameSets( $expected_posts, $nolang['posts'] );
+		$this->assertSameSets( $expected_terms, $nolang['terms'] );
 
 		_unregister_post_type( 'cpt' );
 		_unregister_taxonomy( 'tax' );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -192,6 +192,9 @@ class Filters_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_adjacent_post_and_archives() {
+		$en = array();
+		$fr = array();
+
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$m = 2 * $i - 1;
 			$en[ $i ] = self::factory()->post->create( array( 'post_date' => "2012-0$m-01 12:00:00" ) );
@@ -223,16 +226,18 @@ class Filters_Test extends PLL_UnitTestCase {
 	public function test_adjacent_post_and_archives_for_untranslated_post_type() {
 		register_post_type( 'cpt', array( 'public' => true, 'has_archive' => true ) ); // *untranslated* custom post type with archives
 
+		$posts = array();
+
 		for ( $m = 1; $m <= 3; $m++ ) {
-			$p[ $m ] = self::factory()->post->create( array( 'post_type' => 'cpt', 'post_date' => "2012-0$m-01 12:00:00" ) );
+			$posts[ $m ] = self::factory()->post->create( array( 'post_type' => 'cpt', 'post_date' => "2012-0$m-01 12:00:00" ) );
 		}
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		new PLL_Frontend_Filters( $this->frontend );
-		$this->go_to( get_permalink( $p[2] ) );
+		$this->go_to( get_permalink( $posts[2] ) );
 
-		$this->assertEquals( get_post( $p[1] ), get_previous_post() );
-		$this->assertEquals( get_post( $p[3] ), get_next_post() );
+		$this->assertEquals( get_post( $posts[1] ), get_previous_post() );
+		$this->assertEquals( get_post( $posts[3] ), get_next_post() );
 
 		ob_start();
 		wp_get_archives( array( 'post_type' => 'cpt' ) );

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -205,8 +205,10 @@ class Switcher_Test extends PLL_UnitTestCase {
 
 		self::$model->clean_languages_cache(); // FIXME for some reason, I need to clear the cache to get an exact count
 
-		$args['hide_if_no_translation'] = 1;
-		$args['echo'] = 0;
+		$args = array(
+			'hide_if_no_translation' => 1,
+			'echo'                   => 0,
+		);
 		$switcher = $this->switcher->the_languages( $this->pll_admin->links, $args );
 
 		$this->assertNotEmpty( $switcher );

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -267,7 +267,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$model->post->save_translations( $from, array( 'fr' => $to ) );
 
 		$key = add_post_meta( $from, 'key', 'value' );
-		$metas[ $key ] = array( 'key' => 'key', 'value' => 'value' );
+		$metas = array(
+			$key => array( 'key' => 'key', 'value' => 'value' ),
+		);
 
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
@@ -635,7 +637,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		add_post_meta( $to, 'key2', 'value1' );
 		add_post_meta( $to, 'key2', 'value2' );
 		$key = add_post_meta( $from, 'key2', 'value1' );
-		$metas[ $key ] = array( 'key' => 'key2', 'value' => 'value1' );
+		$metas = array(
+			$key => array( 'key' => 'key2', 'value' => 'value1' ),
+		);
 
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );


### PR DESCRIPTION
Due to our current PHPCS config, this check is currently deactivated for tests.
This PR fixes the issues. The PHPCS config will be fixed in a separated PR.