### PR TITLE
Move create_media_translation() to PLL_Translated_Posts

### DIFF
--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -96,7 +96,7 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 				exit;
 			}
 
-			$tr_id = $this->posts->create_media_translation( $post_id, sanitize_key( $_GET['new_lang'] ) );
+			$tr_id = $this->model->post->create_media_translation( $post_id, sanitize_key( $_GET['new_lang'] ) );
 			wp_safe_redirect( admin_url( sprintf( 'post.php?post=%d&action=edit', $tr_id ) ) ); // WP 3.5+
 			exit;
 		}

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -277,71 +277,15 @@ class PLL_CRUD_Posts {
 	 * Creates a media translation
 	 *
 	 * @since 1.8
+	 * @since 3.6 Deprecated in favor of PLL_Translated_Post::create_media_translation().
 	 *
 	 * @param int           $post_id Original attachment id.
 	 * @param string|object $lang    New translation language.
 	 * @return int Attachment id of the translated media.
 	 */
 	public function create_media_translation( $post_id, $lang ) {
-		if ( empty( $post_id ) ) {
-			return 0;
-		}
-
-		$post = get_post( $post_id, ARRAY_A );
-
-		if ( empty( $post ) ) {
-			return 0;
-		}
-
-		$lang = $this->model->get_language( $lang ); // Make sure we get a valid language slug.
-
-		if ( empty( $lang ) ) {
-			return 0;
-		}
-
-		// Create a new attachment ( translate attachment parent if exists ).
-		add_filter( 'pll_enable_duplicate_media', '__return_false', 99 ); // Avoid a conflict with automatic duplicate at upload.
-		unset( $post['ID'] ); // Will force the creation.
-		if ( ! empty( $post['post_parent'] ) ) {
-			$post['post_parent'] = (int) $this->model->post->get_translation( $post['post_parent'], $lang->slug );
-		}
-		$post['tax_input'] = array( 'language' => array( $lang->slug ) ); // Assigns the language.
-		$tr_id = wp_insert_attachment( wp_slash( $post ) );
-		remove_filter( 'pll_enable_duplicate_media', '__return_false', 99 ); // Restore automatic duplicate at upload.
-
-		// Copy metadata.
-		$data = wp_get_attachment_metadata( $post_id, true ); // Unfiltered.
-		if ( is_array( $data ) ) {
-			wp_update_attachment_metadata( $tr_id, wp_slash( $data ) ); // Directly uses update_post_meta, so expects slashed.
-		}
-
-		// Copy attached file.
-		if ( $file = get_attached_file( $post_id, true ) ) { // Unfiltered.
-			update_attached_file( $tr_id, wp_slash( $file ) ); // Directly uses update_post_meta, so expects slashed.
-		}
-
-		// Copy alternative text. Direct use of the meta as there is no filtered wrapper to manipulate it.
-		if ( $text = get_post_meta( $post_id, '_wp_attachment_image_alt', true ) ) {
-			add_post_meta( $tr_id, '_wp_attachment_image_alt', wp_slash( $text ) );
-		}
-
-		$this->model->post->set_language( $tr_id, $lang );
-
-		$translations = $this->model->post->get_translations( $post_id );
-		$translations[ $lang->slug ] = $tr_id;
-		$this->model->post->save_translations( $tr_id, $translations );
-
-		/**
-		 * Fires after a media translation is created
-		 *
-		 * @since 1.6.4
-		 *
-		 * @param int    $post_id Post id of the source media.
-		 * @param int    $tr_id   Post id of the new media translation.
-		 * @param string $slug    Language code of the new translation.
-		 */
-		do_action( 'pll_translate_media', $post_id, $tr_id, $lang->slug );
-		return $tr_id;
+		_deprecated_function( __METHOD__, '3.6', 'PLL_Translated_Post::create_media_translation()' );
+		return $this->model->post->create_media_translation( $post_id, $lang );
 	}
 
 	/**

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -279,8 +279,8 @@ class PLL_CRUD_Posts {
 	 * @since 1.8
 	 * @since 3.7 Deprecated in favor of PLL_Translated_Post::create_media_translation().
 	 *
-	 * @param int           $post_id Original attachment id.
-	 * @param string|object $lang    New translation language.
+	 * @param int                 $post_id Original attachment id.
+	 * @param string|PLL_Language $lang    New translation language.
 	 * @return int Attachment id of the translated media.
 	 */
 	public function create_media_translation( $post_id, $lang ) {

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -277,14 +277,14 @@ class PLL_CRUD_Posts {
 	 * Creates a media translation
 	 *
 	 * @since 1.8
-	 * @since 3.6 Deprecated in favor of PLL_Translated_Post::create_media_translation().
+	 * @since 3.7 Deprecated in favor of PLL_Translated_Post::create_media_translation().
 	 *
 	 * @param int           $post_id Original attachment id.
 	 * @param string|object $lang    New translation language.
 	 * @return int Attachment id of the translated media.
 	 */
 	public function create_media_translation( $post_id, $lang ) {
-		_deprecated_function( __METHOD__, '3.6', 'PLL_Translated_Post::create_media_translation()' );
+		_deprecated_function( __METHOD__, '3.7', 'PLL_Translated_Post::create_media_translation()' );
 		return $this->model->post->create_media_translation( $post_id, $lang );
 	}
 

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -307,7 +307,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * Creates a media translation
 	 *
 	 * @since 1.8
-	 * @since 3.6 Moved from PLL_CRUD_Posts.
+	 * @since 3.7 Moved from PLL_CRUD_Posts.
 	 *
 	 * @param int           $post_id Original attachment id.
 	 * @param string|object $lang    New translation language.

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -309,8 +309,8 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @since 1.8
 	 * @since 3.7 Moved from PLL_CRUD_Posts.
 	 *
-	 * @param int           $post_id Original attachment id.
-	 * @param string|object $lang    New translation language.
+	 * @param int                 $post_id Original attachment id.
+	 * @param string|PLL_Language $lang    New translation language.
 	 * @return int Attachment id of the translated media.
 	 */
 	public function create_media_translation( $post_id, $lang ) {
@@ -324,7 +324,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 			return 0;
 		}
 
-		$lang = $this->model->get_language( $lang ); // Make sure we get a valid language slug.
+		$lang = $this->languages->get( $lang ); // Make sure we get a valid language slug.
 
 		if ( empty( $lang ) ) {
 			return 0;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,11 +66,6 @@ parameters:
 			path: admin/admin-filters-columns.php
 
 		-
-			message: "#^Cannot call method create_media_translation\\(\\) on PLL_CRUD_Posts\\|null\\.$#"
-			count: 1
-			path: admin/admin-filters-media.php
-
-		-
 			message: "#^Parameter \\#1 \\$location of function wp_safe_redirect expects string, string\\|false given\\.$#"
 			count: 1
 			path: admin/admin-filters-media.php

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -328,7 +328,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$en = self::factory()->attachment->create_object( 'image0.jpg' );
 		self::$model->post->set_language( $en, 'en' );
 
-		$post_ID = $this->pll_admin->posts->create_media_translation( $en, 'fr' );
+		$post_ID = $this->pll_admin->model->post->create_media_translation( $en, 'fr' );
 
 		$lang = self::$model->get_language( 'fr' );
 

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -47,7 +47,7 @@ class Media_Test extends PLL_UnitTestCase {
 
 		$filename = __DIR__ . '/../data/image.jpg';
 		$en = self::factory()->attachment->create_upload_object( $filename );
-		$fr = $this->pll_admin->posts->create_media_translation( $en, 'fr' );
+		$fr = $this->pll_admin->model->post->create_media_translation( $en, 'fr' );
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $fr )->slug );
 		$this->assertEquals( self::$model->post->get_translation( $en, 'fr' ), $fr );
@@ -98,7 +98,7 @@ class Media_Test extends PLL_UnitTestCase {
 		add_post_meta( $en, '_wp_attachment_image_alt', $slash_2 );
 		self::$model->post->set_language( $en, 'en' );
 
-		$fr = $this->pll_admin->posts->create_media_translation( $en, 'fr' );
+		$fr = $this->pll_admin->model->post->create_media_translation( $en, 'fr' );
 		$post = get_post( $fr );
 		$this->assertEquals( wp_unslash( $slash_2 ), $post->post_title );
 		$this->assertEquals( wp_unslash( $slash_2 ), $post->post_content );

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -141,7 +141,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		);
 		update_post_meta( $en, '_wp_attachment_image_alt', 'Alt text EN' );
 
-		$fr = $pll_admin->posts->create_media_translation( $en, 'fr' );
+		$fr = $pll_admin->model->post->create_media_translation( $en, 'fr' );
 		wp_update_post(
 			array(
 				'ID'           => $fr,


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1360
See also https://github.com/polylang/polylang-pro/issues/1108

`PLL_CRUD_Posts` should only include methods hooked to actions fired when posts are created, updated or deleted and should not include public method used outside these contexts.

This PR proposes to move the method `create_media_translation()` to `PLL_Translated_Posts`