### PR TITLE
Improve PHPCS config

### DIFF
--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -105,9 +105,8 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 			}
 
 			// The function idn_to_ascii() is much faster than the WordPress method.
-			if ( function_exists( 'idn_to_ascii' ) ) {
-				// The use of the constant is mandatory in PHP 7.2 and PHP 7.3 to avoid a deprecated notice.
-				$hosts[ $lang ] = defined( 'INTL_IDNA_VARIANT_UTS46' ) ? idn_to_ascii( $host, 0, INTL_IDNA_VARIANT_UTS46 ) : idn_to_ascii( $host );
+			if ( function_exists( 'idn_to_ascii' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
+				$hosts[ $lang ] = idn_to_ascii( $host, 0, INTL_IDNA_VARIANT_UTS46 );
 			} elseif ( class_exists( 'WpOrg\Requests\IdnaEncoder' ) ) {
 				// Since WP 6.2.
 				$hosts[ $lang ] = \WpOrg\Requests\IdnaEncoder::encode( $host );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,10 +53,24 @@
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
 	</rule>
 
+	<!--
+	#############################################################################
+	Customized properties.
+	#############################################################################
+	-->
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
 				<element value="polylang"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Security.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" type="array">
+				<element value="sanitize_locale_name"/>
 			</property>
 		</properties>
 	</rule>
@@ -69,13 +83,11 @@
 		</properties>
 	</rule>
 
-	<rule ref="WordPress.Security.EscapeOutput">
-		<properties>
-			<property name="customAutoEscapedFunctions" type="array">
-				<element value="sanitize_locale_name"/>
-			</property>
-		</properties>
-	</rule>
+	<!--
+	#############################################################################
+	Global exclusions for tests.
+	#############################################################################
+	-->
 
 	<rule ref="Generic.Commenting.Fixme.CommentFound">
 		<exclude-pattern>*/tests/*</exclude-pattern>
@@ -129,16 +141,12 @@
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<!-- PHPCS cannot correctly parse JavaScript syntax -->
-	<rule ref="PEAR.Functions.FunctionCallSignature">
-		<exclude-pattern>*/*.js</exclude-pattern>
-	</rule>
+	<!--
+	#############################################################################
+	Global exclusions for js files.
+	#############################################################################
+	-->
 
-	<rule ref="Generic.WhiteSpace.ScopeIndent">
-		<exclude-pattern>*/*.js</exclude-pattern>
-	</rule>
-
-	<!-- PHPCS cannot correctly parse JavaScript syntax -->
 	<rule ref="PEAR.Functions.FunctionCallSignature">
 		<exclude-pattern>*/*.js</exclude-pattern>
 	</rule>
@@ -148,12 +156,18 @@
 	</rule>
 
 	<rule ref="WordPress.WhiteSpace.OperatorSpacing">
-		<exclude-pattern>*/*./js</exclude-pattern>
+		<exclude-pattern>*/*.js</exclude-pattern>
 	</rule>
 
 	<rule ref="Generic.Formatting.MultipleStatementAlignment">
 		<exclude-pattern>*/*.js</exclude-pattern>
 	</rule>
+
+	<!--
+	#############################################################################
+	Excluded files.
+	#############################################################################
+	-->
 
 	<exclude-pattern>js/*.min.js</exclude-pattern>
 	<exclude-pattern>js/build</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,10 +9,9 @@
 	<file>.</file>
 
 	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="testVersion" value="7.0-"/><!-- PHPCompatibilityWP -->
 
-	<rule ref="PHPCompatibilityWP">
-		<config name="testVersion" value="7.0-"/>
-	</rule>
+	<rule ref="PHPCompatibilityWP"/>
 
 	<rule ref="WordPressVIPMinimum">
 		<exclude-pattern>*/tests/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -63,10 +63,15 @@
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
-			<property name="customSanitizingFunctions" type="array">
+			<property name="customUnslashingSanitizingFunctions" type="array">
 				<element value="sanitize_locale_name"/>
 			</property>
-			<property name="customUnslashingSanitizingFunctions" type="array">
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Security.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" type="array">
 				<element value="sanitize_locale_name"/>
 			</property>
 		</properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -61,12 +61,12 @@
 		</properties>
 	</rule>
 
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable" >
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
 		<exclude-pattern>/load.php</exclude-pattern>
 		<exclude-pattern>/view-*</exclude-pattern>
 	</rule>
 
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" >
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
 		<properties>
 			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
 		</properties>
@@ -83,47 +83,55 @@
 		</properties>
 	</rule>
 
-	<rule ref="Generic.Commenting.Fixme.CommentFound" >
+	<rule ref="Generic.Commenting.Fixme.CommentFound">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Generic.Files.OneObjectStructurePerFile.MultipleFound" >
+	<rule ref="Generic.Files.OneObjectStructurePerFile.MultipleFound">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.ClassComment.Missing" >
+	<rule ref="Generic.PHP.NoSilencedErrors.Forbidden">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.FileComment" >
+	<rule ref="Squiz.Commenting.ClassComment.Missing">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.FunctionComment.Missing" >
+	<rule ref="Squiz.Commenting.FileComment">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.FunctionComment.MissingParamComment" >
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.Commenting.VariableComment.Missing" >
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamComment">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="Squiz.PHP.CommentedOutCode.Found" >
+	<rule ref="Squiz.Commenting.VariableComment.Missing">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores" >
+	<rule ref="Squiz.PHP.CommentedOutCode.Found">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.PHP.NoSilencedErrors.Discouraged" >
+	<rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.Security" >
+	<rule ref="WordPress.PHP.NoSilencedErrors.Discouraged">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.Security">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPressVIPMinimum.Files.IncludingFile.UsingVariable">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -61,17 +61,6 @@
 		</properties>
 	</rule>
 
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
-		<exclude-pattern>/load.php</exclude-pattern>
-		<exclude-pattern>/view-*</exclude-pattern>
-	</rule>
-
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
-		<properties>
-			<property name="allowUnusedVariablesBeforeRequire" value="true"/>
-		</properties>
-	</rule>
-
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
 			<property name="customSanitizingFunctions" type="array">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,21 +8,10 @@
 
 	<file>.</file>
 
-	<config name="minimum_supported_wp_version" value="5.9"/>
 	<config name="testVersion" value="7.0-"/><!-- PHPCompatibilityWP -->
+	<config name="minimum_supported_wp_version" value="5.9"/>
 
 	<rule ref="PHPCompatibilityWP"/>
-
-	<rule ref="WordPressVIPMinimum">
-		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant"/>
-		<exclude name="WordPressVIPMinimum.Functions.CheckReturnValue.NonCheckedVariable"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions"/>
-		<exclude name="WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts"/>
-		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown"/>
-		<exclude name="WordPressVIPMinimum.Performance.NoPaging.nopaging_nopaging"/>
-		<exclude name="WordPressVIPMinimum.Performance.TaxonomyMetaInOptions.PossibleTermMetaInOptions"/>
-		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE"/>
-	</rule>
 
 	<rule ref="WordPress">
 		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.Found"/>
@@ -51,6 +40,17 @@
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedScript" />
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.NotInFooter" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
+	</rule>
+
+	<rule ref="WordPressVIPMinimum">
+		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant"/>
+		<exclude name="WordPressVIPMinimum.Functions.CheckReturnValue.NonCheckedVariable"/>
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions"/>
+		<exclude name="WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts"/>
+		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown"/>
+		<exclude name="WordPressVIPMinimum.Performance.NoPaging.nopaging_nopaging"/>
+		<exclude name="WordPressVIPMinimum.Performance.TaxonomyMetaInOptions.PossibleTermMetaInOptions"/>
+		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE"/>
 	</rule>
 
 	<!--

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,25 +14,14 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<rule ref="WordPressVIPMinimum">
-		<exclude-pattern>*/tests/*</exclude-pattern>
 		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant"/>
 		<exclude name="WordPressVIPMinimum.Functions.CheckReturnValue.NonCheckedVariable"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.term_exists_term_exists"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.user_meta_delete_user_meta"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.user_meta_get_user_meta"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.user_meta_update_user_meta"/>
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get"/>
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions"/>
 		<exclude name="WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts"/>
-		<exclude name="WordPressVIPMinimum.Performance.BatcacheWhitelistedParams.StrippedGetParam"/>
 		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown"/>
 		<exclude name="WordPressVIPMinimum.Performance.NoPaging.nopaging_nopaging"/>
 		<exclude name="WordPressVIPMinimum.Performance.TaxonomyMetaInOptions.PossibleTermMetaInOptions"/>
 		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE"/>
-		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__usermeta"/>
 	</rule>
 
 	<rule ref="WordPress">

--- a/tests/phpunit/includes/polyfills.php
+++ b/tests/phpunit/includes/polyfills.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'did_filter' ) ) {
 
 	add_filter(
 		'all',
-		function ( $hook_name ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
+		function ( $hook_name ) {
 			global $wp_filters;
 
 			if ( ! isset( $wp_filters[ $hook_name ] ) ) {
@@ -20,6 +20,8 @@ if ( ! function_exists( 'did_filter' ) ) {
 			} else {
 				++$wp_filters[ $hook_name ];
 			}
+
+			return $hook_name;
 		}
 	);
 

--- a/tests/phpunit/includes/polyfills.php
+++ b/tests/phpunit/includes/polyfills.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'did_filter' ) ) {
 
 	add_filter(
 		'all',
-		function ( $hook_name ) {
+		function ( $hook_name ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
 			global $wp_filters;
 
 			if ( ! isset( $wp_filters[ $hook_name ] ) ) {

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -15,7 +15,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 	protected function expect_wp_redirect() {
 		add_filter(
 			'wp_redirect',
-			function () {
+			function () { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
 				throw new Exception( 'Call to wp_redirect' );
 			}
 		);

--- a/tests/phpunit/tests/test-customizer.php
+++ b/tests/phpunit/tests/test-customizer.php
@@ -59,7 +59,7 @@ class Customizer_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_static_front_page_update() {
-		$_POST['customized'] = json_encode(
+		$_POST['customized'] = wp_json_encode(
 			array(
 				'show_on_front' => 'page',
 				'page_on_front' => $this->page_fr,

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -65,11 +65,11 @@ class Filters_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( 'fr' ), array_values( array_unique( $languages ) ) );
 
 		$fr_page_id = reset( $fr_page_ids ); // Just one valid page id
-		$pages = get_pages( array( 'number' => 1, 'exclude' => array( $fr_page_id ) ) );
+		$pages = get_pages( array( 'number' => 1, 'exclude' => array( $fr_page_id ) ) ); // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 		$this->assertCount( 1, $pages );
 
 		// Warning fixed in 2.3.2
-		$pages = get_pages( array( 'number' => 1, 'exclude' => $fr_page_id ) );
+		$pages = get_pages( array( 'number' => 1, 'exclude' => $fr_page_id ) ); // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 		$this->assertCount( 1, $pages );
 	}
 

--- a/tests/phpunit/tests/test-preload-paths.php
+++ b/tests/phpunit/tests/test-preload-paths.php
@@ -41,26 +41,18 @@ class Preload_Paths_Test extends PLL_Preload_Paths_TestCase {
 	/**
 	 * @dataProvider preload_paths_provider
 	 *
-	 * @param string|array $path            The preload path under test. Could be an array if provided along a HTTP method.
-	 * @param bool         $is_filtered     Whether the path should be filtered or not.
-	 * @param WP_Post      $post            The post provided for the context.
-	 * @param string       $language        The post's language slug.
-	 * @param bool         $is_translatable Whether or not the post type is translatable.
+	 * @param string|array $path The preload path under test. Could be an array if provided along a HTTP method.
 	 */
-	public function test_preload_paths_in_site_editor_context( $path, $is_filtered, $post, $language, $is_translatable ) {
+	public function test_preload_paths_in_site_editor_context( $path ) {
 		$this->assert_unfiltered_path_for_context( $path, 'core/edit-site' );
 	}
 
 	/**
 	 * @dataProvider preload_paths_provider
 	 *
-	 * @param string|array $path            The preload path under test. Could be an array if provided along a HTTP method.
-	 * @param bool         $is_filtered     Whether the path should be filtered or not.
-	 * @param WP_Post      $post            The post provided for the context.
-	 * @param string       $language        The post's language slug.
-	 * @param bool         $is_translatable Whether or not the post type is translatable.
+	 * @param string|array $path The preload path under test. Could be an array if provided along a HTTP method.
 	 */
-	public function test_preload_paths_in_widget_editor_context( $path, $is_filtered, $post, $language, $is_translatable ) {
+	public function test_preload_paths_in_widget_editor_context( $path ) {
 		$this->assert_unfiltered_path_for_context( $path, 'core/edit-widgets' );
 	}
 

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -103,7 +103,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		);
 
 		if ( 'OBJECT' === $method ) {
-			$options = json_decode( json_encode( $options ) ); // Recursively converts the arrays to objects.
+			$options = json_decode( wp_json_encode( $options ) ); // Recursively converts the arrays to objects.
 		}
 
 		add_option( 'my_options', $options );
@@ -151,7 +151,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		);
 
 		if ( 'OBJECT' === $method ) {
-			$options = json_decode( json_encode( $options ) ); // Recursively converts the arrays to objects.
+			$options = json_decode( wp_json_encode( $options ) ); // Recursively converts the arrays to objects.
 		}
 
 		update_option( 'my_options', $options );
@@ -283,7 +283,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		);
 
 		if ( 'OBJECT' === $method ) {
-			$options = json_decode( json_encode( $options ) ); // Recursively converts the arrays to objects.
+			$options = json_decode( wp_json_encode( $options ) ); // Recursively converts the arrays to objects.
 		}
 
 		PLL()->curlang = self::$model->get_language( 'en' );

--- a/tests/phpunit/tests/test-widget-nav-menu.php
+++ b/tests/phpunit/tests/test-widget-nav-menu.php
@@ -91,19 +91,24 @@ class Widget_Nav_Menu_Test extends PLL_UnitTestCase {
 		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
 		$this->pll_rest->init();
-		$request = new WP_REST_Request( 'POST', '/wp/v2/widget-types/nav_menu/render' );
-		$params = array(
+
+		$instance = array(
 			'nav_menu' => $menu_id,
 			'pll_lang' => 'en',
 		);
+
+		$serialized_instance = serialize( $instance ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+
 		$body = array(
 			'instance' => array(
-				'encoded' => base64_encode( serialize( $params ) ),
-				'hash'    => wp_hash( serialize( $params ) ),
-				'raw'     => $params,
+				'encoded' => base64_encode( $serialized_instance ),
+				'hash'    => wp_hash( $serialized_instance ),
+				'raw'     => $instance,
 			),
 			'lang'     => 'en',
 		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/widget-types/nav_menu/render' );
 		$request->set_body_params( $body );
 		$response = rest_do_request( $request );
 

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -28,7 +28,7 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 		parent::wpTearDownAfterClass();
 
 		// Remove previously copied themes and plugins from wp-content.
-		foreach ( self::$dirs as $type => $path ) {
+		foreach ( self::$dirs as $path ) {
 			$dest_dir = WP_CONTENT_DIR . "/{$path}";
 
 			foreach ( glob( $dest_dir . '/*.*' ) as $file ) {

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -68,7 +68,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		);
 
 		if ( 'OBJECT' === $method ) {
-			$my_plugins_options = json_decode( json_encode( $my_plugins_options ) ); // Recursively converts the arrays to objects.
+			$my_plugins_options = json_decode( wp_json_encode( $my_plugins_options ) ); // Recursively converts the arrays to objects.
 		}
 
 		update_option( 'my_plugins_options', $my_plugins_options );


### PR DESCRIPTION
This PR is a follow-up to #1328, #1333, #1347, #1349, #1362

- Fixes PHPCompatibilityWP config which was inoperative
- Fixes WordPressVIPMinimum config which used to exclude more sniffs in tests than expected
- Combines all `WordPressVIPMinimum.Functions.RestrictedFunctions` exclusions for tests
- Removes some useless config lines
- Adds `sanitize_locale_name()` to  auto escaped functions
- Attempts to clarify the structure of phpcs.xml.dist 
- Fixes some new reported errors and locally ignore others