### PR TITLE
Test wpml config locations

### DIFF
--- a/tests/phpunit/data/plugins/best-plugin/best-plugin.php
+++ b/tests/phpunit/data/plugins/best-plugin/best-plugin.php
@@ -1,0 +1,5 @@
+<?php
+/*
+Plugin Name: Dummy Plugin
+Description: For testing purposes only.
+*/

--- a/tests/phpunit/data/plugins/best-plugin/wpml-config.xml
+++ b/tests/phpunit/data/plugins/best-plugin/wpml-config.xml
@@ -1,0 +1,8 @@
+<wpml-config>
+		<custom-types>
+				<custom-type translate="1">book</custom-type>
+		</custom-types>
+
+</wpml-config>
+
+

--- a/tests/phpunit/data/themes/best-child/style.css
+++ b/tests/phpunit/data/themes/best-child/style.css
@@ -1,0 +1,4 @@
+/*
+Theme Name: Child Theme
+Template: best-theme
+*/

--- a/tests/phpunit/data/themes/best-child/wpml-config.xml
+++ b/tests/phpunit/data/themes/best-child/wpml-config.xml
@@ -1,0 +1,8 @@
+<wpml-config>
+		<custom-types>
+				<custom-type translate="1">book</custom-type>
+		</custom-types>
+
+</wpml-config>
+
+

--- a/tests/phpunit/data/themes/best-theme/style.css
+++ b/tests/phpunit/data/themes/best-theme/style.css
@@ -1,0 +1,4 @@
+/*  
+Theme Name: The best theme.
+Description: For testing purposes only.
+*/

--- a/tests/phpunit/data/themes/best-theme/wpml-config.xml
+++ b/tests/phpunit/data/themes/best-theme/wpml-config.xml
@@ -1,0 +1,8 @@
+<wpml-config>
+		<custom-types>
+				<custom-type translate="1">book</custom-type>
+		</custom-types>
+
+</wpml-config>
+
+

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -90,29 +90,28 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 
 	public function test_in_mu_plugin() {
 		@mkdir( WPMU_PLUGIN_DIR );
-		$filename = WPMU_PLUGIN_DIR . '/wpml-config.xml';
-		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename );
+		$filename_1 = WPMU_PLUGIN_DIR . '/wpml-config.xml';
+		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename_1 );
 
-		$files    = ( new PLL_WPML_Config() )->get_files();
-		$expected = array( 'mu-plugins' => $filename );
-
-		unlink( $filename );
-		rmdir( WPMU_PLUGIN_DIR );
-
-		$this->assertSameSetsWithIndex( $expected, $files );
-	}
-
-	public function test_in_mu_plugin_sub_dir() {
-		@mkdir( WPMU_PLUGIN_DIR );
 		@mkdir( WPMU_PLUGIN_DIR . '/must-use' );
-		$filename = WPMU_PLUGIN_DIR . '/must-use/wpml-config.xml';
-		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename );
+		$filename_2 = WPMU_PLUGIN_DIR . '/must-use/wpml-config.xml';
+		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename_2 );
+
+		symlink( dirname( __DIR__ ) . '/data/plugins/best-plugin', WPMU_PLUGIN_DIR . '/best-plugin' );
 
 		$files    = ( new PLL_WPML_Config() )->get_files();
-		$expected = array( 'mu-plugins/must-use' => $filename );
+		$expected = array(
+			'mu-plugins'             => $filename_1,
+			'mu-plugins/must-use'    => $filename_2,
+			'mu-plugins/best-plugin' => WPMU_PLUGIN_DIR . '/best-plugin/wpml-config.xml',
+		);
 
-		unlink( $filename );
+		unlink( WPMU_PLUGIN_DIR . '/best-plugin' );
+
+		unlink( $filename_2 );
 		rmdir( WPMU_PLUGIN_DIR . '/must-use' );
+
+		unlink( $filename_1 );
 		rmdir( WPMU_PLUGIN_DIR );
 
 		$this->assertSameSetsWithIndex( $expected, $files );

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -3,29 +3,23 @@
 class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 
 	protected static $dirs = array(
-		'themes' => array(
-			'best-theme',
-			'best-child',
-		),
-		'plugins' => array(
-			'best-plugin',
-		),
+		'themes/best-theme',
+		'themes/best-child',
+		'plugins/best-plugin',
 	);
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
 		// Copy themes and plugins from tests/phpunit/data to wp-content.
