### PR TITLE
Unhook `print_emoji_styles()` in tests.

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -65,6 +65,13 @@ trait PLL_UnitTestCase_Trait {
 		remove_action( 'current_screen', '_load_remote_block_patterns' );
 		remove_action( 'current_screen', '_load_remote_featured_patterns' );
 
+		if ( version_compare( $GLOBALS['wp_version'], '6.4', '>=' ) ) {
+			/*
+			 * `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
+			 */
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
+
 		self::filter_doing_it_wrong_trigger_error();
 	}
 

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -65,12 +65,10 @@ trait PLL_UnitTestCase_Trait {
 		remove_action( 'current_screen', '_load_remote_block_patterns' );
 		remove_action( 'current_screen', '_load_remote_featured_patterns' );
 
-		if ( version_compare( $GLOBALS['wp_version'], '6.4', '>=' ) ) {
-			/*
-			 * `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
-			 */
-			remove_action( 'wp_print_styles', 'print_emoji_styles' );
-		}
+		/*
+			* `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
+			*/
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
 		self::filter_doing_it_wrong_trigger_error();
 	}

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -66,7 +66,7 @@ trait PLL_UnitTestCase_Trait {
 		remove_action( 'current_screen', '_load_remote_featured_patterns' );
 
 		/*
-		 * `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
+		 * `print_emoji_styles()` is deprecated since WP 6.4, but still hooked for backward compatibility {@see https://core.trac.wordpress.org/ticket/58775}.
 		 */
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 		remove_action( 'admin_print_styles', 'print_emoji_styles' );

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -69,6 +69,7 @@ trait PLL_UnitTestCase_Trait {
 			* `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
 			*/
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		remove_action( 'admin_print_styles', 'print_emoji_styles' );
 
 		self::filter_doing_it_wrong_trigger_error();
 	}

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -66,8 +66,8 @@ trait PLL_UnitTestCase_Trait {
 		remove_action( 'current_screen', '_load_remote_featured_patterns' );
 
 		/*
-			* `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
-			*/
+		 * `print_emoji_styles()` deprecated since WP 6.4, still hooked for backaward compatibility for other plugins @see {https://github.com/WordPress/wordpress-develop/commit/54c4de13edfaf3b9fbc1b67d6ba384618614d59e}.
+		 */
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 		remove_action( 'admin_print_styles', 'print_emoji_styles' );
 


### PR DESCRIPTION
## What?
`print_emoji_styles()` is deprecated since WP 6.4, but is still hooked for backward compatibility.

## Why?
This triggers a depreciation warning when `wp_head()` is called in tests.

## How?
Remove the action in `PLL_UnitTestCase_Trait::wpSetUpBeforeClass()` so our other plugins benefit from it.

*Note: depreciation warning isn't triggered in Polylang test suite, only on Pro and WC.*