### PR TITLE
Adds sub-levels attribute keys support in wpml config

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -597,13 +597,11 @@ class PLL_WPML_Config {
 	 * @since 3.6
 	 *
 	 * @param  SimpleXMLElement $field A XML node.
-	 * @param  array            $attrs The attributes.
 	 * @return array An array of attributes.
 	 *
-	 * @phpstan-param array<non-empty-string, array|true> $attrs
 	 * @phpstan-return array<non-empty-string, array|true>
 	 */
-	private function get_field_attributes( SimpleXMLElement $field, array $attrs = array() ): array {
+	private function get_field_attributes( SimpleXMLElement $field ): array {
 		$name = $this->get_field_attribute( $field, 'name' );
 
 		if ( '' === $name ) {
@@ -616,25 +614,19 @@ class PLL_WPML_Config {
 			return array( $name => true );
 		}
 
-		if ( ! isset( $attrs[ $name ] ) || ! is_array( $attrs[ $name ] ) ) {
-			$attrs[ $name ] = array();
-		}
+		$sub_attributes = array();
 
 		foreach ( $children as $child ) {
-			$sub = $this->get_field_attributes( $child, $attrs[ $name ] );
+			$sub = $this->get_field_attributes( $child );
 
 			if ( empty( $sub ) ) {
 				continue;
 			}
 
-			$attrs[ $name ] = array_merge( $attrs[ $name ], $sub );
+			$sub_attributes[ $name ] = array_merge( $sub_attributes[ $name ] ?? array(), $sub );
 		}
 
-		if ( empty( $attrs[ $name ] ) ) {
-			unset( $attrs[ $name ] );
-		}
-
-		return $attrs;
+		return $sub_attributes;
 	}
 
 	/**

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -576,7 +576,7 @@ class PLL_WPML_Config {
 	}
 
 	/**
-	 * Gets attributes values.
+	 * Gets attributes values recursively.
 	 *
 	 * @since 3.6
 	 *

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -484,17 +484,18 @@ class PLL_WPML_Config {
 							break;
 					}
 
-					if ( '' === $rule || ( is_array( $rule ) && empty( array_filter( $rule ) ) ) ) {
-						continue;
-					}
-
 					if ( is_array( $rule ) ) {
+						$rule = array_filter( $rule );
+						if ( empty( $rule ) ) {
+							continue;
+						}
+						
 						if ( isset( $parsing_rules[ $child_tag ][ $block_name ] ) ) {
 							$parsing_rules[ $child_tag ][ $block_name ] = array_merge( $parsing_rules[ $child_tag ][ $block_name ], $rule );
 						} else {
 							$parsing_rules[ $child_tag ][ $block_name ] = $rule;
 						}
-					} else {
+					} elseif ( '' !== $rule ) {
 						$parsing_rules[ $child_tag ][ $block_name ][] = $rule;
 					}
 				}

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -583,7 +583,7 @@ class PLL_WPML_Config {
 	 * @param  SimpleXMLElement $field A XML node.
 	 * @param  array            $attrs The attributes.
 	 * @param  bool             $first Tells if this is the first time in the function..
-	 * @return array|string
+	 * @return array|string An array if there are sub-attributes, otherwise a string.
 	 */
 	private function get_field_attributes( SimpleXMLElement $field, array $attrs = array(), bool $first = true ) {
 		$name = $this->get_field_attribute( $field, 'name' );

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -45,7 +45,12 @@ class PLL_WPML_Config {
 	/**
 	 * List of rules to extract strings to translate from blocks.
 	 *
-	 * @var string[][][]|null
+	 * @var array
+	 *
+	 * @phpstan-var array{
+	 *     xpath?: array<non-empty-string, list<non-empty-string>>,
+	 *     key?: array<non-empty-string, array<array|true>>
+	 * }|null
 	 */
 	protected $parsing_rules = null;
 
@@ -431,6 +436,11 @@ class PLL_WPML_Config {
 	 *
 	 * @param string $rule_tag Tag name to extract.
 	 * @return string[][] The rules.
+	 *
+	 * @phpstan-param 'xpath'|'key' $rule_tag
+	 * @phpstan-return (
+	 *     $rule_tag is 'xpath' ? array<non-empty-string, list<non-empty-string>> : array<non-empty-string, array<array|true>>
+	 * )
 	 */
 	protected function get_blocks_parsing_rules( $rule_tag ) {
 
@@ -449,8 +459,8 @@ class PLL_WPML_Config {
 	 * @return string[][][] Rules completed with ones from wpml-config file.
 	 *
 	 * @phpstan-return array{
-	 *     xpath?: array<non-falsy-string, list<non-falsy-string>>,
-	 *     key?: array<non-falsy-string, array<array|true>>
+	 *     xpath?: array<non-empty-string, list<non-empty-string>>,
+	 *     key?: array<non-empty-string, array<array|true>>
 	 * }
 	 */
 	protected function extract_blocks_parsing_rules() {
@@ -485,7 +495,7 @@ class PLL_WPML_Config {
 							$rule = trim( (string) $child );
 
 							if ( '' !== $rule ) {
-								$parsing_rules[ $child_tag ][ $block_name ][] = $rule;
+								$parsing_rules['xpath'][ $block_name ][] = $rule;
 							}
 							break;
 
@@ -496,10 +506,10 @@ class PLL_WPML_Config {
 								break;
 							}
 
-							if ( isset( $parsing_rules[ $child_tag ][ $block_name ] ) ) {
-								$parsing_rules[ $child_tag ][ $block_name ] = array_merge( $parsing_rules[ $child_tag ][ $block_name ], $rule );
+							if ( isset( $parsing_rules['key'][ $block_name ] ) ) {
+								$parsing_rules['key'][ $block_name ] = array_merge( $parsing_rules['key'][ $block_name ], $rule );
 							} else {
-								$parsing_rules[ $child_tag ][ $block_name ] = $rule;
+								$parsing_rules['key'][ $block_name ] = $rule;
 							}
 							break;
 					}
@@ -590,6 +600,7 @@ class PLL_WPML_Config {
 	 * @param  array            $attrs The attributes.
 	 * @return array An array of attributes.
 	 *
+	 * @phpstan-param array<non-empty-string, array|true> $attrs
 	 * @phpstan-return array<non-empty-string, array|true>
 	 */
 	private function get_field_attributes( SimpleXMLElement $field, array $attrs = array() ): array {

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -594,22 +594,18 @@ class PLL_WPML_Config {
 			return $name;
 		}
 
-		if ( count( $children ) ) {
-			foreach ( $children as $child ) {
-				if ( ! isset( $attrs[ $name ] ) || ! is_array( $attrs[ $name ] ) ) {
-					$attrs[ $name ] = array();
-				}
-
-				$sub = $this->get_field_attributes( $child, $attrs[ $name ] );
-
-				if ( is_string( $sub ) ) {
-					$sub = array( $sub => true );
-				}
-
-				$attrs[ $name ] = array_merge( $attrs[ $name ], $sub );
+		foreach ( $children as $child ) {
+			if ( ! isset( $attrs[ $name ] ) || ! is_array( $attrs[ $name ] ) ) {
+				$attrs[ $name ] = array();
 			}
-		} else {
-			$attrs[ $name ] = true;
+
+			$sub = $this->get_field_attributes( $child, $attrs[ $name ] );
+
+			if ( is_string( $sub ) ) {
+				$sub = array( $sub => true );
+			}
+
+			$attrs[ $name ] = array_merge( $attrs[ $name ], $sub );
 		}
 
 		return $attrs;

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -507,7 +507,7 @@ class PLL_WPML_Config {
 							}
 
 							if ( isset( $parsing_rules['key'][ $block_name ] ) ) {
-								$parsing_rules['key'][ $block_name ] = array_merge( $parsing_rules['key'][ $block_name ], $rule );
+								$parsing_rules['key'][ $block_name ] = $this->array_merge_recursive( $parsing_rules['key'][ $block_name ], $rule );
 							} else {
 								$parsing_rules['key'][ $block_name ] = $rule;
 							}
@@ -518,6 +518,28 @@ class PLL_WPML_Config {
 		}
 
 		return $parsing_rules;
+	}
+
+	/**
+	 * Merge two arrays recursively.
+	 * Unlike `array_merge_recursive()`, this method doesn't change the type of the values.
+	 *
+	 * @since 3.6
+	 *
+	 * @param array $array1 Array to merge into.
+	 * @param array $array2 Array to merge.
+	 * @return array
+	 */
+	protected function array_merge_recursive( array $array1, array $array2 ): array {
+		foreach ( $array2 as $key => $value ) {
+			if ( is_array( $value ) && isset( $array1[ $key ] ) && is_array( $array1[ $key ] ) ) {
+				$array1[ $key ] = $this->array_merge_recursive( $array1[ $key ], $value );
+			} else {
+				$array1[ $key ] = $value;
+			}
+		}
+
+		return $array1;
 	}
 
 	/**

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -582,15 +582,14 @@ class PLL_WPML_Config {
 	 *
 	 * @param  SimpleXMLElement $field A XML node.
 	 * @param  array            $attrs The attributes.
-	 * @param  bool             $first Tells if this is the first time in the function..
 	 * @return array|string An array if there are sub-attributes, otherwise a string.
 	 */
-	private function get_field_attributes( SimpleXMLElement $field, array $attrs = array(), bool $first = true ) {
+	private function get_field_attributes( SimpleXMLElement $field, array $attrs = array() ) {
 		$name = $this->get_field_attribute( $field, 'name' );
 
 		$children = $field->children();
 
-		if ( $first && 0 === count( $children ) ) {
+		if ( 0 === count( $children ) ) {
 			// No sub-attributes, don't go further and just return the attribute's value.
 			return $name;
 		}
@@ -600,7 +599,14 @@ class PLL_WPML_Config {
 				if ( ! isset( $attrs[ $name ] ) || ! is_array( $attrs[ $name ] ) ) {
 					$attrs[ $name ] = array();
 				}
-				$attrs[ $name ] = $this->get_field_attributes( $child, $attrs[ $name ], false );
+
+				$sub = $this->get_field_attributes( $child, $attrs[ $name ] );
+
+				if ( is_string( $sub ) ) {
+					$sub = array( $sub => true );
+				}
+
+				$attrs[ $name ] = array_merge( $attrs[ $name ], $sub );
 			}
 		} else {
 			$attrs[ $name ] = true;

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -99,6 +99,24 @@
 				<xpath>//div/p/a</xpath>
 				<key name=" " />
 			</gutenberg-block>
+			<gutenberg-block type="my-plugin/my-block-7" translate="1">
+				<key name="first-level">
+					<key name="second-level" />
+					<key name="second-level-2" />
+					<key name="second-level-3" >
+						<key name="third-level" />
+					</key>
+					<key name="second-level-4" >
+						<key name="third-level-2" >
+							<key name="fourth-level" />
+							<key name="fourth-level-2" />
+						</key>
+					</key>
+				</key>
+				<key name="first-level-2" >
+					<key name="first-level-2-second-level" />
+				</key>
+			</gutenberg-block>
 		</gutenberg-blocks>
 		<language-switcher-settings>
 				<key name="icl_lang_sel_config">

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -423,6 +423,24 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 			'my-plugin/my-block-5' => array(
 				'iconLabel',
 			),
+			'my-plugin/my-block-7' => array(
+				'first-level' => array(
+					'second-level' => true,
+					'second-level-2' => true,
+					'second-level-3' => array(
+						'third-level' => true,
+					),
+					'second-level-4' => array(
+						'third-level-2' => array(
+							'fourth-level' => true,
+							'fourth-level-2' => true,
+						),
+					),
+				),
+				'first-level-2' => array(
+					'first-level-2-second-level' => true,
+				)
+			),
 		);
 
 		$parsing_rules                = apply_filters( 'pll_blocks_xpath_rules', $parsing_rules );

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -396,7 +396,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		);
 		$parsing_rules_for_attributes = array(
 			'my-plugin/my-block' => array(
-				'buttonText',
+				'buttonText' => true,
 			),
 		);
 
@@ -414,14 +414,14 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		);
 		$expected_parsing_rules_for_attributes = array(
 			'my-plugin/my-block' => array(
-				'headingTitle',
-				'text',
+				'headingTitle' => true,
+				'text'         => true,
 			),
 			'my-plugin/my-block-2' => array(
-				'iconLabel',
+				'iconLabel' => true,
 			),
 			'my-plugin/my-block-5' => array(
-				'iconLabel',
+				'iconLabel' => true,
 			),
 			'my-plugin/my-block-7' => array(
 				'first-level' => array(
@@ -447,6 +447,6 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$parsing_rules_for_attributes = apply_filters( 'pll_blocks_rules_for_attributes', $parsing_rules_for_attributes );
 
 		$this->assertSameSets( $expected_parsing_rules, $parsing_rules, 'Rules from WPML config should be added and override the existing ones for each block.' );
-		$this->assertSameSets( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules for blocks attributes from WPML config should be added and override the existing ones for each block.' );
+		$this->assertSameSetsWithIndex( $expected_parsing_rules_for_attributes, $parsing_rules_for_attributes, 'Rules for blocks attributes from WPML config should be added and override the existing ones for each block.' );
 	}
 }

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -439,7 +439,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 				),
 				'first-level-2' => array(
 					'first-level-2-second-level' => true,
-				)
+				),
 			),
 		);
 


### PR DESCRIPTION
See https://github.com/polylang/polylang-pro/issues/1933

Adds a `get_field_attributes()` method to handle block sub-attributes in the **wpml-config.xml** file.