### PR TITLE
Move `expect_wp_redirect()` in `PLL_UnitTestCase`.

### DIFF
--- a/tests/phpunit/includes/exceptions.php
+++ b/tests/phpunit/includes/exceptions.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Exception for `wp_redirect()` + exit.
+ */
+class PLL_WP_Redirect_Exit_Exception extends Exception {}

--- a/tests/phpunit/includes/handle-wp-redirect-trait.php
+++ b/tests/phpunit/includes/handle-wp-redirect-trait.php
@@ -47,7 +47,7 @@ trait PLL_Handle_WP_Redirect_Trait {
 				$this->redirect_location = $location;
 				$this->redirect_status   = $status;
 
-				throw new PLL_WP_Redirect_Exit_Exception( 'wp_redirect' );
+				throw new PLL_WP_Redirect_Exit_Exception();
 			},
 			10,
 			2

--- a/tests/phpunit/includes/handle-wp-redirect-trait.php
+++ b/tests/phpunit/includes/handle-wp-redirect-trait.php
@@ -27,11 +27,14 @@ trait PLL_Handle_WP_Redirect_Trait {
 	protected $last_status;
 
 	/**
-	 * Allows to continue the execution after wp_redirect + exit.
+	 * Allows to continue the execution after wp_redirect() + exit.
 	 *
 	 * @return void
 	 */
 	protected function handle_wp_redirect() {
+		$this->redirect_location = '';
+		$this->redirect_status = 0;
+		
 		add_filter(
 			'wp_redirect',
 			function ( $location, $status ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
@@ -39,7 +42,7 @@ trait PLL_Handle_WP_Redirect_Trait {
 				$this->last_location = $location;
 				$this->last_status   = $status;
 
-				throw new Exception( 'Call to `wp_redirect()`.' );
+				throw new Exception( 'wp_redirect' );
 			},
 			10,
 			2
@@ -53,8 +56,8 @@ trait PLL_Handle_WP_Redirect_Trait {
 	 *
 	 * @return void
 	 */
-	protected function assert_has_redirected( $message = '' ) {
-		$this->assertTrue( $this->has_redirect, $message );
+	protected function assert_redirect( $message = '' ) {
+		$this->assertNotEmpty( $this->redirect_location, $message );
 	}
 
 	/**

--- a/tests/phpunit/includes/handle-wp-redirect-trait.php
+++ b/tests/phpunit/includes/handle-wp-redirect-trait.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Trait to run tests containing `wp_redirect()` and `exit`.
+ * Also privides some assertions for the redirection.
+ */
+trait PLL_Handle_WP_Redirect_Trait {
+	/**
+	 * Whether or not `wp_redirect()` has been called.
+	 *
+	 * @var bool
+	 */
+	protected $has_redirect = false;
+
+	/**
+	 * Stores the last redirection location made with `wp_redirect()`.
+	 *
+	 * @var string
+	 */
+	protected $last_location;
+
+	/**
+	 * Stores the last redirection status made with `wp_redirect()`.
+	 *
+	 * @var int
+	 */
+	protected $last_status;
+
+	/**
+	 * Allows to continue the execution after wp_redirect + exit.
+	 *
+	 * @return void
+	 */
+	protected function handle_wp_redirect() {
+		add_filter(
+			'wp_redirect',
+			function ( $location, $status ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
+				$this->has_redirect  = true;
+				$this->last_location = $location;
+				$this->last_status   = $status;
+
+				throw new Exception( 'Call to `wp_redirect()`.' );
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Asserts `wp_redirect()` has been called.
+	 *
+	 * @param string $message Error message to display.
+	 *
+	 * @return void
+	 */
+	protected function assert_has_redirected( $message = '' ) {
+		$this->assertTrue( $this->has_redirect, $message );
+	}
+
+	/**
+	 * Asserts last redirection location is as expected.
+	 *
+	 * @param string $expected_location Expected location of the redirection.
+	 * @param string $message           Error message to display.
+	 *
+	 * @return void
+	 */
+	protected function assert_redirect_location( $expected_location, $message = '' ) {
+		$this->assertSame( $expected_location, $this->last_location, $message );
+	}
+
+	/**
+	 * Asserts last redirection status code is as expected.
+	 *
+	 * @param string $expected_status Expected status of the redirection.
+	 * @param string $message         Error message to display.
+	 *
+	 * @return void
+	 */
+	protected function assert_redirect_status( $expected_status, $message = '' ) {
+		$this->assertSame( $expected_status, $this->last_status, $message );
+	}
+
+	/**
+	 * Resets the hanbdler so a new call to `wp_redirect()` and new assertions can be made safely.
+	 * Should be called in `tear_down()` as well.
+	 *
+	 * @return void
+	 */
+	protected function reset_wp_redirect_handler() {
+		$this->has_redirect  = false;
+		$this->last_location = null;
+		$this->last_status   = null;
+	}
+}

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -37,9 +37,9 @@ abstract class PLL_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * Allows to continue the execution after wp_redirect + exit.
 	 *
-	 * @param string $expected_location
-	 * @param int    $expected_status
-	 * @param string $message
+	 * @param string $expected_location Expected location.
+	 * @param int    $expected_status   Expected Status.
+	 * @param string $message           Error message.
 	 * @return void
 	 */
 	protected function expect_wp_redirect( $expected_location = '', $expected_status = 0, $message = '' ) {

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -60,7 +60,7 @@ abstract class PLL_UnitTestCase extends WP_UnitTestCase {
 			2
 		);
 
-		$this->expectException( 'Exception' );
+		$this->expectException( 'Exception', 'wp_redirect() was not called as expected.' );
 		$this->expectExceptionMessage( 'Call to wp_redirect', $message );
 	}
 }

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -33,34 +33,4 @@ abstract class PLL_UnitTestCase extends WP_UnitTestCase {
 		$this->assertNotFalse( $object_language, $message );
 		$this->assertSame( $language, $object_language->slug, $message );
 	}
-
-	/**
-	 * Allows to continue the execution after wp_redirect + exit.
-	 *
-	 * @param string $expected_location Expected location.
-	 * @param int    $expected_status   Expected Status.
-	 * @param string $message           Error message.
-	 * @return void
-	 */
-	protected function expect_wp_redirect( $expected_location = '', $expected_status = 0, $message = '' ) {
-		add_filter(
-			'wp_redirect',
-			function ( $location, $status ) use ( $expected_location, $expected_status ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
-				if ( ! empty( $expected_location ) ) {
-					$this->assertSame( $expected_location, $location );
-				}
-
-				if ( ! empty( $expected_status ) ) {
-					$this->assertSame( $expected_status, $status );
-				}
-
-				throw new Exception( 'Call to wp_redirect' );
-			},
-			10,
-			2
-		);
-
-		$this->expectException( 'Exception', 'wp_redirect() was not called as expected.' );
-		$this->expectExceptionMessage( 'Call to wp_redirect', $message );
-	}
 }

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -33,4 +33,34 @@ abstract class PLL_UnitTestCase extends WP_UnitTestCase {
 		$this->assertNotFalse( $object_language, $message );
 		$this->assertSame( $language, $object_language->slug, $message );
 	}
+
+	/**
+	 * Allows to continue the execution after wp_redirect + exit.
+	 *
+	 * @param string $expected_location
+	 * @param int    $expected_status
+	 * @param string $message
+	 * @return void
+	 */
+	protected function expect_wp_redirect( $expected_location = '', $expected_status = 0, $message = '' ) {
+		add_filter(
+			'wp_redirect',
+			function ( $location, $status ) use ( $expected_location, $expected_status ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
+				if ( ! empty( $expected_location ) ) {
+					$this->assertSame( $expected_location, $location );
+				}
+
+				if ( ! empty( $expected_status ) ) {
+					$this->assertSame( $expected_status, $status );
+				}
+
+				throw new Exception( 'Call to wp_redirect' );
+			},
+			10,
+			2
+		);
+
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage( 'Call to wp_redirect', $message );
+	}
 }

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -10,15 +10,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
-	public function tear_down() {
-		$this->reset_wp_redirect_handler();
-
-		parent::tear_down();
-	}
-
 	public function test_hide_notice() {
-		$this->handle_wp_redirect();
-
 		wp_set_current_user( 1 );
 
 		$_GET = $_REQUEST = array(
@@ -28,13 +20,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 
 		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
-		try {
-			$this->pll_admin->admin_notices->hide_notice();
-		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			unset( $e );
-		}
-
-		$this->assert_has_redirected( 'A redirection should have been made.' );
+		$this->assert_redirect( array( $this->pll_admin->admin_notices, 'hide_notice' ) );
 		$this->assert_redirect_status( 302, 'Redirection status code sould be 302.' );
 		$this->assertSame( array( 'review' ), get_option( 'pll_dismissed_notices' ) );
 	}

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -1,6 +1,7 @@
 <?php
 
 class Admin_Notices_Test extends PLL_UnitTestCase {
+	use PLL_Handle_WP_Redirect_Trait;
 
 	public function set_up() {
 		parent::set_up();
@@ -9,8 +10,14 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
+	public function tear_down() {
+		$this->reset_wp_redirect_handler();
+
+		parent::tear_down();
+	}
+
 	public function test_hide_notice() {
-		$this->expect_wp_redirect();
+		$this->handle_wp_redirect();
 
 		wp_set_current_user( 1 );
 
@@ -24,13 +31,12 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		try {
 			$this->pll_admin->admin_notices->hide_notice();
 		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Silence.
+			unset( $e );
 		}
 
+		$this->assert_has_redirected( 'A redirection should have been made.' );
+		$this->assert_redirect_status( 302, 'Redirection status code sould be 302.' );
 		$this->assertSame( array( 'review' ), get_option( 'pll_dismissed_notices' ) );
-
-		// We have to throw the exception made in `expect_wp_redirect()`.
-		throw $e;
 	}
 
 	public function test_no_review_notice_for_old_users() {

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -9,21 +9,6 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->pll_admin = new PLL_Admin( $links_model );
 	}
 
-	/**
-	 * Allows to continue the execution after wp_redirect + exit.
-	 */
-	protected function expect_wp_redirect() {
-		add_filter(
-			'wp_redirect',
-			function () { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
-				throw new Exception( 'Call to wp_redirect' );
-			}
-		);
-
-		$this->expectException( 'Exception' );
-		$this->expectExceptionMessage( 'Call to wp_redirect' );
-	}
-
 	public function test_hide_notice() {
 		$this->expect_wp_redirect();
 

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -20,9 +20,17 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		);
 
 		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
-		$this->pll_admin->admin_notices->hide_notice();
 
-		$this->assertEquals( array( 'review' ), get_user_meta( 1, 'pll_dismissed_notices', true ) );
+		try {
+			$this->pll_admin->admin_notices->hide_notice();
+		} catch ( Exception $e ) {
+			// Silence.
+		}
+
+		$this->assertSame( array( 'review' ), get_option( 'pll_dismissed_notices' ) );
+
+		// We have to throw the exception made in `expect_wp_redirect()`.
+		throw $e;
 	}
 
 	public function test_no_review_notice_for_old_users() {

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -21,7 +21,6 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 
 		$this->assert_redirect( array( $this->pll_admin->admin_notices, 'hide_notice' ) );
-		$this->assert_redirect_status( 302, 'Redirection status code sould be 302.' );
 		$this->assertSame( array( 'review' ), get_option( 'pll_dismissed_notices' ) );
 	}
 

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -23,7 +23,7 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 
 		try {
 			$this->pll_admin->admin_notices->hide_notice();
-		} catch ( Exception $e ) {
+		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Silence.
 		}
 


### PR DESCRIPTION
All in the title.
The purpose is to make `expect_wp_redirect()` reusable.
It also fixes `test_hide_notice()` whose assertion was never called because of `expect_wp_redirect()`, fixing it showed it failed so I made it work.