### PR TITLE
Filter rewrite rules correctly in multisite.

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -174,7 +174,7 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		 * to add the filters only once and if all custom post types and taxonomies
 		 * have been registered.
 		 */
-		if ( ! $this->model->has_languages() || ! did_action( 'wp_loaded' ) || has_filter( 'language_rewrite_rules', '__return_empty_array' ) ) {
+		if ( ! $this->model->has_languages() || ! did_action( 'wp_loaded' ) || ! self::$can_filter_rewrite_rules ) {
 			return;
 		}
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -36,6 +36,13 @@ abstract class PLL_Links_Model {
 	public $home;
 
 	/**
+	 * Whether rewrite rules can be filtered or not. Default to `false`.
+	 *
+	 * @var boolean
+	 */
+	protected static $can_filter_rewrite_rules = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.5
@@ -251,5 +258,7 @@ abstract class PLL_Links_Model {
 	 *
 	 * @return void
 	 */
-	public function remove_filters() {}
+	public function remove_filters() {
+		self::$can_filter_rewrite_rules = false;
+	}
 }

--- a/include/links-permalinks.php
+++ b/include/links-permalinks.php
@@ -88,6 +88,8 @@ abstract class PLL_Links_Permalinks extends PLL_Links_Model {
 	 * @return void
 	 */
 	public function do_prepare_rewrite_rules() {
+		self::$can_filter_rewrite_rules = true;
+
 		/**
 		 * Tells when Polylang is able to prepare rewrite rules filters.
 		 * Action fired right after `wp_loaded` and just before WordPress `WP_Rewrite::flush_rules()` callback.


### PR DESCRIPTION
## What?
As of today, `has_filter( 'language_rewrite_rules', '__return_empty_array' )` is checked before adding rewrite rules hooks.
But during a switch blog, `$links_model->remove_filters()`  is called. It does what it says appart for the previously mentioned hook... (tldr; to avoid conflict with third party).

## How?
Introduce a new static property in `PLL_Links_Model` to check whether or not rewrite rules hooks can be added.