### PR TITLE
Cast `pll_get_post_types` and `pll_get_taxonomies` returned values.

### DIFF
--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -144,7 +144,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 			 * @param string[] $post_types  List of post type names (as array keys and values).
 			 * @param bool     $is_settings True when displaying the list of custom post types in Polylang settings.
 			 */
-			$post_types = apply_filters( 'pll_get_post_types', $post_types, false );
+			$post_types = (array) apply_filters( 'pll_get_post_types', $post_types, false );
 
 			if ( did_action( 'after_setup_theme' ) ) {
 				$this->model->cache->set( 'post_types', $post_types );

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -212,7 +212,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			 * @param string[] $taxonomies  List of taxonomy names (as array keys and values).
 			 * @param bool     $is_settings True when displaying the list of custom taxonomies in Polylang settings.
 			 */
-			$taxonomies = apply_filters( 'pll_get_taxonomies', $taxonomies, false );
+			$taxonomies = (array) apply_filters( 'pll_get_taxonomies', $taxonomies, false );
 
 			if ( did_action( 'after_setup_theme' ) ) {
 				$this->model->cache->set( 'taxonomies', $taxonomies );


### PR DESCRIPTION
## What?
To allow type hinted value in some of our methods, it's better to cast `pll_get_post_types` and `pll_get_taxonomies` returned values to prevent any fatal errors.

## To go further:
Should we review all of our filters to do the same thing?