### PR TITLE
Use a template and generics to document `PLL_Cache`

### DIFF
--- a/frontend/frontend-filters-links.php
+++ b/frontend/frontend-filters-links.php
@@ -18,7 +18,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	/**
 	 * Our internal non persistent cache object
 	 *
-	 * @var PLL_Cache
+	 * @var PLL_Cache<string>
 	 */
 	public $cache;
 

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -63,9 +63,7 @@ class PLL_Frontend_Filters_Widgets {
 
 		$sidebars_widgets = $this->filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets );
 
-		$this->cache->set( "sidebars_widgets_{$cache_key}", $sidebars_widgets );
-
-		return $sidebars_widgets;
+		return $this->cache->set( "sidebars_widgets_{$cache_key}", $sidebars_widgets );
 	}
 
 	/**

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -12,7 +12,7 @@ class PLL_Frontend_Filters_Widgets {
 	/**
 	 * Internal non persistent cache object.
 	 *
-	 * @var PLL_Cache
+	 * @var PLL_Cache<array>
 	 */
 	public $cache;
 

--- a/frontend/frontend-filters-widgets.php
+++ b/frontend/frontend-filters-widgets.php
@@ -54,8 +54,8 @@ class PLL_Frontend_Filters_Widgets {
 			return $sidebars_widgets;
 		}
 
