### PR TITLE
Polylang PHPUnit Factories.

### DIFF
--- a/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
+++ b/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
@@ -21,7 +21,7 @@ trait Factory_For_Translated_Object_Trait {
 		$has_language = $this->translatable_object->set_language( $object_id, $args['lang'] );
 
 		if ( ! $has_language ) {
-			return new WP_Error( 'pll-test-error', 'Language cannot be assigned to the given object.' );
+			return new WP_Error( 'pll-test-error', 'Could not assign a language to the created object.' );
 		}
 
 		return $object_id;
@@ -33,7 +33,7 @@ trait Factory_For_Translated_Object_Trait {
 
 		foreach ( $others as $object ) {
 			if ( empty( $object['lang'] ) ) {
-				throw new InvalidArgumentException( 'Please pass a language to assign to the given object.' );
+				throw new InvalidArgumentException( 'A language is required for all translated objects.' );
 			}
 
 			$translations[ $object['lang'] ] = $this->create( $object );

--- a/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
+++ b/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
@@ -13,6 +13,11 @@ trait Factory_For_Translated_Object_Trait {
 			return $object_id;
 		}
 
+		$existing_language = $this->translatable_object->get_language( $object_id );
+		if ( $existing_language instanceof PLL_Language && $existing_language->slug === $args['lang'] ) {
+			return $object_id;
+		}
+
 		$has_language = $this->translatable_object->set_language( $object_id, $args['lang'] );
 
 		if ( ! $has_language ) {
@@ -34,7 +39,7 @@ trait Factory_For_Translated_Object_Trait {
 			$translations[ $object['lang'] ] = $this->create( $object );
 		}
 
-		return $this->translatable_object->save_translations( $translations );
+		return $this->translatable_object->save_translations( reset( $translations ), $translations );
 	}
 
 	public function create_translated_and_get( array $first, array $second, array $others = array() ) {

--- a/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
+++ b/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
@@ -1,0 +1,48 @@
+<?php
+
+trait Factory_For_Translated_Object_Trait {
+	/**
+	 * @var PLL_Translated_Post
+	 */
+	protected $translatable_object;
+
+	public function create( $args = array(), $generation_definitions = null ) {
+		$object_id = parent::create( $args, $generation_definitions );
+
+		if ( empty( $args['lang'] ) || ! $object_id || is_wp_error( $object_id ) ) {
+			return $object_id;
+		}
+
+		$has_language = $this->translatable_object->set_language( $object_id, $args['lang'] );
+
+		if ( ! $has_language ) {
+			return new WP_Error( 'pll-test-error', 'Language cannot be assigned to the given object.' );
+		}
+
+		return $object_id;
+	}
+
+	public function create_translated( array $first, array $second, array $others = array() ) {
+		$others       = array_merge( array( $first ), array( $second ), $others );
+		$translations = array();
+
+		foreach ( $others as $object ) {
+			if ( empty( $object['lang'] ) ) {
+				throw new InvalidArgumentException( 'Please pass a language to assign to the given object.' );
+			}
+
+			$translations[ $object['lang'] ] = $this->create( $object );
+		}
+
+		return $this->translatable_object->save_translations( $translations );
+	}
+
+	public function create_translated_and_get( array $first, array $second, array $others = array() ) {
+		$translations = $this->create_translated( $first, $second, $others );
+
+		return array_map(
+			array( $this, 'get_object_by_id' ),
+			$translations
+		);
+	}
+}

--- a/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
+++ b/tests/phpunit/includes/factory/factory-for-translated-object-trait.php
@@ -27,11 +27,10 @@ trait Factory_For_Translated_Object_Trait {
 		return $object_id;
 	}
 
-	public function create_translated( array $first, array $second, array $others = array() ) {
-		$others       = array_merge( array( $first ), array( $second ), $others );
+	public function create_translated( array ...$objects ) {
 		$translations = array();
 
-		foreach ( $others as $object ) {
+		foreach ( $objects as $object ) {
 			if ( empty( $object['lang'] ) ) {
 				throw new InvalidArgumentException( 'A language is required for all translated objects.' );
 			}
@@ -42,8 +41,8 @@ trait Factory_For_Translated_Object_Trait {
 		return $this->translatable_object->save_translations( reset( $translations ), $translations );
 	}
 
-	public function create_translated_and_get( array $first, array $second, array $others = array() ) {
-		$translations = $this->create_translated( $first, $second, $others );
+	public function create_translated_and_get( array ...$objects ) {
+		$translations = $this->create_translated( ...$objects );
 
 		return array_map(
 			array( $this, 'get_object_by_id' ),

--- a/tests/phpunit/includes/factory/unittest-factory-for-language.php
+++ b/tests/phpunit/includes/factory/unittest-factory-for-language.php
@@ -33,7 +33,7 @@ class PLL_UnitTest_Factory_For_Language extends WP_UnitTest_Factory_For_Thing {
 	 */
 	public function create( $args = array(), $generation_definitions = null ) {
 		if ( empty( $args['locale'] ) ) {
-			throw new InvalidArgumentException( 'Please pass at least a locale to create a language.' );
+			throw new InvalidArgumentException( 'A locale is required to create a language.' );
 		}
 
 		$languages = include POLYLANG_DIR . '/settings/languages.php';
@@ -93,7 +93,7 @@ class PLL_UnitTest_Factory_For_Language extends WP_UnitTest_Factory_For_Thing {
 		$language = $this->pll_model->get_language( $args['slug'] );
 
 		if ( ! $language instanceof PLL_Language ) {
-			return new WP_Error( 'Something went wrong when retrieving the language.' );
+			return new WP_Error( 'Could not get the created language.' );
 		}
 
 		return $language->term_id;
@@ -112,7 +112,7 @@ class PLL_UnitTest_Factory_For_Language extends WP_UnitTest_Factory_For_Thing {
 			return $language;
 		}
 
-		return new WP_Error( 'Cannot find a language for the given term ID.' );
+		return new WP_Error( 'Could not find a language for the given term ID.' );
 	}
 
 	/**

--- a/tests/phpunit/includes/factory/unittest-factory-for-language.php
+++ b/tests/phpunit/includes/factory/unittest-factory-for-language.php
@@ -12,7 +12,7 @@ class PLL_UnitTest_Factory_For_Language extends WP_UnitTest_Factory_For_Thing {
 	protected $default_languages = array(
 		'en_US',
 		'fr_FR',
-		'de_DE',
+		'de_DE_formal',
 		'es_ES',
 	);
 

--- a/tests/phpunit/includes/factory/unittest-factory-for-language.php
+++ b/tests/phpunit/includes/factory/unittest-factory-for-language.php
@@ -1,0 +1,126 @@
+<?php
+
+class PLL_UnitTest_Factory_For_Language extends WP_UnitTest_Factory_For_Thing {
+	/**
+	 * @var PLL_Admin_Model
+	 */
+	protected $pll_model;
+
+	/**
+	 * @var PLL_Language[]
+	 */
+	protected $default_languages = array(
+		'en_US',
+		'fr_FR',
+		'de_DE',
+		'es_ES',
+	);
+
+	public function __construct( PLL_UnitTest_Factory $factory ) {
+		$this->pll_model = $factory->pll_model;
+	}
+
+	/**
+	 * Creates a language and returns its term ID.
+	 *
+	 * @param array $args                   The arguments for the object to create.
+	 *                                      Default empty array.
+	 * @param null  $generation_definitions Not used.
+	 *
+	 * @return int|WP_Error The object ID on success, WP_Error object on failure.
+	 *
+	 * @throws InvalidArgumentException Throw exception when badly used.
+	 */
+	public function create( $args = array(), $generation_definitions = null ) {
+		if ( empty( $args['locale'] ) ) {
+			throw new InvalidArgumentException( 'Please pass at least a locale to create a language.' );
+		}
+
+		$languages = include POLYLANG_DIR . '/settings/languages.php';
+		$values    = $languages[ $args['locale'] ];
+
+		$values['slug']       = $values['code'];
+		$values['rtl']        = (int) ( 'rtl' === $values['dir'] );
+		$values['term_group'] = 0;
+
+		$args = array_merge( $values, $args );
+
+		$result = $this->create_object( $args );
+
+		$this->pll_model->clean_languages_cache();
+
+		return $result;
+	}
+
+	/**
+	 * Creates multiple objects.
+	 *
+	 * @param int   $count                  Amount of objects to create.
+	 * @param array $args                   Not used.
+	 * @param null  $generation_definitions Not Used.
+	 *
+	 * @return array
+	 *
+	 * @throws InvalidArgumentException Throw exception when badly used.
+	 */
+	public function create_many( $count, $args = array(), $generation_definitions = null ) {
+		if ( $count > count( $this->default_languages ) ) {
+			throw new InvalidArgumentException( "Don't be so greedy." );
+		}
+
+		$results = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$results[] = $this->create( array( 'locale' => $this->default_languages[ $i ] ), $generation_definitions );
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Creates a language object.
+	 *
+	 * @param array $args Language data.
+	 * @return int|WP_Error Language term ID on success, `WP_Error` on failure.
+	 */
+	public function create_object( $args ) {
+		$errors = $this->pll_model->add_language( $args );
+
+		if ( is_wp_error( $errors ) ) {
+			return $errors;
+		}
+
+		$language = $this->pll_model->get_language( $args['slug'] );
+
+		if ( ! $language instanceof PLL_Language ) {
+			return new WP_Error( 'Something went wrong when retrieving the language.' );
+		}
+
+		return $language->term_id;
+	}
+
+	/**
+	 * Returns a language object for a givern term ID.
+	 *
+	 * @param int $object_id Term ID.
+	 * @return PLL_Language|WP_Error
+	 */
+	public function get_object_by_id( $object_id ) {
+		$language = $this->pll_model->get_language( $object_id );
+
+		if ( $language instanceof PLL_Language ) {
+			return $language;
+		}
+
+		return new WP_Error( 'Cannot find a language for the given term ID.' );
+	}
+
+	/**
+	 * Does nothing because it's only used in `WP_UnitTest_Factory_For_Thing::create()` and this method has been overridden.
+	 *
+	 * @param int   $object_id
+	 * @param array $fields
+	 * @return void
+	 */
+	public function update_object( $object_id, $fields ) {} // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+}

--- a/tests/phpunit/includes/factory/unittest-factory-for-post.php
+++ b/tests/phpunit/includes/factory/unittest-factory-for-post.php
@@ -1,0 +1,10 @@
+<?php
+
+class PLL_UnitTest_Factory_For_Post extends WP_UnitTest_Factory_For_Post {
+	use Factory_For_Translated_Object_Trait;
+
+	public function __construct( PLL_UnitTest_Factory $factory ) {
+		parent::__construct( $factory );
+		$this->translatable_object = $factory->pll_model->post;
+	}
+}

--- a/tests/phpunit/includes/factory/unittest-factory-for-term.php
+++ b/tests/phpunit/includes/factory/unittest-factory-for-term.php
@@ -1,0 +1,10 @@
+<?php
+
+class PLL_UnitTest_Factory_For_Term extends WP_UnitTest_Factory_For_Term {
+	use Factory_For_Translated_Object_Trait;
+
+	public function __construct( PLL_UnitTest_Factory $factory, $taxonomy = null ) {
+		parent::__construct( $factory, $taxonomy );
+		$this->translatable_object = $factory->pll_model->term;
+	}
+}

--- a/tests/phpunit/includes/factory/unittest-factory.php
+++ b/tests/phpunit/includes/factory/unittest-factory.php
@@ -11,6 +11,34 @@ class PLL_UnitTest_Factory extends WP_UnitTest_Factory {
 	 */
 	public $pll_model;
 
+	/**
+	 * Generates post fixtures for use in tests with assignated languages and translations.
+	 *
+	 * @var PLL_UnitTest_Factory_For_Post
+	 */
+	public $post;
+
+	/**
+	 * Generates taxonomy term fixtures for use in tests with assignated languages and translations.
+	 *
+	 * @var PLL_UnitTest_Factory_For_Term
+	 */
+	public $term;
+
+	/**
+	 * Generates taxonomy term fixtures for use in tests with assignated languages and translations.
+	 *
+	 * @var PLL_UnitTest_Factory_For_Term
+	 */
+	public $category;
+
+	/**
+	 * Generates taxonomy term fixtures for use in tests with assignated languages and translations.
+	 *
+	 * @var PLL_UnitTest_Factory_For_Term
+	 */
+	public $tag;
+
 	public function __construct() {
 		$options                  = PLL_Install::get_default_options();
 		$options['hide_default']  = 0;

--- a/tests/phpunit/includes/factory/unittest-factory.php
+++ b/tests/phpunit/includes/factory/unittest-factory.php
@@ -1,0 +1,35 @@
+<?php
+
+class PLL_UnitTest_Factory extends WP_UnitTest_Factory {
+	/**
+	 * @var PLL_UnitTest_Factory_For_Language
+	 */
+	public $language;
+
+	/**
+	 * @var PLL_Admin_Model
+	 */
+	public $pll_model;
+
+	public function __construct() {
+		$options                  = PLL_Install::get_default_options();
+		$options['hide_default']  = 0;
+		$options['media_support'] = 1;
+		$this->pll_model          = new PLL_Admin_Model( $options );
+
+		$this->language = new PLL_UnitTest_Factory_For_Language( $this );
+
+		$this->post       = new PLL_UnitTest_Factory_For_Post( $this );
+		$this->attachment = new WP_UnitTest_Factory_For_Attachment( $this );
+		$this->comment    = new WP_UnitTest_Factory_For_Comment( $this );
+		$this->user       = new WP_UnitTest_Factory_For_User( $this );
+		$this->term       = new PLL_UnitTest_Factory_For_Term( $this );
+		$this->category   = new PLL_UnitTest_Factory_For_Term( $this, 'category' );
+		$this->tag        = new PLL_UnitTest_Factory_For_Term( $this, 'post_tag' );
+		$this->bookmark   = new WP_UnitTest_Factory_For_Bookmark( $this );
+		if ( is_multisite() ) {
+			$this->blog    = new WP_UnitTest_Factory_For_Blog( $this );
+			$this->network = new WP_UnitTest_Factory_For_Network( $this );
+		}
+	}
+}

--- a/tests/phpunit/includes/polyfill-testcase.php
+++ b/tests/phpunit/includes/polyfill-testcase.php
@@ -2,7 +2,7 @@
 
 /**
  * Polyfill class to replace `WP_UnitTest_Factory` with `PLL_UnitTest_Factory`.
- * Backward compatibility for WordPress < 6.5-alpha.
+ * The whole class exists only for backward compatibility with WordPress < 6.5-alpha.
  * Back then, `WP_UnitTestCase::factory()` was called with `self` instead of `static` keyword,
  * preventing us to override it.
  *
@@ -10,8 +10,8 @@
  */
 abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 	/**
-	 * Rewrites `WP_UnitTestCase::set_up_before_class()` using `static` keyword.
-	 * If no polfill required, call `WP_UnitTestCase::set_up_before_class()` as usual.
+	 * Rewrites `WP_UnitTestCase::set_up_before_class()` using `static` keyword for `factory()` call.
+	 * If no polyfill is required, call `WP_UnitTestCase::set_up_before_class()` as usual.
 	 */
 	public static function set_up_before_class() {
 		global $wpdb, $wp_version;
@@ -38,8 +38,8 @@ abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Rewrites `WP_UnitTestCase::set_up()` using `static` keyword.
-	 * If no polfill required, call `WP_UnitTestCase::set_up()` as usual.
+	 * Rewrites `WP_UnitTestCase::set_up()` using `static` keyword for `factory()` call.
+	 * If no polyfill is required, call `WP_UnitTestCase::set_up()` as usual.
 	 */
 	public function set_up() {
 		global $wp_version;

--- a/tests/phpunit/includes/polyfill-testcase.php
+++ b/tests/phpunit/includes/polyfill-testcase.php
@@ -20,6 +20,7 @@ abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 			return parent::set_up_before_class();
 		}
 
+		// Backward compatibility with WP < 6.5.
 		PHPUnit_Adapter_TestCase::set_up_before_class(); // Call grandpa!
 
 		$wpdb->suppress_errors = false;
@@ -47,6 +48,7 @@ abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 			return parent::set_up();
 		}
 
+		// Backward compatibility with WP < 6.5.
 		set_time_limit( 0 );
 
 		$this->factory = static::factory();

--- a/tests/phpunit/includes/polyfill-testcase.php
+++ b/tests/phpunit/includes/polyfill-testcase.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Polyfill class to replace `WP_UnitTest_Factory` with `PLL_UnitTest_Factory`.
+ * Backward compatibility for WordPress < 6.5-alpha.
+ * Back then, `WP_UnitTestCase::factory()` was called with `self` instead of `static` keyword,
+ * preventing us to override it.
+ *
+ * @see https://github.com/WordPress/wordpress-develop/pull/5723.
+ */
+abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
+	/**
+	 * Rewrites `WP_UnitTestCase::set_up_before_class()` using `static` keyword.
+	 * If no polfill required, call `WP_UnitTestCase::set_up_before_class()` as usual.
+	 */
+	public static function set_up_before_class() {
+		global $wpdb, $wp_version;
+
+		if ( version_compare( $wp_version, '6.5-alpha', '>=' ) ) {
+			return parent::set_up_before_class();
+		}
+
+		PHPUnit_Adapter_TestCase::set_up_before_class(); // Call grandpa!
+
+		$wpdb->suppress_errors = false;
+		$wpdb->show_errors     = true;
+		$wpdb->db_connect();
+		ini_set( 'display_errors', 1 ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Disallowed
+
+		$class = get_called_class();
+
+		if ( method_exists( $class, 'wpSetUpBeforeClass' ) ) {
+			call_user_func( array( $class, 'wpSetUpBeforeClass' ), static::factory() );
+		}
+
+		self::commit_transaction();
+	}
+
+	/**
+	 * Rewrites `WP_UnitTestCase::set_up()` using `static` keyword.
+	 * If no polfill required, call `WP_UnitTestCase::set_up()` as usual.
+	 */
+	public function set_up() {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '6.5-alpha', '>=' ) ) {
+			return parent::set_up();
+		}
+
+		set_time_limit( 0 );
+
+		$this->factory = static::factory();
+
+		if ( ! self::$ignore_files ) {
+			self::$ignore_files = $this->scan_user_uploads();
+		}
+
+		if ( ! self::$hooks_saved ) {
+			$this->_backup_hooks();
+		}
+
+		global $wp_rewrite;
+
+		$this->clean_up_global_scope();
+
+		/*
+		 * When running core tests, ensure that post types and taxonomies
+		 * are reset for each test. We skip this step for non-core tests,
+		 * given the large number of plugins that register post types and
+		 * taxonomies at 'init'.
+		 */
+		if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+			$this->reset_post_types();
+			$this->reset_taxonomies();
+			$this->reset_post_statuses();
+			$this->reset__SERVER();
+
+			if ( $wp_rewrite->permalink_structure ) {
+				$this->set_permalink_structure( '' );
+			}
+		}
+
+		$this->start_transaction();
+		$this->expectDeprecated();
+		add_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
+	}
+}

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -88,8 +88,8 @@ trait PLL_UnitTestCase_Trait {
 		self::filter_doing_it_wrong_trigger_error();
 
 		/*
-		 * Even though `$factory` should always be an instance of `PLL_UnitTest_Factory`,
-		 * it allows us to safely type hint `self::pllSetUpBeforeClass()`.
+		 * Ensure `$factory` is an instance of `PLL_UnitTest_Factory` otherwise testcases directly
+		 * extending WordPress ones intead of our `WP_UnitTestCase_Polyfill` would get a fatal error.
 		 */
 		if ( $factory instanceof PLL_UnitTest_Factory ) {
 			static::pllSetUpBeforeClass( $factory );
@@ -180,6 +180,7 @@ trait PLL_UnitTestCase_Trait {
 	 * @return void
 	 */
 	public static function delete_all_languages() {
+		self::$model->options['default_lang'] = ''; // Force a dummy value to avoid warnings.
 		$languages = self::$model->get_languages_list();
 
 		if ( ! is_array( $languages ) ) {

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -82,7 +82,7 @@ trait PLL_UnitTestCase_Trait {
 		 * it allows us to safely type hint `self::pllSetUpBeforeClass()`.
 		 */
 		if ( $factory instanceof PLL_UnitTest_Factory ) {
-			self::pllSetUpBeforeClass( $factory );
+			static::pllSetUpBeforeClass( $factory );
 		}
 	}
 

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -3,7 +3,7 @@
 /**
  * A test case class for Polylang standard tests
  */
-abstract class PLL_UnitTestCase extends WP_UnitTestCase {
+abstract class PLL_UnitTestCase extends WP_UnitTestCase_Polyfill {
 	use PLL_UnitTestCase_Trait;
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -9,9 +9,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
 		parent::pllSetUpBeforeClass( $factory );
 
-		$factory->language->create( array( 'locale' => 'en_US' ) );
-		$factory->language->create( array( 'locale' => 'fr_FR' ) );
-		self::$model->options['default_lang'] = 'en'; // Otherwise static model isn't aware of the created languages...
+		$factory->language->create_many( 2 );
 	}
 
 	public function set_up() {
@@ -170,7 +168,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		register_taxonomy( 'test-tax', 'post' ); // Not translatable by default.
 
 		// Filter the language to try to reproduce an error.
-		$fr_lang = self::$model->get_language( 'fr' );
+		$fr_lang = $this->pll_admin->model->get_language( 'fr' );
 		add_filter(
 			'pll_inserted_term_language',
 			function ( $found_language ) use ( $fr_lang ) {

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -8,8 +8,9 @@ class Slugs_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+		self::factory()->language->create( array( 'locale' => 'en_US' ) );
+		self::factory()->language->create( array( 'locale' => 'fr_FR' ) );
+		self::$model->options['default_lang'] = 'en'; // Otherwise static model isn't aware of the created languages...
 	}
 
 	public function set_up() {
@@ -25,28 +26,49 @@ class Slugs_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_term_slugs() {
-		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $term_id, 'en' );
+		$term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'lang'     => 'en',
+			)
+		);
 
 		$_POST['term_lang_choice'] = 'fr';
-		$term_id                   = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $term_id, 'fr' );
+		$term_id                   = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'lang'     => 'fr',
+			)
+		);
 
 		$term = get_term( $term_id, 'category' );
 		$this->assertSame( 'test-fr', $term->slug );
 	}
 
 	public function test_translated_terms_with_parents_sharing_same_name() {
-		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+		$en_parent = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'lang'     => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
 		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
-		$this->pll_admin->model->term->set_language( $en, 'en' );
+		$en                        = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'parent'   => $en_parent->term_id,
+				'lang'     => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $en );
 		$this->assertSame( 'test-en', $en->slug );
@@ -55,53 +77,92 @@ class Slugs_Test extends PLL_UnitTestCase {
 		unset( $_POST );
 
 		$_POST['term_lang_choice'] = 'fr';
-		$fr_parent                 = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $fr_parent->term_id, 'fr' );
+		$fr_parent                 = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'lang'     => 'fr',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $fr_parent );
 		$this->assertSame( 'test-fr', $fr_parent->slug );
 
 		$_POST['parent'] = $fr_parent->term_id;
-		$fr              = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $fr_parent->term_id ) );
-		$this->pll_admin->model->term->set_language( $fr->term_id, 'fr' );
+		$fr              = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'parent'   => $fr_parent->term_id,
+				'lang'     => 'fr',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $fr );
 		$this->assertSame( 'test-fr-test-fr', $fr->slug );
 	}
 
 	public function test_already_existing_term_slugs_with_parent() {
-		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+		$en_parent = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'lang'     => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
 		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
-		$this->pll_admin->model->term->set_language( $en, 'en' );
+		$en                        = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'parent'   => $en_parent->term_id,
+				'lang'     => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $en );
 		$this->assertSame( 'test-en', $en->slug );
 
 		// Let's create another child term with the same parent and the same name.
-		$en_new = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
-		$this->pll_admin->model->term->set_language( $en_new, 'en' );
+		$en_new = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'parent'   => $en_parent->term_id,
+				'lang'     => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Error::class, $en_new );
 	}
 
 	public function test_update_existing_term_slugs_with_parent() {
-		$en_parent = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test' ) );
-		$this->pll_admin->model->term->set_language( $en_parent->term_id, 'en' );
+		$en_parent = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'test',
+				'lang'     => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $en_parent );
 		$this->assertSame( 'test', $en_parent->slug );
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get( array( 'taxonomy' => 'category', 'name' => 'test', 'parent' => $en_parent->term_id ) );
-		$this->pll_admin->model->term->set_language( $en, 'en' );
+		$en                        = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'name' => 'test',
+				'parent' => $en_parent->term_id,
+				'lang' => 'en',
+			)
+		);
 
 		$this->assertInstanceOf( WP_Term::class, $en );
 		$this->assertSame( 'test-en', $en->slug );

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -3,13 +3,14 @@
 class Slugs_Test extends PLL_UnitTestCase {
 
 	/**
-	 * @param WP_UnitTest_Factory $factory
+	 * @param PLL_UnitTest_Factory $factory
+	 * @return void
 	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
 
-		self::factory()->language->create( array( 'locale' => 'en_US' ) );
-		self::factory()->language->create( array( 'locale' => 'fr_FR' ) );
+		$factory->language->create( array( 'locale' => 'en_US' ) );
+		$factory->language->create( array( 'locale' => 'fr_FR' ) );
 		self::$model->options['default_lang'] = 'en'; // Otherwise static model isn't aware of the created languages...
 	}
 

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -26,20 +26,18 @@ class Slugs_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_term_slugs() {
-		$term_id = self::factory()->term->create(
+		$term_id = self::factory()->category->create(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'lang'     => 'en',
+				'name' => 'test',
+				'lang' => 'en',
 			)
 		);
 
 		$_POST['term_lang_choice'] = 'fr';
-		$term_id                   = self::factory()->term->create(
+		$term_id                   = self::factory()->category->create(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'lang'     => 'fr',
+				'name' => 'test',
+				'lang' => 'fr',
 			)
 		);
 
@@ -48,11 +46,10 @@ class Slugs_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_translated_terms_with_parents_sharing_same_name() {
-		$en_parent = self::factory()->term->create_and_get(
+		$en_parent = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'lang'     => 'en',
+				'name' => 'test',
+				'lang' => 'en',
 			)
 		);
 
@@ -61,12 +58,11 @@ class Slugs_Test extends PLL_UnitTestCase {
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get(
+		$en                        = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'parent'   => $en_parent->term_id,
-				'lang'     => 'en',
+				'name'   => 'test',
+				'parent' => $en_parent->term_id,
+				'lang'   => 'en',
 			)
 		);
 
@@ -77,11 +73,10 @@ class Slugs_Test extends PLL_UnitTestCase {
 		unset( $_POST );
 
 		$_POST['term_lang_choice'] = 'fr';
-		$fr_parent                 = self::factory()->term->create_and_get(
+		$fr_parent                 = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'lang'     => 'fr',
+				'name' => 'test',
+				'lang' => 'fr',
 			)
 		);
 
@@ -89,12 +84,11 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'test-fr', $fr_parent->slug );
 
 		$_POST['parent'] = $fr_parent->term_id;
-		$fr              = self::factory()->term->create_and_get(
+		$fr              = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'parent'   => $fr_parent->term_id,
-				'lang'     => 'fr',
+				'name'   => 'test',
+				'parent' => $fr_parent->term_id,
+				'lang'   => 'fr',
 			)
 		);
 
@@ -103,11 +97,10 @@ class Slugs_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_already_existing_term_slugs_with_parent() {
-		$en_parent = self::factory()->term->create_and_get(
+		$en_parent = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'lang'     => 'en',
+				'name' => 'test',
+				'lang' => 'en',
 			)
 		);
 
@@ -116,12 +109,11 @@ class Slugs_Test extends PLL_UnitTestCase {
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get(
+		$en                        = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'parent'   => $en_parent->term_id,
-				'lang'     => 'en',
+				'name'   => 'test',
+				'parent' => $en_parent->term_id,
+				'lang'   => 'en',
 			)
 		);
 
@@ -129,12 +121,11 @@ class Slugs_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'test-en', $en->slug );
 
 		// Let's create another child term with the same parent and the same name.
-		$en_new = self::factory()->term->create_and_get(
+		$en_new = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'parent'   => $en_parent->term_id,
-				'lang'     => 'en',
+				'name'   => 'test',
+				'parent' => $en_parent->term_id,
+				'lang'   => 'en',
 			)
 		);
 
@@ -142,11 +133,10 @@ class Slugs_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_update_existing_term_slugs_with_parent() {
-		$en_parent = self::factory()->term->create_and_get(
+		$en_parent = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name'     => 'test',
-				'lang'     => 'en',
+				'name' => 'test',
+				'lang' => 'en',
 			)
 		);
 
@@ -155,12 +145,11 @@ class Slugs_Test extends PLL_UnitTestCase {
 
 		$_POST['term_lang_choice'] = 'en';
 		$_POST['parent']           = $en_parent->term_id;
-		$en                        = self::factory()->term->create_and_get(
+		$en                        = self::factory()->category->create_and_get(
 			array(
-				'taxonomy' => 'category',
-				'name' => 'test',
+				'name'   => 'test',
 				'parent' => $en_parent->term_id,
-				'lang' => 'en',
+				'lang'   => 'en',
 			)
 		);
 

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -34,12 +34,10 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 				'lang'         => 'fr',
 			),
 			array(
-				array(
-					'post_title'   => 'startseite',
-					'post_type'    => 'page',
-					'post_content' => 'de1<!--nextpage-->de2',
-					'lang'         => 'de',
-				),
+				'post_title'   => 'startseite',
+				'post_type'    => 'page',
+				'post_content' => 'de1<!--nextpage-->de2',
+				'lang'         => 'de',
 			)
 		);
 		self::$home_en = $home_pages['en'];

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -9,6 +9,10 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	protected static $posts_en;
 	protected static $posts_fr;
 
+	/**
+	 * @param PLL_UnitTest_Factory $factory
+	 * @return void
+	 */
 	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
 		parent::pllSetUpBeforeClass( $factory );
 

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -35,7 +35,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 					'post_type'    => 'page',
 					'post_content' => 'de1<!--nextpage-->de2',
 					'lang'         => 'de',
-				)
+				),
 			)
 		);
 		self::$home_en = $home_pages['en'];

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -9,56 +9,56 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	protected static $posts_en;
 	protected static $posts_fr;
 
-	/**
-	 * @param WP_UnitTest_Factory $factory
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
-		self::create_language( 'de_DE_formal' );
-		self::create_language( 'es_ES' );
+		$factory->language->create_many( 4 );
+		self::$model->options['default_lang'] = 'en'; // Otherwise static model isn't aware of the created languages...
 
 		// page on front
-		self::$home_en = $en = self::factory()->post->create(
+		$home_pages = $factory->post->create_translated(
 			array(
 				'post_title'   => 'home',
 				'post_type'    => 'page',
 				'post_content' => 'en1<!--nextpage-->en2',
-			)
-		);
-		self::$model->post->set_language( $en, 'en' );
-
-		self::$home_fr = $fr = self::factory()->post->create(
+				'lang'         => 'en',
+			),
 			array(
 				'post_title'   => 'accueil',
 				'post_type'    => 'page',
 				'post_content' => 'fr1<!--nextpage-->fr2',
-			)
-		);
-		self::$model->post->set_language( $fr, 'fr' );
-
-		self::$home_de = $de = self::factory()->post->create(
+				'lang'         => 'fr',
+			),
 			array(
-				'post_title'   => 'startseite',
-				'post_type'    => 'page',
-				'post_content' => 'de1<!--nextpage-->de2',
+				array(
+					'post_title'   => 'startseite',
+					'post_type'    => 'page',
+					'post_content' => 'de1<!--nextpage-->de2',
+					'lang'         => 'de',
+				)
 			)
 		);
-		self::$model->post->set_language( $de, 'de' );
-
-		self::$model->post->save_translations( $en, compact( 'en', 'fr', 'de' ) );
+		self::$home_en = $home_pages['en'];
+		self::$home_fr = $home_pages['fr'];
+		self::$home_de = $home_pages['de'];
 
 		// page for posts
 		// intentionally do not create one in German
-		self::$posts_en = $en = self::factory()->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
-		self::$model->post->set_language( $en, 'en' );
+		$posts = $factory->post->create_translated(
+			array(
+				'post_title' => 'posts',
+				'post_type'  => 'page',
+				'lang'       => 'en',
+			),
+			array(
+				'post_title' => 'articles',
+				'post_type'  => 'page',
+				'lang'       => 'fr',
+			)
+		);
+		self::$posts_en = $posts['en'];
+		self::$posts_fr = $posts['fr'];
 
-		self::$posts_fr = $fr = self::factory()->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
-		self::$model->post->set_language( $fr, 'fr' );
-
-		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
 		self::$model->clean_languages_cache();
 	}


### PR DESCRIPTION
## What?
Enhance our test suite with reusable factories for translated objects and languages.

## How?
- Create a factory for languages, usable before all test classes (also in tests).
- Create factories for posts and terms, usable everywhere in the test suite.
- https://github.com/WordPress/wordpress-develop/pull/5723 being merged, we still need a polyfill so WordPress to 6.4 can run smoothly.