### PR TITLE
Don't minify files in tests folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ function configureWebpack( options ){
 		'node_modules/**',
 		'vendor/**',
 		'tmp/**',
+		'tests/**',
 		'webpack/**',
 		'**/build/**',
 	];


### PR DESCRIPTION
Since #1373 two CSS files have been added in `tests/` folder and are built in the production folder (css/build).

`.tests/phpunit/data/themes/best-child/style.css`
`.tests/phpunit/data/themes/best-theme/style.css`

This PR propose to exclude `tests/` folder to avoid to build js or css files that it could contain.