### PR TITLE
Fixes PHPStan WP_Query::$query undefined error

### DIFF
--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -252,7 +252,7 @@ class PLL_Canonical {
 
 		$backup_wp_query = $wp_query;
 
-		if ( isset( $wp_query->tax_query ) ) {
+		if ( ! is_null( $wp_query->tax_query ) ) {
 			unset( $wp_query->tax_query->queried_terms['language'] );
 			unset( $wp_query->query['lang'] );
 		}

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -246,13 +246,16 @@ class PLL_Canonical {
 	 * @return string
 	 */
 	protected function redirect_canonical( $url, $language ) {
+		/**
+		 * @var WP_Query
+		 */
 		global $wp_query;
 
 		$this->curlang = $language; // Hack to filter the `page_for_posts` option in the correct language.
 
 		$backup_wp_query = $wp_query;
 
-		if ( ! is_null( $wp_query->tax_query ) ) {
+		if ( isset( $wp_query->tax_query ) ) {
 			unset( $wp_query->tax_query->queried_terms['language'] );
 			unset( $wp_query->query['lang'] );
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -40,3 +40,9 @@ parameters:
 			message: "#^Call to static method encode\\(\\) on an unknown class Requests_IDNAEncoder\\.$#"
 			count: 1
 			path: include/links-domain.php
+
+		# Ignored by waiting WordPress documentation enhancement https://core.trac.wordpress.org/ticket/60563
+		-
+			message: "#^Property WP_Query::\\$tax_query \\(WP_Tax_Query\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: frontend/canonical.php


### PR DESCRIPTION
This [error reported](https://github.com/polylang/polylang/actions/runs/7905456130/job/21578129342?pr=1423)

```log
Error: Access to an undefined property object::$query.
 ------ -------------------------------------------------------------------------- 
  Line   frontend/canonical.php                                                    
 ------ -------------------------------------------------------------------------- 
  257    Access to an undefined property object::$query.                           
         💡 Learn more:                                                             
            https://phpstan.org/blog/solving-phpstan-access-to-undefined-property  
 ------ -------------------------------------------------------------------------- 

```
seems due to PHPStan [1.10.58](https://github.com/phpstan/phpstan/releases/tag/1.10.58) release.

If seems that PHPdoc `@global WP_Query $wp_query` annotation has no effect because when add a `@var WP_Query` annotation 

```
/**
 * @var WP_Query
 */
global $wp_query;

```
we don't have the same error

```
  Line   canonical.php
 ------ --------------------------------------------------------------------------
  :258   Property WP_Query::$tax_query (WP_Tax_Query) in isset() is not nullable.
 ------ --------------------------------------------------------------------------

```

exactly like in this [PHPstan playground](https://phpstan.org/r/9e08cc6d-b602-46d4-995f-830fe7f59d47).

Uses `! is_null()` instead of `isset()` seems to solve the error.

NB: uses `! empty()` has the same effect as `isset()` ➡ the initial PHPStan error reported.