### PR TITLE
Use _prime_post_caches() to cache the pages for posts

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,9 +26,6 @@ parameters:
 			count: 1
 			path: admin/admin-base.php
 
-		# Ignored because the WordPress stubs doesn't know our added 'lang' parameter in get_posts() and PLL_Model::get_languages_list() seems not to always return int[] as expected by 'post__in' parameter
-		- "#^Parameter \\#1 \\$args of function get_posts expects array(.+)\\|null, array\\{posts_per_page: 99, post_type: 'page', post__in: array\\<int, int\\|null\\>, lang: ''\\} given\\.$#"
-
 		# Ignored because the WordPress stubs doesn't know a dynamic key in the associative array passed to the get_terms() parameter
 		- "#^Parameter \\#1 \\$args of function get_terms expects array(.+), non\\-empty\\-array\\<string, int\\|string\\> given\\.$#"
 


### PR DESCRIPTION
We used to call `get_posts()` to cache the page for posts to reduce the number of DB queries.
The method used doesn't work as expect.

This PR uses `_prime_post_caches()` which is intended for this use.
On my test site with 3 languages, The number of DB queries goes down from 31 to 27 when querying a page for posts.
Additionally the whole method is reformatted.