### PR TITLE
Don't set post tags with names. Use term ids instead

### DIFF
--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -355,12 +355,20 @@ class PLL_CRUD_Posts {
 	 * @return void
 	 */
 	public function force_tags_translation( $post_id, $post_after, $post_before ) {
-		$post_before = $post_before->to_array();
-
-		if ( ! empty( $post_before['tags_input'] ) ) {
-			// Let's ensure that `PLL_CRUD_Posts::set_object_terms()` will do its job.
-			wp_set_post_tags( $post_id, $post_before['tags_input'] );
+		if ( ! is_object_in_taxonomy( $post_before, 'post_tag' ) ) {
+			return;
 		}
+
+		$terms = get_the_terms( $post_before, 'post_tag' );
+
+		if ( empty( $terms ) ) {
+			return;
+		}
+
+		$term_ids = wp_list_pluck( $terms, 'term_id' );
+
+		// Let's ensure that `PLL_CRUD_Posts::set_object_terms()` will do its job.
+		wp_set_post_terms( $post_id, $term_ids, 'post_tag' );
 	}
 
 	/**

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -355,13 +355,13 @@ class PLL_CRUD_Posts {
 	 * @return void
 	 */
 	public function force_tags_translation( $post_id, $post_after, $post_before ) {
-		if ( ! is_object_in_taxonomy( $post_before, 'post_tag' ) ) {
+		if ( ! is_object_in_taxonomy( $post_before->post_type, 'post_tag' ) ) {
 			return;
 		}
 
 		$terms = get_the_terms( $post_before, 'post_tag' );
 
-		if ( empty( $terms ) ) {
+		if ( empty( $terms ) || ! is_array( $terms ) ) {
 			return;
 		}
 

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -215,10 +215,10 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 	 * due to the post being saved 2 times (once with the REST API, once with edit_post().
 	 */
 	public function test_simple_update_of_post_with_tag_mixing_slug_and_name() {
-		$tag1 = self::factory()->tag->create( array( 'name' => 'Unique name', 'slug' => 'common', 'lang' => 'en' ) );
-		$tag2 = self::factory()->tag->create( array( 'name' => 'Common', 'slug' => 'unique-slug', 'lang' => 'en' ) );
+		self::factory()->tag->create( array( 'name' => 'Unique name', 'slug' => 'common', 'lang' => 'en' ) );
+		$tag = self::factory()->tag->create( array( 'name' => 'Common', 'slug' => 'unique-slug', 'lang' => 'en' ) );
 
-		$post_id = self::factory()->post->create( array( 'tax_input' => array( 'post_tag' => array( $tag2 ) ), 'lang' => 'en' ) );
+		$post_id = self::factory()->post->create( array( 'tax_input' => array( 'post_tag' => array( $tag ) ), 'lang' => 'en' ) );
 		wp_update_post( array( 'ID' => $post_id ) );
 
 		$tags = wp_get_post_tags( $post_id );
@@ -234,11 +234,11 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 	 * The sequence typically occurs when assigning the "faulty" tag in the classic editor.
 	 */
 	public function test_existing_post_updated_with_tag_mixing_slug_and_name() {
-		$tag1 = self::factory()->tag->create( array( 'name' => 'Unique name', 'slug' => 'common', 'lang' => 'en' ) );
-		$tag2 = self::factory()->tag->create( array( 'name' => 'Common', 'slug' => 'unique-slug', 'lang' => 'en' ) );
+		self::factory()->tag->create( array( 'name' => 'Unique name', 'slug' => 'common', 'lang' => 'en' ) );
+		$tag = self::factory()->tag->create( array( 'name' => 'Common', 'slug' => 'unique-slug', 'lang' => 'en' ) );
 
 		$post_id = self::factory()->post->create( array( 'lang' => 'en' ) );
-		wp_update_post( array( 'ID' => $post_id, 'tax_input' => array( 'post_tag' => array( $tag2 ) )  ) );
+		wp_update_post( array( 'ID' => $post_id, 'tax_input' => array( 'post_tag' => array( $tag ) ) ) );
 
 		$tags = wp_get_post_tags( $post_id );
 		$this->assertNotWPError( $tags );


### PR DESCRIPTION
Fixes #1401 
May fix #1385 too.

WordPress may mix 2 post different post tags if the if the slug of the first tag is the same as the name of the second tag.
This is due to `wp_set_object_terms()` calling [`term_exists()`](https://github.com/WordPress/wordpress-develop/blob/6.4.3/src/wp-includes/taxonomy.php#L2806) which [searches either among slugs or names](https://github.com/WordPress/wordpress-develop/blob/6.4.3/src/wp-includes/taxonomy.php#L1606-L1611).
As a consequence, we should **never** use term names or slugs when setting post terms.

This PR replaces a call to `wp_set_post_tags()` with tag names by a call to `wp_set_post_terms()` with corresponding term_ids.

It adds 2 tests which are supposed to mimic the behavior of the classic editor and the block editor when we assign a post tag to a post.