### PR TITLE
Migrate some tests to use the new context init and factory

### DIFF
--- a/tests/phpunit/includes/context/context-base.php
+++ b/tests/phpunit/includes/context/context-base.php
@@ -20,9 +20,12 @@ abstract class PLL_Context_Base {
 	public function __construct( array $settings = array() ) {
 		global $wp_rewrite;
 
-		$default_lang = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false, 'orderby' => 'term_id', 'fields' => 'slugs' ) );
+		$options = PLL_Install::get_default_options();
 
-		$options = array_merge( PLL_Install::get_default_options(), array( 'default_lang' => reset( $default_lang ) ) );
+		$language_terms = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false, 'orderby' => 'term_id', 'fields' => 'slugs' ) );
+		if ( is_array( $language_terms ) && ! empty( $language_terms ) ) {
+			$options = array_merge( $options, array( 'default_lang' => reset( $language_terms ) ) );
+		}
 
 		if ( isset( $settings['options'] ) && is_array( $settings['options'] ) && ! empty( $settings['options'] ) ) {
 			$options = array_merge( $options, $settings['options'] );

--- a/tests/phpunit/includes/context/context-frontend.php
+++ b/tests/phpunit/includes/context/context-frontend.php
@@ -37,5 +37,6 @@ class PLL_Context_Frontend extends PLL_Context_Base {
 
 		$this->do_pll_actions( 'parse_request' );
 		$this->do_pll_actions( 'wp' );
+		$this->do_pll_actions( 'template_redirect' );
 	}
 }

