### PR TITLE
Better handling of wp_redirect() in test

### DIFF
--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -15,7 +15,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 	protected function expect_wp_redirect() {
 		add_filter(
 			'wp_redirect',
-			function() {
+			function () {
 				throw new Exception( 'Call to wp_redirect' );
 			}
 		);

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -9,20 +9,23 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
-	public static function wp_redirect() {
-		throw new Exception( 'Call to wp_redirect' );
+	/**
+	 * Allows to continue the execution after wp_redirect + exit.
+	 */
+	protected function filter_wp_redirect() {
+		add_filter(
+			'wp_redirect',
+			function() {
+				throw new Exception( 'Call to wp_redirect' );
+			}
+		);
+
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage( 'Call to wp_redirect' );
 	}
 
 	public function test_hide_notice() {
-		// Allows to continue the execution after wp_redirect + exit.
-		add_filter( 'wp_redirect', array( __CLASS__, 'wp_redirect' ) );
-		if ( method_exists( $this, 'setExpectedException' ) ) {
-			// setExpectedException has been deprecated in recent versions of phpunit
-			$this->setExpectedException( 'Exception', 'Call to wp_redirect' );
-		} else {
-			$this->expectException( 'Exception' );
-			$this->expectExceptionMessage( 'Call to wp_redirect' );
-		}
+		$this->filter_wp_redirect();
 
 		wp_set_current_user( 1 );
 

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -12,7 +12,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 	/**
 	 * Allows to continue the execution after wp_redirect + exit.
 	 */
-	protected function filter_wp_redirect() {
+	protected function expect_wp_redirect() {
 		add_filter(
 			'wp_redirect',
 			function() {
@@ -25,7 +25,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_hide_notice() {
-		$this->filter_wp_redirect();
+		$this->expect_wp_redirect();
 
 		wp_set_current_user( 1 );
 


### PR DESCRIPTION
This PR:
- Moves the complete process to handle `wp_redirect()` to a unique re-usable method.
- Avoids a false positive for the sniff `WordPressVIPMinimum.Security.ExitAfterRedirect.NoExitInConditional`.
- Removes the (now useless) usage of the deprecated PHPUnit method `setExpectedException()`.