### PR TITLE
Hide the "The language is set from content" option

### DIFF
--- a/include/Options/Abstract_Option.php
+++ b/include/Options/Abstract_Option.php
@@ -52,9 +52,9 @@ abstract class Abstract_Option {
 	 *
 	 * @since 3.7
 	 *
-	 * @param mixed $value Optional. Option value.
+	 * @param mixed $value Option value. Use `null` to set the default value.
 	 */
-	public function __construct( $value = null ) {
+	public function __construct( $value ) {
 		$this->errors = new WP_Error();
 
 		if ( ! isset( $value ) ) {

--- a/include/Options/Business/Force_Lang.php
+++ b/include/Options/Business/Force_Lang.php
@@ -6,15 +6,38 @@
 namespace WP_Syntex\Polylang\Options\Business;
 
 use WP_Syntex\Polylang\Options\Abstract_Option;
+use WP_Syntex\Polylang\Options\Options;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class defining the "Determine how the current language is defined" option.
+ * /!\ Constructor depends on `hide_language_from_content_option`: this option must be set AFTER `hide_language_from_content_option`.
  *
  * @since 3.7
  */
 class Force_Lang extends Abstract_Option {
+	/**
+	 * @var array
+	 */
+	private $enum = array( 0, 1, 2, 3 );
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.7
+	 *
+	 * @param mixed   $value   Option value. Use `null` to set the default value.
+	 * @param Options $options All options.
+	 */
+	public function __construct( $value, Options $options ) {
+		if ( $options->get( 'hide_language_from_content_option' ) ) {
+			$this->enum = array( 1, 2, 3 );
+		}
+
+		parent::__construct( $value );
+	}
+
 	/**
 	 * Returns option key.
 	 *
@@ -51,7 +74,7 @@ class Force_Lang extends Abstract_Option {
 	protected function get_data_structure(): array {
 		return array(
 			'type' => 'integer',
-			'enum' => array( 0, 1, 2, 3 ),
+			'enum' => $this->enum,
 		);
 	}
 

--- a/include/Options/Business/Force_Lang.php
+++ b/include/Options/Business/Force_Lang.php
@@ -20,7 +20,7 @@ class Force_Lang extends Abstract_Option {
 	/**
 	 * @var array
 	 */
-	private $enum = array( 0, 1, 2, 3 );
+	private $enum = array( 1, 2, 3 );
 
 	/**
 	 * Constructor.
@@ -31,8 +31,8 @@ class Force_Lang extends Abstract_Option {
 	 * @param Options $options All options.
 	 */
 	public function __construct( $value, Options $options ) {
-		if ( $options->get( 'hide_language_from_content_option' ) ) {
-			$this->enum = array( 1, 2, 3 );
+		if ( ! $options->get( 'hide_language_from_content_option' ) ) {
+			$this->enum = array( 0, 1, 2, 3 );
 		}
 
 		parent::__construct( $value );

--- a/include/Options/Business/Hide_Language_From_Content_Option.php
+++ b/include/Options/Business/Hide_Language_From_Content_Option.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Options\Business;
+
+use PLL_Install;
+use WP_Error;
+use WP_Syntex\Polylang\Options\Primitive\Abstract_Boolean;
+use WP_Syntex\Polylang\Options\Options;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class defining the "Hide Language From Content Option" boolean option.
+ *
+ * @since 3.7
+ */
+class Hide_Language_From_Content_Option extends Abstract_Boolean {
+	/**
+	 * Returns option key.
+	 *
+	 * @since 3.7
+	 *
+	 * @return string
+	 *
+	 * @phpstan-return 'hide_language_from_content_option'
+	 */
+	public static function key(): string {
+		return 'hide_language_from_content_option';
+	}
+
+	/**
+	 * Returns the default value.
+	 *
+	 * @since 3.7
+	 *
+	 * @return bool
+	 */
+	protected function get_default() {
+		return PLL_Install::should_hide_language_from_content_option();
+	}
+
+	/**
+	 * Returns the description used in the JSON schema.
+	 *
+	 * @since 3.7
+	 *
+	 * @return string
+	 */
+	protected function get_description(): string {
+		return __( 'Tells if the choice allowing to define the current language from content must be hidden.', 'polylang' );
+	}
+}

--- a/include/Options/Options.php
+++ b/include/Options/Options.php
@@ -102,7 +102,7 @@ class Options implements ArrayAccess, IteratorAggregate {
 
 			if ( ! array_key_exists( $key, $options ) ) {
 				// Option raw value doesn't exist in database, use default instead.
-				$options[ $key ] = new $class_name();
+				$options[ $key ] = new $class_name( null, $this );
 				continue;
 			}
 
@@ -113,7 +113,7 @@ class Options implements ArrayAccess, IteratorAggregate {
 			}
 
 			// Option raw value exists in database, use it.
-			$options[ $key ] = new $class_name( $options[ $key ] );
+			$options[ $key ] = new $class_name( $options[ $key ], $this );
 		}
 
 		return $this;

--- a/include/Options/Registry.php
+++ b/include/Options/Registry.php
@@ -35,6 +35,7 @@ class Registry {
 		Business\Language_Taxonomies::class,
 		// Read only.
 		Business\First_Activation::class,
+		Business\Hide_Language_From_Content_Option::class,
 		Business\Previous_Version::class,
 		Business\Version::class,
 	);

--- a/include/Options/Registry.php
+++ b/include/Options/Registry.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Registry {
 	protected const OPTIONS = array(
+		// Read only.
+		Business\Hide_Language_From_Content_Option::class,
 		// URL modifications.
 		Business\Force_Lang::class,
 		Business\Domains::class,
@@ -35,7 +37,6 @@ class Registry {
 		Business\Language_Taxonomies::class,
 		// Read only.
 		Business\First_Activation::class,
-		Business\Hide_Language_From_Content_Option::class,
 		Business\Previous_Version::class,
 		Business\Version::class,
 	);

--- a/install/install.php
+++ b/install/install.php
@@ -83,49 +83,23 @@ class PLL_Install extends PLL_Install_Base {
 	}
 
 	/**
-	 * Get default Polylang options.
-	 *
-	 * @since 1.8
-	 *
-	 * @return array
-	 */
-	public static function get_default_options() {
-		return array(
-			'browser'                           => 0, // Default language for the front page is not set by browser preference (was the opposite before 3.1).
-			'rewrite'                           => 1, // Remove /language/ in permalinks (was the opposite before 0.7.2).
-			'hide_default'                      => 1, // Remove URL language information for default language (was the opposite before 2.1.5).
-			'force_lang'                        => 1, // Add URL language information (was 0 before 1.7).
-			'redirect_lang'                     => 0, // Do not redirect the language page to the homepage.
-			'media_support'                     => 0, // Do not support languages and translation for media by default (was the opposite before 3.1).
-			'uninstall'                         => 0, // Do not remove data when uninstalling Polylang.
-			'sync'                              => array(), // Synchronisation is disabled by default (was the opposite before 1.2).
-			'post_types'                        => array(),
-			'taxonomies'                        => array(),
-			'domains'                           => array(),
-			'version'                           => POLYLANG_VERSION,
-			'first_activation'                  => time(),
-			'hide_language_from_content_option' => self::should_hide_language_from_content_option(),
-		);
-	}
-
-	/**
-	 * Tells whether the "The language is set from content" option should be shown.
+	 * Tells whether the "The language is set from content" option should be hidden.
 	 *
 	 * @since 3.7
 	 *
 	 * @return bool
 	 */
 	public static function should_hide_language_from_content_option(): bool {
-		$show_option = defined( 'PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION' ) && PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION;
+		$display_option = defined( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION' ) && PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION;
 
 		/**
-		 * Filters whether the "The language is set from content" option should be shown.
+		 * Filters whether the "The language is set from content" option should be displayed.
 		 *
 		 * @since 3.7
 		 *
-		 * @param bool $show_option True to show the option, false otherwise.
+		 * @param bool $display_option True to display the option, false otherwise.
 		 */
-		return ! apply_filters( 'pll_show_language_from_content_option', $show_option );
+		return ! apply_filters( 'pll_display_language_from_content_option', $display_option );
 	}
 
 	/**

--- a/install/install.php
+++ b/install/install.php
@@ -90,7 +90,7 @@ class PLL_Install extends PLL_Install_Base {
 	 * @return bool
 	 */
 	public static function should_hide_language_from_content_option(): bool {
-		$display_option = pll_get_constant( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION', false );
+		$display_option = (bool) pll_get_constant( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION', false );
 
 		/**
 		 * Filters whether the "The language is set from content" option should be displayed.

--- a/install/install.php
+++ b/install/install.php
@@ -83,6 +83,43 @@ class PLL_Install extends PLL_Install_Base {
 	}
 
 	/**
+	 * Get default Polylang options.
+	 *
+	 * @since 1.8
+	 *
+	 * @return array
+	 */
+	public static function get_default_options() {
+		$hide_option = ! defined( 'PLL_HIDE_LANGUAGE_FROM_CONTENT_OPTION' ) || PLL_HIDE_LANGUAGE_FROM_CONTENT_OPTION;
+		/**
+		 * Filters whether the "The language is set from content" option should be hidden on new installations.
+		 * This is only available during Polylang's first activation.
+		 *
+		 * @since 3.7
+		 *
+		 * @param bool $hide_option True to hide the option on new installations, false otherwise. Default is true.
+		 */
+		$hide_option = (bool) apply_filters( 'pll_hide_language_from_content_option', $hide_option );
+
+		return array(
+			'browser'                           => 0, // Default language for the front page is not set by browser preference (was the opposite before 3.1).
+			'rewrite'                           => 1, // Remove /language/ in permalinks (was the opposite before 0.7.2).
+			'hide_default'                      => 1, // Remove URL language information for default language (was the opposite before 2.1.5).
+			'force_lang'                        => 1, // Add URL language information (was 0 before 1.7).
+			'redirect_lang'                     => 0, // Do not redirect the language page to the homepage.
+			'media_support'                     => 0, // Do not support languages and translation for media by default (was the opposite before 3.1).
+			'uninstall'                         => 0, // Do not remove data when uninstalling Polylang.
+			'sync'                              => array(), // Synchronisation is disabled by default (was the opposite before 1.2).
+			'post_types'                        => array(),
+			'taxonomies'                        => array(),
+			'domains'                           => array(),
+			'version'                           => POLYLANG_VERSION,
+			'first_activation'                  => time(),
+			'hide_language_from_content_option' => $hide_option,
+		);
+	}
+
+	/**
 	 * Plugin activation
 	 *
 	 * @since 0.5

--- a/install/install.php
+++ b/install/install.php
@@ -90,17 +90,6 @@ class PLL_Install extends PLL_Install_Base {
 	 * @return array
 	 */
 	public static function get_default_options() {
-		$show_option = defined( 'PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION' ) && PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION;
-		/**
-		 * Filters whether the "The language is set from content" option should be shown on new installations.
-		 * This is only available during Polylang's first activation.
-		 *
-		 * @since 3.7
-		 *
-		 * @param bool $show_option True to show the option on new installations, false otherwise.
-		 */
-		$show_option = (bool) apply_filters( 'pll_show_language_from_content_option', $show_option );
-
 		return array(
 			'browser'                           => 0, // Default language for the front page is not set by browser preference (was the opposite before 3.1).
 			'rewrite'                           => 1, // Remove /language/ in permalinks (was the opposite before 0.7.2).
@@ -115,8 +104,28 @@ class PLL_Install extends PLL_Install_Base {
 			'domains'                           => array(),
 			'version'                           => POLYLANG_VERSION,
 			'first_activation'                  => time(),
-			'hide_language_from_content_option' => ! $show_option,
+			'hide_language_from_content_option' => self::should_hide_language_from_content_option(),
 		);
+	}
+
+	/**
+	 * Tells whether the "The language is set from content" option should be shown.
+	 *
+	 * @since 3.7
+	 *
+	 * @return bool
+	 */
+	public static function should_hide_language_from_content_option(): bool {
+		$show_option = defined( 'PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION' ) && PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION;
+
+		/**
+		 * Filters whether the "The language is set from content" option should be shown.
+		 *
+		 * @since 3.7
+		 *
+		 * @param bool $show_option True to show the option, false otherwise.
+		 */
+		return ! apply_filters( 'pll_show_language_from_content_option', $show_option );
 	}
 
 	/**

--- a/install/install.php
+++ b/install/install.php
@@ -90,16 +90,16 @@ class PLL_Install extends PLL_Install_Base {
 	 * @return array
 	 */
 	public static function get_default_options() {
-		$hide_option = ! defined( 'PLL_HIDE_LANGUAGE_FROM_CONTENT_OPTION' ) || PLL_HIDE_LANGUAGE_FROM_CONTENT_OPTION;
+		$show_option = defined( 'PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION' ) && PLL_SHOW_LANGUAGE_FROM_CONTENT_OPTION;
 		/**
-		 * Filters whether the "The language is set from content" option should be hidden on new installations.
+		 * Filters whether the "The language is set from content" option should be shown on new installations.
 		 * This is only available during Polylang's first activation.
 		 *
 		 * @since 3.7
 		 *
-		 * @param bool $hide_option True to hide the option on new installations, false otherwise. Default is true.
+		 * @param bool $show_option True to show the option on new installations, false otherwise.
 		 */
-		$hide_option = (bool) apply_filters( 'pll_hide_language_from_content_option', $hide_option );
+		$show_option = (bool) apply_filters( 'pll_show_language_from_content_option', $show_option );
 
 		return array(
 			'browser'                           => 0, // Default language for the front page is not set by browser preference (was the opposite before 3.1).
@@ -115,7 +115,7 @@ class PLL_Install extends PLL_Install_Base {
 			'domains'                           => array(),
 			'version'                           => POLYLANG_VERSION,
 			'first_activation'                  => time(),
-			'hide_language_from_content_option' => $hide_option,
+			'hide_language_from_content_option' => ! $show_option,
 		);
 	}
 

--- a/install/install.php
+++ b/install/install.php
@@ -90,7 +90,7 @@ class PLL_Install extends PLL_Install_Base {
 	 * @return bool
 	 */
 	public static function should_hide_language_from_content_option(): bool {
-		$display_option = defined( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION' ) && PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION;
+		$display_option = pll_get_constant( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION', false );
 
 		/**
 		 * Filters whether the "The language is set from content" option should be displayed.

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -104,7 +104,7 @@ class PLL_Upgrade {
 	 * @return void
 	 */
 	public function _upgrade() {
-		foreach ( array( '2.0.8', '2.1', '2.7', '3.4' ) as $version ) {
+		foreach ( array( '2.0.8', '2.1', '2.7', '3.4', '3.7' ) as $version ) {
 			if ( version_compare( $this->options['version'], $version, '<' ) ) {
 				$method_to_call = array( $this, 'upgrade_' . str_replace( '.', '_', $version ) );
 				if ( is_callable( $method_to_call ) ) {
@@ -200,6 +200,20 @@ class PLL_Upgrade {
 		$this->migrate_locale_fallback_to_language_description();
 
 		$this->migrate_strings_translations();
+	}
+
+	/**
+	 * Upgrades if the previous version is < 3.7.
+	 * Hides the "The language is set from content" option if it isn't the one selected.
+	 *
+	 * @since 3.7
+	 *
+	 * @return void
+	 */
+	protected function upgrade_3_7() {
+		if ( ! empty( $this->options['force_lang'] ) ) {
+			$this->options['hide_language_from_content_option'] = true;
+		}
 	}
 
 	/**

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -212,7 +212,7 @@ class PLL_Upgrade {
 	 */
 	protected function upgrade_3_7() {
 		if ( ! empty( $this->options['force_lang'] ) ) {
-			$this->options['hide_language_from_content_option'] = true;
+			$this->options['hide_language_from_content_option'] = PLL_Install::should_hide_language_from_content_option();
 		}
 	}
 

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -175,6 +175,14 @@ class PLL_Admin_Site_Health {
 					$value = '0: ' . esc_html__( 'Synchronization disabled', 'polylang' );
 				}
 				break;
+
+			case 'hide_language_from_content_option':
+				if ( empty( $value ) ) {
+					$value = '0: ' . esc_html__( 'The option "The language is set from content" is shown', 'polylang' );
+				} else {
+					$value = '1: ' . esc_html__( 'The option "The language is set from content" is hidden', 'polylang' );
+				}
+				break;
 		}
 
 		return $value;

--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -178,7 +178,7 @@ class PLL_Admin_Site_Health {
 
 			case 'hide_language_from_content_option':
 				if ( empty( $value ) ) {
-					$value = '0: ' . esc_html__( 'The option "The language is set from content" is shown', 'polylang' );
+					$value = '0: ' . esc_html__( 'The option "The language is set from content" is displayed', 'polylang' );
 				} else {
 					$value = '1: ' . esc_html__( 'The option "The language is set from content" is hidden', 'polylang' );
 				}

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -51,18 +51,28 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function force_lang() {
-		?>
-		<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by the content or by domains.', 'polylang' ); ?></p>
-		<label>
-			<?php
-			printf(
-				'<input name="force_lang" type="radio" value="0" %s /> %s',
-				checked( $this->options['force_lang'], 0, false ),
-				esc_html__( 'The language is set from content', 'polylang' )
-			);
+		if ( ! empty( $this->options['hide_language_from_content_option'] ) ) {
+			// Hide the "Language is set from content" option.
 			?>
-		</label>
-		<p class="description"><?php esc_html_e( 'Posts, pages, categories and tags URLs will not be modified.', 'polylang' ); ?></p>
+			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by domains.', 'polylang' ); ?></p>
+			<?php
+		} else {
+			// Display the "Language is set from content" option.
+			?>
+			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by the content or by domains.', 'polylang' ); ?></p>
+			<label>
+				<?php
+				printf(
+					'<input name="force_lang" type="radio" value="0" %s /> %s',
+					checked( $this->options['force_lang'], 0, false ),
+					esc_html__( 'The language is set from content', 'polylang' )
+				);
+				?>
+			</label>
+			<p class="description"><?php esc_html_e( 'Posts, pages, categories and tags URLs will not be modified.', 'polylang' ); ?></p>
+			<?php
+		}
+		?>
 		<label>
 			<?php
 			printf(

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -51,7 +51,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function force_lang() {
-		if ( ! empty( $this->options['hide_language_from_content_option'] ) ) {
+		if ( $this->options['hide_language_from_content_option'] && 0 !== $this->options['force_lang'] ) {
 			// Hide the "Language is set from content" option.
 			?>
 			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by domains.', 'polylang' ); ?></p>

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -51,7 +51,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function force_lang() {
-		if ( $this->options['hide_language_from_content_option'] && 0 !== $this->options['force_lang'] ) {
+		if ( $this->options['hide_language_from_content_option'] ) {
 			// Hide the "Language is set from content" option.
 			?>
 			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by domains.', 'polylang' ); ?></p>

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -1,9 +1,12 @@
 <?php
 
 class Install_Test extends PLL_UnitTestCase {
+	use PLL_Mocks_Trait;
 
 	public function test_activate() {
 		delete_option( 'polylang' );
+		$this->mock_constants( array( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION' => false ) );
+
 		do_action( 'activate_' . POLYLANG_BASENAME );
 
 		// Check a few options
@@ -13,6 +16,19 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertSame( 1, $options['force_lang'] );
 		$this->assertEmpty( $options['sync'] );
 		$this->assertSame( POLYLANG_VERSION, $options['version'] );
+		$this->assertTrue( $options['hide_language_from_content_option'] );
+	}
+
+	public function test_activate_display_language_defined_from_content_option() {
+		delete_option( 'polylang' );
+		$this->mock_constants( array( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION' => true ) );
+
+		do_action( 'activate_' . POLYLANG_BASENAME );
+
+		// Check a few options
+		$options = get_option( 'polylang' );
+		$this->assertIsArray( $options );
+		$this->assertFalse( $options['hide_language_from_content_option'] );
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/1921.

This PR completely hides the "The language is set from content" option in two cases:
- on new installations,
- on upgrade, if it isn't the option selected.

## Two ways to keep it

1- Define a constant in the `wp-config.php` file, this works only if added BEFORE the first activation or upgrade to 3.7:
```php
define( 'PLL_DISPLAY_LANGUAGE_FROM_CONTENT_OPTION', true );
```

2- Or add a filter to a Must-Use plugin, this works only if added BEFORE the first activation or upgrade to 3.7:
```php
add_filter( 'pll_display_language_from_content_option', '__return_true' );
```

Both can be removed after Polylang's first activation/upgrade.

## Dev note

```php
abstract class Abstract_Option {
    public function __construct( $value = null, Options $options ) {
```
>Optional `$value` before `$options`: deprecated in php 8.0.

```php
abstract class Abstract_Option {
    public function __construct( Options $options, $value ) {
```
>PHPStan: `$options` is not used.

```php
abstract class Abstract_Option {
    public function __construct( $value, Options $options ) {
```
>PHPStan: `$options` is not used.

So the solution I chose is:

```php
abstract class Abstract_Option {
    public function __construct( $value ) {} // Default value `null` removed so it behaves the same for each class.
}

class Force_Lang extends Abstract_Option {
    public function __construct( $value, Options $options ) {}
}
```