### PR TITLE
Fix filterable REST routes

### DIFF
--- a/include/filter-rest-routes.php
+++ b/include/filter-rest-routes.php
@@ -143,7 +143,7 @@ class PLL_Filter_REST_Routes {
 	}
 
 	/**
-	 * Exctracts filterable REST route from an array of entity objects
+	 * Extracts filterable REST route from an array of entity objects
 	 * from a list of translatable entities (e.g. post types or taxonomies).
 	 *
 	 * @since 3.5

--- a/include/filter-rest-routes.php
+++ b/include/filter-rest-routes.php
@@ -157,7 +157,8 @@ class PLL_Filter_REST_Routes {
 		$this->filtered_entities = array();
 		foreach ( $rest_entities as $rest_entity ) {
 			if ( in_array( $rest_entity->name, $translatable_entities, true ) ) {
-				$this->filtered_entities[ $rest_entity->name ] = "{$rest_entity->rest_namespace}/{$rest_entity->rest_base}";
+				$rest_base = empty( $rest_entity->rest_base ) ? $rest_entity->name : $rest_entity->rest_base;
+				$this->filtered_entities[ $rest_entity->name ] = "{$rest_entity->rest_namespace}/{$rest_base}";
 			}
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/1861.

The `rest_base` property is set to `false` by default if not defined for a taxonomy.

This PR sets the `WP_Taxonomy` name if the `rest_base` is false (to send the correct REST route to be filtered).