### PR TITLE
Adds an add_settings_error() wrapper and uses it

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -201,3 +201,37 @@ function pll_is_plugin_active( string $plugin_name ) {
 
 	return in_array( $plugin_name, $plugins );
 }
+
+/**
+ * Prepares and registers errors
+ *
+ * Wraps `add_settings_error()` to make its use more consistent.
+ *
+ * @since 3.6
+ *
+ * @param WP_Error $error Error object.
+ * @return void
+ */
+function pll_add_settings_error( WP_Error $error ) {
+	if ( ! $error->has_errors() ) {
+		return;
+	}
+
+	foreach ( $error->get_error_codes() as $error_code ) {
+		// Extract the "error" type.
+		$data = $error->get_error_data( $error_code );
+		$type = empty( $data ) || ! is_string( $data ) ? 'error' : $data;
+
+		$message = wp_kses(
+			$error->get_error_message( $error_code ),
+			array(
+				'a' => array( 'href' ),
+				'br',
+				'code',
+				'em',
+			)
+		);
+
+		add_settings_error( 'polylang', $error_code, $message, $type );
+	}
+}

--- a/include/functions.php
+++ b/include/functions.php
@@ -203,7 +203,7 @@ function pll_is_plugin_active( string $plugin_name ) {
 }
 
 /**
- * Prepares and registers errors
+ * Prepares and registers errors.
  *
  * Wraps `add_settings_error()` to make its use more consistent.
  *

--- a/include/functions.php
+++ b/include/functions.php
@@ -225,10 +225,10 @@ function pll_add_settings_error( WP_Error $error ) {
 		$message = wp_kses(
 			$error->get_error_message( $error_code ),
 			array(
-				'a' => array( 'href' ),
-				'br',
-				'code',
-				'em',
+				'a'    => array( 'href' ),
+				'br'   => array(),
+				'code' => array(),
+				'em'   => array(),
 			)
 		);
 

--- a/include/functions.php
+++ b/include/functions.php
@@ -203,7 +203,7 @@ function pll_is_plugin_active( string $plugin_name ) {
 }
 
 /**
- * Prepares and registers errors.
+ * Prepares and registers notices.
  *
  * Wraps `add_settings_error()` to make its use more consistent.
  *
@@ -212,7 +212,7 @@ function pll_is_plugin_active( string $plugin_name ) {
  * @param WP_Error $error Error object.
  * @return void
  */