--- a/tests/phpunit/includes/context/context-rest.php
+++ b/tests/phpunit/includes/context/context-rest.php
@@ -27,11 +27,16 @@ class PLL_Context_Rest extends PLL_Context_Base {
 	 * @return void
 	 */
 	protected function do_wordpress_actions() {
+		global $wp_rest_server;
+
 		$this->do_pll_actions( 'setup_theme' );
 		$this->do_pll_actions( 'after_setup_theme' );
 		$this->do_pll_actions( 'init' );
 		$this->do_pll_actions( 'widgets_init' );
-		$this->do_pll_actions( 'rest_api_init' );
+
+		$wp_rest_server = new Spy_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
 		$this->do_pll_actions( 'wp_loaded' );
 
 		flush_rewrite_rules();

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -24,7 +24,7 @@ class Columns_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Set a user to pass current_user_can tests.
+		// Sets a user to pass current_user_can tests.
 		wp_set_current_user( self::$editor );
 	}
 

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -1,16 +1,22 @@
 <?php
 
+/**
+ * Note: Some tests require posts or terms without language.
+ * As Polylang automatically assigns the default language to all objects,
+ * we need to instantiate `PLL_Context_Admin` after these objects are created.
+ * This prevents us to do it in `set_up()`.
+ */
 class Columns_Test extends PLL_UnitTestCase {
 	protected static $editor;
 
 	/**
-	 * @param WP_UnitTest_Factory $factory
+	 * @param PLL_UnitTest_Factory $factory
+	 * @return void
 	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+		$factory->language->create_many( 2 );
 
 		self::$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 	}
@@ -18,28 +24,15 @@ class Columns_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// set a user to pass current_user_can tests
+		// Set a user to pass current_user_can tests.
 		wp_set_current_user( self::$editor );
-
-		$links_model     = self::$model->get_links_model();
-		$this->pll_admin = new PLL_Admin( $links_model );
-
-		$this->pll_admin->links        = new PLL_Admin_Links( $this->pll_admin );
-		$this->pll_admin->default_term = new PLL_Admin_Default_Term( $this->pll_admin );
-		$this->pll_admin->default_term->add_hooks();
-		$this->pll_admin->filters_columns = new PLL_Admin_Filters_Columns( $this->pll_admin );
-	}
-
-	public function tear_down() {
-		unset( $this->pll_admin->filter_lang );
-
-		parent::tear_down();
 	}
 
 	/**
 	 * This must be the first test due to the static variable in get_culumn_headers().
 	 */
 	public function test_no_screen_options_in_term_screen() {
+		new PLL_Context_Admin();
 		set_current_screen( 'term.php' );
 		$this->assertEmpty( get_column_headers( get_current_screen() ) );
 	}
@@ -47,45 +40,49 @@ class Columns_Test extends PLL_UnitTestCase {
 	public function test_post_with_no_language() {
 		$post_id = self::factory()->post->create();
 
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_en', $post_id );
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $post_id );
+		$pll_admin->filters_columns->post_column( 'language_en', $post_id );
+		$pll_admin->filters_columns->post_column( 'language_fr', $post_id );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
 	public function test_post_language() {
-		$en = self::factory()->post->create();
-		self::$model->post->set_language( $en, 'en' );
+		$en = self::factory()->post->create( array( 'lang' => 'en' ) );
+
+		$pll_admin = ( new PLL_Context_Admin() )->get();
 
 		// with capability
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_en', $en );
+		$pll_admin->filters_columns->post_column( 'language_en', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) && strpos( $column, 'href' ) );
 
 		// without capability
 		wp_set_current_user( 0 );
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_en', $en );
+		$pll_admin->filters_columns->post_column( 'language_en', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) );
 		$this->assertFalse( strpos( $column, 'href' ) );
 	}
 
 	public function test_untranslated_post() {
-		$en = self::factory()->post->create();
-		self::$model->post->set_language( $en, 'en' );
+		$en = self::factory()->post->create( array( 'lang' => 'en' ) );
 
-		// with capability
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+
+		// With capability.
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
+		$pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_icon_add' ) && strpos( $column, 'from_post' ) );
 
-		// without capability
+		// Without capability.
 		wp_set_current_user( 0 );
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
+		$pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
@@ -93,40 +90,41 @@ class Columns_Test extends PLL_UnitTestCase {
 	 * Special case for media.
 	 */
 	public function test_untranslated_media() {
-		$en = self::factory()->attachment->create_object( 'image.jpg' );
-		self::$model->post->set_language( $en, 'en' );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
 
-		// with capability
+		$en = self::factory()->attachment->create_object( 'image.jpg' );
+		$pll_admin->model->post->set_language( $en, 'en' );
+
+		// With capability.
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
+		$pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$column = ob_get_clean();
 		$this->assertNotFalse( strpos( $column, 'pll_icon_add' ) && strpos( $column, 'from_media' ) );
 
-		// without capability
+		// Without capability.
 		wp_set_current_user( 0 );
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
+		$pll_admin->filters_columns->post_column( 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
 	public function test_translated_post() {
-		$en = self::factory()->post->create();
-		self::$model->post->set_language( $en, 'en' );
+		$posts = self::factory()->post->create_translated(
+			array( 'lang' => 'en' ),
+			array( 'lang' => 'fr' )
+		);
 
-		$fr = self::factory()->post->create();
-		self::$model->post->set_language( $fr, 'fr' );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
 
-		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
-
-		// with capability
+		// With capability.
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
+		$pll_admin->filters_columns->post_column( 'language_fr', $posts['en'] );
 		$this->assertNotFalse( strpos( ob_get_clean(), 'pll_icon_edit' ) );
 
-		// without capability
+		// Without capability.
 		wp_set_current_user( 0 );
 		ob_start();
-		$this->pll_admin->filters_columns->post_column( 'language_fr', $en );
+		$pll_admin->filters_columns->post_column( 'language_fr', $posts['en'] );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
@@ -136,8 +134,10 @@ class Columns_Test extends PLL_UnitTestCase {
 
 		$term_id = self::factory()->category->create();
 
-		$column_en = $this->pll_admin->filters_columns->term_column( '', 'language_en', $term_id );
-		$column_fr = $this->pll_admin->filters_columns->term_column( '', 'language_fr', $term_id );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+
+		$column_en = $pll_admin->filters_columns->term_column( '', 'language_en', $term_id );
+		$column_fr = $pll_admin->filters_columns->term_column( '', 'language_fr', $term_id );
 		$this->assertEmpty( $column_en );
 		$this->assertEmpty( $column_fr );
 	}
@@ -146,16 +146,17 @@ class Columns_Test extends PLL_UnitTestCase {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
-		$en = self::factory()->category->create();
-		self::$model->term->set_language( $en, 'en' );
+		$en = self::factory()->category->create( array( 'lang' => 'en' ) );
 
-		// with capability
-		$column = $this->pll_admin->filters_columns->term_column( '', 'language_en', $en );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+
+		// With capability.
+		$column = $pll_admin->filters_columns->term_column( '', 'language_en', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) && strpos( $column, 'href' ) );
 
-		// without capability
+		// Without capability.
 		wp_set_current_user( 0 );
-		$column = $this->pll_admin->filters_columns->term_column( '', 'language_en', $en );
+		$column = $pll_admin->filters_columns->term_column( '', 'language_en', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_column_flag' ) );
 		$this->assertFalse( strpos( $column, 'href' ) );
 	}
@@ -164,17 +165,18 @@ class Columns_Test extends PLL_UnitTestCase {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
-		$en = self::factory()->category->create();
-		self::$model->term->set_language( $en, 'en' );
+		$en = self::factory()->category->create( array( 'lang' => 'en' ) );
 
-		// with capability
-		$column = $this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+
+		// With capability.
+		$column = $pll_admin->filters_columns->term_column( '', 'language_fr', $en );
 		$this->assertNotFalse( strpos( $column, 'pll_icon_add' ) );
 
-		// without capability
+		// Without capability.
 		wp_set_current_user( 0 );
 		ob_start();
-		$this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
+		$pll_admin->filters_columns->term_column( '', 'language_fr', $en );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
@@ -182,30 +184,31 @@ class Columns_Test extends PLL_UnitTestCase {
 		$GLOBALS['post_type'] = 'post';
 		$GLOBALS['taxonomy'] = 'category';
 
-		$en = self::factory()->category->create();
-		self::$model->term->set_language( $en, 'en' );
+		$cats = self::factory()->category->create_translated(
+			array( 'lang' => 'en' ),
+			array( 'lang' => 'fr' )
+		);
 
-		$fr = self::factory()->category->create();
-		self::$model->term->set_language( $fr, 'fr' );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
 
-		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
-
-		// with capability
-		$column = $this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
+		// With capability.
+		$column = $pll_admin->filters_columns->term_column( '', 'language_fr', $cats['en'] );
 		$this->assertNotFalse( strpos( $column, 'pll_icon_edit' ) );
 
-		// without capability
+		// Without capability.
 		wp_set_current_user( 0 );
 		ob_start();
-		$this->pll_admin->filters_columns->term_column( '', 'language_fr', $en );
+		$pll_admin->filters_columns->term_column( '', 'language_fr', $cats['en'] );
 		$this->assertEmpty( ob_get_clean() );
 	}
 
 	public function test_add_post_column() {
-		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
+		new PLL_Context_Admin();
+
+		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers().
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		$columns = $list_table->get_column_info()[0];
-		$columns = array_intersect_key( $columns, array_flip( array( 'comments' ) ) ); // Keep only the Comments column
+		$columns = array_intersect_key( $columns, array_flip( array( 'comments' ) ) ); // Keep only the Comments column.
 		$columns = apply_filters( 'manage_edit-post_columns', $columns );
 		$columns = array_keys( $columns );
 		$en = array_search( 'language_en', $columns );
@@ -216,7 +219,9 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_add_post_column_with_filter() {
-		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+		$pll_admin->filter_lang = $pll_admin->model->get_language( 'en' );
+
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		$hidden = $list_table->get_column_info()[1];
 		$this->assertNotFalse( array_search( 'language_en', $hidden ) );
@@ -224,11 +229,13 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_add_term_column() {
+		new PLL_Context_Admin();
 		set_current_screen( 'edit-tags.php' );
-		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers()
+
+		// We need to call directly the filter "manage_{$screen->id}_columns" due to the static var in get_column_headers().
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
 		$columns = $list_table->get_column_info()[0];
-		$columns = array_intersect_key( $columns, array_flip( array( 'posts' ) ) ); // Keep only the Count column
+		$columns = array_intersect_key( $columns, array_flip( array( 'posts' ) ) ); // Keep only the Count column.
 		$columns = apply_filters( 'manage_edit-post_tag_columns', $columns );
 		$columns = array_keys( $columns );
 		$en = array_search( 'language_en', $columns );
@@ -239,8 +246,10 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_add_term_column_with_filter() {
+		$pll_admin = ( new PLL_Context_Admin() )->get();
+		$pll_admin->filter_lang = self::$model->get_language( 'fr' );
 		set_current_screen( 'edit-tags.php' );
-		$this->pll_admin->filter_lang = self::$model->get_language( 'fr' );
+
 		$list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-tags.php' ) );
 		$hidden = $list_table->get_column_info()[1];
 		$this->assertNotFalse( array_search( 'language_fr', $hidden ) );
@@ -248,12 +257,13 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_post_inline_edit() {
-		$en = self::factory()->post->create();
-		self::$model->post->set_language( $en, 'en' );
+		self::factory()->post->create( array( 'lang' => 'en' ) );
+
+		new PLL_Context_Admin();
 
 		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
 		$list_table->prepare_items();
-		$GLOBALS['post'] = $GLOBALS['wp_the_query']->post; // Needed by touch_time
+		$GLOBALS['post'] = $GLOBALS['wp_the_query']->post; // Needed by touch_time.
 
 		ob_start();
 		$list_table->inline_edit();
@@ -262,7 +272,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		$doc->loadHTML( $form );
 		$xpath = new DOMXpath( $doc );
 
-		// Quick Edit
+		// Quick Edit.
 		$tr      = $doc->getElementById( 'inline-edit' );
 		$options = $xpath->query( './/select[@name="inline_lang_choice"]/option', $tr );
 		$this->assertSame( 2, $options->length, 'Expected the <select> tag to contain 2 <option> tags.' );
@@ -275,7 +285,7 @@ class Columns_Test extends PLL_UnitTestCase {
 			"'Expected the <select> tag to contain a 'en' and a 'fr' choices."
 		);
 
-		// Bulk Edit
+		// Bulk Edit.
 		$tr      = $doc->getElementById( 'bulk-edit' );
 		$options = $xpath->query( './/select[@name="inline_lang_choice"]/option', $tr );
 		$this->assertSame( 3, $options->length, 'Expected the <select> tag to contain 3 <option> tags.' );

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -5,20 +5,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options       = PLL_Install::get_default_options();
-		$model         = new PLL_Admin_Model( $options );
-		$links_model   = $model->get_links_model();
-		$this->pll_env = new PLL_Admin( $links_model );
-	}
-
-	public function tear_down() {
-		remove_action( 'pre_delete_term', array( $this, 'clean_languages_cache_and_build_languages_list' ) );
-
-		foreach ( $this->pll_env->model->get_languages_list() as $lang ) {
-			$this->pll_env->model->delete_language( $lang->term_id );
-		}
-
-		parent::tear_down();
+		$this->pll_env = ( new PLL_Context_Settings() )->get();
 	}
 
 	public function test_add_and_delete_language() {
@@ -41,6 +28,9 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en_US', $lang->locale );
 		$this->assertEquals( 0, $lang->is_rtl );
 		$this->assertEquals( 2, $lang->term_group );
+
+		// Check default language.
+		$this->assertEquals( 'en', $this->pll_env->model->options['default_lang'] );
 
 		// Second language (rtl).
 		$args = array(

--- a/tests/phpunit/tests/test-hreflang.php
+++ b/tests/phpunit/tests/test-hreflang.php
@@ -81,7 +81,7 @@ class Hreflang_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_paged_archive() {
-		update_option( 'posts_per_page', 2 ); // to avoid creating too many posts.
+		update_option( 'posts_per_page', 2 ); // To avoid creating too many posts.
 
 		for ( $i = 0; $i < 3; $i++ ) {
 			self::factory()->post->create_translated(

--- a/tests/phpunit/tests/test-slugs.php
+++ b/tests/phpunit/tests/test-slugs.php
@@ -3,6 +3,11 @@
 class Slugs_Test extends PLL_UnitTestCase {
 
 	/**
+	 * @var PLL_Context_Admin
+	 */
+	protected $pll_context;
+
+	/**
 	 * @param PLL_UnitTest_Factory $factory
 	 * @return void
 	 */
@@ -15,13 +20,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$options                       = PLL_Install::get_default_options();
-		$options['default_lang']       = 'en'; // Default language is the first one created, see self::wpSetUpBeforeClass().
-		$model                         = new PLL_Admin_Model( $options );
-		$links_model                   = new PLL_Links_Default( $model );
-		$this->pll_admin               = new PLL_Admin( $links_model );
-		$this->pll_admin->term         = new PLL_CRUD_Terms( $this->pll_admin ); // Activates our generic term filters.
-		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );  // Activates our filters for admin.
+		$this->pll_context = new PLL_Context_Admin();
 	}
 
 	public function test_term_slugs() {
@@ -168,7 +167,7 @@ class Slugs_Test extends PLL_UnitTestCase {
 		register_taxonomy( 'test-tax', 'post' ); // Not translatable by default.
 
 		// Filter the language to try to reproduce an error.
-		$fr_lang = $this->pll_admin->model->get_language( 'fr' );
+		$fr_lang = $this->pll_context->get()->model->get_language( 'fr' );
 		add_filter(
 			'pll_inserted_term_language',
 			function ( $found_language ) use ( $fr_lang ) {


### PR DESCRIPTION
- This PR fixes how the default language is assigned when initializing the Polylang context.
- It adds the `template_redirect` action to the Frontend context.
- It instanciates `Spy_REST_Server` in the REST context fire `rest_api_init` with the test REST server.

It completes the migration of:
- Admin_Filters_Test started in #1390 
- Slugs_Test started in #1389

It also migrates a sample of test classes:
- Auto_Translate_Test
- Columns_Test
- Create_Delete_Languages_Test
- CRUD_Posts_Test
- Hreflang_Test
- Rest_Request_Test

A list of current tests to migrate is maintained in https://kdrive.infomaniak.com/app/office/336014/1341807