### PR TITLE
Remove unused variables in tests

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -56,7 +56,7 @@ trait PLL_UnitTestCase_Trait {
 	 *
 	 * @param WP_UnitTest_Factory $factory WP_UnitTest_Factory object.
 	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$options = PLL_Install::get_default_options();
 		$options['hide_default'] = 0; // Force option to pre 2.1.5 value otherwise phpunit tests break on Travis.
 		$options['media_support'] = 1; // Force option to pre 3.1 value otherwise phpunit tests break on Travis.

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -98,14 +98,14 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		);
 
 		do_action( 'load-edit.php' );
-		$done = bulk_edit_posts( $_REQUEST );
+		bulk_edit_posts( $_REQUEST );
 		$this->assertEquals( 'en', self::$model->post->get_language( $posts[0] )->slug );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $posts[1] )->slug );
 
 		// Second modify all languages
 		$_REQUEST['inline_lang_choice'] = $_GET['inline_lang_choice'] = 'fr';
 		do_action( 'load-edit.php' );
-		$done = bulk_edit_posts( $_REQUEST );
+		bulk_edit_posts( $_REQUEST );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $posts[0] )->slug );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $posts[1] )->slug );
 	}
@@ -440,7 +440,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_categories_script_data_in_footer() {
-		$hook_suffix = $GLOBALS['hook_suffix'] = 'edit.php';
+		$GLOBALS['hook_suffix'] = 'edit.php';
 		set_current_screen( 'edit' );
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		wp_default_scripts( $GLOBALS['wp_scripts'] );
@@ -465,8 +465,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$fr = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $fr, 'fr' );
 
-		$hook_suffix = $GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type'] = 'page';
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type']  = 'page';
 		set_current_screen();
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		wp_default_scripts( $GLOBALS['wp_scripts'] );

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -142,7 +142,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'tax_input'          => array( 'post_tag' => 'new_tag,test_tag' ),
 		);
 		do_action( 'load-edit.php' );
-		$done = bulk_edit_posts( $_REQUEST );
+		bulk_edit_posts( $_REQUEST );
 
 		$tags_en = wp_get_post_tags( $posts[0] );
 		$new_en = wp_filter_object_list( $tags_en, array( 'name' => 'new_tag' ), 'AND', 'term_id' );
@@ -168,7 +168,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$_GET['inline_lang_choice'] = $_REQUEST['inline_lang_choice'] = 'fr';
 		$_GET['tax_input']  = $_REQUEST['tax_input'] = array( 'post_tag' => 'third_tag' );
 		do_action( 'load-edit.php' );
-		$done = bulk_edit_posts( $_REQUEST );
+		bulk_edit_posts( $_REQUEST );
 
 		$tags = wp_get_post_tags( $posts[0] );
 		$third = wp_filter_object_list( $tags, array( 'name' => 'third_tag' ), 'AND', 'term_id' );

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -88,9 +88,6 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		self::factory()->post->create( array( 'tags_input' => 'test' ) );
 		self::factory()->post->create( array( 'tags_input' => 'essai' ) );
 