-function pll_add_settings_error( WP_Error $error ) {
+function pll_add_notice( WP_Error $error ) {
 	if ( ! $error->has_errors() ) {
 		return;
 	}

--- a/include/functions.php
+++ b/include/functions.php
@@ -223,7 +223,7 @@ function pll_add_settings_error( WP_Error $error ) {
 		$type = empty( $data ) || ! is_string( $data ) ? 'error' : $data;
 
 		$message = wp_kses(
-			$error->get_error_message( $error_code ),
+			implode( '<br>', $error->get_error_messages( $error_code ) ),
 			array(
 				'a'    => array( 'href' ),
 				'br'   => array(),

--- a/settings/settings-licenses.php
+++ b/settings/settings-licenses.php
@@ -110,7 +110,7 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 			}
 
 			// Updated message
-			pll_add_settings_error( new WP_Error( 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' ) );
+			pll_add_notice( new WP_Error( 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' ) );
 			ob_start();
 			settings_errors( 'polylang' );
 			$x->Add( array( 'what' => 'success', 'data' => ob_get_clean() ) );

--- a/settings/settings-licenses.php
+++ b/settings/settings-licenses.php
@@ -110,7 +110,7 @@ class PLL_Settings_Licenses extends PLL_Settings_Module {
 			}
 
 			// Updated message
-			add_settings_error( 'polylang', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' );
+			pll_add_settings_error( new WP_Error( 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' ) );
 			ob_start();
 			settings_errors( 'polylang' );
 			$x->Add( array( 'what' => 'success', 'data' => ob_get_clean() ) );

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -286,7 +286,7 @@ class PLL_Settings_Module {
 
 			if ( empty( get_settings_errors( 'polylang' ) ) ) {
 				// Send update message
-				pll_add_settings_error( new WP_Error( 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' ) );
+				pll_add_notice( new WP_Error( 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' ) );
 				settings_errors( 'polylang' );
 				$x = new WP_Ajax_Response( array( 'what' => 'success', 'data' => ob_get_clean() ) );
 				$x->send();

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -286,7 +286,7 @@ class PLL_Settings_Module {
 
 			if ( empty( get_settings_errors( 'polylang' ) ) ) {
 				// Send update message
-				add_settings_error( 'polylang', 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' );
+				pll_add_settings_error( new WP_Error( 'settings_updated', __( 'Settings saved.', 'polylang' ), 'success' ) );
 				settings_errors( 'polylang' );
 				$x = new WP_Ajax_Response( array( 'what' => 'success', 'data' => ob_get_clean() ) );
 				$x->send();

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -261,10 +261,9 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			foreach ( $options['domains'] as $key => $domain ) {
 				if ( empty( $domain ) ) {
 					$lang = $this->model->get_language( $key );
-					add_settings_error(
-						'polylang',
-						sprintf( 'pll_invalid_domain_%s', $key ),
-						esc_html(
+					pll_add_settings_error(
+						new WP_Error(
+							sprintf( 'pll_invalid_domain_%s', $key ),
 							sprintf(
 								/* translators: %s is a native language name */
 								__( 'Please enter a valid URL for %s.', 'polylang' ),
@@ -317,10 +316,9 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			$response_code = wp_remote_retrieve_response_code( $response );
 
 			if ( 200 != $response_code ) {
-				add_settings_error(
-					'polylang',
-					sprintf( 'pll_invalid_domain_%s', $lang->slug ),
-					esc_html(
+				pll_add_settings_error(
+					new WP_Error(
+						sprintf( 'pll_invalid_domain_%s', $lang->slug ),
 						sprintf(
 							/* translators: %s is an url */
 							__( 'Polylang was unable to access the %s URL. Please check that the URL is valid.', 'polylang' ),

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -261,7 +261,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			foreach ( $options['domains'] as $key => $domain ) {
 				if ( empty( $domain ) ) {
 					$lang = $this->model->get_language( $key );
-					pll_add_settings_error(
+					pll_add_notice(
 						new WP_Error(
 							sprintf( 'pll_invalid_domain_%s', $key ),
 							sprintf(
@@ -316,7 +316,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			$response_code = wp_remote_retrieve_response_code( $response );
 
 			if ( 200 != $response_code ) {
-				pll_add_settings_error(
+				pll_add_notice(
 					new WP_Error(
 						sprintf( 'pll_invalid_domain_%s', $lang->slug ),
 						sprintf(

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -180,18 +180,16 @@ class PLL_Settings extends PLL_Admin_Base {
 				$errors = $this->model->add_language( $_POST );
 
 				if ( is_wp_error( $errors ) ) {
-					foreach ( $errors->get_error_codes() as $code ) {
-						add_settings_error( 'polylang', $code, $errors->get_error_message( $code ) );
-					}
+						pll_add_settings_error( $errors );
 				} else {
-					add_settings_error( 'polylang', 'pll_languages_created', __( 'Language added.', 'polylang' ), 'success' );
+					pll_add_settings_error( new WP_Error( 'pll_languages_created', __( 'Language added.', 'polylang' ), 'success' ) );
 					$locale = sanitize_locale_name( $_POST['locale'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 					if ( 'en_US' !== $locale && current_user_can( 'install_languages' ) ) {
 						// Attempts to install the language pack
 						require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 						if ( ! wp_download_language_pack( $locale ) ) {
-							add_settings_error( 'polylang', 'pll_download_mo', __( 'The language was created, but the WordPress language file was not downloaded. Please install it manually.', 'polylang' ), 'warning' );
+							pll_add_settings_error( new WP_Error( 'pll_download_mo', __( 'The language was created, but the WordPress language file was not downloaded. Please install it manually.', 'polylang' ), 'warning' ) );
 						}
 
 						// Force checking for themes and plugins translations updates
@@ -206,7 +204,7 @@ class PLL_Settings extends PLL_Admin_Base {
 				check_admin_referer( 'delete-lang' );
 
 				if ( ! empty( $_GET['lang'] ) && $this->model->delete_language( (int) $_GET['lang'] ) ) {
-					add_settings_error( 'polylang', 'pll_languages_deleted', __( 'Language deleted.', 'polylang' ), 'success' );
+					pll_add_settings_error( new WP_Error( 'pll_languages_deleted', __( 'Language deleted.', 'polylang' ), 'success' ) );
 				}
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )
@@ -217,11 +215,9 @@ class PLL_Settings extends PLL_Admin_Base {
 				$errors = $this->model->update_language( $_POST );
 
 				if ( is_wp_error( $errors ) ) {
-					foreach ( $errors->get_error_codes() as $code ) {
-						add_settings_error( 'polylang', $code, $errors->get_error_message( $code ) );
-					}
+					pll_add_settings_error( $errors );
 				} else {
-					add_settings_error( 'polylang', 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'success' );
+					pll_add_settings_error( new WP_Error( 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'success' ) );
 				}
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -180,16 +180,16 @@ class PLL_Settings extends PLL_Admin_Base {
 				$errors = $this->model->add_language( $_POST );
 
 				if ( is_wp_error( $errors ) ) {
-						pll_add_settings_error( $errors );
+						pll_add_notice( $errors );
 				} else {
-					pll_add_settings_error( new WP_Error( 'pll_languages_created', __( 'Language added.', 'polylang' ), 'success' ) );
+					pll_add_notice( new WP_Error( 'pll_languages_created', __( 'Language added.', 'polylang' ), 'success' ) );
 					$locale = sanitize_locale_name( $_POST['locale'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 					if ( 'en_US' !== $locale && current_user_can( 'install_languages' ) ) {
 						// Attempts to install the language pack
 						require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 						if ( ! wp_download_language_pack( $locale ) ) {
-							pll_add_settings_error( new WP_Error( 'pll_download_mo', __( 'The language was created, but the WordPress language file was not downloaded. Please install it manually.', 'polylang' ), 'warning' ) );
+							pll_add_notice( new WP_Error( 'pll_download_mo', __( 'The language was created, but the WordPress language file was not downloaded. Please install it manually.', 'polylang' ), 'warning' ) );
 						}
 
 						// Force checking for themes and plugins translations updates
@@ -204,7 +204,7 @@ class PLL_Settings extends PLL_Admin_Base {
 				check_admin_referer( 'delete-lang' );
 
 				if ( ! empty( $_GET['lang'] ) && $this->model->delete_language( (int) $_GET['lang'] ) ) {
-					pll_add_settings_error( new WP_Error( 'pll_languages_deleted', __( 'Language deleted.', 'polylang' ), 'success' ) );
+					pll_add_notice( new WP_Error( 'pll_languages_deleted', __( 'Language deleted.', 'polylang' ), 'success' ) );
 				}
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )
@@ -215,9 +215,9 @@ class PLL_Settings extends PLL_Admin_Base {
 				$errors = $this->model->update_language( $_POST );
 
 				if ( is_wp_error( $errors ) ) {
-					pll_add_settings_error( $errors );
+					pll_add_notice( $errors );
 				} else {
-					pll_add_settings_error( new WP_Error( 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'success' ) );
+					pll_add_notice( new WP_Error( 'pll_languages_updated', __( 'Language updated.', 'polylang' ), 'success' ) );
 				}
 
 				self::redirect(); // To refresh the page ( possible thanks to the $_GET['noheader']=true )

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -419,7 +419,7 @@ class PLL_Table_String extends WP_List_Table {
 				isset( $new_mo ) ? $new_mo->export_to_db( $language ) : $mo->export_to_db( $language );
 			}
 
-			add_settings_error( 'polylang', 'pll_strings_translations_updated', __( 'Translations updated.', 'polylang' ), 'success' );
+			pll_add_settings_error( new WP_Error( 'pll_strings_translations_updated', __( 'Translations updated.', 'polylang' ), 'success' ) );
 
 			/**
 			 * Fires after the strings translations are saved in DB

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -419,7 +419,7 @@ class PLL_Table_String extends WP_List_Table {
 				isset( $new_mo ) ? $new_mo->export_to_db( $language ) : $mo->export_to_db( $language );
 			}
 
-			pll_add_settings_error( new WP_Error( 'pll_strings_translations_updated', __( 'Translations updated.', 'polylang' ), 'success' ) );
+			pll_add_notice( new WP_Error( 'pll_strings_translations_updated', __( 'Translations updated.', 'polylang' ), 'success' ) );
 
 			/**
 			 * Fires after the strings translations are saved in DB


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/2060 (Polylang parts)

See [#2060](https://github.com/polylang/polylang-pro/issues/2060) for explanations of what this PR propose.
First step required before applying to Polylang Pro.

Finally, this wrapper function name is `pll_add_notice()`.

We will need to take in account the [Polylang Pro special case](https://github.com/polylang/polylang-pro/blob/3.6-beta1/modules/machine-translation/Module_Settings.php#L129-L144).  ➡ In https://github.com/polylang/polylang-pro/pull/2067 we decided to pass the whole data as a `WP_Error()` extra data string. So the string is passed to `add_settings_error()` $type parameter as before.
