### PR TITLE
Prevent a `open_basedir` error when fetching `wpml-config.xml` files

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -773,16 +773,16 @@ class PLL_WPML_Config {
 			return false;
 		}
 
-		$open_basedir = $this->get_open_basedir();
+		$open_basedir_paths = $this->get_open_basedir_paths();
 
-		if ( empty( $open_basedir ) ) {
+		if ( empty( $open_basedir_paths ) ) {
 			return true;
 		}
 
 		$dir = $this->normalize_path( $dir );
 
-		foreach ( $open_basedir as $basedir ) {
-			if ( str_starts_with( $dir, $basedir ) ) {
+		foreach ( $open_basedir_paths as $path ) {
+			if ( str_starts_with( $dir, $path ) ) {
 				return true;
 			}
 		}
@@ -798,13 +798,13 @@ class PLL_WPML_Config {
 	 *
 	 * @return string[] An array of formatted paths.
 	 */
-	private function get_open_basedir(): array {
+	private function get_open_basedir_paths(): array {
 		if ( is_array( $this->open_basedir_paths ) ) {
 			return $this->open_basedir_paths;
 		}
 
 		$this->open_basedir_paths = array();
-		$open_basedir       = ini_get( 'open_basedir' ); // Can be `false` or an empty string.
+		$open_basedir             = ini_get( 'open_basedir' ); // Can be `false` or an empty string.
 
 		if ( empty( $open_basedir ) ) {
 			return $this->open_basedir_paths;


### PR DESCRIPTION
[Issue](https://wordpress.org/support/topic/fatal-error-open_basedir-restricton/).
Bug introduced by #1140.

This PR prevents the following fatal error:
```
PHP Fatal error: Uncaught RuntimeException: SplFileInfo::isDir(): open_basedir restriction in effect.
File(/wp-content/mu-plugins/foobar.php) is not within the allowed path(s): (/var/www/example.com/:/tmp/) in /wp-content/plugins/polylang/modules/wpml/wpml-config.php:607
```

Stack trace:
```
0 /wp-content/plugins/polylang/modules/wpml/wpml-config.php(607): SplFileInfo->isDir()
1 /wp-content/plugins/polylang/modules/wpml/wpml-config.php(160): PLL_WPML_Config->get_mu_plugin_files()
2 /wp-content/plugins/polylang/modules/wpml/wpml-config.php(78): PLL_WPML_Config->get_files()
3 /wp-content/plugins/polylang/modules/wpml/wpml-config.php(51): PLL_WPML_Config->init()
4 /wp-content/plugins/polylang/modules/wpml/wpml-config.php(64): PLL_WPML_Config->__construct()
5 /wp-content/plugins/polylang/modules/wpml/load.php(15): PLL_WPML_Config::instance()
6 /wp-content/plugins/polylang/include/class-polylang.php(259): require_once('…')
7 /wp-includes/class-wp-hook.php(310): Polylang->init()
8 /wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters()
9 /wp-includes/plugin.php(517): WP_Hook->do_action()
10 /wp-settings.php(495): do_action()
11 /wp-config.php(111): require_once('…')
12 /wp-load.php(50): require_once('…')
13 /wp-blog-header.php(13): require_once('…')
14 /index.php(17): require('…') 15 {main}
```

I managed to reproduce the issue by creating a symlinked MU plugin that is outside the `open_basedir`.

The proposed solution is a mix between `WP_Automatic_Updater::is_allowed_dir()` and `wp-includes/ID3/getid3.php`.

Some details:
- Comparing `$file_info->getPathname()` and `SplFileInfo->getRealPath()` can tell us if the file is a symlink.
- `open_basedir` is processed only when the file is a symlink.
- Paths are normalized by replacing all slashes and back-slashes with `DIRECTORY_SEPARATOR`.
- Paths are suffixed with a `DIRECTORY_SEPARATOR`: this is to prevent false positives like a path `/foo/bar` matching `/foo/barbaz`. Even non-directory files are suffixed but this is not an issue for this purpose (comparing paths).

For references:
https://github.com/WordPress/WordPress/blob/6.3.2/wp-admin/includes/class-wp-automatic-updater.php#L61-L107
https://github.com/WordPress/WordPress/blob/6.3.2/wp-includes/ID3/getid3.php#L42-L65