### PR TITLE
Remove flag alternative text if name is already rendered in the language switcher.

### DIFF
--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -119,7 +119,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 				// parent item for dropdown
 				if ( ! empty( $options['dropdown'] ) ) {
 					$name = isset( $options['display_names_as'] ) && 'slug' === $options['display_names_as'] ? $this->curlang->slug : $this->curlang->name;
-					$item->title = $this->get_item_title( $this->curlang->get_display_flag(), $name, $options );
+					$item->title = $this->get_item_title( $this->curlang->get_display_flag( empty( $options['show_names'] ) ? 'alt' : 'no-alt' ), $name, $options );
 					$item->attr_title = '';
 					$item->classes = array( 'pll-parent-menu-item' );
 					$item->menu_order += $offset;

--- a/include/language.php
+++ b/include/language.php
@@ -483,7 +483,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 			return $flag;
 		}
 
-		return (string) preg_replace( '/(?<=alt=\")([^"]+)(?=\")/', '', $flag );
+		return (string) preg_replace( '/(?<=\salt=\")([^"]+)(?=\")/', '', $flag );
 	}
 
 	/**

--- a/include/language.php
+++ b/include/language.php
@@ -468,7 +468,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * Returns the html of the custom flag if any, or the default flag otherwise.
 	 *
 	 * @since 2.8
-	 * @since 3.5.3 Introduce `$alt` parameter.
+	 * @since 3.5.3 Added the `$alt` parameter.
 	 *
 	 * @param string $alt Whether or not the alternative text should be set. Accepts 'alt' and 'no-alt'.
 	 *

--- a/include/language.php
+++ b/include/language.php
@@ -468,11 +468,22 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * Returns the html of the custom flag if any, or the default flag otherwise.
 	 *
 	 * @since 2.8
+	 * @since 3.5.3 Introduce `$alt` parameter.
+	 *
+	 * @param string $alt Whether or not the alternative text should be set. Accepts 'alt' and 'no-alt'.
 	 *
 	 * @return string
+	 *
+	 * @phpstan-param 'alt'|'no-alt' $alt
 	 */
