### PR TITLE
Make PHPCS and PHPStan ready to run on PHP 8.0

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PHPCS and PHPStan tests
-      uses: polylang/actions/static-analysis@lint-php80
+      uses: polylang/actions/static-analysis@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PHPCS and PHPStan tests
-      uses: polylang/actions/static-analysis@main
+      uses: polylang/actions/static-analysis@lint-php80

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PHPCS and PHPStan tests
-      uses: polylang/actions/static-analysis@dev-lint-php80
+      uses: polylang/actions/static-analysis@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PHPCS and PHPStan tests
-      uses: polylang/actions/static-analysis@main
+      uses: polylang/actions/static-analysis@dev-lint-php80

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -281,11 +281,6 @@ parameters:
 			path: admin/admin.php
 
 		-
-			message: "#^Parameter \\#1 \\$subtags of class PLL_Accept_Language constructor expects array\\<string\\>, array\\<string, string\\>\\|false given\\.$#"
-			count: 1
-			path: frontend/accept-language.php
-
-		-
 			message: "#^Parameter \\#1 \\$curlang of method PLL_Choose_Lang_Content\\:\\:set_language\\(\\) expects PLL_Language, PLL_Language\\|false given\\.$#"
 			count: 1
 			path: frontend/choose-lang-content.php
@@ -644,11 +639,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, array\\{mixed, 'get_terms_args'\\} given\\.$#"
 			count: 1
 			path: include/model.php
-
-		-
-			message: "#^Method PLL_Nav_Menu\\:\\:explode_location\\(\\) should return array\\<string\\> but returns array\\<string, mixed\\>\\|false\\.$#"
-			count: 1
-			path: include/nav-menu.php
 
 		-
 			message: "#^Property PLL_Nav_Menu\\:\\:\\$theme \\(string\\) does not accept mixed\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,18 +38,6 @@ parameters:
 			count: 1
 			path: frontend/frontend.php
 
-		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
-			count: 1
-			path: include/translated-post.php
-
-		# Ignored because array_combine() cannot return false when feeded with 2 identical arrays.
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, array\\|false given\\.$#"
-			count: 1
-			path: include/translated-term.php
-
 		# Ignored because the class Requests_IDNAEncoder exists in WP < 6.2.
 		-
 			message: "#^Call to static method encode\\(\\) on an unknown class Requests_IDNAEncoder\\.$#"


### PR DESCRIPTION
PHPCS: ✅
PHPStan: removed 4 ignored messages.

Requires https://github.com/polylang/actions/pull/4.