### PR TITLE
Wilcards in `PLL_WPML_Config` and `PLL_Translate_Option`

### DIFF
--- a/include/format-util.php
+++ b/include/format-util.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+/**
+ * A class to match values against a given format.
+ *
+ * @since 3.6
+ */
+class PLL_Format_Util {
+	/**
+	 * Cache for regex patterns.
+	 * Useful when using `filter_list()` for example.
+	 *
+	 * @var string[] Formats as array keys, patterns as array values.
+	 *
+	 * @phpstan-var array<non-empty-string, non-empty-string>
+	 */
+	private $patterns = array();
+
+	/**
+	 * Filters the given list to return only the values whose the key or value matches the given format.
+	 *
+	 * @since 3.6
+	 *
+	 * @param array|Traversable|stdClass $list   An list with keys or values to match against `$format`.
+	 * @param string                     $format A format, where `*` means "any characters" (`.*`), unless escaped.
+	 * @param string                     $mode   Optional. Tell if we should filter the keys or values from `$list`.
+	 *                                           Possible values are `'use_keys'` and `'use_values'`. Default is `'use_keys'`.
+	 * @return array
+	 *
+	 * @template TArrayValue
+	 * @phpstan-param (
+	 *     $mode is 'use_keys' ?
+	 *         array<string, TArrayValue>|Traversable<string, TArrayValue>|stdClass :
+	 *         array<string>|Traversable<string>|stdClass
+	 * ) $list
+	 * @phpstan-param 'use_keys'|'use_values' $mode
+	 * @phpstan-return ($mode is 'use_keys' ? array<string, TArrayValue> : array<string>)
+	 */
+	public function filter_list( $list, string $format, string $mode = 'use_keys' ): array {
+		$filter = function ( $key ) use ( $format ) {
+			return $this->matches( (string) $key, $format );
+		};
+
+		if ( $list instanceof Traversable ) {
+			$list = iterator_to_array( $list );
+		} elseif ( ! is_array( $list ) ) {
+			$list = (array) $list;
+		}
+
+		if ( 'use_values' === $mode ) {
+			return array_filter( $list, $filter );
+		}
+
+		return array_filter( $list, $filter, ARRAY_FILTER_USE_KEY );
+	}
+
+	/**
+	 * Tells if the given string matches the given format.
+	 *
+	 * @since 3.6
+	 *
+	 * @param string $key    A string to test.
+	 * @param string $format A format, where `*` means "any characters" (`.*`), unless escaped.
+	 * @return bool
+	 */
+	public function matches( string $key, string $format ): bool {
+		if ( ! $this->is_format( $format ) ) {
+			return $key === $format;
+		}
+
+		if ( '*' === $format ) {
+			return true;
+		}
+
+		if ( empty( $this->patterns[ $format ] ) ) {
+			$pattern = addcslashes( $format, '.+?[^]$(){}=!<>|:-#/' ); // Escape regular expression characters (list from `preg_quote()` but `*` and `\` are ignored).
+			$pattern = preg_replace(
+				array(
+					'/\\\(?!\*)/', // Escape `\` characters except if followed by `*`.
+					'/(?<!\\\)\*/', // Replace `*` characters by `.*` except if preceded by `\`.
+				),
+				array( '\\', '.*' ),
+				$pattern
+			);
+
+			if ( empty( $pattern ) ) {
+				// Error.
+				return false;
+			}
+
+			$this->patterns[ $format ] = $pattern;
+		} else {
+			$pattern = $this->patterns[ $format ];
+		}
+
+		return (bool) preg_match( "/^{$pattern}$/", $key );
+	}
+
+	/**
+	 * Tells if the given string is a format (that includes a `*`).
+	 *
+	 * @since 3.6
+	 *
+	 * @param string $format Format to test.
+	 * @return bool
+	 *
+	 * @phpstan-assert-if-true non-empty-string $format
+	 */
+	public function is_format( string $format ): bool {
+		return (bool) preg_match( '/(?<!\\\)\*/', $format );
+	}
+}

--- a/include/format-util.php
+++ b/include/format-util.php
@@ -6,7 +6,7 @@
 /**
  * A class to match values against a given format.
  *
- * @since 3.6
+ * @since 3.7
  */
 class PLL_Format_Util {
 	/**
@@ -22,7 +22,7 @@ class PLL_Format_Util {
 	/**
 	 * Filters the given list to return only the values whose the key or value matches the given format.
 	 *
-	 * @since 3.6
+	 * @since 3.7
 	 *
 	 * @param array|Traversable|stdClass $list   An list with keys or values to match against `$format`.
 	 * @param string                     $format A format, where `*` means "any characters" (`.*`), unless escaped.
@@ -60,7 +60,7 @@ class PLL_Format_Util {
 	/**
 	 * Tells if the given string matches the given format.
 	 *
-	 * @since 3.6
+	 * @since 3.7
 	 *
 	 * @param string $key    A string to test.
 	 * @param string $format A format, where `*` means "any characters" (`.*`), unless escaped.
@@ -102,7 +102,7 @@ class PLL_Format_Util {
 	/**
 	 * Tells if the given string is a format (that includes a `*`).
 	 *
-	 * @since 3.6
+	 * @since 3.7
 	 *
 	 * @param string $format Format to test.
 	 * @return bool

--- a/include/format-util.php
+++ b/include/format-util.php
@@ -102,6 +102,6 @@ class PLL_Format_Util {
 	 * @phpstan-assert-if-true non-empty-string $format
 	 */
 	public function is_format( string $format ): bool {
-		return (bool) preg_match( '/(?<!\\\)\*/', $format );
+		return (bool) preg_match( '/(?<!\\\)\*/', $format ); // Match `*` characters unless if preceded by `\`.
 	}
 }

