### PR TITLE
Support JSON encoding for metas in `wpml-config.xml`

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -931,14 +931,14 @@ class PLL_WPML_Config {
 		$this->parsed_metas[ $xpath ] = array();
 
 		foreach ( $this->xmls as $xml ) {
-			$cfs = $xml->xpath( $xpath );
+			$custom_fields = $xml->xpath( $xpath );
 
-			if ( ! is_array( $cfs ) ) {
+			if ( ! is_array( $custom_fields ) ) {
 				continue;
 			}
 
-			foreach ( $cfs as $cf ) {
-				$name = (string) $cf;
+			foreach ( $custom_fields as $custom_field ) {
+				$name = (string) $custom_field;
 
 				if ( empty( $name ) ) {
 					continue;
@@ -946,8 +946,8 @@ class PLL_WPML_Config {
 
 				$data = array(
 					'name'     => $name,
-					'action'   => $this->get_field_attribute( $cf, 'action' ),
-					'encoding' => $this->get_field_attribute( $cf, 'encoding' ),
+					'action'   => $this->get_field_attribute( $custom_field, 'action' ),
+					'encoding' => $this->get_field_attribute( $custom_field, 'encoding' ),
 				);
 
 				$data['encoding'] = 'json' === $data['encoding'] ? 'json' : ''; // Only JSON is supported for now.

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -123,14 +123,14 @@ class PLL_WPML_Config {
 		add_filter( 'pll_copy_term_metas', array( $this, 'copy_term_metas' ), 20, 2 );
 		add_filter( 'pll_get_post_types', array( $this, 'translate_types' ), 10, 2 );
 		add_filter( 'pll_get_taxonomies', array( $this, 'translate_taxonomies' ), 10, 2 );
-		add_filter( 'pll_blocks_xpath_rules', array( $this, 'translate_blocks' ) );
-		add_filter( 'pll_blocks_rules_for_attributes', array( $this, 'translate_blocks_attributes' ) );
 
 		// Export.
 		add_filter( 'pll_post_metas_to_export', array( $this, 'post_metas_to_export' ) );
 		add_filter( 'pll_term_metas_to_export', array( $this, 'term_metas_to_export' ) );
 		add_filter( 'pll_post_meta_encodings', array( $this, 'add_post_meta_encodings' ), 20 );
 		add_filter( 'pll_term_meta_encodings', array( $this, 'add_term_meta_encodings' ), 20 );
+		add_filter( 'pll_blocks_xpath_rules', array( $this, 'translate_blocks' ) );
+		add_filter( 'pll_blocks_rules_for_attributes', array( $this, 'translate_blocks_attributes' ) );
 
 		foreach ( $this->xmls as $context => $xml ) {
 			$keys = $xml->xpath( 'admin-texts/key' );

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -7,6 +7,7 @@
 				<custom-field action="copy-once">bg-color</custom-field>
 				<custom-field action="translate">custom-description</custom-field>
 				<custom-field action="ignore">date-added</custom-field>
+				<custom-field action="translate" encoding="json">a_json_meta</custom-field>
 		</custom-fields>
 		<custom-fields-texts>
 			<key name="custom|nested">
@@ -19,6 +20,9 @@
 						<key />
 					</key>
 				</key>
+			</key>
+			<key name="a_json_meta">
+				<key name="to_translate" />
 			</key>
 			<key name="custom-nested-2">
 				<key name="sub-1" />

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -107,52 +107,93 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_cf() {
-		wp_set_current_user( 1 ); // To pass current_user_can_synchronize() test
+		wp_set_current_user( 1 ); // To pass current_user_can_synchronize() test.
+		$json_en         = '{"to_translate":"Value 1","not_to_translate":"Value other"}';
+		$json_fr         = '{"to_translate":"Valeur 1","not_to_translate":"Value other"}';
+		$json_fr_unknown = '{"to_translate":"Valeur inconnue","not_to_translate":"Value other"}';
 
 		$pll_admin = new PLL_Admin( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
 		$en = $from = self::factory()->post->create();
 		self::$model->post->set_language( $from, 'en' );
-		add_post_meta( $from, 'quantity', 1 ); // copy
-		add_post_meta( $from, 'custom-title', 'title' ); // translate
-		add_post_meta( $from, 'bg-color', '#23282d' ); // copy-once
-		add_post_meta( $from, 'date-added', 2007 ); // ignore
+		add_post_meta( $from, 'quantity', 1 ); // `copy`
+		add_post_meta( $from, 'custom-title', 'title' ); // `translate`
+		add_post_meta( $from, 'bg-color', '#23282d' ); // `copy-once`
+		add_post_meta( $from, 'date-added', 2007 ); // `ignore`
+		add_post_meta( $from, 'a_json_meta', $json_en ); // `translate` + encoding.
 
 		$fr = $to = self::factory()->post->create();
 		self::$model->post->set_language( $to, 'fr' );
 		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
 
-		// copy
+		// Enable translation for the JSON meta.
+		add_filter(
+			'pll_translate_post_meta',
+			function ( $value, $key, $lang ) {
+				if ( 'a_json_meta' !== $key ) {
+					return $value;
+				}
+
+				$value = json_decode( $value, true );
+
+				// Very sophisticated way of translating a string.
+				$trs = array(
+					'fr' => array(
+						'Value 1' => 'Valeur 1',
+						'Value 2' => 'Valeur 2',
+					),
+					'en' => array(
+						'Valeur 1' => 'Value 1',
+						'Valeur 2' => 'Value 2',
+					),
+				);
+
+				if ( isset( $trs[ $lang ][ $value['to_translate'] ] ) ) {
+					$value['to_translate'] = $trs[ $lang ][ $value['to_translate'] ];
+				}
+
+				return wp_json_encode( $value, JSON_PRESERVE_ZERO_FRACTION );
+			},
+			10,
+			3
+		);
+
+		// Copy.
 		$sync = new PLL_Admin_Sync( $pll_admin );
-		$sync->post_metas->copy( $from, $to, 'fr' ); // copy
+		$sync->post_metas->copy( $from, $to, 'fr' ); // Copy.
 
 		$this->assertEquals( 1, get_post_meta( $to, 'quantity', true ) );
 		$this->assertEquals( 'title', get_post_meta( $to, 'custom-title', true ) );
 		$this->assertEquals( '#23282d', get_post_meta( $to, 'bg-color', true ) );
 		$this->assertEmpty( get_post_meta( $to, 'date-added', true ) );
+		$this->assertSame( $json_fr, get_post_meta( $to, 'a_json_meta', true ) );
 
-		// sync
+		// Sync.
 		update_post_meta( $to, 'quantity', 2 );
 		update_post_meta( $to, 'custom-title', 'titre' );
 		update_post_meta( $to, 'bg-color', '#ffeedd' );
 		update_post_meta( $to, 'date-added', 2008 );
+		update_post_meta( $to, 'a_json_meta', $json_fr_unknown ); // `translate` + encoding.
 
 		$this->assertEquals( 2, get_post_meta( $from, 'quantity', true ) );
 		$this->assertEquals( 'title', get_post_meta( $from, 'custom-title', true ) );
 		$this->assertEquals( '#23282d', get_post_meta( $from, 'bg-color', true ) );
 		$this->assertEquals( 2007, get_post_meta( $from, 'date-added', true ) );
+		$this->assertSame( $json_en, get_post_meta( $from, 'a_json_meta', true ) );
 
-		// remove custom field and sync
+		// Remove custom field and sync.
 		delete_post_meta( $to, 'quantity' );
 		delete_post_meta( $to, 'custom-title' );
 		delete_post_meta( $to, 'bg-color' );
 		delete_post_meta( $to, 'date-added' );
+		delete_post_meta( $to, 'a_json_meta' );
 
 		$this->assertEmpty( get_post_meta( $from, 'quantity', true ) );
 		$this->assertEquals( 'title', get_post_meta( $from, 'custom-title', true ) );
 		$this->assertEquals( '#23282d', get_post_meta( $from, 'bg-color', true ) );
 		$this->assertEquals( 2007, get_post_meta( $from, 'date-added', true ) );
+		$this->assertSame( $json_en, get_post_meta( $from, 'a_json_meta', true ) );
 	}
 
 	public function test_custom_term_field() {
@@ -219,6 +260,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 				),
 			),
 			'custom-description' => 1,
+			'a_json_meta'        => array(
+				'to_translate' => 1,
+			),
 		);
 		$result   = $wpml_config->post_metas_to_export( array( 'previous-value' => 1 ) );
 


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1936.

This PR is about 2 things:
- Grad the encoding for metas from the `wpml-config.xml` files, and filter `pll_post_meta_encodings` + `pll_term_meta_encodings` accordingly.
- Reduce duplicated code in metas-related methods in `PLL_WPML_Config`.

The method `PLL_WPML_Config::parse_xml_metas()` will fetch the data from the files and it to cache, to prevent re-doing `SimpleXMLElement::xpath()` + fetching attributes for the same fields. Benefits from this cache are probably low though.