### PR TITLE
Fix DB failure in PHPUnit CI.

### DIFF
--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -7,12 +7,14 @@ on:
       - '**.php'
       - 'phpunit.xml'
       - 'composer.json'
+      - '**.yml'
   pull_request:
     branches: master
     paths:
       - '**.php'
       - 'phpunit.xml'
       - 'composer.json'
+      - '**.yml'
   workflow_dispatch:
 
 jobs:
@@ -23,7 +25,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:latest
+        image: mariadb:11.2
         ports:
           - '3306:3306'
         env:


### PR DESCRIPTION
## What?
All in the title.
Fixes the following error in CI:
```
PHP Warning:  mysqli_real_connect(): Server sent charset (0) unknown to the client. Please, report to the developers in /tmp/wordpress/wp-includes/class-wpdb.php on line 1987

PHP Warning:  mysqli_real_connect(): (HY000/2054): Server sent charset unknown to the client. Please, report to the developers in /tmp/wordpress/wp-includes/class-wpdb.php on line 1987
```

## How?
- Require a specific mariadb version in services image for GitHub Actions. The latest seems to not be compatible with WordPress...
- Took the opportunity to run PHPUnit Ci when a config file is modified.