### PR TITLE
Fix broken tests on windows

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -7,8 +7,14 @@ require_once $_tests_dir . '/includes/functions.php';
 // load the plugin however *no* Polylang instance is created as no languages exist in DB
 tests_add_filter(
 	'muplugins_loaded',
-	function () use ( $_root_dir ) {
-		require_once $_root_dir . '/polylang.php';
+	function () use ( $_root_dir, $_tests_dir ) {
+		// Kind of doing the job of `wp_register_plugin_realpath()` since the plugin is not in the plugins folder (not even as a symlink).
+		$real_file_path   = realpath( $_root_dir . '/polylang.php' );
+		$symlink_dir_path = wp_normalize_path( dirname( $_tests_dir ) . '/wordpress/wp-content/plugins/polylang' );
+
+		$GLOBALS['wp_plugin_paths'][ $symlink_dir_path ] = wp_normalize_path( dirname( $real_file_path ) );
+
+		require_once $real_file_path;
 	}
 );
 

--- a/tests/phpunit/includes/links-trait.php
+++ b/tests/phpunit/includes/links-trait.php
@@ -35,7 +35,9 @@ trait PLL_Test_Links_Trait {
 					$url = str_replace( $orig_siteurl, $siteurl, $url );
 				}
 
-				return str_replace( POLYLANG_DIR . '/', '/polylang/', $url );
+				// Paths on Windows never start with a slash.
+				$replacement = ( stripos( PHP_OS, 'WIN' ) !== 0 ? '/' : '' ) . 'polylang/';
+				return str_replace( wp_normalize_path( POLYLANG_DIR ) . '/', $replacement, $url );
 			},
 			-1
 		);

--- a/tests/phpunit/includes/links-trait.php
+++ b/tests/phpunit/includes/links-trait.php
@@ -35,9 +35,7 @@ trait PLL_Test_Links_Trait {
 					$url = str_replace( $orig_siteurl, $siteurl, $url );
 				}
 
-				// Paths on Windows never start with a slash.
-				$replacement = ( stripos( PHP_OS, 'WIN' ) !== 0 ? '/' : '' ) . 'polylang/';
-				return str_replace( wp_normalize_path( POLYLANG_DIR ) . '/', $replacement, $url );
+				return $url;
 			},
 			-1
 		);

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -27,6 +27,7 @@ class Media_Test extends PLL_UnitTestCase {
 		$this->pll_admin                = new PLL_Admin( $links_model );
 		$this->pll_admin->filters_media = new PLL_Admin_Filters_Media( $this->pll_admin );
 		$this->pll_admin->posts         = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->sync          = new PLL_Admin_Sync( $this->pll_admin );
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );  // don't create intermediate sizes to save time
 	}
 

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -96,14 +96,22 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 
 		@symlink( PLL_TEST_DATA_DIR . 'plugins/best-plugin', WPMU_PLUGIN_DIR . '/best-plugin' );
 
-		$files    = ( new PLL_WPML_Config() )->get_files();
-		$expected = array(
-			'mu-plugins'             => $filename_1,
-			'mu-plugins/must-use'    => $filename_2,
-			'mu-plugins/best-plugin' => WPMU_PLUGIN_DIR . '/best-plugin/wpml-config.xml',
+		$files    = array_map( 'wp_normalize_path', ( new PLL_WPML_Config() )->get_files() );
+		$expected = array_map(
+			'wp_normalize_path',
+			array(
+				'mu-plugins'             => $filename_1,
+				'mu-plugins/must-use'    => $filename_2,
+				'mu-plugins/best-plugin' => WPMU_PLUGIN_DIR . '/best-plugin/wpml-config.xml',
+			)
 		);
 
-		unlink( WPMU_PLUGIN_DIR . '/best-plugin' );
+		if ( stripos( PHP_OS, 'WIN' ) === 0 ) {
+			// Uses rmdir() to remove symbolic link on Windows. See https://www.php.net/manual/fr/function.unlink.php
+			rmdir( WPMU_PLUGIN_DIR . '/best-plugin' );
+		} else {
+			unlink( WPMU_PLUGIN_DIR . '/best-plugin' );
+		}
 
 		unlink( $filename_2 );
 		rmdir( WPMU_PLUGIN_DIR . '/must-use' );

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -107,8 +107,12 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 		);
 
 		if ( stripos( PHP_OS, 'WIN' ) === 0 ) {
-			// Uses rmdir() to remove symbolic link on Windows. See https://www.php.net/manual/fr/function.unlink.php
-			rmdir( WPMU_PLUGIN_DIR . '/best-plugin' );
+			/*
+			 * Uses rmdir() to remove symbolic link on Windows. See https://www.php.net/manual/fr/function.unlink.php
+			 * Because symbolic link could not be created before if we don't have permissions, it needs to protect rmdir() call to prevent any error.
+			 * And thus to be sure WPMU_PLUGIN_DIR will be removed at the end of this test.
+			 */
+			@rmdir( WPMU_PLUGIN_DIR . '/best-plugin' );
 		} else {
 			unlink( WPMU_PLUGIN_DIR . '/best-plugin' );
 		}

