### PR TITLE
Register the language taxonomy only once

### DIFF
--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -84,8 +84,18 @@ abstract class PLL_Translatable_Object {
 
 		/*
 		 * Register our taxonomy as soon as possible.
-		 * This is early registration, not ready for rewrite rules as $wp_rewrite will be setup later.
 		 */
+		$this->register_language_taxonomy();
+	}
+
+	/**
+	 * Registers the language taxonomy.
+	 *
+	 * @since 3.6
+	 *
+	 * @return void
+	 */
+	protected function register_language_taxonomy() {
 		register_taxonomy(
 			$this->tax_language,
 			(array) $this->object_type,

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -95,7 +95,7 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @return void
 	 */
-	protected function register_language_taxonomy() {
+	protected function register_language_taxonomy(): void {
 		register_taxonomy(
 			$this->tax_language,
 			(array) $this->object_type,

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -91,7 +91,7 @@ abstract class PLL_Translatable_Object {
 	/**
 	 * Registers the language taxonomy.
 	 *
-	 * @since 3.6
+	 * @since 3.7
 	 *
 	 * @return void
 	 */

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -36,6 +36,17 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 		/*
 		 * Register our taxonomy as soon as possible.
 		 */
+		$this->register_translations_taxonomy();
+	}
+
+	/**
+	 * Registers the translations taxonomy.
+	 *
+	 * @since 3.6
+	 *
+	 * @return void
+	 */
+	protected function register_translations_taxonomy() {
 		register_taxonomy(
 			$this->tax_translations,
 			(array) $this->object_type,

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -46,7 +46,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 *
 	 * @return void
 	 */
-	protected function register_translations_taxonomy() {
+	protected function register_translations_taxonomy(): void {
 		register_taxonomy(
 			$this->tax_translations,
 			(array) $this->object_type,

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -42,7 +42,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	/**
 	 * Registers the translations taxonomy.
 	 *
-	 * @since 3.6
+	 * @since 3.7
 	 *
 	 * @return void
 	 */

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -74,7 +74,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 *
 	 * @return void
 	 */
-	protected function register_language_taxonomy() {
+	protected function register_language_taxonomy(): void {
 		register_taxonomy(
 			$this->tax_language,
 			(array) $this->get_translated_object_types(),

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -67,6 +67,35 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
+	 * Registers the language taxonomy.
+	 *
+	 * @since 1.2
+	 * @since 3.6 Protected and renamed from `register_taxonomy()`.
+	 *
+	 * @return void
+	 */
+	protected function register_language_taxonomy() {
+		register_taxonomy(
+			$this->tax_language,
+			(array) $this->get_translated_object_types(),
+			array(
+				'labels' => array(
+					'name'          => __( 'Languages', 'polylang' ),
+					'singular_name' => __( 'Language', 'polylang' ),
+					'all_items'     => __( 'All languages', 'polylang' ),
+				),
+				'public'             => false,
+				'show_ui'            => false, // Hide the taxonomy on admin side, needed for WP 4.4.x.
+				'show_in_nav_menus'  => false, // No metabox for nav menus, needed for WP 4.4.x.
+				'publicly_queryable' => true, // Since WP 4.5.
+				'query_var'          => 'lang',
+				'rewrite'            => false, // Rewrite rules are added through filters when needed.
+				'_pll'               => true, // Polylang taxonomy.
+			)
+		);
+	}
+
+	/**
 	 * Adds hooks.
 	 *
 	 * @since 3.4
@@ -74,9 +103,6 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @return static
 	 */
 	public function init() {
-		// Registers completely the language taxonomy.
-		add_action( 'setup_theme', array( $this, 'register_taxonomy' ), 1 );
-
 		// Setups post types to translate.
 		add_action( 'registered_post_type', array( $this, 'registered_post_type' ) );
 
@@ -168,34 +194,6 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	public function is_translated_object_type( $object_type ) {
 		$post_types = $this->get_translated_object_types( false );
 		return ( is_array( $object_type ) && array_intersect( $object_type, $post_types ) ) || in_array( $object_type, $post_types ) || ( 'any' === $object_type && ! empty( $post_types ) );
-	}
-
-	/**
-	 * Registers the language taxonomy.
-	 *
-	 * @since 1.2
-	 *
-	 * @return void
-	 */
-	public function register_taxonomy() {
-		register_taxonomy(
-			$this->tax_language,
-			$this->model->get_translated_post_types(),
-			array(
-				'labels' => array(
-					'name'          => __( 'Languages', 'polylang' ),
-					'singular_name' => __( 'Language', 'polylang' ),
-					'all_items'     => __( 'All languages', 'polylang' ),
-				),
-				'public'             => false,
-				'show_ui'            => false, // Hide the taxonomy on admin side, needed for WP 4.4.x.
-				'show_in_nav_menus'  => false, // No metabox for nav menus, needed for WP 4.4.x.
-				'publicly_queryable' => true, // Since WP 4.5.
-				'query_var'          => 'lang',
-				'rewrite'            => false, // Rewrite rules are added through filters when needed.
-				'_pll'               => true, // Polylang taxonomy.
-			)
-		);
 	}
 
 	/**

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -70,7 +70,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * Registers the language taxonomy.
 	 *
 	 * @since 1.2
-	 * @since 3.6 Protected and renamed from `register_taxonomy()`.
+	 * @since 3.7 Protected and renamed from `register_taxonomy()`.
 	 *
 	 * @return void
 	 */

--- a/tests/features/bootstrap/BrowserPreferredLanguageContext.php
+++ b/tests/features/bootstrap/BrowserPreferredLanguageContext.php
@@ -17,7 +17,6 @@ class BrowserPreferredLanguageContext extends PLL_UnitTestCase implements Contex
 	 */
 	public static function prepare_for_feature() {
 		self::setUpBeforeClass();
-		self::$model->post->register_taxonomy();
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -50,7 +50,6 @@ abstract class PLL_Canonical_UnitTestCase extends WP_Canonical_UnitTestCase {
 		$_SERVER['REQUEST_URI'] = $test_url;
 
 		$model = new PLL_Model( $this->options );
-		$model->post->register_taxonomy(); // needs this for 'lang' query var
 
 		static::register_post_types_and_taxonomies();
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -9,8 +9,6 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
-		self::$model->post->register_taxonomy();
-
 		$links_model     = self::$model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
 		$admin_default_term = new PLL_Admin_Default_Term( $pll_admin );

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -86,8 +86,6 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	public function test_page_lang_choice() {
 		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // we need this for the pages dropdown
 
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
-
 		// possible parents
 		$en = self::factory()->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -29,7 +29,6 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -42,7 +42,6 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-choose-lang.php
+++ b/tests/phpunit/tests/test-choose-lang.php
@@ -2,15 +2,6 @@
 
 class Choose_Lang_Test extends PLL_UnitTestCase {
 
-	/**
-	 * @param WP_UnitTest_Factory $factory
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
-
-		self::$model->post->register_taxonomy();
-	}
-
 	public function tear_down() {
 		self::delete_all_languages();
 

--- a/tests/phpunit/tests/test-filters-links.php
+++ b/tests/phpunit/tests/test-filters-links.php
@@ -29,7 +29,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		// switch to pretty permalinks
 		$wp_rewrite->init();
 		$wp_rewrite->set_permalink_structure( $this->structure );
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
+
 		create_initial_taxonomies();
 		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -15,8 +15,6 @@ class Filters_Test extends PLL_UnitTestCase {
 		self::create_language( 'es_ES' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
-
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -15,8 +15,6 @@ class Model_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_languages_list() {
-		self::$model->post->register_taxonomy(); // needed otherwise posts are not counted
-
 		$this->assertSame( array( 'en', 'fr' ), self::$model->get_languages_list( array( 'fields' => 'slug' ) ) );
 		$this->assertSame( array( 'English', 'Français' ), self::$model->get_languages_list( array( 'fields' => 'name' ) ) );
 		$this->assertSame( array(), self::$model->get_languages_list( array( 'hide_empty' => true ) ) );

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -31,7 +31,6 @@ class Query_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // translated custom post type with archives
 		register_taxonomy( 'trtax', 'trcpt' ); // translated custom tax

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -25,7 +25,6 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
 		create_initial_taxonomies();
 
 		$this->links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -54,7 +54,6 @@ class Single_Language_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		$model->post->register_taxonomy(); // needs this for 'lang' query var
 		$links_model = $model->get_links_model();
 		$links_model->init();
 

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -22,7 +22,6 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // Brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
-		self::$model->post->register_taxonomy(); // Needs this for 'lang' query var.
 		create_initial_taxonomies();
 		register_post_type( 'cpt', array( 'public' => true ) ); // *Untranslated* custom post type.
 		register_taxonomy( 'tax', 'cpt' ); // *Untranslated* custom tax.

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -79,8 +79,6 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		$wp_rewrite->extra_rules_top = array(); // brute force since WP does not do it :(
 		$wp_rewrite->set_permalink_structure( $this->structure );
 
-		self::$model->post->register_taxonomy(); // needs this for 'lang' query var
-
 		$this->links_model = self::$model->get_links_model();
 		$this->links_model->init();
 	}

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -16,8 +16,6 @@ class Switcher_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 
 		require_once POLYLANG_DIR . '/include/api.php';
-
-		self::$model->post->register_taxonomy(); // Needed for post counting
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -53,8 +53,6 @@ class WPML_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_wpml_active_languages() {
-		self::$model->post->register_taxonomy(); // Needed otherwise posts are not counted
-
 		$en = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 


### PR DESCRIPTION
Working on #1345 and more specifically on b294b355c428550847fb85c58f2c4d0b826c95fc, it looked like (since the beginning!) we are adding language rewrite rules to remove them later.

Moreover, we register the language taxonomy 2 times (as WP does) because of the `rewrite` param which cannot be added before `setup_theme` is fired.

#1457 removed the `rewrite` param from the language taxonomy and the related code now useless. This PR focuses on registering the taxonomy only once.

Tests are adapted. Probably it will be necessary to do the same in Polylang Pro and Polylang for WooCommerce. 