-	public function get_display_flag() {
-		return empty( $this->custom_flag ) ? $this->flag : $this->custom_flag;
+	public function get_display_flag( $alt = 'alt' ) {
+		$flag = empty( $this->custom_flag ) ? $this->flag : $this->custom_flag;
+
+		if ( 'alt' === $alt ) {
+			return $flag;
+		}
+
+		return (string) preg_replace( '/(?<=alt=\")([^"]+)(?=\")/', '', $flag );
 	}
 
 	/**

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -169,7 +169,8 @@ class PLL_Switcher {
 			$url = empty( $url ) || $args['force_home'] ? $this->links->get_home_url( $language ) : $url; // If the page is not translated, link to the home page
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
-			$flag = $args['raw'] && ! $args['show_flags'] ? $language->get_display_flag_url() : ( $args['show_flags'] ? $language->get_display_flag() : '' );
+
+			$flag = $this->get_flag( $args, $language );
 
 			if ( $first ) {
 				$classes[] = 'lang-item-first';
@@ -282,5 +283,24 @@ class PLL_Switcher {
 			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput
 		}
 		return $out;
+	}
+
+	private function get_flag( $args, $language ) {
+		if ( $args['raw'] && ! $args['show_flags'] ) {
+			return $language->get_display_flag_url();
+		}
+
+		if ( $args['show_flags'] ) {
+			$flag = $language->get_display_flag();
+
+			// Strip alternative text out when language name is already displayed.
+			if ( $args['show_names'] ) {
+				$flag = preg_replace( '/alt=\"[^"]+\"/', '', $flag );
+			}
+
+			return $flag;
+		}
+
+		return '';
 	}
 }

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -239,7 +239,6 @@ class PLL_Switcher {
 
 		// Prevents showing empty options in `<select>`.
 		if ( $args['dropdown'] && ! $args['raw'] ) {
-			$args['show_flags'] = 0;
 			$args['show_names'] = 1;
 		}
 

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -299,17 +299,17 @@ class PLL_Switcher {
 			return $language->get_display_flag_url();
 		}
 
-		if ( $args['show_flags'] ) {
-			$flag = $language->get_display_flag();
-
-			// Strip alternative text out when language name is already displayed.
-			if ( $args['show_names'] ) {
-				$flag = preg_replace( '/alt=\"[^"]+\"/', '', $flag );
-			}
-
-			return is_string( $flag ) ? $flag : '';
+		if ( ! $args['show_flags'] ) {
+			return '';
 		}
 
-		return '';
+		$flag = $language->get_display_flag();
+
+		// Strip alternative text out when language name is already displayed.
+		if ( $args['show_names'] ) {
+			$flag = (string) preg_replace( '/alt=\"[^"]+\"/', '', $flag );
+		}
+
+		return $flag;
 	}
 }

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -285,6 +285,15 @@ class PLL_Switcher {
 		return $out;
 	}
 
+	/**
+	 * Returns flag for the switcher.
+	 *
+	 * @since 3.5.3
+	 *
+	 * @param array        $args     Switcher arguments. @see {self::the_languages} for possible values.
+	 * @param PLL_Language $language Language object to get flag from.
+	 * @return string Either a link, HTML or empty string.
+	 */
 	private function get_flag( $args, $language ) {
 		if ( $args['raw'] && ! $args['show_flags'] ) {
 			return $language->get_display_flag_url();
@@ -298,7 +307,7 @@ class PLL_Switcher {
 				$flag = preg_replace( '/alt=\"[^"]+\"/', '', $flag );
 			}
 
-			return $flag;
+			return is_string( $flag ) ? $flag : '';
 		}
 
 		return '';

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -170,12 +170,12 @@ class PLL_Switcher {
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
 
-			$flag = '';
-
 			if ( $args['raw'] && ! $args['show_flags'] ) {
 				$flag = $language->get_display_flag_url();
 			} elseif ( $args['show_flags'] ) {
 				$flag = $language->get_display_flag( empty( $args['show_names'] ) ? 'alt' : 'no-alt' );
+			} else {
+				$flag = '';
 			}
 
 			if ( $first ) {

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -170,7 +170,13 @@ class PLL_Switcher {
 
 			$name = $args['show_names'] || ! $args['show_flags'] || $args['raw'] ? ( 'slug' == $args['display_names_as'] ? $slug : $language->name ) : '';
 
-			$flag = $this->get_flag( $args, $language );
+			$flag = '';
+
+			if ( $args['raw'] && ! $args['show_flags'] ) {
+				$flag = $language->get_display_flag_url();
+			} elseif ( $args['show_flags'] ) {
+				$flag = $language->get_display_flag( empty( $args['show_names'] ) ? 'alt' : 'no-alt' );
+			}
 
 			if ( $first ) {
 				$classes[] = 'lang-item-first';
@@ -283,33 +289,5 @@ class PLL_Switcher {
 			echo $out; // phpcs:ignore WordPress.Security.EscapeOutput
 		}
 		return $out;
-	}
-
-	/**
-	 * Returns flag for the switcher.
-	 *
-	 * @since 3.5.3
-	 *
-	 * @param array        $args     Switcher arguments. @see {self::the_languages} for possible values.
-	 * @param PLL_Language $language Language object to get flag from.
-	 * @return string Either a link, HTML or empty string.
-	 */
-	private function get_flag( $args, $language ) {
-		if ( $args['raw'] && ! $args['show_flags'] ) {
-			return $language->get_display_flag_url();
-		}
-
-		if ( ! $args['show_flags'] ) {
-			return '';
-		}
-
-		$flag = $language->get_display_flag();
-
-		// Strip alternative text out when language name is already displayed.
-		if ( $args['show_names'] ) {
-			$flag = (string) preg_replace( '/alt=\"[^"]+\"/', '', $flag );
-		}
-
-		return $flag;
 	}
 }

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -237,8 +237,9 @@ class PLL_Switcher {
 			$args['hide_if_no_translation'] = 0;
 		}
 
-		// Prevents showing empty options in dropdown
-		if ( $args['dropdown'] ) {
+		// Prevents showing empty options in `<select>`.
+		if ( $args['dropdown'] && ! $args['raw'] ) {
+			$args['show_flags'] = 0;
 			$args['show_names'] = 1;
 		}
 

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -228,7 +228,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 	 * @ticket #1890
 	 * @see https://github.com/polylang/polylang-pro/issues/1890.
 	 */
-	public function test_flags_a11y_without_named_displayed() {
+	public function test_flags_a11y_without_names_displayed() {
 		$args = array(
 			'show_flags'    => 1,
 			'show_names'    => 0, // Don't display names.

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -223,4 +223,64 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$a = $xpath->query( '//li/a[@lang="fr-FR"]' );
 		$this->assertEquals( $this->pll_admin->links->get_home_url( self::$model->get_language( 'fr' ) ), $a->item( 0 )->getAttribute( 'href' ) );
 	}
+
+	/**
+	 * @ticket #1890
+	 * @see https://github.com/polylang/polylang-pro/issues/1890.
+	 */
+	public function test_flags_a11y_without_named_displayed() {
+		$args = array(
+			'show_flags'    => 1,
+			'show_names'    => 0, // Don't display names.
+			'echo'          => 0,
+			'hide_if_empty' => 0,
+		);
+		$this->frontend->links->curlang = self::$model->get_language( 'en' );
+		$switcher = $this->switcher->the_languages( $this->frontend->links, $args );
+
+		$this->assertNotEmpty( $switcher );
+
+		$doc  = new DomDocument();
+		$html = '<?xml encoding="UTF-8">' . $switcher; // Ensure encoding is correct.
+		$doc->loadHTML( $html );
+		$xpath = new DOMXpath( $doc );
+
+		$a = $xpath->query( '//li/a[@lang="en-US"]' );
+		$this->assertSame( 1, $a->length, 'There should be only one child node.' );
+		$this->assertSame( 'English', $a->item( 0 )->childNodes->item( 0 )->getAttribute( 'alt' ), 'Alternative text value should be "English".' );
+
+		$a = $xpath->query( '//li/a[@lang="fr-FR"]' );
+		$this->assertSame( 1, $a->length, 'There should be only one child node.' );
+		$this->assertSame( 'Français', $a->item( 0 )->childNodes->item( 0 )->getAttribute( 'alt' ), 'Alternative text value should be "Français".' );
+	}
+
+	/**
+	 * @ticket #1890
+	 * @see https://github.com/polylang/polylang-pro/issues/1890.
+	 */
+	public function test_flags_a11y_with_names_displayed() {
+		$args = array(
+			'show_flags'    => 1,
+			'show_names'    => 1, // Display names.
+			'echo'          => 0,
+			'hide_if_empty' => 0,
+		);
+		$this->frontend->links->curlang = self::$model->get_language( 'en' );
+		$switcher = $this->switcher->the_languages( $this->frontend->links, $args );
+
+		$this->assertNotEmpty( $switcher );
+
+		$doc  = new DomDocument();
+		$html = '<?xml encoding="UTF-8">' . $switcher; // Ensure encoding is correct.
+		$doc->loadHTML( $html );
+		$xpath = new DOMXpath( $doc );
+
+		$a = $xpath->query( '//li/a[@lang="en-US"]' );
+		$this->assertSame( 1, $a->length, 'There should be only one child node.' );
+		$this->assertEmpty( $a->item( 0 )->childNodes->item( 0 )->getAttribute( 'alt' ), 'There should be no alternative texts.' );
+
+		$a = $xpath->query( '//li/a[@lang="fr-FR"]' );
+		$this->assertSame( 1, $a->length, 'There should be only one child node.' );
+		$this->assertEmpty( $a->item( 0 )->childNodes->item( 0 )->getAttribute( 'alt' ), 'There should be no alternative texts.' );
+	}
 }


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/1890

## How?
- Conditionally render alternative text image attribute of the flag regarding arguments passed to the switcher (i.e. `show_names`).
- Add tests for both cases (with and without alt text).