### PR TITLE
Test failing when the cache is deactivated

### DIFF
--- a/tests/phpunit/tests/test-settings-cpt.php
+++ b/tests/phpunit/tests/test-settings-cpt.php
@@ -5,10 +5,6 @@ class Settings_CPT_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// De-activate cache for translated post types and taxonomies
-		self::$model->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		self::$model->cache->method( 'get' )->willReturn( false );
-
 		self::$model->options['post_types'] = array();
 		self::$model->options['taxonomies'] = array();
 


### PR DESCRIPTION
When running `vendor/bin/phpunit --filter Settings_CPT_Test`, the last test fails
```
There was 1 failure:

1) Settings_CPT_Test::tearDownAfterClass
Exception in Settings_CPT_Test::tearDownAfterClass
array_intersect(): Argument #2 must be of type array, null given

/home/fred/dev/git/polylang/include/translatable-object-with-types-trait.php:62
/home/fred/dev/git/polylang/include/model.php:389
/home/fred/dev/git/polylang/include/translated-term.php:243
/home/fred/dev/git/polylang/tmp/wordpress-6.3.1/wp-includes/class-wp-hook.php:312
/home/fred/dev/git/polylang/tmp/wordpress-6.3.1/wp-includes/plugin.php:205
/home/fred/dev/git/polylang/tmp/wordpress-6.3.1/wp-includes/taxonomy.php:1330
/home/fred/dev/git/polylang/include/model.php:1042
/home/fred/dev/git/polylang/include/model.php:969
/home/fred/dev/git/polylang/include/model.php:152
/home/fred/dev/git/polylang/tests/phpunit/includes/testcase-trait.php:129
/home/fred/dev/git/polylang/tests/phpunit/includes/testcase-trait.php:81
/home/fred/dev/git/polylang/tmp/wordpress-tests-lib-6.3.1/includes/abstract-testcase.php:88
/home/fred/dev/git/polylang/vendor/yoast/phpunit-polyfills/src/TestCases/TestCasePHPUnitGte8.php:105
```

This seems to be related to the cache not working as expected.