### PR TITLE
Delete all user metas at once

### DIFF
--- a/admin/admin-model.php
+++ b/admin/admin-model.php
@@ -132,10 +132,8 @@ class PLL_Admin_Model extends PLL_Model {
 		}
 
 		// Delete users options
-		foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
-			delete_user_meta( $user_id, 'pll_filter_content', $lang->slug );
-			delete_user_meta( $user_id, 'description_' . $lang->slug );
-		}
+		delete_metadata( 'user', 0, 'pll_filter_content', '', true );
+		delete_metadata( 'user', 0, "description_{$lang->slug}", '', true );
 
 		// Delete domain
 		unset( $this->options['domains'][ $lang->slug ] );

--- a/uninstall.php
+++ b/uninstall.php
@@ -61,12 +61,10 @@ class PLL_Uninstall {
 		$languages = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false ) );
 
 		// Delete users options
-		foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
-			delete_user_meta( $user_id, 'pll_filter_content' );
-			delete_user_meta( $user_id, 'pll_dismissed_notices' ); // Legacy meta.
-			foreach ( $languages as $lang ) {
-				delete_user_meta( $user_id, 'description_' . $lang->slug );
-			}
+		delete_metadata( 'user', 0, 'pll_filter_content', '', true );
+		delete_metadata( 'user', 0, 'pll_dismissed_notices', '', true ); // Legacy meta.
+		foreach ( $languages as $lang ) {
+			delete_metadata( 'user', 0, "description_{$lang->slug}", '', true );
 		}
 
 		// Delete menu language switchers


### PR DESCRIPTION
Use `delete_metadata()` to delete a user meta from all users at once instead of looping through all users.

From [this comment](https://github.com/polylang/polylang-pro/pull/1997#discussion_r1466160791).