-		// The post_tag.
-		$term_id = self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) );
-
 		$_POST = array(
 			'action'     => 'term_lang_choice',
 			'_pll_nonce' => wp_create_nonce( 'pll_language' ),

--- a/tests/phpunit/tests/test-canonical-domain.php
+++ b/tests/phpunit/tests/test-canonical-domain.php
@@ -27,12 +27,12 @@ class Canonical_Domain_Test extends PLL_UnitTestCase {
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
-		$this->links_model = self::$model->get_links_model();
-		$frontend          = new PLL_Frontend( $this->links_model );
-		$frontend->links   = new PLL_Frontend_Links( $frontend );
-		$frontend->curlang = self::$model->get_language( 'fr' );
-		$filters_links     = new PLL_Frontend_Filters_Links( $frontend );
-		$this->canonical   = new PLL_Canonical( $frontend );
+		$this->links_model       = self::$model->get_links_model();
+		$frontend                = new PLL_Frontend( $this->links_model );
+		$frontend->links         = new PLL_Frontend_Links( $frontend );
+		$frontend->curlang       = self::$model->get_language( 'fr' );
+		$frontend->filters_links = new PLL_Frontend_Filters_Links( $frontend );
+		$this->canonical         = new PLL_Canonical( $frontend );
 
 		$GLOBALS['wp_actions']['template_redirect'] = 1; // For the home_url filter.
 	}

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -204,7 +204,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	public function test_add_post_column() {
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
-		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
+		$columns = $list_table->get_column_info()[0];
 		$columns = array_intersect_key( $columns, array_flip( array( 'comments' ) ) ); // Keep only the Comments column
 		$columns = apply_filters( 'manage_edit-post_columns', $columns );
 		$columns = array_keys( $columns );
@@ -218,7 +218,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	public function test_add_post_column_with_filter() {
 		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
-		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
+		$hidden = $list_table->get_column_info()[1];
 		$this->assertNotFalse( array_search( 'language_en', $hidden ) );
 		$this->assertFalse( array_search( 'language_fr', $hidden ) );
 	}
@@ -227,7 +227,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		set_current_screen( 'edit-tags.php' );
 		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
-		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
+		$columns = $list_table->get_column_info()[0];
 		$columns = array_intersect_key( $columns, array_flip( array( 'posts' ) ) ); // Keep only the Count column
 		$columns = apply_filters( 'manage_edit-post_tag_columns', $columns );
 		$columns = array_keys( $columns );
@@ -242,7 +242,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		set_current_screen( 'edit-tags.php' );
 		$this->pll_admin->filter_lang = self::$model->get_language( 'fr' );
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
-		list( $columns, $hidden, $sortable, $primary ) = $list_table->get_column_info();
+		$hidden = $list_table->get_column_info()[1];
 		$this->assertNotFalse( array_search( 'language_fr', $hidden ) );
 		$this->assertFalse( array_search( 'language_en', $hidden ) );
 	}

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -111,8 +111,6 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_invalid_languages() {
-		global $wp_settings_errors;
-
 		$args = array(
 			'name'       => '',
 			'slug'       => 'en',

--- a/tests/phpunit/tests/test-email-strings.php
+++ b/tests/phpunit/tests/test-email-strings.php
@@ -100,7 +100,7 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 		// Set PLL environment.
 		$admin = new PLL_Admin( $this->links_model );
 		$admin->init();
-		new PLL_Admin_Filters( $admin );
+		$admin->filters = new PLL_Admin_Filters( $admin );
 
 		$userdata = array(
 			'ID'        => $user_id,

--- a/tests/phpunit/tests/test-email-strings.php
+++ b/tests/phpunit/tests/test-email-strings.php
@@ -100,7 +100,7 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 		// Set PLL environment.
 		$admin = new PLL_Admin( $this->links_model );
 		$admin->init();
-		$frontend_filters = new PLL_Admin_Filters( $admin );
+		new PLL_Admin_Filters( $admin );
 
 		$userdata = array(
 			'ID'        => $user_id,

--- a/tests/phpunit/tests/test-filters-links.php
+++ b/tests/phpunit/tests/test-filters-links.php
@@ -210,8 +210,8 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$filename = __DIR__ . '/../data/image.jpg';
 		$contents = file_get_contents( $filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$upload   = wp_upload_bits( basename( $filename ), null, $contents );
-		$custom_logo_url = $upload['url'];
-		$custom_logo_id  = $this->_make_attachment( $upload );
+
+		$custom_logo_id = $this->_make_attachment( $upload );
 		set_theme_mod( 'custom_logo', $custom_logo_id );
 
 		// For home_url filter

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -363,6 +363,6 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->frontend->init();
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 		add_action( 'pre_get_posts', array( $this, '_action_pre_get_posts' ) );
-		$posts = get_posts();
+		get_posts(); // fires the action and performs the assertions.
 	}
 }

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -25,9 +25,9 @@ class Flags_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options       = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
-		$model         = new PLL_Model( $options );
-		$links_model   = new PLL_Links_Default( $model ); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
+		$options     = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => 'en_US' ) );
+		$model       = new PLL_Model( $options );
+		$model->get_links_model(); // Registers the 'pll_languages_list' and 'pll_after_languages_cache' filters.
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/tests/test-license.php
+++ b/tests/phpunit/tests/test-license.php
@@ -12,7 +12,7 @@ class License_Test extends PLL_UnitTestCase {
 		// Fake the http call to not connect to the Internet for doing tests.
 		add_filter(
 			'pre_http_request',
-			function ( $preempt, $parsed_args, $url ) {
+			function () {
 				return array(
 					'headers' => null,
 					'body'    => '{"success": true,"license": "valid","item_id": false,"item_name": "Polylang+Pro","license_limit": 1,"site_count": 1,"expires": "2020-05-28 23: 59: 59","activations_left": 0,"checksum": "11112222333344445555666677778888","payment_id": 9999,"customer_name": "","customer_email": "john@doe.com","price_id": "3"}',

--- a/tests/phpunit/tests/test-links-multi-domains-to-one.php
+++ b/tests/phpunit/tests/test-links-multi-domains-to-one.php
@@ -68,7 +68,7 @@ class Links_Multi_Domains_To_One_Test extends PLL_UnitTestCase {
 		$this->init_links_model();
 		$frontend = new PLL_Frontend( $this->links_model );
 		$frontend->init();
-		$languages = $frontend->model->get_languages_list(); // Create the transient with main domain.
+		$frontend->model->get_languages_list(); // Create the transient with main domain.
 
 		// Then relaunch the context to filter home and site URLs with the secondary domain.
 		add_filter(

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -33,7 +33,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		// create 3 menus
 		$menu_en = wp_create_nav_menu( 'menu_en' );
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello World' ) );
-		$item_id = wp_update_nav_menu_item(
+		wp_update_nav_menu_item(
 			$menu_en,
 			0,
 			array(
@@ -47,7 +47,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 
 		$menu_fr = wp_create_nav_menu( 'menu_fr' );
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Bonjour' ) );
-		$item_id = wp_update_nav_menu_item(
+		wp_update_nav_menu_item(
 			$menu_fr,
 			0,
 			array(
@@ -61,7 +61,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 
 		$menu_0 = wp_create_nav_menu( 'menu_0' );
 		$post_id = self::factory()->post->create( array( 'post_title' => 'No language' ) );
-		$item_id = wp_update_nav_menu_item(
+		wp_update_nav_menu_item(
 			$menu_0,
 			0,
 			array(
@@ -424,7 +424,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 			'update-nav-menu-nonce' => wp_create_nonce( 'update-nav_menu' ),
 		);
 
-		$mods = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
+		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$options = get_option( 'polylang' );
 		$this->assertEqualSets( array( 'en' => 2, 'fr' => 3 ), $options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
 		$options = get_option( 'theme_mods_' . get_stylesheet() );
@@ -454,7 +454,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$_GET['action'] = 'locations';
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'save-menu-locations' );
 
-		$mods = set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
+		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$options = get_option( 'polylang' );
 		$this->assertEqualSets( array( 'en' => 4, 'fr' => 5 ), $options['nav_menus'][ get_stylesheet() ][ $primary_location ] );
 		$options = get_option( 'theme_mods_' . get_stylesheet() );

--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -48,7 +48,6 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 		do_action( 'load-post.php' );
 		edit_post();
 
-		$child_page = get_post( $child_page_id );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $child_page_id )->slug );
 		$this->assertEquals( get_post( $child_page_id )->post_parent, $fr );
 	}
@@ -74,7 +73,6 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 		do_action( 'load-post.php' );
 		edit_post();
 
-		$child_page = get_post( $child_page_id );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $child_page_id )->slug );
 		$this->assertEquals( get_post( $child_page_id )->post_parent, 0 );
 	}
@@ -89,7 +87,6 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 
 		wp_update_post( array( 'ID' => $child_page_id, 'post_parent' => $parent_id ) );
 
-		$child_page = get_post( $child_page_id );
 		$this->assertEquals( get_post( $child_page_id )->post_parent, $parent_id, "The unstranlated parent post id should be {$parent_id}" );
 	}
 }

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -136,7 +136,7 @@ class Query_Test extends PLL_UnitTestCase {
 
 		// French Posts.
 		$french_posts_cat_1 = self::factory()->post->create_many( 3, array( 'post_type' => 'post' ) );
-		foreach ( $french_posts_cat_1 as $index => $post ) {
+		foreach ( $french_posts_cat_1 as $post ) {
 			$term = $is_translated_tax ? $first_cat_fr : $first_cat;
 			self::$model->post->set_language( $post, 'fr' );
 			wp_set_post_terms( $post, array( $term ), $taxonomy );
@@ -340,7 +340,7 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_untranslated_custom_tax() {
-		$term_id = self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
+		self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
 		$post_id = self::factory()->post->create( array( 'post_type' => 'cpt' ) );
 		wp_set_post_terms( $post_id, 'test', 'tax' );
 
@@ -380,8 +380,8 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
 		$this->assertEmpty( $this->frontend->links->get_translation_url( self::$model->get_language( 'fr' ) ) );
 
-		// Secondary query which would erroneously forces the language
-		$query = new WP_Query( array( 'post_type' => 'cpt', 'lang' => 'fr' ) );
+		// Secondary query which would erroneously forces the language.
+		new WP_Query( array( 'post_type' => 'cpt', 'lang' => 'fr' ) );
 		$this->assertEquals( array( get_post( $post_id ) ), $GLOBALS['wp_query']->posts );
 	}
 
@@ -570,7 +570,7 @@ class Query_Test extends PLL_UnitTestCase {
 	 */
 	public function test_untranslated_custom_tax_with_translated_cpt() {
 		register_taxonomy( 'tax', 'trcpt' );
-		$term_id = self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
+		self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
 
 		$en = self::factory()->post->create( array( 'post_type' => 'trcpt' ) );
 		self::$model->post->set_language( $en, 'en' );

--- a/tests/phpunit/tests/test-settings-cpt.php
+++ b/tests/phpunit/tests/test-settings-cpt.php
@@ -23,7 +23,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		_unregister_taxonomy( 'tax' );
 	}
 
-	public function filter_translated_post_type_in_settings( $post_types, $is_settings ) {
+	public function filter_translated_post_type_in_settings( $post_types ) {
 		$post_types[] = 'cpt';
 		return $post_types;
 	}
@@ -45,7 +45,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 		return $post_types;
 	}
 
-	public function filter_translated_taxonomy_in_settings( $taxonomies, $is_settings ) {
+	public function filter_translated_taxonomy_in_settings( $taxonomies ) {
 		$taxonomies[] = 'tax';
 		return $taxonomies;
 	}
@@ -100,7 +100,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_programmatically_translated_public_post_type() {
-		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ), 10, 2 );
+		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
 		register_post_type( 'cpt', array( 'public' => true, 'label' => 'CPT' ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 
@@ -190,7 +190,7 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_programmatically_translated_public_taxonomy() {
-		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_in_settings' ), 10, 2 );
+		add_filter( 'pll_get_taxonomies', array( $this, 'filter_translated_taxonomy_in_settings' ) );
 		register_taxonomy( 'tax', array( 'post' ), array( 'public' => true ) );
 		$module = new PLL_Settings_CPT( $this->pll_env );
 

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -71,7 +71,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		set_current_screen();
 
 		$links_model = self::$model->get_links_model();
-		$pll_env = new PLL_Settings( $links_model );
+		new PLL_Settings( $links_model );
 		do_action( 'load-toplevel_page_mlang' );
 
 		ob_start();

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -118,7 +118,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	public function test_sitemaps_untranslated_cpt_and_tax() {
 		$this->init();
 
-		$term_id = self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
+		self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
 		$post_id = self::factory()->post->create( array( 'post_type' => 'cpt' ) );
 		wp_set_post_terms( $post_id, 'test', 'tax' );
 

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -531,7 +531,6 @@ class Sync_Test extends PLL_UnitTestCase {
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		wp_update_post( array( 'ID' => $from ) ); // fires the sync
-		$page = get_post( $to );
 
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
 	}
@@ -594,7 +593,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_sync_multiple_term_metas() {
-		$sync = new PLL_Admin_Sync( $this->pll_admin );
+		new PLL_Admin_Sync( $this->pll_admin );
 
 		$from = self::factory()->term->create();
 		self::$model->term->set_language( $from, 'en' );

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -231,7 +231,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_cpt() {
-		$frontend = new PLL_Frontend( $this->links_model );
+		new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
 		register_post_type( 'book' ); // translated
@@ -253,7 +253,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_tax() {
-		$frontend = new PLL_Frontend( $this->links_model );
+		new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
 		register_post_type( 'book' ); // translated


### PR DESCRIPTION
Due to our current PHPCS config, this check is currently deactivated for tests.
This PR fixes the issues. The PHPCS config will be fixed in a separated PR.