### PR TITLE
Strings review

### DIFF
--- a/modules/machine-translation/settings-preview-machine-translation.php
+++ b/modules/machine-translation/settings-preview-machine-translation.php
@@ -36,12 +36,8 @@ class PLL_Settings_Preview_Machine_Translation extends PLL_Settings_Module {
 	public function __construct( &$polylang, array $args = array() ) {
 		$default = array(
 			'module'        => 'machine_translation',
-			'title'         => sprintf(
-				/* translators: %s is a service name. */
-				__( 'Machine Translation by %s', 'polylang' ),
-				'DeepL'
-			),
-			'description'   => __( 'Allows linkage to an external translation solution.', 'polylang' ),
+			'title'         => __( 'Machine Translation', 'polylang' ),
+			'description'   => __( 'Allows linkage to DeepL translate.', 'polylang' ),
 			'active_option' => 'preview',
 		);
 


### PR DESCRIPTION
Let's keep the machine translation module title generic and include the service name (currently only one) in the description.