-		foreach ( self::$dirs as $type => $subdirs ) {
-			foreach ( $subdirs as $name ) {
-				$source_dir = dirname( __DIR__ ) . "/data/{$type}/{$name}";
-				$dest_dir   = WP_CONTENT_DIR . "/{$type}/{$name}";
+		foreach ( self::$dirs as $type => $path ) {
+			$source_dir = PLL_TEST_DATA_DIR . "/{$path}";
+			$dest_dir   = WP_CONTENT_DIR . "/{$path}";
 
-				@mkdir( $dest_dir );
+			@mkdir( $dest_dir );
 
-				foreach ( glob( $source_dir . '/*.*' ) as $file ) {
-					copy( $file, $dest_dir . '/' . basename( $file ) );
-				}
+			foreach ( glob( $source_dir . '/*.*' ) as $file ) {
+				copy( $file, $dest_dir . '/' . basename( $file ) );
 			}
 		}
 	}
@@ -34,16 +28,14 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 		parent::wpTearDownAfterClass();
 
 		// Remove previously copied themes and plugins from wp-content.
-		foreach ( self::$dirs as $type => $subdirs ) {
-			foreach ( $subdirs as $name ) {
-				$dest_dir = WP_CONTENT_DIR . "/{$type}/{$name}";
+		foreach ( self::$dirs as $type => $path ) {
+			$dest_dir = WP_CONTENT_DIR . "/{$path}";
 
-				foreach ( glob( $dest_dir . '/*.*' ) as $file ) {
-					unlink( $file );
-				}
-
-				rmdir( $dest_dir );
+			foreach ( glob( $dest_dir . '/*.*' ) as $file ) {
+				unlink( $file );
 			}
+
+			rmdir( $dest_dir );
 		}
 	}
 

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -97,7 +97,7 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 		$filename_2 = WPMU_PLUGIN_DIR . '/must-use/wpml-config.xml';
 		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename_2 );
 
-		symlink( dirname( __DIR__ ) . '/data/plugins/best-plugin', WPMU_PLUGIN_DIR . '/best-plugin' );
+		@symlink( dirname( __DIR__ ) . '/data/plugins/best-plugin', WPMU_PLUGIN_DIR . '/best-plugin' );
 
 		$files    = ( new PLL_WPML_Config() )->get_files();
 		$expected = array(

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -1,0 +1,120 @@
+<?php
+
+class WPML_Config_Locations_Test extends PLL_UnitTestCase {
+
+	protected static $dirs = array(
+		'themes' => array(
+			'best-theme',
+			'best-child',
+		),
+		'plugins' => array(
+			'best-plugin',
+		),
+	);
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		// Copy themes and plugins from tests/phpunit/data to wp-content.
+		foreach ( self::$dirs as $type => $subdirs ) {
+			foreach ( $subdirs as $name ) {
+				$source_dir = dirname( __DIR__ ) . "/data/{$type}/{$name}";
+				$dest_dir   = WP_CONTENT_DIR . "/{$type}/{$name}";
+
+				@mkdir( $dest_dir );
+
+				foreach ( glob( $source_dir . '/*.*' ) as $file ) {
+					copy( $file, $dest_dir . '/' . basename( $file ) );
+				}
+			}
+		}
+	}
+
+	public static function wpTearDownAfterClass() {
+		parent::wpTearDownAfterClass();
+
+		// Remove previously copied themes and plugins from wp-content.
+		foreach ( self::$dirs as $type => $subdirs ) {
+			foreach ( $subdirs as $name ) {
+				$dest_dir = WP_CONTENT_DIR . "/{$type}/{$name}";
+
+				foreach ( glob( $dest_dir . '/*.*' ) as $file ) {
+					unlink( $file );
+				}
+
+				rmdir( $dest_dir );
+			}
+		}
+	}
+
+	public function test_in_polylang() {
+		@mkdir( WP_CONTENT_DIR . '/polylang' );
+		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
+
+		$files    = ( new PLL_WPML_Config() )->get_files();
+		$expected = array( 'Polylang' => WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
+
+		unlink( WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
+		rmdir( WP_CONTENT_DIR . '/polylang' );
+
+		$this->assertSameSetsWithIndex( $expected, $files );
+	}
+
+	public function test_in_theme() {
+		switch_theme( 'best-theme' );
+
+		$files    = ( new PLL_WPML_Config() )->get_files();
+		$expected = array( 'themes/best-theme' => get_theme_root() . '/best-theme/wpml-config.xml' );
+
+		$this->assertSameSetsWithIndex( $expected, $files );
+	}
+
+	public function test_in_child_theme() {
+		switch_theme( 'best-child' );
+		$files    = ( new PLL_WPML_Config() )->get_files();
+		$expected = array(
+			'themes/best-theme' => get_theme_root() . '/best-theme/wpml-config.xml',
+			'themes/best-child' => get_theme_root() . '/best-child/wpml-config.xml',
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $files );
+	}
+
+	public function test_in_active_plugin() {
+		activate_plugin( 'best-plugin/best-plugin.php' );
+		$files    = ( new PLL_WPML_Config() )->get_files();
+		$expected = array( 'plugins/best-plugin' => WP_PLUGIN_DIR . '/best-plugin/wpml-config.xml' );
+
+		$this->assertSameSetsWithIndex( $expected, $files );
+	}
+
+	public function test_in_mu_plugin() {
+		@mkdir( WPMU_PLUGIN_DIR );
+		$filename = WPMU_PLUGIN_DIR . '/wpml-config.xml';
+		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename );
+
+		$files    = ( new PLL_WPML_Config() )->get_files();
+		$expected = array( 'mu-plugins' => $filename );
+
+		unlink( $filename );
+		rmdir( WPMU_PLUGIN_DIR );
+
+		$this->assertSameSetsWithIndex( $expected, $files );
+	}
+
+	public function test_in_mu_plugin_sub_dir() {
+		@mkdir( WPMU_PLUGIN_DIR );
+		@mkdir( WPMU_PLUGIN_DIR . '/must-use' );
+		$filename = WPMU_PLUGIN_DIR . '/must-use/wpml-config.xml';
+		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename );
+
+		$files    = ( new PLL_WPML_Config() )->get_files();
+		$expected = array( 'mu-plugins/must-use' => $filename );
+
+		unlink( $filename );
+		rmdir( WPMU_PLUGIN_DIR . '/must-use' );
+		rmdir( WPMU_PLUGIN_DIR );
+
+		$this->assertSameSetsWithIndex( $expected, $files );
+	}
+}

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -58,16 +58,21 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 		$files    = ( new PLL_WPML_Config() )->get_files();
 		$expected = array( 'themes/best-theme' => get_theme_root() . '/best-theme/wpml-config.xml' );
 
+		switch_theme( 'default' );
+
 		$this->assertSameSetsWithIndex( $expected, $files );
 	}
 
 	public function test_in_child_theme() {
 		switch_theme( 'best-child' );
+
 		$files    = ( new PLL_WPML_Config() )->get_files();
 		$expected = array(
 			'themes/best-theme' => get_theme_root() . '/best-theme/wpml-config.xml',
 			'themes/best-child' => get_theme_root() . '/best-child/wpml-config.xml',
 		);
+
+		switch_theme( 'default' );
 
 		$this->assertSameSetsWithIndex( $expected, $files );
 	}

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -49,7 +49,7 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 
 	public function test_in_polylang() {
 		@mkdir( WP_CONTENT_DIR . '/polylang' );
-		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
+		copy( PLL_TEST_DATA_DIR . 'wpml-config.xml', WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
 
 		$files    = ( new PLL_WPML_Config() )->get_files();
 		$expected = array( 'Polylang' => WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
@@ -91,13 +91,13 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 	public function test_in_mu_plugin() {
 		@mkdir( WPMU_PLUGIN_DIR );
 		$filename_1 = WPMU_PLUGIN_DIR . '/wpml-config.xml';
-		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename_1 );
+		copy( PLL_TEST_DATA_DIR . 'wpml-config.xml', $filename_1 );
 
 		@mkdir( WPMU_PLUGIN_DIR . '/must-use' );
 		$filename_2 = WPMU_PLUGIN_DIR . '/must-use/wpml-config.xml';
-		copy( dirname( __DIR__ ) . '/data/wpml-config.xml', $filename_2 );
+		copy( PLL_TEST_DATA_DIR . 'wpml-config.xml', $filename_2 );
 
-		@symlink( dirname( __DIR__ ) . '/data/plugins/best-plugin', WPMU_PLUGIN_DIR . '/best-plugin' );
+		@symlink( PLL_TEST_DATA_DIR . 'plugins/best-plugin', WPMU_PLUGIN_DIR . '/best-plugin' );
 
 		$files    = ( new PLL_WPML_Config() )->get_files();
 		$expected = array(

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -12,8 +12,8 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 		parent::wpSetUpBeforeClass( $factory );
 
 		// Copy themes and plugins from tests/phpunit/data to wp-content.
-		foreach ( self::$dirs as $type => $path ) {
-			$source_dir = PLL_TEST_DATA_DIR . "/{$path}";
+		foreach ( self::$dirs as $path ) {
+			$source_dir = PLL_TEST_DATA_DIR . $path;
 			$dest_dir   = WP_CONTENT_DIR . "/{$path}";
 
 			@mkdir( $dest_dir );


### PR DESCRIPTION
Tested locations for the `wpml-config.xml` file:
- Active plugin root
- Active theme root
- Active child theme root + parent theme root
- mu plugins root + plugin in a subdirectory + symlinked plugin
- `wp-content/polylang`
Not tested:
- Networked activated plugin on multisite.