-		$cache_key         = md5( maybe_serialize( $sidebars_widgets ) );
-		$_sidebars_widgets = $this->cache->get( "sidebars_widgets_{$cache_key}" );
+		$cache_key         = $this->cache->get_unique_key( 'sidebars_widgets_', $sidebars_widgets );
+		$_sidebars_widgets = $this->cache->get( $cache_key );
 
 		if ( false !== $_sidebars_widgets ) {
 			return $_sidebars_widgets;
@@ -63,7 +63,7 @@ class PLL_Frontend_Filters_Widgets {
 
 		$sidebars_widgets = $this->filter_widgets_sidebars( $sidebars_widgets, $wp_registered_widgets );
 
-		return $this->cache->set( "sidebars_widgets_{$cache_key}", $sidebars_widgets );
+		return $this->cache->set( $cache_key, $sidebars_widgets );
 	}
 
 	/**

--- a/frontend/frontend-links.php
+++ b/frontend/frontend-links.php
@@ -13,7 +13,7 @@ class PLL_Frontend_Links extends PLL_Links {
 	/**
 	 * Internal non persistent cache object.
 	 *
-	 * @var PLL_Cache
+	 * @var PLL_Cache<string>
 	 */
 	public $cache;
 
@@ -175,7 +175,7 @@ class PLL_Frontend_Links extends PLL_Links {
 		 * @param null|string $url      The translation url, null if none was found
 		 * @param string      $language The language code of the translation
 		 */
-		$translation_url = apply_filters( 'pll_translation_url', $url, $language->slug );
+		$translation_url = (string) apply_filters( 'pll_translation_url', $url, $language->slug );
 
 		// Don't cache before template_redirect to avoid a conflict with Barrel + WP Bakery Page Builder
 		if ( did_action( 'template_redirect' ) ) {

--- a/include/cache.php
+++ b/include/cache.php
@@ -63,7 +63,7 @@ class PLL_Cache {
 	 * @phpstan-param TCacheData $data
 	 * @phpstan-return TCacheData
 	 */
-	public function set( string $key, $data ) {
+	public function set( $key, $data ) {
 		$this->cache[ $this->blog_id ][ $key ] = $data;
 		return $data;
 	}
@@ -79,7 +79,7 @@ class PLL_Cache {
 	 * @phpstan-param non-empty-string $key
 	 * @phpstan-return TCacheData|false
 	 */
-	public function get( string $key ) {
+	public function get( $key ) {
 		return isset( $this->cache[ $this->blog_id ][ $key ] ) ? $this->cache[ $this->blog_id ][ $key ] : false;
 	}
 
@@ -92,7 +92,7 @@ class PLL_Cache {
 	 *                    Default is an empty string.
 	 * @return void
 	 */
-	public function clean( string $key = '' ) {
+	public function clean( $key = '' ) {
 		if ( '' === $key ) {
 			unset( $this->cache[ $this->blog_id ] );
 		} else {

--- a/include/cache.php
+++ b/include/cache.php
@@ -109,7 +109,8 @@ class PLL_Cache {
 	 * @param string|array|object $data   Data.
 	 * @return string
 	 *
-	 * @phpstan-return ( $prefix is non-empty-string ? non-empty-string : string )
+	 * @phpstan-param non-empty-string $prefix
+	 * @phpstan-return non-empty-string
 	 */
 	public function get_unique_key( string $prefix, $data ): string {
 		$data = maybe_serialize( $data );

--- a/include/cache.php
+++ b/include/cache.php
@@ -99,4 +99,21 @@ class PLL_Cache {
 			unset( $this->cache[ $this->blog_id ][ $key ] );
 		}
 	}
+
+	/**
+	 * Generates and returns a "unique" cache key, depending on `$data` and prefixed by `$prefix`.
+	 *
+	 * @since 3.6
+	 *
+	 * @param string              $prefix String to prefix the cache key.
+	 * @param string|array|object $data   Data.
+	 * @return string
+	 *
+	 * @phpstan-return ( $prefix is non-empty-string ? non-empty-string : string )
+	 */
+	public function get_unique_key( string $prefix, $data ): string {
+		$data = maybe_serialize( $data );
+		$data = is_scalar( $data ) ? (string) $data : '';
+		return $prefix . md5( $data );
+	}
 }

--- a/include/cache.php
+++ b/include/cache.php
@@ -88,11 +88,12 @@ class PLL_Cache {
 	 *
 	 * @since 1.7
 	 *
-	 * @param string $key Optional. Cache key. Default is an empty string.
+	 * @param string $key Optional. Cache key. An empty string to clean the whole cache for the current blog.
+	 *                    Default is an empty string.
 	 * @return void
 	 */
 	public function clean( $key = '' ) {
-		if ( empty( $key ) ) {
+		if ( '' === $key ) {
 			unset( $this->cache[ $this->blog_id ] );
 		} else {
 			unset( $this->cache[ $this->blog_id ][ $key ] );

--- a/include/cache.php
+++ b/include/cache.php
@@ -113,8 +113,8 @@ class PLL_Cache {
 	 * @phpstan-return non-empty-string
 	 */
 	public function get_unique_key( string $prefix, $data ): string {
-		$data = maybe_serialize( $data );
-		$data = is_scalar( $data ) ? (string) $data : '';
-		return $prefix . md5( $data );
+		/** @var scalar **/
+		$serialized = maybe_serialize( $data );
+		return $prefix . md5( (string) $serialized );
 	}
 }

--- a/include/cache.php
+++ b/include/cache.php
@@ -113,7 +113,7 @@ class PLL_Cache {
 	 * @phpstan-return non-empty-string
 	 */
 	public function get_unique_key( string $prefix, $data ): string {
-		/** @var scalar **/
+		/** @var scalar */
 		$serialized = maybe_serialize( $data );
 		return $prefix . md5( (string) $serialized );
 	}

--- a/include/cache.php
+++ b/include/cache.php
@@ -53,6 +53,7 @@ class PLL_Cache {
 	 * Adds a value in cache.
 	 *
 	 * @since 1.7
+	 * @since 3.6 Returns the cached value.
 	 *
 	 * @param string $key  Cache key.
 	 * @param mixed  $data The value to add to the cache.
@@ -60,9 +61,11 @@ class PLL_Cache {
 	 *
 	 * @phpstan-param non-empty-string $key
 	 * @phpstan-param TCacheData $data
+	 * @phpstan-return TCacheData
 	 */
 	public function set( $key, $data ) {
 		$this->cache[ $this->blog_id ][ $key ] = $data;
+		return $data;
 	}
 
 	/**

--- a/include/cache.php
+++ b/include/cache.php
@@ -63,7 +63,7 @@ class PLL_Cache {
 	 * @phpstan-param TCacheData $data
 	 * @phpstan-return TCacheData
 	 */
-	public function set( $key, $data ) {
+	public function set( string $key, $data ) {
 		$this->cache[ $this->blog_id ][ $key ] = $data;
 		return $data;
 	}
@@ -79,7 +79,7 @@ class PLL_Cache {
 	 * @phpstan-param non-empty-string $key
 	 * @phpstan-return TCacheData|false
 	 */
-	public function get( $key ) {
+	public function get( string $key ) {
 		return isset( $this->cache[ $this->blog_id ][ $key ] ) ? $this->cache[ $this->blog_id ][ $key ] : false;
 	}
 
@@ -92,7 +92,7 @@ class PLL_Cache {
 	 *                    Default is an empty string.
 	 * @return void
 	 */
-	public function clean( $key = '' ) {
+	public function clean( string $key = '' ) {
 		if ( '' === $key ) {
 			unset( $this->cache[ $this->blog_id ] );
 		} else {

--- a/include/cache.php
+++ b/include/cache.php
@@ -7,6 +7,8 @@
  * An extremely simple non persistent cache system.
  *
  * @since 1.7
+ *
+ * @template TCacheData
  */
 class PLL_Cache {
 	/**
@@ -20,6 +22,8 @@ class PLL_Cache {
 	 * The cache container.
 	 *
 	 * @var array
+	 *
+	 * @phpstan-var array<int, array<non-empty-string, TCacheData>>
 	 */
 	protected $cache = array();
 
@@ -46,36 +50,42 @@ class PLL_Cache {
 	}
 
 	/**
-	 * Add a value in cache.
+	 * Adds a value in cache.
 	 *
 	 * @since 1.7
 	 *
 	 * @param string $key  Cache key.
 	 * @param mixed  $data The value to add to the cache.
-	 * @return void
+	 * @return mixed
+	 *
+	 * @phpstan-param non-empty-string $key
+	 * @phpstan-param TCacheData $data
 	 */
 	public function set( $key, $data ) {
 		$this->cache[ $this->blog_id ][ $key ] = $data;
 	}
 
 	/**
-	 * Get value from cache.
+	 * Returns value from cache.
 	 *
 	 * @since 1.7
 	 *
 	 * @param string $key Cache key.
 	 * @return mixed
+	 *
+	 * @phpstan-param non-empty-string $key
+	 * @phpstan-return TCacheData|false
 	 */
 	public function get( $key ) {
 		return isset( $this->cache[ $this->blog_id ][ $key ] ) ? $this->cache[ $this->blog_id ][ $key ] : false;
 	}
 
 	/**
-	 * Clean the cache (for this blog only).
+	 * Cleans the cache (for this blog only).
 	 *
 	 * @since 1.7
 	 *
-	 * @param string $key Cache key.
+	 * @param string $key Optional. Cache key. Default is an empty string.
 	 * @return void
 	 */
 	public function clean( $key = '' ) {

--- a/include/model.php
+++ b/include/model.php
@@ -12,7 +12,7 @@ class PLL_Model {
 	/**
 	 * Internal non persistent cache object.
 	 *
-	 * @var PLL_Cache
+	 * @var PLL_Cache<mixed>
 	 */
 	public $cache;
 

--- a/include/model.php
+++ b/include/model.php
@@ -585,8 +585,8 @@ class PLL_Model {
 			$q['post_type'] = array( 'post' ); // We *need* a post type.
 		}
 
-		$cache_key = 'pll_count_posts_' . md5( maybe_serialize( $q ) );
-		$counts = wp_cache_get( $cache_key, 'counts' );
+		$cache_key = $this->cache->get_unique_key( 'pll_count_posts_', $q );
+		$counts    = wp_cache_get( $cache_key, 'counts' );
 
 		if ( ! is_array( $counts ) ) {
 			$counts  = array();

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -40,7 +40,7 @@ class PLL_Translate_Option {
 	/**
 	 * Cache for the translated values.
 	 *
-	 * @var PLL_Cache<mixed>
+	 * @var PLL_Cache<array|string>
 	 */
 	private $cache;
 

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -40,7 +40,7 @@ class PLL_Translate_Option {
 	/**
 	 * Cache for the translated values.
 	 *
-	 * @var PLL_Cache
+	 * @var PLL_Cache<mixed>
 	 */
 	private $cache;
 

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -110,6 +110,10 @@ class PLL_Translate_Option {
 
 		$lang = $GLOBALS['l10n']['pll_string']->get_header( 'Language' );
 
+		if ( ! is_string( $lang ) || '' === $lang ) {
+			return $value;
+		}
+
 		$cache = $this->cache->get( $lang );
 		if ( false === $cache ) {
 			$cache = $this->translate_string_recursive( $value, $this->keys );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -321,21 +321,6 @@ parameters:
 			path: frontend/frontend-filters-links.php
 
 		-
-			message: "#^Method PLL_Frontend_Filters_Links\\:\\:_get_page_link\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
-			message: "#^Method PLL_Frontend_Filters_Links\\:\\:attachment_link\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
-			message: "#^Method PLL_Frontend_Filters_Links\\:\\:post_type_link\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: frontend/frontend-filters-links.php
-
-		-
 			message: "#^Parameter \\#1 \\$post_type of method PLL_Model\\:\\:is_translated_post_type\\(\\) expects array\\<string\\>\\|string, string\\|false given\\.$#"
 			count: 1
 			path: frontend/frontend-filters-links.php
@@ -357,11 +342,6 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$slug on PLL_Language\\|null\\.$#"
-			count: 1
-			path: frontend/frontend-filters-widgets.php
-
-		-
-			message: "#^Method PLL_Frontend_Filters_Widgets\\:\\:sidebars_widgets\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: frontend/frontend-filters-widgets.php
 
@@ -398,16 +378,6 @@ parameters:
 		-
 			message: "#^Cannot access property \\$name on WP_Taxonomy\\|false\\.$#"
 			count: 2
-			path: frontend/frontend-links.php
-
-		-
-			message: "#^Method PLL_Frontend_Links\\:\\:get_translation_url\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: frontend/frontend-links.php
-
-		-
-			message: "#^Method PLL_Frontend_Links\\:\\:get_translation_url\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
 			path: frontend/frontend-links.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -346,11 +346,6 @@ parameters:
 			path: frontend/frontend-filters-widgets.php
 
 		-
-			message: "#^Parameter \\#1 \\$.+ of function md5 expects string, mixed given\\.$#"
-			count: 1
-			path: frontend/frontend-filters-widgets.php
-
-		-
 			message: "#^Cannot access property \\$locale on PLL_Language\\|null\\.$#"
 			count: 2
 			path: frontend/frontend-filters.php
@@ -577,11 +572,6 @@ parameters:
 
 		-
 			message: "#^Method PLL_Model\\:\\:get_links_model\\(\\) should return PLL_Links_Model but returns object\\.$#"
-			count: 1
-			path: include/model.php
-
-		-
-			message: "#^Parameter \\#1 \\$.+ of function md5 expects string, mixed given\\.$#"
 			count: 1
 			path: include/model.php
 

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -204,13 +204,12 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 		$frontend->filters_widgets = new PLL_Frontend_Filters_Widgets( $frontend );
 		$frontend->curlang = self::$model->get_language( 'en' );
 
-		$frontend->filters_widgets->cache = $this->getMockBuilder( 'PLL_Cache' )->getMock();
-		$frontend->filters_widgets->cache->method( 'get' )->willReturn( false );
-
 		$sidebars = wp_get_sidebars_widgets();
 		$this->assertTrue( in_array( 'search-2', $sidebars['sidebar-1'] ) );
 
 		$frontend->curlang = self::$model->get_language( 'fr' );
+		$frontend->filters_widgets->cache->clean();
+
 		$sidebars = wp_get_sidebars_widgets();
 		$this->assertFalse( in_array( 'search-2', $sidebars['sidebar-1'] ) );
 	}


### PR DESCRIPTION
With this PR, `PLL_Cache` is not stuck with `mixed` for the cached data anymore.

This allows to be more precise about the data stored by `->set()` and returned by `->get()`.

##Impact in Polylang

Minimal. For now on, we need to specify the type of data stored by `PLL_Cache`.
Example:
```php
/**
 * @var PLL_Cache<string>
 */
private $cache;
```
Cache keys are already expected to be `non-empty-string`, and with this we specify to PHPStan that the data stored is expected to be strings. Of course we can still use `PLL_Cache<mixed>` when we expect to cache any kind of data.

##Also in this PR
- `set()` now returns the cached value. This only allows a shorthand like `return $this->cache->set( 'foobar', $data );` instead of setting the cache then returning the value.
- In `clean()`, the value `'0'` is allowed as a valid key.
- Several entries removed from the baseline.
- `$key` is type-hinted as a string. Debatable, maybe we'll want to use numbers someday.
- New method `PLL_Cache::get_unique_key()`.