### PR TITLE
Don't print the setting form of an inactive module

### DIFF
--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -232,6 +232,10 @@ class PLL_Settings_Module {
 	 * @return string
 	 */
 	public function get_form() {
+		if ( ! $this->is_active() ) {
+			return '';
+		}
+
 		// Read the form only once
 		if ( false === $this->form ) {
 			ob_start();


### PR DESCRIPTION
This PR prevents to print the setting form of an inactive module:
- The form is hidden, so it is useless to print it.
- The form could perform actions that are now prevented (like contacting a service to fetch data).