### PR TITLE
Fix usages of `add_settings_error()`

### DIFF
--- a/settings/settings-licenses.php
+++ b/settings/settings-licenses.php
@@ -110,7 +110,7 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 			}
 
 			// Updated message
-			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'updated' );
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' );
 			ob_start();
 			settings_errors();
 			$x->Add( array( 'what' => 'success', 'data' => ob_get_clean() ) );

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -261,7 +261,7 @@ class PLL_Settings_Module {
 
 			if ( empty( get_settings_errors() ) ) {
 				// Send update message
-				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'updated' );
+				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' );
 				settings_errors();
 				$x = new WP_Ajax_Response( array( 'what' => 'success', 'data' => ob_get_clean() ) );
 				$x->send();

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -263,7 +263,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 					$lang = $this->model->get_language( $key );
 					add_settings_error(
 						'general',
-						'pll_invalid_domain',
+						sprintf( 'pll_invalid_domain_%s', $key ),
 						esc_html(
 							sprintf(
 								/* translators: %s is a native language name */
@@ -319,7 +319,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			if ( 200 != $response_code ) {
 				add_settings_error(
 					'general',
-					'pll_invalid_domain',
+					sprintf( 'pll_invalid_domain_%s', $lang->slug ),
 					esc_html(
 						sprintf(
 							/* translators: %s is an url */

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -184,7 +184,7 @@ class PLL_Settings extends PLL_Admin_Base {
 						add_settings_error( 'general', $code, $errors->get_error_message( $code ) );
 					}
 				} else {
-					add_settings_error( 'general', 'pll_languages_created', __( 'Language added.', 'polylang' ), 'updated' );
+					add_settings_error( 'general', 'pll_languages_created', __( 'Language added.', 'polylang' ), 'success' );
 					$locale = sanitize_locale_name( $_POST['locale'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 					if ( 'en_US' !== $locale && current_user_can( 'install_languages' ) ) {
@@ -206,7 +206,7 @@ class PLL_Settings extends PLL_Admin_Base {
 				check_admin_referer( 'delete-lang' );
 
 				if ( ! empty( $_GET['lang'] ) && $this->model->delete_language( (int) $_GET['lang'] ) ) {
-					add_settings_error( 'general', 'pll_languages_deleted', __( 'Language deleted.', 'polylang' ), 'updated' );
+					add_settings_error( 'general', 'pll_languages_deleted', __( 'Language deleted.', 'polylang' ), 'success' );
 				}
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )
@@ -221,7 +221,7 @@ class PLL_Settings extends PLL_Admin_Base {
 						add_settings_error( 'general', $code, $errors->get_error_message( $code ) );
 					}
 				} else {
-					add_settings_error( 'general', 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'updated' );
+					add_settings_error( 'general', 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'success' );
 				}
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -180,8 +180,8 @@ class PLL_Settings extends PLL_Admin_Base {
 				$errors = $this->model->add_language( $_POST );
 
 				if ( is_wp_error( $errors ) ) {
-					foreach ( $errors->get_error_messages() as $message ) {
-						add_settings_error( 'general', 'pll_add_language', $message );
+					foreach ( $errors->get_error_codes() as $code ) {
+						add_settings_error( 'general', $code, $errors->get_error_message( $code ) );
 					}
 				} else {
 					add_settings_error( 'general', 'pll_languages_created', __( 'Language added.', 'polylang' ), 'updated' );
@@ -217,8 +217,8 @@ class PLL_Settings extends PLL_Admin_Base {
 				$errors = $this->model->update_language( $_POST );
 
 				if ( is_wp_error( $errors ) ) {
-					foreach ( $errors->get_error_messages() as $message ) {
-						add_settings_error( 'general', 'pll_update_language', $message );
+					foreach ( $errors->get_error_codes() as $code ) {
+						add_settings_error( 'general', $code, $errors->get_error_message( $code ) );
 					}
 				} else {
 					add_settings_error( 'general', 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'updated' );

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -191,7 +191,7 @@ class PLL_Settings extends PLL_Admin_Base {
 						// Attempts to install the language pack
 						require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 						if ( ! wp_download_language_pack( $locale ) ) {
-							add_settings_error( 'general', 'pll_download_mo', __( 'The language was created, but the WordPress language file was not downloaded. Please install it manually.', 'polylang' ) );
+							add_settings_error( 'general', 'pll_download_mo', __( 'The language was created, but the WordPress language file was not downloaded. Please install it manually.', 'polylang' ), 'warning' );
 						}
 
 						// Force checking for themes and plugins translations updates

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -419,7 +419,7 @@ class PLL_Table_String extends WP_List_Table {
 				isset( $new_mo ) ? $new_mo->export_to_db( $language ) : $mo->export_to_db( $language );
 			}
 
-			add_settings_error( 'general', 'pll_strings_translations_updated', __( 'Translations updated.', 'polylang' ), 'updated' );
+			add_settings_error( 'general', 'pll_strings_translations_updated', __( 'Translations updated.', 'polylang' ), 'success' );
 
 			/**
 			 * Fires after the strings translations are saved in DB


### PR DESCRIPTION
This PR fixes incorrect usages of `add_settings_error()`:

- Make sure to use a unique ID when reporting errors when a language is added or updated.
- Make sure to use a unique ID when reporting errors when domains per language are saved.
- Replace legacy `updated`param value by `success`.

Additionally the error reported when no language pack is found when a language is added has been switched to a warning.

See also https://github.com/polylang/polylang-pro/issues/1856