--- a/include/format-util.php
+++ b/include/format-util.php
@@ -6,7 +6,8 @@
 /**
  * A class to match values against a given format.
  *
- * @since 3.7
+ * @since 3.6
+ * @since 3.7 Moved from Polylang Pro to Polylang.
  */
 class PLL_Format_Util {
 	/**
@@ -22,7 +23,8 @@ class PLL_Format_Util {
 	/**
 	 * Filters the given list to return only the values whose the key or value matches the given format.
 	 *
-	 * @since 3.7
+	 * @since 3.6
+	 * @since 3.7 Only accepts arrays as first parameter.
 	 *
 	 * @param array  $list   A list with keys or values to match against `$format`.
 	 * @param string $format A format, where `*` means "any characters" (`.*`), unless escaped.
@@ -50,7 +52,7 @@ class PLL_Format_Util {
 	/**
 	 * Tells if the given string matches the given format.
 	 *
-	 * @since 3.7
+	 * @since 3.6
 	 *
 	 * @param string $key    A string to test.
 	 * @param string $format A format, where `*` means "any characters" (`.*`), unless escaped.

--- a/include/format-util.php
+++ b/include/format-util.php
@@ -24,31 +24,21 @@ class PLL_Format_Util {
 	 *
 	 * @since 3.7
 	 *
-	 * @param array|Traversable|stdClass $list   A list with keys or values to match against `$format`.
-	 * @param string                     $format A format, where `*` means "any characters" (`.*`), unless escaped.
-	 * @param string                     $mode   Optional. Tell if we should filter the keys or values from `$list`.
-	 *                                           Possible values are `'use_keys'` and `'use_values'`. Default is `'use_keys'`.
+	 * @param array  $list   A list with keys or values to match against `$format`.
+	 * @param string $format A format, where `*` means "any characters" (`.*`), unless escaped.
+	 * @param string $mode   Optional. Tell if we should filter the keys or values from `$list`.
+	 *                       Possible values are `'use_keys'` and `'use_values'`. Default is `'use_keys'`.
 	 * @return array
 	 *
 	 * @template TArrayValue
-	 * @phpstan-param (
-	 *     $mode is 'use_keys' ?
-	 *         array<string, TArrayValue>|Traversable<string, TArrayValue>|stdClass :
-	 *         array<string>|Traversable<string>|stdClass
-	 * ) $list
+	 * @phpstan-param ($mode is 'use_keys' ? array<string, TArrayValue> : array<string>) $list
 	 * @phpstan-param 'use_keys'|'use_values' $mode
 	 * @phpstan-return ($mode is 'use_keys' ? array<string, TArrayValue> : array<string>)
 	 */
-	public function filter_list( $list, string $format, string $mode = 'use_keys' ): array {
+	public function filter_list( array $list, string $format, string $mode = 'use_keys' ): array {
 		$filter = function ( $key ) use ( $format ) {
 			return $this->matches( (string) $key, $format );
 		};
-
-		if ( $list instanceof Traversable ) {
-			$list = iterator_to_array( $list );
-		} elseif ( ! is_array( $list ) ) {
-			$list = (array) $list;
-		}
 
 		if ( 'use_values' === $mode ) {
 			return array_filter( $list, $filter );

--- a/include/format-util.php
+++ b/include/format-util.php
@@ -24,7 +24,7 @@ class PLL_Format_Util {
 	 *
 	 * @since 3.7
 	 *
-	 * @param array|Traversable|stdClass $list   An list with keys or values to match against `$format`.
+	 * @param array|Traversable|stdClass $list   A list with keys or values to match against `$format`.
 	 * @param string                     $format A format, where `*` means "any characters" (`.*`), unless escaped.
 	 * @param string                     $mode   Optional. Tell if we should filter the keys or values from `$list`.
 	 *                                           Possible values are `'use_keys'` and `'use_values'`. Default is `'use_keys'`.

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -130,13 +130,16 @@ class PLL_Translate_Option {
 	 *
 	 * @param mixed      $values Either a string to translate or a list of strings to translate.
 	 * @param array|bool $key    Array of option keys to translate.
-	 * @return array|string Translated string(s)
+	 * @return array|string Translated string(s).
 	 */
 	protected function translate_string_recursive( $values, $key ) {
 		$children = is_array( $key ) ? $key : array();
 
 		if ( is_array( $values ) || is_object( $values ) ) {
+			/** @var array|Traversable $values */
 			if ( count( $children ) ) {
+				$matcher = new PLL_Format_Util();
+
 				foreach ( $children as $name => $child ) {
 					if ( is_array( $values ) && isset( $values[ $name ] ) ) {
 						$values[ $name ] = $this->translate_string_recursive( $values[ $name ], $child );
@@ -148,11 +151,9 @@ class PLL_Translate_Option {
 						continue;
 					}
 
-					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
-
 					foreach ( $values as $n => &$value ) {
 						// The first case could be handled by the next one, but we avoid calls to preg_match here.
-						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
+						if ( $matcher->matches( $n, $name ) ) {
 							$value = $this->translate_string_recursive( $value, $child );
 						}
 					}
@@ -191,17 +192,17 @@ class PLL_Translate_Option {
 			$children = is_array( $key ) ? $key : array();
 
 			if ( count( $children ) ) {
+				$matcher = new PLL_Format_Util();
+
 				foreach ( $children as $name => $child ) {
 					if ( isset( $values[ $name ] ) ) {
 						$this->register_string_recursive( $context, $name, $values[ $name ], $child );
 						continue;
 					}
 
-					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
-
 					foreach ( $values as $n => $value ) {
 						// The first case could be handled by the next one, but we avoid calls to preg_match here.
-						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
+						if ( $matcher->matches( $n, $name ) ) {
 							$this->register_string_recursive( $context, $n, $value, $child );
 						}
 					}
@@ -339,7 +340,10 @@ class PLL_Translate_Option {
 		$children = is_array( $key ) ? $key : array();
 
 		if ( is_array( $values ) || is_object( $values ) ) {
+			/** @var array|Traversable $values */
 			if ( count( $children ) ) {
+				$matcher = new PLL_Format_Util();
+
 				foreach ( $children as $name => $child ) {
 					if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $name ], $values[ $name ] ) ) {
 						$values[ $name ] = $this->check_value_recursive( $old_values[ $name ], $values[ $name ], $child, $mo );
@@ -351,11 +355,9 @@ class PLL_Translate_Option {
 						continue;
 					}
 
-					$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
-
 					foreach ( $values as $n => $value ) {
 						// The first case could be handled by the next one, but we avoid calls to preg_match here.
-						if ( '*' === $name || ( false !== strpos( $name, '*' ) && preg_match( $pattern, $n ) ) ) {
+						if ( $matcher->matches( $n, $name ) ) {
 							if ( is_array( $values ) && is_array( $old_values ) && isset( $old_values[ $n ] ) ) {
 								$values[ $n ] = $this->check_value_recursive( $old_values[ $n ], $value, $child, $mo );
 							}

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -200,6 +200,10 @@ class PLL_Translate_Option {
 						continue;
 					}
 
+					if ( ! $matcher->is_format( $name ) ) {
+						continue;
+					}
+
 					foreach ( $values as $n => $value ) {
 						if ( $matcher->matches( $n, $name ) ) {
 							$this->register_string_recursive( $context, $n, $value, $child );

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -201,7 +201,6 @@ class PLL_Translate_Option {
 					}
 
 					foreach ( $values as $n => $value ) {
-						// The first case could be handled by the next one, but we avoid calls to preg_match here.
 						if ( $matcher->matches( $n, $name ) ) {
 							$this->register_string_recursive( $context, $n, $value, $child );
 						}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -134,6 +134,8 @@ class PLL_WPML_Config {
 		add_filter( 'pll_blocks_xpath_rules', array( $this, 'translate_blocks' ) );
 		add_filter( 'pll_blocks_rules_for_attributes', array( $this, 'translate_blocks_attributes' ) );
 
+		$matcher = new PLL_Format_Util();
+
 		foreach ( $this->xmls as $context => $xml ) {
 			$keys = $xml->xpath( 'admin-texts/key' );
 
@@ -144,19 +146,14 @@ class PLL_WPML_Config {
 			foreach ( $keys as $key ) {
 				$name = $this->get_field_attribute( $key, 'name' );
 
-				if ( false === strpos( $name, '*' ) ) {
+				if ( ! $matcher->is_format( $name ) ) {
 					$this->register_or_translate_option( $context, $name, $key );
 					continue;
 				}
 
-				$pattern = '#^' . str_replace( '*', '(?:.+)', $name ) . '$#';
-				$names = preg_grep( $pattern, array_keys( wp_load_alloptions() ) );
+				$names = $matcher->filter_list( wp_load_alloptions(), $name );
 
-				if ( ! is_array( $names ) ) {
-					continue;
-				}
-
-				foreach ( $names as $_name ) {
+				foreach ( $names as $_name => $_val ) {
 					$this->register_or_translate_option( $context, $_name, $key );
 				}
 			}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -151,7 +151,7 @@ class PLL_WPML_Config {
 					continue;
 				}
 
-				$names = $matcher->filter_list( wp_load_alloptions(), $name );
+				$names = $matcher->filter_list( (array) wp_load_alloptions(), $name );
 
 				foreach ( $names as $_name => $_val ) {
 					$this->register_or_translate_option( $context, $_name, $key );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -616,12 +616,7 @@ parameters:
 			path: include/switcher.php
 
 		-
-			message: "#^Argument of an invalid type array\\|object supplied for foreach, only iterables are supported\\.$#"
-			count: 4
-			path: include/translate-option.php
-
-		-
-			message: "#^Method PLL_Translate_Option\\:\\:translate_string_recursive\\(\\) should return array\\|string but returns array\\|object\\|string\\.$#"
+			message: "#^Method PLL_Translate_Option\\:\\:translate_string_recursive\\(\\) should return array\\|string but returns array\\|string\\|Traversable\\.$#"
 			count: 1
 			path: include/translate-option.php
 

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -1,140 +1,138 @@
 <wpml-config>
-	<custom-fields>
-		<custom-field action="copy">quantity</custom-field>
-		<custom-field action="translate">custom-title</custom-field>
-		<custom-field action="translate">custom|nested</custom-field>
-		<custom-field action="copy">weight</custom-field>
-		<custom-field action="copy-once">bg-color</custom-field>
-		<custom-field action="translate">custom-description</custom-field>
-		<custom-field action="ignore">date-added</custom-field>
-		<custom-field action="translate" encoding="json">a_json_meta</custom-field>
-	</custom-fields>
-	<custom-fields-texts>
-		<key name="custom|nested">
-			<key name="sub-1" />
-			<key name="sub-2">
-				<key name="sub|21">
-					<key name="sub-211" />
-					<key name=" " />
-					<key name="" />
-					<key />
+		<custom-fields>
+				<custom-field action="copy">quantity</custom-field>
+				<custom-field action="translate">custom-title</custom-field>
+				<custom-field action="translate">custom|nested</custom-field>
+				<custom-field action="copy">weight</custom-field>
+				<custom-field action="copy-once">bg-color</custom-field>
+				<custom-field action="translate">custom-description</custom-field>
+				<custom-field action="ignore">date-added</custom-field>
+				<custom-field action="translate" encoding="json">a_json_meta</custom-field>
+		</custom-fields>
+		<custom-fields-texts>
+			<key name="custom|nested">
+				<key name="sub-1" />
+				<key name="sub-2">
+					<key name="sub|21">
+						<key name="sub-211" />
+						<key name=" " />
+						<key name="" />
+						<key />
+					</key>
 				</key>
 			</key>
-		</key>
-		<key name="a_json_meta">
-			<key name="to_translate" />
-		</key>
-		<key name="custom-nested-2">
-			<key name="sub-1" />
-		</key>
-	</custom-fields-texts>
-	<custom-term-fields>
-		<custom-term-field action="copy">term_meta_A</custom-term-field>
-		<custom-term-field action="translate">term_meta_B</custom-term-field>
-		<custom-term-field action="ignore">term_meta_C</custom-term-field>
-		<custom-term-field action="copy-once">term_meta_D</custom-term-field>
-	</custom-term-fields>
-	<custom-types>
-		<custom-type translate="1">book</custom-type>
-		<custom-type translate="0">DVD</custom-type>
-	</custom-types>
-	<taxonomies>
-		<taxonomy translate="1">genre</taxonomy>
-		<taxonomy translate="1">type</taxonomy>
-		<taxonomy translate="0">publisher</taxonomy>
-	</taxonomies>
-	<admin-texts>
-		<key name="my_plugins_options">
-			<key name="option_name_1" />
-			<key name="option_name_2" />
-			<key name="options_group_1">
-				<key name="sub_option_name_11" />
-				<key name="sub_option_name_12" />
+			<key name="a_json_meta">
+				<key name="to_translate" />
 			</key>
-			<key name="options_group_2">
-				<key name="*"/>
+			<key name="custom-nested-2">
+				<key name="sub-1" />
 			</key>
-			<key name="options_group_3">
-				<key name="*">
-					<key name="sub_sub_option_name_3x1" />
-					<key name="sub_sub_option_name_3x2" />
+		</custom-fields-texts>
+		<custom-term-fields>
+			<custom-term-field action="copy">term_meta_A</custom-term-field>
+			<custom-term-field action="translate">term_meta_B</custom-term-field>
+			<custom-term-field action="ignore">term_meta_C</custom-term-field>
+			<custom-term-field action="copy-once">term_meta_D</custom-term-field>
+		</custom-term-fields>
+		<custom-types>
+				<custom-type translate="1">book</custom-type>
+				<custom-type translate="0">DVD</custom-type>
+		</custom-types>
+		<taxonomies>
+				<taxonomy translate="1">genre</taxonomy>
+				<taxonomy translate="1">type</taxonomy>
+				<taxonomy translate="0">publisher</taxonomy>
+		</taxonomies>
+		<admin-texts>
+				<key name="my_plugins_options">
+						<key name="option_name_1" />
+						<key name="option_name_2" />
+						<key name="options_group_1">
+								<key name="sub_option_name_11" />
+								<key name="sub_option_name_12" />
+						</key>
+						<key name="options_group_2">
+								<key name="*"/>
+						</key>
+						<key name="options_group_3">
+								<key name="*">
+										<key name="sub_sub_option_name_3x1" />
+										<key name="sub_sub_option_name_3x2" />
+								</key>
+						</key>
+						<key name="options_group_4">
+								<key name="sub_option_name_*" />
+						</key>
 				</key>
-			</key>
-			<key name="options_group_4">
-				<key name="sub_option_name_*" />
-			</key>
-		</key>
-		<key name="empty_option">
-			<key name="*">
-				<key name="label"/>
-			</key>
-		</key>
-		<key name="simple_string_option" />
-		<key name="generi(_option_*" />
-	</admin-texts>
-	<gutenberg-blocks>
-		<gutenberg-block type="my-plugin/my-block" translate="1">
-			<xpath>//figure/figcaption</xpath>
-			<xpath>//figure/img/@alt</xpath>
-			<key name="headingTitle" />
-			<key name="text" />
-		</gutenberg-block>
-		<gutenberg-block type="my-plugin/my-block-2" translate="1">
-			<xpath>//div/p/a</xpath>
-			<key name="iconLabel" />
-		</gutenberg-block>
-		<gutenberg-block type=" " translate="1">
-			<xpath>//div/p/a</xpath>
-			<key name="iconLabel" />
-		</gutenberg-block>
-		<gutenberg-block type="my-plugin/my-block-4">
-			<xpath>//div/p/a</xpath>
-			<key name="iconLabel" />
-		</gutenberg-block>
-		<gutenberg-block type="my-plugin/my-block-5" translate="1">
-			<xpath> </xpath>
-			<key name="iconLabel" />
-		</gutenberg-block>
-		<gutenberg-block type="my-plugin/my-block-6" translate="1">
-			<xpath>//div/p/a</xpath>
-			<key name=" " />
-		</gutenberg-block>
-	</gutenberg-blocks>
-	<language-switcher-settings>
-		<key name="icl_lang_sel_config">
-			<key name="font-current-normal">#444444</key>
-			<key name="font-current-hover">#000000</key>
-			<key name="background-current-normal">#ffffff</key>
-			<key name="background-current-hover">#eeeeee</key>
-			<key name="font-other-normal">#444444</key>
-			<key name="font-other-hover">#000000</key>
-			<key name="background-other-normal">#ffffff</key>
-			<key name="background-other-hover">#eeeeee</key>
-			<key name="border">#cdcdcd</key>
-		</key>
-		<key name="icl_lang_sel_footer_config">
-			<key name="font-current-normal">#444444</key>
-			<key name="font-current-hover">#000000</key>
-			<key name="background-current-normal">#ffffff</key>
-			<key name="background-current-hover">#eeeeee</key>
-			<key name="font-other-normal">#444444</key>
-			<key name="font-other-hover">#000000</key>
-			<key name="background-other-normal">#ffffff</key>
-			<key name="background-other-hover">#eeeeee</key>
-			<key name="border">#cdcdcd</key>
-		</key>
-		<key name="icl_language_switcher_sidebar">0</key>
-		<key name="icl_widget_title_show">0</key>
-		<key name="icl_lang_sel_type">dropdown</key>
-		<key name="icl_lso_link_empty">0</key>
-		<key name="icl_lso_flags">0</key>
-		<key name="icl_lso_native_lang">1</key>
-		<key name="icl_lso_display_lang">1</key>
-		<key name="icl_lang_sel_footer">0</key>
-		<key name="icl_post_availability">0</key>
-		<key name="icl_post_availability_position">below</key>
-		<key name="icl_post_availability_text">This post is also available in: %s</key>
-	</language-switcher-settings>
+				<key name="empty_option">
+					<key name="*">
+						<key name="label"/>
+					</key>
+				</key>
+				<key name="simple_string_option" />
+				<key name="generi(_option_*" />
+		</admin-texts>
+		<gutenberg-blocks>
+			<gutenberg-block type="my-plugin/my-block" translate="1">
+				<xpath>//figure/figcaption</xpath>
+				<xpath>//figure/img/@alt</xpath>
+				<key name="headingTitle" />
+				<key name="text" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-2" translate="1">
+				<xpath>//div/p/a</xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type=" " translate="1">
+				<xpath>//div/p/a</xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-4">
+				<xpath>//div/p/a</xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-5" translate="1">
+				<xpath> </xpath>
+				<key name="iconLabel" />
+			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-6" translate="1">
+				<xpath>//div/p/a</xpath>
+				<key name=" " />
+			</gutenberg-block>
+		</gutenberg-blocks>
+		<language-switcher-settings>
+				<key name="icl_lang_sel_config">
+						<key name="font-current-normal">#444444</key>
+						<key name="font-current-hover">#000000</key>
+						<key name="background-current-normal">#ffffff</key>
+						<key name="background-current-hover">#eeeeee</key>
+						<key name="font-other-normal">#444444</key>
+						<key name="font-other-hover">#000000</key>
+						<key name="background-other-normal">#ffffff</key>
+						<key name="background-other-hover">#eeeeee</key>
+						<key name="border">#cdcdcd</key>
+				</key>
+				<key name="icl_lang_sel_footer_config">
+						<key name="font-current-normal">#444444</key>
+						<key name="font-current-hover">#000000</key>
+						<key name="background-current-normal">#ffffff</key>
+						<key name="background-current-hover">#eeeeee</key>
+						<key name="font-other-normal">#444444</key>
+						<key name="font-other-hover">#000000</key>
+						<key name="background-other-normal">#ffffff</key>
+						<key name="background-other-hover">#eeeeee</key>
+						<key name="border">#cdcdcd</key>
+				</key>
+				<key name="icl_language_switcher_sidebar">0</key>
+				<key name="icl_widget_title_show">0</key>
+				<key name="icl_lang_sel_type">dropdown</key>
+				<key name="icl_lso_link_empty">0</key>
+				<key name="icl_lso_flags">0</key>
+				<key name="icl_lso_native_lang">1</key>
+				<key name="icl_lso_display_lang">1</key>
+				<key name="icl_lang_sel_footer">0</key>
+				<key name="icl_post_availability">0</key>
+				<key name="icl_post_availability_position">below</key>
+				<key name="icl_post_availability_text">This post is also available in: %s</key>
+		</language-switcher-settings>
 </wpml-config>
-
-

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -1,140 +1,140 @@
 <wpml-config>
-		<custom-fields>
-				<custom-field action="copy">quantity</custom-field>
-				<custom-field action="translate">custom-title</custom-field>
-				<custom-field action="translate">custom|nested</custom-field>
-				<custom-field action="copy">weight</custom-field>
-				<custom-field action="copy-once">bg-color</custom-field>
-				<custom-field action="translate">custom-description</custom-field>
-				<custom-field action="ignore">date-added</custom-field>
-				<custom-field action="translate" encoding="json">a_json_meta</custom-field>
-		</custom-fields>
-		<custom-fields-texts>
-			<key name="custom|nested">
-				<key name="sub-1" />
-				<key name="sub-2">
-					<key name="sub|21">
-						<key name="sub-211" />
-						<key name=" " />
-						<key name="" />
-						<key />
-					</key>
+	<custom-fields>
+		<custom-field action="copy">quantity</custom-field>
+		<custom-field action="translate">custom-title</custom-field>
+		<custom-field action="translate">custom|nested</custom-field>
+		<custom-field action="copy">weight</custom-field>
+		<custom-field action="copy-once">bg-color</custom-field>
+		<custom-field action="translate">custom-description</custom-field>
+		<custom-field action="ignore">date-added</custom-field>
+		<custom-field action="translate" encoding="json">a_json_meta</custom-field>
+	</custom-fields>
+	<custom-fields-texts>
+		<key name="custom|nested">
+			<key name="sub-1" />
+			<key name="sub-2">
+				<key name="sub|21">
+					<key name="sub-211" />
+					<key name=" " />
+					<key name="" />
+					<key />
 				</key>
 			</key>
-			<key name="a_json_meta">
-				<key name="to_translate" />
+		</key>
+		<key name="a_json_meta">
+			<key name="to_translate" />
+		</key>
+		<key name="custom-nested-2">
+			<key name="sub-1" />
+		</key>
+	</custom-fields-texts>
+	<custom-term-fields>
+		<custom-term-field action="copy">term_meta_A</custom-term-field>
+		<custom-term-field action="translate">term_meta_B</custom-term-field>
+		<custom-term-field action="ignore">term_meta_C</custom-term-field>
+		<custom-term-field action="copy-once">term_meta_D</custom-term-field>
+	</custom-term-fields>
+	<custom-types>
+		<custom-type translate="1">book</custom-type>
+		<custom-type translate="0">DVD</custom-type>
+	</custom-types>
+	<taxonomies>
+		<taxonomy translate="1">genre</taxonomy>
+		<taxonomy translate="1">type</taxonomy>
+		<taxonomy translate="0">publisher</taxonomy>
+	</taxonomies>
+	<admin-texts>
+		<key name="my_plugins_options">
+			<key name="option_name_1" />
+			<key name="option_name_2" />
+			<key name="options_group_1">
+				<key name="sub_option_name_11" />
+				<key name="sub_option_name_12" />
 			</key>
-			<key name="custom-nested-2">
-				<key name="sub-1" />
+			<key name="options_group_2">
+				<key name="*"/>
 			</key>
-		</custom-fields-texts>
-		<custom-term-fields>
-			<custom-term-field action="copy">term_meta_A</custom-term-field>
-			<custom-term-field action="translate">term_meta_B</custom-term-field>
-			<custom-term-field action="ignore">term_meta_C</custom-term-field>
-			<custom-term-field action="copy-once">term_meta_D</custom-term-field>
-		</custom-term-fields>
-		<custom-types>
-				<custom-type translate="1">book</custom-type>
-				<custom-type translate="0">DVD</custom-type>
-		</custom-types>
-		<taxonomies>
-				<taxonomy translate="1">genre</taxonomy>
-				<taxonomy translate="1">type</taxonomy>
-				<taxonomy translate="0">publisher</taxonomy>
-		</taxonomies>
-		<admin-texts>
-				<key name="my_plugins_options">
-						<key name="option_name_1" />
-						<key name="option_name_2" />
-						<key name="options_group_1">
-								<key name="sub_option_name_11" />
-								<key name="sub_option_name_12" />
-						</key>
-						<key name="options_group_2">
-								<key name="*"/>
-						</key>
-						<key name="options_group_3">
-								<key name="*">
-										<key name="sub_sub_option_name_3x1" />
-										<key name="sub_sub_option_name_3x2" />
-								</key>
-						</key>
-						<key name="options_group_4">
-								<key name="sub_option_name_*" />
-						</key>
+			<key name="options_group_3">
+				<key name="*">
+					<key name="sub_sub_option_name_3x1" />
+					<key name="sub_sub_option_name_3x2" />
 				</key>
-				<key name="empty_option">
-					<key name="*">
-						<key name="label"/>
-					</key>
-				</key>
-				<key name="simple_string_option" />
-				<key name="generi(_option_*" />
-		</admin-texts>
-		<gutenberg-blocks>
-			<gutenberg-block type="my-plugin/my-block" translate="1">
-				<xpath>//figure/figcaption</xpath>
-				<xpath>//figure/img/@alt</xpath>
-				<key name="headingTitle" />
-				<key name="text" />
-			</gutenberg-block>
-			<gutenberg-block type="my-plugin/my-block-2" translate="1">
-				<xpath>//div/p/a</xpath>
-				<key name="iconLabel" />
-			</gutenberg-block>
-			<gutenberg-block type=" " translate="1">
-				<xpath>//div/p/a</xpath>
-				<key name="iconLabel" />
-			</gutenberg-block>
-			<gutenberg-block type="my-plugin/my-block-4">
-				<xpath>//div/p/a</xpath>
-				<key name="iconLabel" />
-			</gutenberg-block>
-			<gutenberg-block type="my-plugin/my-block-5" translate="1">
-				<xpath> </xpath>
-				<key name="iconLabel" />
-			</gutenberg-block>
-			<gutenberg-block type="my-plugin/my-block-6" translate="1">
-				<xpath>//div/p/a</xpath>
-				<key name=" " />
-			</gutenberg-block>
-		</gutenberg-blocks>
-		<language-switcher-settings>
-				<key name="icl_lang_sel_config">
-						<key name="font-current-normal">#444444</key>
-						<key name="font-current-hover">#000000</key>
-						<key name="background-current-normal">#ffffff</key>
-						<key name="background-current-hover">#eeeeee</key>
-						<key name="font-other-normal">#444444</key>
-						<key name="font-other-hover">#000000</key>
-						<key name="background-other-normal">#ffffff</key>
-						<key name="background-other-hover">#eeeeee</key>
-						<key name="border">#cdcdcd</key>
-				</key>
-				<key name="icl_lang_sel_footer_config">
-						<key name="font-current-normal">#444444</key>
-						<key name="font-current-hover">#000000</key>
-						<key name="background-current-normal">#ffffff</key>
-						<key name="background-current-hover">#eeeeee</key>
-						<key name="font-other-normal">#444444</key>
-						<key name="font-other-hover">#000000</key>
-						<key name="background-other-normal">#ffffff</key>
-						<key name="background-other-hover">#eeeeee</key>
-						<key name="border">#cdcdcd</key>
-				</key>
-				<key name="icl_language_switcher_sidebar">0</key>
-				<key name="icl_widget_title_show">0</key>
-				<key name="icl_lang_sel_type">dropdown</key>
-				<key name="icl_lso_link_empty">0</key>
-				<key name="icl_lso_flags">0</key>
-				<key name="icl_lso_native_lang">1</key>
-				<key name="icl_lso_display_lang">1</key>
-				<key name="icl_lang_sel_footer">0</key>
-				<key name="icl_post_availability">0</key>
-				<key name="icl_post_availability_position">below</key>
-				<key name="icl_post_availability_text">This post is also available in: %s</key>
-		</language-switcher-settings>
+			</key>
+			<key name="options_group_4">
+				<key name="sub_option_name_*" />
+			</key>
+		</key>
+		<key name="empty_option">
+			<key name="*">
+				<key name="label"/>
+			</key>
+		</key>
+		<key name="simple_string_option" />
+		<key name="generi(_option_*" />
+	</admin-texts>
+	<gutenberg-blocks>
+		<gutenberg-block type="my-plugin/my-block" translate="1">
+			<xpath>//figure/figcaption</xpath>
+			<xpath>//figure/img/@alt</xpath>
+			<key name="headingTitle" />
+			<key name="text" />
+		</gutenberg-block>
+		<gutenberg-block type="my-plugin/my-block-2" translate="1">
+			<xpath>//div/p/a</xpath>
+			<key name="iconLabel" />
+		</gutenberg-block>
+		<gutenberg-block type=" " translate="1">
+			<xpath>//div/p/a</xpath>
+			<key name="iconLabel" />
+		</gutenberg-block>
+		<gutenberg-block type="my-plugin/my-block-4">
+			<xpath>//div/p/a</xpath>
+			<key name="iconLabel" />
+		</gutenberg-block>
+		<gutenberg-block type="my-plugin/my-block-5" translate="1">
+			<xpath> </xpath>
+			<key name="iconLabel" />
+		</gutenberg-block>
+		<gutenberg-block type="my-plugin/my-block-6" translate="1">
+			<xpath>//div/p/a</xpath>
+			<key name=" " />
+		</gutenberg-block>
+	</gutenberg-blocks>
+	<language-switcher-settings>
+		<key name="icl_lang_sel_config">
+			<key name="font-current-normal">#444444</key>
+			<key name="font-current-hover">#000000</key>
+			<key name="background-current-normal">#ffffff</key>
+			<key name="background-current-hover">#eeeeee</key>
+			<key name="font-other-normal">#444444</key>
+			<key name="font-other-hover">#000000</key>
+			<key name="background-other-normal">#ffffff</key>
+			<key name="background-other-hover">#eeeeee</key>
+			<key name="border">#cdcdcd</key>
+		</key>
+		<key name="icl_lang_sel_footer_config">
+			<key name="font-current-normal">#444444</key>
+			<key name="font-current-hover">#000000</key>
+			<key name="background-current-normal">#ffffff</key>
+			<key name="background-current-hover">#eeeeee</key>
+			<key name="font-other-normal">#444444</key>
+			<key name="font-other-hover">#000000</key>
+			<key name="background-other-normal">#ffffff</key>
+			<key name="background-other-hover">#eeeeee</key>
+			<key name="border">#cdcdcd</key>
+		</key>
+		<key name="icl_language_switcher_sidebar">0</key>
+		<key name="icl_widget_title_show">0</key>
+		<key name="icl_lang_sel_type">dropdown</key>
+		<key name="icl_lso_link_empty">0</key>
+		<key name="icl_lso_flags">0</key>
+		<key name="icl_lso_native_lang">1</key>
+		<key name="icl_lso_display_lang">1</key>
+		<key name="icl_lang_sel_footer">0</key>
+		<key name="icl_post_availability">0</key>
+		<key name="icl_post_availability_position">below</key>
+		<key name="icl_post_availability_text">This post is also available in: %s</key>
+	</language-switcher-settings>
 </wpml-config>
 
 

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -70,7 +70,7 @@
 					</key>
 				</key>
 				<key name="simple_string_option" />
-				<key name="generic_option_*" />
+				<key name="generi(_option_*" />
 		</admin-texts>
 		<gutenberg-blocks>
 			<gutenberg-block type="my-plugin/my-block" translate="1">

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -97,8 +97,11 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 	protected function prepare_option_multiple( $method = 'ARRAY' ) {
 		$options = array(
 			'option_name_1'   => 'val1',
-			'options_group_1' => array(
+			'option$_group_1' => array(
 				'sub_option_name_11' => 'val11',
+			),
+			'option$_'        => array(
+				'sub_option_name_12' => 'val12',
 			),
 		);
 
@@ -112,8 +115,11 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 	protected function register_option_multiple() {
 		$keys = array(
 			'option_name_1'   => 1,
-			'options_group_1' => array(
+			'option$_group_1' => array(
 				'sub_option_name_11' => 1,
+			),
+			'option$_'        => array(
+				'sub_option_name_12' => 1,
 			),
 		);
 
@@ -123,7 +129,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 	protected function register_option_multiple_with_wildcard() {
 		$keys = array(
 			'option_name_1' => 1,
-			'options_*'     => 1,
+			'option$_*'     => 1, // Match `option$_group_1` and `option$_`.
 		);
 
 		new PLL_Translate_Option( 'my_options', $keys );
@@ -137,6 +143,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			$translations = array(
 				'val1'  => 'val1_' . $lang,
 				'val11' => 'val11_' . $lang,
+				'val12' => 'val12_' . $lang,
 			);
 			$this->add_string_translations( $lang, $translations );
 		}
@@ -145,8 +152,11 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 	protected function update_option_with_new_val( $method = 'ARRAY' ) {
 		$options = array(
 			'option_name_1'   => 'new_val1',
-			'options_group_1' => array(
+			'option$_group_1' => array(
 				'sub_option_name_11' => 'new_val11',
+			),
+			'option$_'        => array(
+				'sub_option_name_12' => 'new_val12',
 			),
 		);
 
@@ -167,7 +177,8 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			$this->pll_admin->load_strings_translations( $lang );
 			$options = get_option( 'my_options' );
 			$this->assertSame( 'val1_' . $lang, $options['option_name_1'] );
-			$this->assertSame( 'val11_' . $lang, $options['options_group_1']['sub_option_name_11'] );
+			$this->assertSame( 'val11_' . $lang, $options['option$_group_1']['sub_option_name_11'] );
+			$this->assertSame( 'val12_' . $lang, $options['option$_']['sub_option_name_12'] );
 		}
 
 		$this->update_option_with_new_val( 'ARRAY' );
@@ -176,7 +187,8 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			$this->pll_admin->load_strings_translations( $lang );
 			$options = get_option( 'my_options' );
 			$this->assertSame( 'val1_' . $lang, $options['option_name_1'] );
-			$this->assertSame( 'val11_' . $lang, $options['options_group_1']['sub_option_name_11'] );
+			$this->assertSame( 'val11_' . $lang, $options['option$_group_1']['sub_option_name_11'] );
+			$this->assertSame( 'val12_' . $lang, $options['option$_']['sub_option_name_12'] );
 		}
 	}
 
@@ -202,7 +214,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 			$this->pll_admin->load_strings_translations( $lang );
 			$options = get_option( 'my_options' );
 			$this->assertSame( 'val1_' . $lang, $options->option_name_1 );
-			$this->assertSame( 'val11_' . $lang, $options->options_group_1->sub_option_name_11 );
+			$this->assertSame( 'val11_' . $lang, $options->{'option$_group_1'}->sub_option_name_11 );
 		}
 	}
 
@@ -234,7 +246,8 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->pll_admin->load_strings_translations( 'en' );
 		$options = get_option( 'my_options' );
 		$this->assertSame( 'new_val1', $options['option_name_1'] );
-		$this->assertSame( 'new_val11', $options['options_group_1']['sub_option_name_11'] );
+		$this->assertSame( 'new_val11', $options['option$_group_1']['sub_option_name_11'] );
+		$this->assertSame( 'new_val12', $options['option$_']['sub_option_name_12'] );
 	}
 
 	public function test_update_option_multiple_with_no_translation() {
@@ -257,7 +270,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->pll_admin->load_strings_translations( 'en' );
 		$options = get_option( 'my_options' );
 		$this->assertSame( 'new_val1', $options->option_name_1 );
-		$this->assertSame( 'new_val11', $options->options_group_1->sub_option_name_11 );
+		$this->assertSame( 'new_val11', $options->{'option$_group_1'}->sub_option_name_11 );
 	}
 
 	public function test_update_object_option_multiple_with_no_translation() {
@@ -277,8 +290,11 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 
 		$options = array(
 			'option_name_1'   => 'val1_en',
-			'options_group_1' => array(
+			'option$_group_1' => array(
 				'sub_option_name_11' => 'val11_en',
+			),
+			'option$_'        => array(
+				'sub_option_name_12' => 'val12_en',
 			),
 		);
 
@@ -296,6 +312,8 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertArrayNotHasKey( 'val1_en', $mo->entries );
 		$this->assertArrayHasKey( 'val11', $mo->entries );
 		$this->assertArrayNotHasKey( 'val11_en', $mo->entries );
+		$this->assertArrayHasKey( 'val12', $mo->entries );
+		$this->assertArrayNotHasKey( 'val12_en', $mo->entries );
 	}
 
 	public function test_update_option_multiple_when_filtered() {

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -76,8 +76,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 
 		update_option( 'my_plugins_options', $my_plugins_options );
 		update_option( 'simple_string_option', 'val' );
-		update_option( 'generic_option_1', 'generic_val_1' );
-		update_option( 'generic_option_2', 'generic_val_2' );
+		update_option( 'generi(_option_', 'generic_val_0' );
+		update_option( 'generi(_option_1', 'generic_val_1' );
+		update_option( 'generi(_option_2', 'generic_val_2' );
 	}
 
 	protected function translate_options( $slug ) {
@@ -101,6 +102,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$mo->add_entry( $mo->make_entry( 'val41', "val41_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val42', "val42_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'val43', "val43_$slug" ) );
+		$mo->add_entry( $mo->make_entry( 'generic_val_0', "generic_val_0_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'generic_val_1', "generic_val_1_$slug" ) );
 		$mo->add_entry( $mo->make_entry( 'generic_val_2', "generic_val_2_$slug" ) );
 		$mo->export_to_db( $language );
@@ -320,8 +322,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'val42_fr', $options['options_group_4']['sub_option_name_42'] );
 		$this->assertEquals( 'val43', $options['options_group_4']['sub_option_diff_43'] ); // This one must not be translated.
 		$this->assertEquals( 'val_fr', get_option( 'simple_string_option' ) );
-		$this->assertEquals( 'generic_val_1_fr', get_option( 'generic_option_1' ) );
-		$this->assertEquals( 'generic_val_2_fr', get_option( 'generic_option_2' ) );
+		$this->assertEquals( 'generic_val_0_fr', get_option( 'generi(_option_' ) );
+		$this->assertEquals( 'generic_val_1_fr', get_option( 'generi(_option_1' ) );
+		$this->assertEquals( 'generic_val_2_fr', get_option( 'generi(_option_2' ) );
 	}
 
 	public function test_translate_strings_object() {
@@ -372,6 +375,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertContains( 'val42', $strings );
 		$this->assertNotContains( 'val43', $strings ); // This one must not be registered.
 		$this->assertContains( 'val', $strings );
+		$this->assertContains( 'generic_val_0', $strings );
 		$this->assertContains( 'generic_val_1', $strings );
 		$this->assertContains( 'generic_val_2', $strings );
 	}


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1937.
Related: https://github.com/polylang/polylang-pro/pull/2073.

This PR introduces the class `PLL_Format_Util`. This PR doesn't add wildcard support to anything, it only uses the new class where wildcards were already in use.

Things to note:
1. There are some differences from the version from Polylang Pro:
    - `filter_list()` supports arrays only (we don't use anything else anymore).
    - New method `is_format()` to tell if a given string has a wildcard.
2. Thanks to the new class, `PLL_WPML_Config` and `PLL_Translate_Option` now support keys with special characters.

`PLL_Format_Util` must then be removed from Polylang Pro.