### PR TITLE
Trigger a JS hook when settings are saved

### DIFF
--- a/js/src/admin.js
+++ b/js/src/admin.js
@@ -297,6 +297,16 @@ jQuery(
 						$.each(
 							res.responses,
 							function() {
+								/**
+								 * Fires after saving the settings, before applying changes to the DOM.
+								 *
+								 * @since 5.6.0
+								 *
+								 * @param {Object}      response The response from the AJAX call.
+								 * @param {HTMLElement} tr       The HTML element containing the fields.
+								 */
+								wp.hooks.doAction( 'pll_settings_saved', this, tr.get( 0 ) );
+
 								switch ( this.what ) {
 									case 'license-update':
 										$( '#pll-license-' + this.data ).replaceWith( this.supplemental.html );

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -323,7 +323,7 @@ class PLL_Settings extends PLL_Admin_Base {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		wp_enqueue_script( 'pll_admin', plugins_url( '/js/build/admin' . $suffix . '.js', POLYLANG_ROOT_FILE ), array( 'jquery', 'wp-ajax-response', 'postbox', 'jquery-ui-selectmenu' ), POLYLANG_VERSION, true );
+		wp_enqueue_script( 'pll_admin', plugins_url( '/js/build/admin' . $suffix . '.js', POLYLANG_ROOT_FILE ), array( 'jquery', 'wp-ajax-response', 'postbox', 'jquery-ui-selectmenu', 'wp-hooks' ), POLYLANG_VERSION, true );
 		wp_localize_script( 'pll_admin', 'pll_admin', array( 'dismiss_notice' => esc_html__( 'Dismiss this notice.', 'polylang' ) ) );
 
 		wp_enqueue_style( 'pll_selectmenu', plugins_url( '/css/build/selectmenu' . $suffix . '.css', POLYLANG_ROOT_FILE ), array(), POLYLANG_VERSION );


### PR DESCRIPTION
This JS hook provides a way to perform custom actions when the settings are saved. This is required by PLL Pro.