### PR TITLE
Sets rest_namespace to default wp/v2 if not set.

### DIFF
--- a/include/filter-rest-routes.php
+++ b/include/filter-rest-routes.php
@@ -157,8 +157,10 @@ class PLL_Filter_REST_Routes {
 		$this->filtered_entities = array();
 		foreach ( $rest_entities as $rest_entity ) {
 			if ( in_array( $rest_entity->name, $translatable_entities, true ) ) {
-				$rest_base = empty( $rest_entity->rest_base ) ? $rest_entity->name : $rest_entity->rest_base;
-				$this->filtered_entities[ $rest_entity->name ] = "{$rest_entity->rest_namespace}/{$rest_base}";
+				$rest_base      = empty( $rest_entity->rest_base ) ? $rest_entity->name : $rest_entity->rest_base;
+				$rest_namespace = empty( $rest_entity->rest_namespace ) ? 'wp/v2' : $rest_entity->rest_namespace;
+
+				$this->filtered_entities[ $rest_entity->name ] = "{$rest_namespace}/{$rest_base}";
 			}
 		}
 	}


### PR DESCRIPTION
Issue with CPT UI, we had a `rest_namespace` set to `null`, so the filtered route was wrong.

This PR sets the default route if the `rest_namespace` is not defined, as [WP](https://github.com/WordPress/WordPress/blob/6.3.2/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php#L70).