### PR TITLE
Fix translations not loaded when the language is set from the content

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -51,7 +51,7 @@ class Polylang {
 		// Override load text domain waiting for the language to be defined
 		// Here for plugins which load text domain as soon as loaded :(
 		if ( ! defined( 'PLL_OLT' ) || PLL_OLT ) {
-			PLL_OLT_Manager::instance();
+			new PLL_OLT_Manager();
 		}
 
 		/*

--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -51,7 +51,7 @@ class Polylang {
 		// Override load text domain waiting for the language to be defined
 		// Here for plugins which load text domain as soon as loaded :(
 		if ( ! defined( 'PLL_OLT' ) || PLL_OLT ) {
-			new PLL_OLT_Manager();
+			PLL_OLT_Manager::instance();
 		}
 
 		/*

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -36,7 +36,7 @@ class PLL_OLT_Manager {
 		}
 
 		// Filters for text domain management.
-		add_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ) );
+		add_filter( 'load_textdomain_mofile', array( $this, 'bypass_load_textdomain_mofile' ) );
 
 		// Loads text domains.
 		add_action( 'pll_language_defined', array( $this, 'load_textdomains' ), 2 ); // After PLL_Frontend::pll_language_defined.
@@ -88,10 +88,11 @@ class PLL_OLT_Manager {
 	 * Prevents WP loading textdomains before we set the locale ourselves.
 	 *
 	 * @since 2.0.4
+	 * @since 3.6 Renamed from `load_textdomain_mofile()`.
 	 *
 	 * @return string
 	 */
-	public function load_textdomain_mofile() {
+	public function bypass_load_textdomain_mofile() {
 		return '';
 	}
 

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -11,15 +11,9 @@
  * or in a `wp` action (when the language is set from content on frontend).
  *
  * @since 1.2
+ * @since 3.6 Singleton removed, instantiate at your own risk!
  */
 class PLL_OLT_Manager {
-	/**
-	 * Singleton instance
-	 *
-	 * @var PLL_OLT_Manager|null
-	 */
-	protected static $instance;
-
 	/**
 	 * Constructor: setups relevant filters.
 	 *
@@ -41,21 +35,6 @@ class PLL_OLT_Manager {
 		// Loads text domains.
 		add_action( 'pll_language_defined', array( $this, 'load_textdomains' ), 2 ); // After PLL_Frontend::pll_language_defined.
 		add_action( 'pll_no_language_defined', array( $this, 'load_textdomains' ) );
-	}
-
-	/**
-	 * Access to the single instance of the class.
-	 *
-	 * @since 1.7
-	 *
-	 * @return PLL_OLT_Manager
-	 */
-	public static function instance() {
-		if ( empty( self::$instance ) ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
 	}
 
 	/**

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -11,7 +11,6 @@
  * or in a `wp` action (when the language is set from content on frontend).
  *
  * @since 1.2
- * @since 3.6 Singleton removed, instantiate at your own risk!
  */
 class PLL_OLT_Manager {
 	/**
@@ -37,7 +36,7 @@ class PLL_OLT_Manager {
 		}
 
 		// Filters for text domain management.
-		add_filter( 'load_textdomain_mofile', array( $this, 'bypass_load_textdomain_mofile' ) );
+		add_filter( 'load_textdomain_mofile', '__return_empty_string' );
 
 		// Loads text domains.
 		add_action( 'pll_language_defined', array( $this, 'load_textdomains' ), 2 ); // After PLL_Frontend::pll_language_defined.
@@ -67,8 +66,8 @@ class PLL_OLT_Manager {
 	 * @return void
 	 */
 	public function load_textdomains() {
-		// Our load_textdomain_mofile filter has done its job. let's remove it before calling load_textdomain.
-		remove_filter( 'load_textdomain_mofile', array( $this, 'bypass_load_textdomain_mofile' ) );
+		// Our load_textdomain_mofile filter has done its job. let's remove it to enable translation.
+		remove_filter( 'load_textdomain_mofile', '__return_empty_string' );
 
 		$GLOBALS['l10n'] = array();
 		$new_locale      = get_locale();
@@ -82,9 +81,10 @@ class PLL_OLT_Manager {
 			$GLOBALS['wp_locale'] = new WP_Locale();
 		}
 
+		/** This action is documented in wp-includes/class-wp-locale-switcher.php */
 		do_action( 'change_locale', $new_locale );
 
-		do_action_deprecated( 'pll_translate_labels', array(), '3.6', 'change_locale' );
+		do_action_deprecated( 'pll_translate_labels', array(), '3.7', 'change_locale' );
 	}
 
 	/**

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -38,6 +38,21 @@ class PLL_OLT_Manager {
 	}
 
 	/**
+	 * Access to the single instance of the class
+	 *
+	 * @since 1.7
+	 *
+	 * @return PLL_OLT_Manager
+	 */
+	public static function instance() {
+		if ( empty( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
 	 * Loads textdomains.
 	 *
 	 * @since 0.1

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -15,6 +15,13 @@
  */
 class PLL_OLT_Manager {
 	/**
+	 * Singleton instance
+	 *
+	 * @var PLL_OLT_Manager|null
+	 */
+	protected static $instance;
+
+	/**
 	 * Constructor: setups relevant filters.
 	 *
 	 * @since 1.2

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -21,27 +21,6 @@ class PLL_OLT_Manager {
 	protected static $instance;
 
 	/**
-	 * Stores the default site locale before it is modified.
-	 *
-	 * @var string|null
-	 */
-	protected $default_locale;
-
-	/**
-	 * Stores all loaded text domains and mo files.
-	 *
-	 * @var string[][]
-	 */
-	protected $list_textdomains = array();
-
-	/**
-	 * Stores post types an taxonomies labels to translate.
-	 *
-	 * @var string[][]
-	 */
-	public $labels = array();
-
-	/**
 	 * Constructor: setups relevant filters.
 	 *
 	 * @since 1.2

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -82,6 +82,8 @@ class PLL_OLT_Manager {
 		}
 
 		do_action( 'change_locale', $new_locale );
+
+		do_action_deprecated( 'pll_translate_labels', array(), '3.6', 'change_locale' );
 	}
 
 	/**

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -4,11 +4,11 @@
  */
 
 /**
- * It is best practice that plugins do nothing before plugins_loaded is fired
- * so it is what Polylang intends to do
- * but some plugins load their text domain as soon as loaded, thus before plugins_loaded is fired
- * this class differs text domain loading until the language is defined
- * either in a plugins_loaded action or in a wp action ( when the language is set from content on frontend )
+ * It is best practice that plugins do nothing before `plugins_loaded` is fired.
+ * So it is what Polylang intends to do.
+ * But some plugins load their textdomain as soon as loaded, thus before `plugins_loaded` is fired.
+ * This class defers textdomain loading until the language is defined either in a `plugins_loaded` action
+ * or in a `wp` action (when the language is set from content on frontend).
  *
  * @since 1.2
  */
@@ -42,7 +42,7 @@ class PLL_OLT_Manager {
 	public $labels = array();
 
 	/**
-	 * Constructor: setups relevant filters
+	 * Constructor: setups relevant filters.
 	 *
 	 * @since 1.2
 	 */
@@ -56,21 +56,16 @@ class PLL_OLT_Manager {
 			return;
 		}
 
-		// Saves the default locale before we start any language manipulation
-		$this->default_locale = get_locale();
+		// Filters for text domain management.
+		add_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ) );
 
-		// Filters for text domain management
-		add_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ), 10, 2 );
-		add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
-		add_filter( 'gettext_with_context', array( $this, 'gettext_with_context' ), 10, 4 );
-
-		// Loads text domains
-		add_action( 'pll_language_defined', array( $this, 'load_textdomains' ), 2 ); // After PLL_Frontend::pll_language_defined
+		// Loads text domains.
+		add_action( 'pll_language_defined', array( $this, 'load_textdomains' ), 2 ); // After PLL_Frontend::pll_language_defined.
 		add_action( 'pll_no_language_defined', array( $this, 'load_textdomains' ) );
 	}
 
 	/**
-	 * Access to the single instance of the class
+	 * Access to the single instance of the class.
 	 *
 	 * @since 1.7
 	 *
@@ -85,155 +80,40 @@ class PLL_OLT_Manager {
 	}
 
 	/**
-	 * Loads text domains
+	 * Loads textdomains.
 	 *
 	 * @since 0.1
 	 *
 	 * @return void
 	 */
 	public function load_textdomains() {
-		// Our load_textdomain_mofile filter has done its job. let's remove it before calling load_textdomain
+		// Our load_textdomain_mofile filter has done its job. let's remove it before calling load_textdomain.
 		remove_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ) );
-		remove_filter( 'gettext', array( $this, 'gettext' ) );
-		remove_filter( 'gettext_with_context', array( $this, 'gettext_with_context' ) );
-		$new_locale = get_locale();
 
-		// Don't try to save time for en_US as some users have theme written in another language
-		// Now we can load all overridden text domains with the right language
-		if ( ! empty( $this->list_textdomains ) ) {
-			foreach ( $this->list_textdomains as $textdomain ) {
-				// Since WP 4.6, plugins translations are first loaded from wp-content/languages
-				if ( ! load_textdomain( $textdomain['domain'], str_replace( "{$this->default_locale}.mo", "$new_locale.mo", $textdomain['mo'] ) ) ) {
-					// Since WP 3.5 themes may store languages files in /wp-content/languages/themes
-					if ( ! load_textdomain( $textdomain['domain'], WP_LANG_DIR . "/themes/{$textdomain['domain']}-$new_locale.mo" ) ) {
-						// Since WP 3.7 plugins may store languages files in /wp-content/languages/plugins
-						load_textdomain( $textdomain['domain'], WP_LANG_DIR . "/plugins/{$textdomain['domain']}-$new_locale.mo" );
-					}
-				}
-			}
-		}
+		$GLOBALS['l10n'] = array();
+		$new_locale      = get_locale();
 
-		// First remove taxonomies and post_types labels that we don't need to translate
-		$taxonomies = get_taxonomies( array( '_pll' => true ) );
-		$post_types = get_post_types( array( '_pll' => true ) );
+		load_default_textdomain( $new_locale );
 
-		// We don't need to translate core taxonomies and post types labels when setting the language from the url
-		// As they will be translated when registered the second time
-		if ( ! did_action( 'setup_theme' ) ) {
-			$taxonomies = array_merge( get_taxonomies( array( '_builtin' => true ) ), $taxonomies );
-			$post_types = array_merge( get_post_types( array( '_builtin' => true ) ), $post_types );
-		}
-
-		// Translate labels of post types and taxonomies
-		foreach ( array_diff_key( $GLOBALS['wp_taxonomies'], array_flip( $taxonomies ) ) as $tax ) {
-			$this->translate_labels( $tax );
-		}
-		foreach ( array_diff_key( $GLOBALS['wp_post_types'], array_flip( $post_types ) ) as $pt ) {
-			$this->translate_labels( $pt );
-		}
-
-		// Act only if the language has not been set early ( before default textdomain loading and $wp_locale creation )
+		// Act only if the language has not been set early (before default textdomain loading and $wp_locale creation).
 		if ( did_action( 'after_setup_theme' ) ) {
-			// Reinitializes wp_locale for weekdays and months
+			// Reinitializes wp_locale for weekdays and months.
 			unset( $GLOBALS['wp_locale'] );
 			$GLOBALS['wp_locale'] = new WP_Locale();
 		}
 
-		/**
-		 * Fires after the post types and taxonomies labels have been translated
-		 * This allows plugins to translate text the same way we do for post types and taxonomies labels
-		 *
-		 * @since 1.2
-		 *
-		 * @param array $labels list of strings to trnaslate
-		 */
-		do_action_ref_array( 'pll_translate_labels', array( &$this->labels ) );
-
-		// Free memory.
-		$this->default_locale   = null;
-		$this->list_textdomains = array();
-		$this->labels           = array();
+		do_action( 'change_locale', $new_locale );
 	}
 
 	/**
-	 * Saves all text domains in a table for later usage.
-	 * It replaces the 'override_load_textdomain' filter previously used.
+	 * Prevents WP loading textdomains before we set the locale ourselves.
 	 *
 	 * @since 2.0.4
 	 *
-	 * @param string $mofile The translation file name.
-	 * @param string $domain The text domain name.
 	 * @return string
 	 */
-	public function load_textdomain_mofile( $mofile, $domain ) {
-		// On multisite, 2 files are sharing the same domain so we need to distinguish them.
-		if ( 'default' === $domain && false !== strpos( $mofile, '/ms-' ) ) {
-			$this->list_textdomains['ms-default'] = array( 'mo' => $mofile, 'domain' => $domain );
-		} else {
-			$this->list_textdomains[ $domain ] = array( 'mo' => $mofile, 'domain' => $domain );
-		}
-		return ''; // Hack to prevent WP loading text domains as we will load them all later.
-	}
-
-	/**
-	 * Saves post types and taxonomies labels for a later usage
-	 *
-	 * @since 0.9
-	 *
-	 * @param string $translation not used
-	 * @param string $text        string to translate
-	 * @param string $domain      text domain
-	 * @return string unmodified $translation
-	 */
-	public function gettext( $translation, $text, $domain ) {
-		if ( is_string( $text ) ) { // Avoid a warning with some buggy plugins which pass an array
-			$this->labels[ $text ] = array( 'domain' => $domain );
-		}
-		return $translation;
-	}
-
-	/**
-	 * Saves post types and taxonomies labels for a later usage
-	 *
-	 * @since 0.9
-	 *
-	 * @param string $translation not used
-	 * @param string $text        string to translate
-	 * @param string $context     some comment to describe the context of string to translate
-	 * @param string $domain      text domain
-	 * @return string unmodified $translation
-	 */
-	public function gettext_with_context( $translation, $text, $context, $domain ) {
-		$this->labels[ $text ] = array( 'domain' => $domain, 'context' => $context );
-		return $translation;
-	}
-
-	/**
-	 * Translates post types and taxonomies labels once the language is known.
-	 *
-	 * @since 0.9
-	 *
-	 * @param WP_Post_Type|WP_Taxonomy $type Either a post type or a taxonomy.
-	 * @return void
-	 */
-	public function translate_labels( $type ) {
-		// Use static array to avoid translating several times the same ( default ) labels
-		static $translated = array();
-
-		foreach ( (array) $type->labels as $key => $label ) {
-			if ( is_string( $label ) && isset( $this->labels[ $label ] ) ) {
-				if ( empty( $translated[ $label ] ) ) {
-					// PHPCS:disable WordPress.WP.I18n
-					$type->labels->$key = $translated[ $label ] = isset( $this->labels[ $label ]['context'] ) ?
-						_x( $label, $this->labels[ $label ]['context'], $this->labels[ $label ]['domain'] ) :
-						__( $label, $this->labels[ $label ]['domain'] );
-					// PHPCS:enable
-				}
-				else {
-					$type->labels->$key = $translated[ $label ];
-				}
-			}
-		}
+	public function load_textdomain_mofile() {
+		return '';
 	}
 
 	/**

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -67,7 +67,7 @@ class PLL_OLT_Manager {
 	 */
 	public function load_textdomains() {
 		// Our load_textdomain_mofile filter has done its job. let's remove it before calling load_textdomain.
-		remove_filter( 'load_textdomain_mofile', array( $this, 'load_textdomain_mofile' ) );
+		remove_filter( 'load_textdomain_mofile', array( $this, 'bypass_load_textdomain_mofile' ) );
 
 		$GLOBALS['l10n'] = array();
 		$new_locale      = get_locale();

--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -88,18 +88,6 @@ class PLL_OLT_Manager {
 	}
 
 	/**
-	 * Prevents WP loading textdomains before we set the locale ourselves.
-	 *
-	 * @since 2.0.4
-	 * @since 3.6 Renamed from `load_textdomain_mofile()`.
-	 *
-	 * @return string
-	 */
-	public function bypass_load_textdomain_mofile() {
-		return '';
-	}
-
-	/**
 	 * Allows Polylang to be the first plugin loaded ;-).
 	 *
 	 * @since 1.2

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -68,6 +68,6 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 
 		$this->assertNotEmpty( $locale );
 		$this->assertSame( 'fr_FR', $locale );
-		$this->assertSame( 'Tableau de bord', __( 'Dashboard', 'foo' ) );
+		$this->assertSame( 'Tableau de bord', __( 'Dashboard', 'foo' ) ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 	}
 }

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -1,6 +1,9 @@
 <?php
 
 class OLT_Manager_Test extends PLL_UnitTestCase {
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		$factory->language->create_many( 2 );
+	}
 
 	public function test_polylang_first() {
 		$plugins = array(
@@ -20,5 +23,30 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 
 		delete_option( 'active_plugins' );
 		delete_option( 'active_sitewide_plugins' );
+	}
+
+	public function test_load_textdomains() {
+		update_option( 'WPLANG', '' );
+
+		new PLL_OLT_Manager();
+
+		load_textdomain( 'foo', PLL_TEST_DATA_DIR . 'fr_FR.mo' );
+
+		$options                 = PLL_Install::get_default_options();
+		$options['force_lang']   = 0;
+		$options['default_lang'] = 'en';
+		$model                   = new PLL_Model( $options );
+		$links_model             = $model->get_links_model();
+		$frontend                = new PLL_Frontend( $links_model );
+		$fr                      = $frontend->model->get_language( 'fr' );
+		$frontend->curlang       = $fr;
+
+		do_action( 'pll_language_defined', 'fr', $fr );
+
+		$locale = get_locale();
+
+		$this->assertNotEmpty( $locale );
+		$this->assertSame( 'fr_FR', $locale );
+		$this->assertSame( 'Tableau de bord', __( 'Dashboard', 'foo' ) );
 	}
 }

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -40,7 +40,7 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 
 		$wp_textdomain_registry = new WP_Textdomain_Registry();
 
-		update_option( 'WPLANG', '' );
+		update_option( 'WPLANG', 'de_DE' );
 
 		// Copy language file.
 		@mkdir( DIR_TESTDATA );
@@ -59,7 +59,7 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 		/*
 		 *  Calls `_load_textdomain_just_in_time()` *before* the current language is defined!
 		 */
-		__( 'Dashboard', 'foo' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+		$this->assertSame( 'Dashboard', __( 'Dashboard', 'foo' ) ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 
 		$frontend->curlang = $frontend->model->get_language( 'fr' );
 

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -56,9 +56,7 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 		$links_model             = $model->get_links_model();
 		$frontend                = new PLL_Frontend( $links_model );
 
-		$is_loaded = load_plugin_textdomain( 'foo' );
-
-		$this->assertFalse( $is_loaded, 'textdomain should be bypassed by PLL_OLT_Manager.' );
+		__( 'Dashboard', 'foo' ); // Calls `_load_textdomain_just_in_time()` *before* the current language is defined!
 
 		$frontend->curlang = $frontend->model->get_language( 'fr' );
 
@@ -68,6 +66,6 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 
 		$this->assertNotEmpty( $locale );
 		$this->assertSame( 'fr_FR', $locale );
-		$this->assertSame( 'Tableau de bord', __( 'Dashboard', 'foo' ) ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+		$this->assertSame( 'Tableau de bord', __( 'Dashboard', 'foo' ), 'fr_FR locale for foo domain should be loaded correctly.' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 	}
 }

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -5,6 +5,12 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 		$factory->language->create_many( 2 );
 	}
 
+	public static function wpTearDownAfterClass() {
+		parent::wpTearDownAfterClass();
+
+		unlink( WP_LANG_DIR . '/plugins/foo-fr_FR.mo' );
+	}
+
 	public function test_polylang_first() {
 		$plugins = array(
 			'jetpack/jetpack.php',
@@ -26,22 +32,37 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_load_textdomains() {
+		// Clean up!
+		unset( $GLOBALS['wp_themes'], $GLOBALS['l10n'], $GLOBALS['l10n_unloaded'] );
+
+		/** @var WP_Textdomain_Registry $wp_textdomain_registry */
+		global $wp_textdomain_registry;
+
+		$wp_textdomain_registry = new WP_Textdomain_Registry();
+
 		update_option( 'WPLANG', '' );
 
+		// Copy language file.
+		@mkdir( DIR_TESTDATA );
+		@mkdir( WP_LANG_DIR );
+		@mkdir( WP_LANG_DIR . '/plugins' );
+		copy( PLL_TEST_DATA_DIR . 'fr_FR.mo', WP_LANG_DIR . '/plugins/foo-fr_FR.mo' );
+
 		new PLL_OLT_Manager();
-
-		load_textdomain( 'foo', PLL_TEST_DATA_DIR . 'fr_FR.mo' );
-
 		$options                 = PLL_Install::get_default_options();
 		$options['force_lang']   = 0;
 		$options['default_lang'] = 'en';
 		$model                   = new PLL_Model( $options );
 		$links_model             = $model->get_links_model();
 		$frontend                = new PLL_Frontend( $links_model );
-		$fr                      = $frontend->model->get_language( 'fr' );
-		$frontend->curlang       = $fr;
 
-		do_action( 'pll_language_defined', 'fr', $fr );
+		$is_loaded = load_plugin_textdomain( 'foo' );
+
+		$this->assertFalse( $is_loaded, 'textdomain should be bypassed by PLL_OLT_Manager.' );
+
+		$frontend->curlang = $frontend->model->get_language( 'fr' );
+
+		do_action( 'pll_language_defined', 'fr', $frontend->curlang );
 
 		$locale = get_locale();
 

--- a/tests/phpunit/tests/test-olt-manager.php
+++ b/tests/phpunit/tests/test-olt-manager.php
@@ -56,7 +56,10 @@ class OLT_Manager_Test extends PLL_UnitTestCase {
 		$links_model             = $model->get_links_model();
 		$frontend                = new PLL_Frontend( $links_model );
 
-		__( 'Dashboard', 'foo' ); // Calls `_load_textdomain_just_in_time()` *before* the current language is defined!
+		/*
+		 *  Calls `_load_textdomain_just_in_time()` *before* the current language is defined!
+		 */
+		__( 'Dashboard', 'foo' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 
 		$frontend->curlang = $frontend->model->get_language( 'fr' );
 


### PR DESCRIPTION
To reproduce:
- Setup a site with Twenty Twenty One.
- Keep en_US as locale in Settings > General.
- Set the language from the content in Polylang settings.
- Visit the homepage in a secondary language.
- Check that Twenty Twenty One translations are not loaded.

The bug happens for all translation loaded by `_load_textdomain_just_in_time()` when the original WordPress locale is `en_US`, probably since WP 6.1. A quick fix for users is to set any locale except `en_US` in Settings > General.

This PR takes the opportunity to greatly simplify the process relying completely internal WP mechanisms (mainly `_load_textdomain_just_in_time()` working correctly since WP 6.1.

It does not include any backward compat for WP < 6.1.