### PR TITLE
Add a test for filtered routes with a null rest_namespace.

### DIFF
--- a/tests/phpunit/includes/testcase-preload-paths.php
+++ b/tests/phpunit/includes/testcase-preload-paths.php
@@ -14,7 +14,7 @@ abstract class PLL_Preload_Paths_TestCase extends PLL_UnitTestCase {
 		register_post_type( 'custom', array( 'public' => true, 'show_in_rest' => true ) ); // Untranslatable CPT.
 		register_post_type( 'trcpt', array( 'public' => true, 'show_in_rest' => true ) ); // Translated CPT.
 		register_taxonomy( 'trtax', 'trcpt', array( 'show_in_rest' => true ) ); // Translated custom taxonomy.
-		register_taxonomy( 'trtax_with_no_namespace', 'trcpt', array( 'show_in_rest' => true, 'rest_namespace' => null ) ); // Translated custom taxonomy with no namespace defined.
+		register_taxonomy( 'trtax_with_no_namespace', 'trcpt', array( 'show_in_rest' => true, 'rest_namespace' => null ) ); // Translated custom taxonomy with namespace explicitly set to null as in CPTUI.
 
 		$options = array_merge(
 			PLL_Install::get_default_options(),

--- a/tests/phpunit/includes/testcase-preload-paths.php
+++ b/tests/phpunit/includes/testcase-preload-paths.php
@@ -14,6 +14,7 @@ abstract class PLL_Preload_Paths_TestCase extends PLL_UnitTestCase {
 		register_post_type( 'custom', array( 'public' => true, 'show_in_rest' => true ) ); // Untranslatable CPT.
 		register_post_type( 'trcpt', array( 'public' => true, 'show_in_rest' => true ) ); // Translated CPT.
 		register_taxonomy( 'trtax', 'trcpt', array( 'show_in_rest' => true ) ); // Translated custom taxonomy.
+		register_taxonomy( 'trtax_with_no_namespace', 'trcpt', array( 'show_in_rest' => true, 'rest_namespace' => null ) ); // Translated custom taxonomy with no namespace defined.
 
 		$options = array_merge(
 			PLL_Install::get_default_options(),
@@ -27,7 +28,8 @@ abstract class PLL_Preload_Paths_TestCase extends PLL_UnitTestCase {
 			),
 			array(
 				'taxonomies' => array(
-					'trtax' => 'trtax',
+					'trtax'                   => 'trtax',
+					'trtax_with_no_namespace' => 'trtax_with_no_namespace',
 				),
 			)
 		);
@@ -44,6 +46,7 @@ abstract class PLL_Preload_Paths_TestCase extends PLL_UnitTestCase {
 		_unregister_post_type( 'custom' );
 		_unregister_post_type( 'trcpt' );
 		_unregister_taxonomy( 'trtax' );
+		_unregister_taxonomy( 'trtax_with_no_namespace' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-preload-paths.php
+++ b/tests/phpunit/tests/test-preload-paths.php
@@ -92,13 +92,18 @@ class Preload_Paths_Test extends PLL_Preload_Paths_TestCase {
 
 	/**
 	 * @ticket #1861 {@see https://github.com/polylang/polylang-pro/issues/1861}
+	 *
+	 * @testWith [ "trtax" ]
+	 *           [ "trtax_with_no_namespace" ]
+	 *
+	 * @param string $taxonomy Taxonomy name.
 	 */
-	public function test_rest_routes_for_custom_taxonomies() {
-		$preload_paths = $this->pll_admin->block_editor->filter_rest_routes->add_query_parameters( array( '/wp/v2/trtax' ), array( 'test' => 'something' ) );
+	public function test_rest_routes_for_custom_taxonomies( $taxonomy ) {
+		$preload_paths = $this->pll_admin->block_editor->filter_rest_routes->add_query_parameters( array( '/wp/v2/' . $taxonomy ), array( 'test' => 'something' ) );
 
 		// If the parameter is added to the route, this means that the route is one of the filterable routes.
 		$this->assertNotEmpty( $preload_paths );
 		$this->assertCount( 1, $preload_paths );
-		$this->assertSame( '/wp/v2/trtax?test=something', reset( $preload_paths ) );
+		$this->assertSame( '/wp/v2/' . $taxonomy . '?test=something', reset( $preload_paths ) );
 	}
 }


### PR DESCRIPTION
Following https://github.com/polylang/polylang/pull/1376.

Adds a test case with a taxonomy with a null `rest_namespace`.

