### PR TITLE
Fix `wp_tag_cloud()` return type for PHPStan

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -478,9 +478,10 @@ class PLL_Admin_Filters_Term {
 					$args = array_merge( $args, array( 'link' => 'edit' ) );
 				}
 
+				/** @var string */
 				$tag_cloud = wp_tag_cloud( $args );
 
-				if ( ! empty( $tag_cloud ) && is_string( $tag_cloud ) ) {
+				if ( ! empty( $tag_cloud ) ) {
 					$html = sprintf( '<div class="tagcloud"><h2>%1$s</h2>%2$s</div>', esc_html( $tax->labels->popular_items ), $tag_cloud );
 					$x->Add( array( 'what' => 'tag_cloud', 'data' => $html ) );
 				}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -478,7 +478,7 @@ class PLL_Admin_Filters_Term {
 					$args = array_merge( $args, array( 'link' => 'edit' ) );
 				}
 
-				/** @var string */
+				/** @var string|void */
 				$tag_cloud = wp_tag_cloud( $args );
 
 				if ( ! empty( $tag_cloud ) ) {

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -478,10 +478,10 @@ class PLL_Admin_Filters_Term {
 					$args = array_merge( $args, array( 'link' => 'edit' ) );
 				}
 
-				/** @var string|void */
 				$tag_cloud = wp_tag_cloud( $args );
 
 				if ( ! empty( $tag_cloud ) ) {
+					/** @phpstan-var non-falsy-string $tag_cloud */
 					$html = sprintf( '<div class="tagcloud"><h2>%1$s</h2>%2$s</div>', esc_html( $tax->labels->popular_items ), $tag_cloud );
 					$x->Add( array( 'what' => 'tag_cloud', 'data' => $html ) );
 				}

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -478,7 +478,9 @@ class PLL_Admin_Filters_Term {
 					$args = array_merge( $args, array( 'link' => 'edit' ) );
 				}
 
-				if ( $tag_cloud = wp_tag_cloud( $args ) ) {
+				$tag_cloud = wp_tag_cloud( $args );
+
+				if ( ! empty( $tag_cloud ) && is_string( $tag_cloud ) ) {
 					$html = sprintf( '<div class="tagcloud"><h2>%1$s</h2>%2$s</div>', esc_html( $tax->labels->popular_items ), $tag_cloud );
 					$x->Add( array( 'what' => 'tag_cloud', 'data' => $html ) );
 				}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,11 +161,6 @@ parameters:
 			path: admin/admin-filters-term.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string\\|void given\\.$#"
-			count: 1
-			path: admin/admin-filters-term.php
-
-		-
 			message: "#^Parameter \\#1 \\$id of method PLL_Translated_Object\\:\\:get_translations\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: admin/admin-filters.php


### PR DESCRIPTION
This PR fixes the following issue reported by PHPStan:
```
 ------ ---------------------------------------------------------------------- 
  Line   admin/admin-filters-term.php                                          
 ------ ---------------------------------------------------------------------- 
         Ignored error pattern #^Parameter \#3 \.\.\.\$values of function      
         sprintf expects bool\|float\|int\|string\|null,                       
         array<string>\|string\|void given\.$# in path                         
         /home/runner/work/polylang/polylang/admin/admin-filters-term.php was  
         not matched in reported errors.                                       
  482    Parameter #3 ...$values of function sprintf expects                   
         bool|float|int|string|null, array<string>|string given.               
 ------ ---------------------------------------------------------------------- 
```