--- a/tests/phpunit/tests/test-wpml-config-locations.php
+++ b/tests/phpunit/tests/test-wpml-config-locations.php
@@ -108,8 +108,8 @@ class WPML_Config_Locations_Test extends PLL_UnitTestCase {
 
 		if ( stripos( PHP_OS, 'WIN' ) === 0 ) {
 			/*
-			 * Uses rmdir() to remove symbolic link on Windows. See https://www.php.net/manual/fr/function.unlink.php
-			 * Because symbolic link could not be created before if we don't have permissions, it needs to protect rmdir() call to prevent any error.
+			 * Use rmdir() to remove symbolic link on Windows. See https://www.php.net/manual/en/function.unlink.php
+			 * In case the symbolic link could not be created if we don't have permissions, we need to remove errors.
 			 * And thus to be sure WPMU_PLUGIN_DIR will be removed at the end of this test.
 			 */
 			@rmdir( WPMU_PLUGIN_DIR . '/best-plugin' );


### PR DESCRIPTION
`Tests: 992, Assertions: 3616, Errors: 1, Failures: 51.`

It's annoying for me because they works very well on Linux or CI but locally they don't on Windows.
It could hide me some tests that really break.

## Which?

- [x] `WPML_Config_Locations_Test::test_in_mu_plugin` (error) fix in commit 7a70b5d865b0c8beb9b8c3d46407b621e668b6a7 but better in ab3252dc4e76e7e4c3bc6034add6feaaa920e2e2 by intializing correctly the Polylang directory realpath.
`unlink()` symbolic link on Windows doesn't work. We must use `rmdir()`. 
After this fix, the test fails because of paths comparison. Indeed on Windows absolute paths returned by PHP have backslash `\` as directory separator. So we need to `wp_normalize_path()` the whole paths to be sure comparison works correctly.

Example before fixing the test

Expected values
```
"mu-plugins"             => "C:\polylang\polylang\tmp/wordpress/wp-content/mu-plugins/wpml-config.xml"
"mu-plugins/must-use"    => "C:\polylang\polylang\tmp/wordpress/wp-content/mu-plugins/must-use/wpml-config.xml"
"mu-plugins/best-plugin" => "C:\polylang\polylang\tmp/wordpress/wp-content/mu-plugins/best-plugin/wpml-config.xml"
```

Calculated values - See backslash between `mu-plugins` folder and `must-use` and `best-plugin` folders.
```
"mu-plugins"             => "C:\polylang\polylang\tmp/wordpress/wp-content/mu-plugins/wpml-config.xml"
"mu-plugins/must-use"    => "C:\polylang\polylang\tmp/wordpress/wp-content/mu-plugins\must-use/wpml-config.xml"
"mu-plugins/best-plugin" => "C:\polylang\polylang\tmp/wordpress/wp-content/mu-plugins\best-plugin/wpml-config.xml"
```
This come from SplFileInfo::getPathname() call here https://github.com/polylang/polylang/blob/3.6.4/modules/wpml/wpml-config.php#L683 which produces the backslash between `WPMU_PLUGIN_DIR` and the detected folder.

~~In addition, it seems that we need permissions to create programatically symbolic link on Windows by using `symlink()`.
For this part, force VS Code execution as an Administrator do the job.~~ In fact, we should add the current user as a specific user in the symlink creation rights by using the `gpedit` program.
![image](https://github.com/user-attachments/assets/aa8b5906-aca3-4705-9599-aec3a0385d0e)

- [x] most of the broken tests (45) due to the use of `PLL_Test_Links_Trait` , the `plugins_url` filter and data provider or @testWith annotation. fix by commit 04ee8c1699d7bde4fb26dee8099dd905cb2a949d and better in ab3252dc4e76e7e4c3bc6034add6feaaa920e2e2 as above
like `Links_Directory_Test::test_flag_url_with_subfolder_install` (5), `Links_Domain_Test::test_flags_urls_curlang_default` (10), `Links_Domain_Test::test_flags_urls_curlang_secondary` (10), `Links_Subdomain_Test::test_flags_urls_curlang_default` (10), `Links_Subdomain_Test::test_flags_urls_curlang_secondary` (10)
`plugins_url()` use `wp_normalize_path()` function and we have to do the same by using the `plugins_url` filter.
In addition, Windows paths never start with a slash `/` but a drive letter. We therefore need to take account of this specific case when replacing the path.
- [x] `Media_Test::test_media_translation_and_delete_attachment`
Strange 🤔 because it works in production. It seems to be due to the way the file path is stored in the translated attachment post meta. (~~absolute path instead of relative path as in the source attachment~~).
This DB request https://github.com/polylang/polylang/blob/3.6.4/include/crud-posts.php#L261-L267 returns no ids when it should.
To initialize data for the test both of the two translated media haven't their corresponding post meta in DB. So, when deleting the first media, its post meta is also deleted and there is no more post meta in DB to avoid the file deletion.
`wp_slash()` here https://github.com/polylang/polylang/blob/3.6.4/include/crud-posts.php#L320 breaks the condition in `_wp_relative_upload_path()` WordPress function (https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/post.php#L901) because it escapes backslash in Windows file path and makes the absolute path stored in `_wp_attached_file` post meta.
So when we pass through `PLL_CRUD_Posts::wp_delete_file()` we calculate the relative path to find the post meta in DB.
However for this translation, it isn't the relative path stored
The diffence with production is that post meta synchronizaton isn't initialized where media post meta are synchronized including `_wp_attached_file` post meta. With the synchronization the source language relative path override the target language absolute path.
See https://github.com/polylang/polylang/blob/3.6.4/modules/sync/sync-post-metas.php#L71 and then the DB request quoted above doesn't return the corresponding id.
Solution: instantiate PLL_Admin_Sync as in production. Fixed in f3b0b2eb3bbdfed7d179d9c85c8a6a284c34072e

- [x] `WPML_Config_Locations_Test::test_in_polylang` ~~this and the 3 next tests are broken probably due to the Windows paths. See the first case in this list.~~ It's due to the fact symbolic link could not be created if we don't have the permissions and then `rmdir()` added in 7a70b5d865b0c8beb9b8c3d46407b621e668b6a7 triggers an error. The `WPML_Config_Locations_Test::test_in_mu_plugin` doesn't remove the `WPMU_PLUGIN_DIR`. So at the next test suite execution this test fails because `( new PLL_WPML_Config() )->get_files()` also gets files in `WPMU_PLUGIN_DIR`. fix in b2d6eaf7d52081fe6aa120a85d3dfeba1c7eaabd 
- [x] `WPML_Config_Locations_Test::test_in_theme` same as above
- [x] `WPML_Config_Locations_Test::test_in_child_theme` same as above
- [x] `WPML_Config_Locations_Test::test_in_active_plugin` same as above
- [x] `WPML_Config_Test::test_gutenberg_blocks` also due to `WPMU_PLUGIN_DIR` not removed and containing a `wpml-config.xml` file with `<gutenberg-blocks>` not concerned by this test. Fix in b2d6eaf7d52081fe6aa120a85d3dfeba1c7eaabd 

## Results
on August 2024 1st
![image](https://github.com/user-attachments/assets/15e1b010-2a54-4c35-a653-f943860c4072)
