### PR TITLE
Feature filters for translation prevention

### DIFF
--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -52,9 +52,16 @@ class PLL_Admin_Strings {
 	 * @return void
 	 */
 	public static function register_string( $name, $string, $context = 'Polylang', $multiline = false ) {
-		if ( $string && is_scalar( $string ) ) {
-			self::$strings[ md5( $string ) ] = compact( 'name', 'string', 'context', 'multiline' );
+		if ( ! $string || ! is_scalar( $string ) ) {
+			return;
 		}
+
+		$is_allowed = apply_filters( 'pll_allow_register_string', true, $name, $string, $context, $multiline );
+		if ( ! $is_allowed ) {
+			return;
+		}
+
+		self::$strings[ md5( $string ) ] = compact( 'name', 'string', 'context', 'multiline' );
 	}
 
 	/**

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -69,10 +69,16 @@ class PLL_Translate_Option {
 	 * }
 	 */
 	public function __construct( $name, $keys = array(), $args = array() ) {
+		$context = isset( $args['context'] ) ? $args['context'] : 'Polylang';
+
+		$is_allowed = apply_filters( 'pll_allow_translate_option', true, $name, $context, $keys, $args );
+		if ( ! $is_allowed ) {
+			return;
+		}
+
 		$this->cache = new PLL_Cache();
 
 		// Registers the strings.
-		$context = isset( $args['context'] ) ? $args['context'] : 'Polylang';
 		$this->register_string_recursive( $context, $name, get_option( $name ), $keys );
 
 		// Translates the strings.

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -519,6 +519,11 @@ class PLL_WPML_Config {
 	 * @return void
 	 */
 	protected function register_or_translate_option( $context, $name, $key ) {
+		$is_allowed = apply_filters( 'pll_allow_register_or_translate_option', true, $name, $context, $key );
+		if ( ! $is_allowed ) {
+			return;
+		}
+
 		$option_keys = $this->xml_to_array( $key );
 		new PLL_Translate_Option( $name, reset( $option_keys ), array( 'context' => $context ) );
 	}


### PR DESCRIPTION
This pull request and the associated commits are motivated by a curious edge case when using Polylang with [WP-Matomo Integration (WP-Piwik)](https://wordpress.org/plugins/wp-piwik/) plugin.

Here's the background briefly,

- A site was setup with Polylang and WP-Matomo Integration plugins
- The site used example.tld domain and 123 Matomo ID
- The site was migrated to foobar.tld domain and the Matomo ID changed to 321
- WP-CLI search-replace was used to change domain in the database, flush rewrites and transients, etc.
- Matomo ID was updated from the Dashboard via the plugin's settings page

**Problem**
After the site migration one could see the correct Matomo ID (321) in the admin view, but on the front-end the old ID (123) was used to generate the tracking script. Rather undesirable result.

**Fix** 
It took me some time to realize that the Matomo ID option (wp-piwik-site_id) had found its way to the Polylang string translations, where the value was showing the new ID (321), but the translations still had the old ID (123). After clearing the string translations I got the tracking script working in the front-end with the correct Matomo ID (321) as Polylang was no longer interfering with the option value retrieval.

**Investigation**
After some digging I figured out that I could use the `pll_get_strings` filter to remove the Matomo ID option from the Polylang string translations list table and loop through the `global $wp_filter` to unhook any `PLL_Translate_Option` objects from the `option_wp-piwik-site_id` filter. This kind of filtering should prevent the same situation from arising again. 

But to me this doesn't seem like an optimal solution as I'm basically erasing something that has already happened. In my opinion a better way would be to prevent the option string registration and the option value translation in the first place so that they don't ever happen.

**Solution**
The proposed filters would provide developers an easy way to prevent Polylang from registering or translating certain options or other strings.