### PR TITLE
Add search REST endpoint to make it filterable by language in javascript

### DIFF
--- a/include/filter-rest-routes.php
+++ b/include/filter-rest-routes.php
@@ -125,6 +125,9 @@ class PLL_Filter_REST_Routes {
 			array_merge( $translatable_post_types, $translatable_taxonomies )
 		);
 
+		// Adds search REST endpoint.
+		$this->filtered_entities['search'] = 'wp/v2/search';
+
 		return $this->filtered_entities;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1905

Since https://github.com/polylang/polylang/pull/1341, only REST request on translatable post types and taxonomies are filtered by language.

As `search` doesn't concern a post type nor a taxonomy, it is no longer filtered by language as in Polylang 3.4.x

This PR propose to add `/wp/v2/search` endpoint in the list of filterable endpoint.