### PR TITLE
Activates PHPstan tool on PHP views

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Manages filters and actions related to the classic editor
  *
@@ -15,7 +17,7 @@ class PLL_Admin_Classic_Editor {
 	public $model;
 
 	/**
-	 * @var PLL_Admin_Links|null
+	 * @var PLL_Admin_Links
 	 */
 	public $links;
 

--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Manages filters and actions related to terms on admin side
  *
@@ -15,7 +17,7 @@ class PLL_Admin_Filters_Term {
 	public $model;
 
 	/**
-	 * @var PLL_Admin_Links|null
+	 * @var PLL_Admin_Links
 	 */
 	public $links;
 

--- a/admin/view-translations-media.php
+++ b/admin/view-translations-media.php
@@ -4,17 +4,19 @@
  * Needs WP 3.5+
  *
  * @package Polylang
+ *
+ * @var PLL_Admin_Classic_Editor $this
+ * @var PLL_Language             $lang
+ * @var int                      $post_ID
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly
 ?>
 <p><strong><?php esc_html_e( 'Translations', 'polylang' ); ?></strong></p>
 <table>
 	<?php
 	foreach ( $this->model->get_languages_list() as $language ) {
-		if ( $language->term_id == $lang->term_id ) {
+		if ( $language->term_id === $lang->term_id ) {
 			continue;
 		}
 		?>
@@ -22,12 +24,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->flag; // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
 			<td class = "pll-media-edit-column">
 				<?php
-				if ( ( $translation_id = $this->model->post->get_translation( $post_ID, $language ) ) && $translation_id !== $post_ID ) {
+				$translation_id = $this->model->post->get_translation( $post_ID, $language );
+				if ( ! empty( $translation_id ) && $translation_id !== $post_ID ) {
 					// The translation exists
 					printf(
 						'<input type="hidden" name="media_tr_lang[%s]" value="%d" />',
 						esc_attr( $language->slug ),
-						esc_attr( $translation_id )
+						esc_attr( (string) $translation_id )
 					);
 					echo $this->links->edit_post_translation_link( $translation_id ); // phpcs:ignore WordPress.Security.EscapeOutput
 				} else {

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -3,9 +3,13 @@
  * Displays the translations fields for posts
  *
  * @package Polylang
+ *
+ * @var PLL_Admin_Classic_Editor $this
+ * @var PLL_Language             $lang
+ * @var int                      $post_ID
  */
 
-defined( 'ABSPATH' ) || exit;
+defined( 'ABSPATH' ) || exit; // Don't access directly
 ?>
 <p><strong><?php esc_html_e( 'Translations', 'polylang' ); ?></strong></p>
 <table>
@@ -55,7 +59,7 @@ defined( 'ABSPATH' ) || exit;
 					esc_attr( $language->slug ),
 					/* translators: accessibility text */
 					esc_html__( 'Translation', 'polylang' ),
-					( empty( $translation ) ? 0 : esc_attr( $translation->ID ) ),
+					( empty( $translation ) ? 0 : esc_attr( (string) $translation->ID ) ),
 					( empty( $translation ) ? '' : esc_attr( $translation->post_title ) ),
 					esc_attr( $language->get_locale( 'display' ) ),
 					( $language->is_rtl ? 'rtl' : 'ltr' )

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -3,11 +3,14 @@
  * Displays the translations fields for terms
  *
  * @package Polylang
+ *
+ * @var PLL_Admin_Filters_Term $this
+ * @var PLL_Language           $lang
+ * @var string                 $taxonomy
+ * @var string                 $post_type
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly
 
 if ( isset( $term_id ) ) {
 	// Edit term form ?>
@@ -31,7 +34,7 @@ else {
 
 		// Look for any existing translation in this language
 		// Take care not to propose a self link
-		$translation = 0;
+		$translation = null;
 		if ( isset( $term_id ) && ( $translation_id = $this->model->term->get_translation( $term_id, $language ) ) && $translation_id != $term_id ) {
 			$translation = get_term( $translation_id, $taxonomy );
 		}
@@ -39,11 +42,14 @@ else {
 			$translation = get_term( $translation_id, $taxonomy );
 		}
 
+		$add_link = '';
+		$link     = '';
 		if ( isset( $term_id ) ) { // Do not display the add new link in add term form ( $term_id not set !!! )
-			$link = $add_link = $this->links->new_term_translation_link( $term_id, $taxonomy, $post_type, $language );
+			$link = $this->links->new_term_translation_link( $term_id, $taxonomy, $post_type, $language );
+			$add_link = $link;
 		}
 
-		if ( $translation ) {
+		if ( $translation instanceof WP_Term ) {
 			$link = $this->links->edit_term_translation_link( $translation->term_id, $taxonomy, $post_type );
 		}
 		?>
@@ -75,8 +81,8 @@ else {
 					esc_attr( $language->slug ),
 					/* translators: accessibility text */
 					esc_html__( 'Translation', 'polylang' ),
-					( empty( $translation ) ? 0 : esc_attr( $translation->term_id ) ),
-					( empty( $translation ) ? '' : esc_attr( $translation->name ) ),
+					( ! $translation instanceof WP_Term ? 0 : esc_attr( (string) $translation->term_id ) ),
+					( ! $translation instanceof WP_Term ? '' : esc_attr( $translation->name ) ),
 					disabled( empty( $disabled ), false, false ),
 					esc_attr( $language->get_locale( 'display' ) ),
 					( $language->is_rtl ? 'rtl' : 'ltr' )

--- a/modules/wizard/view-wizard-page.php
+++ b/modules/wizard/view-wizard-page.php
@@ -5,11 +5,22 @@
  * @package Polylang
  *
  * @since 2.7
+ *
+ * @var array[]    $steps {
+ *   List of steps.
+ *
+ *     @type string   $name    I18n string which names the step.
+ *     @type callable $view    The callback function use to display the step content.
+ *     @type callable $handler The callback function use to process the step after it is submitted.
+ *     @type array    $scripts List of scripts handle needed by the step.
+ *     @type array    $styles  The list of styles handle needed by the step.
+ * }
+ * @var string   $current_step Current step.
+ * @var string[] $styles       List of wizard page styles.
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly.
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly.
+
 $admin_body_class = array( 'pll-wizard', 'wp-core-ui' );
 if ( is_rtl() ) {
 	$admin_body_class[] = 'rtl';
@@ -32,9 +43,8 @@ if ( is_rtl() ) {
 		<script>
 			var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php', 'relative' ) ); ?>';
 		</script>
-		<?php do_action( 'admin_enqueue_scripts' ); ?>
-		<?php wp_print_scripts( $this->steps[ $this->step ]['scripts'] ); ?>
-		<?php wp_print_styles( array_merge( $this->styles, $this->steps[ $this->step ]['styles'] ) ); ?>
+		<?php wp_print_scripts( $steps[ $current_step ]['scripts'] ); ?>
+		<?php wp_print_styles( array_merge( $styles, $steps[ $current_step ]['styles'] ) ); ?>
 		<?php do_action( 'admin_head' ); ?>
 	</head>
 	<body class="<?php echo join( ' ', array_map( 'sanitize_key', $admin_body_class ) ); ?>">
@@ -46,10 +56,10 @@ if ( is_rtl() ) {
 		</h1>
 		<ol class="pll-wizard-steps">
 			<?php
-			foreach ( $this->steps as $step_key => $step ) {
-				$is_completed = array_search( $this->step, array_keys( $this->steps ), true ) > array_search( $step_key, array_keys( $this->steps ), true );
+			foreach ( $steps as $step_key => $step ) {
+				$is_completed = array_search( $step, array_keys( $steps ), true ) > array_search( $step_key, array_keys( $steps ), true );
 
-				if ( $step_key === $this->step ) {
+				if ( $step_key === $current_step ) {
 					?>
 					<li class="active"><?php echo esc_html( $step['name'] ); ?></li>
 					<?php
@@ -72,15 +82,15 @@ if ( is_rtl() ) {
 			?>
 		</ol>
 		<div class="pll-wizard-content">
-			<form method="post" class="<?php echo esc_attr( "{$this->step}-step" ); ?>">
+			<form method="post" class="<?php echo esc_attr( "{$current_step}-step" ); ?>">
 				<?php
 				wp_nonce_field( 'pll-wizard', '_pll_nonce' );
 
-				if ( ! empty( $this->steps[ $this->step ]['view'] ) ) {
-					call_user_func( $this->steps[ $this->step ]['view'], $this );
+				if ( ! empty( $steps[ $current_step ]['view'] ) ) {
+					call_user_func( $steps[ $current_step ]['view'] );
 				}
 				?>
-				<?php if ( 'last' !== $this->step ) : ?>
+				<?php if ( 'last' !== $current_step ) : ?>
 				<p class="pll-wizard-actions step">
 					<button
 						type="submit"
@@ -95,7 +105,7 @@ if ( is_rtl() ) {
 			</form>
 		</div>
 		<div class="pll-wizard-footer">
-			<?php if ( 'last' !== $this->step ) : ?>
+			<?php if ( 'last' !== $current_step ) : ?>
 				<a
 					class="pll-wizard-footer-links"
 					href="<?php echo esc_url( admin_url() ); ?>"

--- a/modules/wizard/view-wizard-step-home-page.php
+++ b/modules/wizard/view-wizard-step-home-page.php
@@ -5,54 +5,60 @@
  * @package Polylang
  *
  * @since 2.7
+ *
+ * @var PLL_Admin_Model $model
+ * @var array           $options
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly.
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly.
 
-$languages = $this->model->get_languages_list();
-$default_language = count( $languages ) > 0 ? $this->options['default_lang'] : null;
+$languages = $model->get_languages_list();
+$default_language = count( $languages ) > 0 ? $options['default_lang'] : null;
 $home_page_id = get_option( 'page_on_front' );
-$translations = $this->model->post->get_translations( $home_page_id );
+$home_page_id = is_scalar( $home_page_id ) ? (int) $home_page_id : 0;
+$translations = $model->post->get_translations( $home_page_id );
 $untranslated_languages = array();
 $home_page = $home_page_id > 0 ? get_post( $home_page_id ) : null;
-$home_page_language = $this->model->post->get_language( $home_page_id );
+$home_page_language = $model->post->get_language( $home_page_id );
+
+if ( empty( $home_page ) ) {
+	return;
+}
 
 foreach ( $languages as $language ) {
-	if ( ! $this->model->post->get( $home_page_id, $language ) ) {
+	if ( ! $model->post->get( $home_page_id, $language ) ) {
 		$untranslated_languages[] = $language;
 	}
 }
 ?>
-<input type="hidden" name="home_page" value="<?php echo esc_attr( $home_page->ID ); ?>" />
+<input type="hidden" name="home_page" value="<?php echo esc_attr( (string) $home_page->ID ); ?>" />
 <input type="hidden" name="home_page_title" value="<?php echo esc_attr( $home_page->post_title ); ?>" />
-<?php if ( false !== $home_page_language ) : ?>
+<?php if ( ! empty( $home_page_language ) ) : ?>
 	<input type="hidden" name="home_page_language" value="<?php echo esc_attr( $home_page_language->slug ); ?>" />
+	<h2><?php esc_html_e( 'Homepage', 'polylang' ); ?></h2>
+	<p>
+		<?php
+			printf(
+				/* translators: %s is the post title of the front page */
+				esc_html__( 'You defined this page as your static homepage: %s.', 'polylang' ),
+				'<strong>' . esc_html( $home_page->post_title ) . '</strong>'
+			);
+		?>
+		<br />
+		<?php
+			printf(
+				/* translators: %s is the language of the front page ( flag, native name and locale ) */
+				esc_html__( 'Its language is : %s.', 'polylang' ),
+				$home_page_language->flag . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			)
+		?>
+		<br />
+		<?php esc_html_e( 'For your site to work correctly, this page must be translated in all available languages.', 'polylang' ); ?>
+	</p>
+	<p>
+		<?php esc_html_e( 'After the pages is created, it is up to you to put the translated content in each page linked to each language.', 'polylang' ); ?>
+	</p>
 <?php endif; ?>
-<h2><?php esc_html_e( 'Homepage', 'polylang' ); ?></h2>
-<p>
-	<?php
-		printf(
-			/* translators: %s is the post title of the front page */
-			esc_html__( 'You defined this page as your static homepage: %s.', 'polylang' ),
-			'<strong>' . esc_html( $home_page->post_title ) . '</strong>'
-		);
-		?>
-	<br />
-	<?php
-		printf(
-			/* translators: %s is the language of the front page ( flag, native name and locale ) */
-			esc_html__( 'Its language is : %s.', 'polylang' ),
-			$home_page_language->flag . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		)
-		?>
-	<br />
-	<?php esc_html_e( 'For your site to work correctly, this page must be translated in all available languages.', 'polylang' ); ?>
-</p>
-<p>
-	<?php esc_html_e( 'After the pages is created, it is up to you to put the translated content in each page linked to each language.', 'polylang' ); ?>
-</p>
 <?php if ( $translations ) : ?>
 <table id="translated-languages" class="striped">
 	<thead>
@@ -63,7 +69,10 @@ foreach ( $languages as $language ) {
 	<tbody>
 	<?php
 	foreach ( array_keys( $translations ) as $lang ) {
-		$language = $this->model->get_language( $lang );
+		$language = $model->get_language( $lang );
+		if ( empty( $language ) ) {
+			continue;
+		}
 		?>
 		<tr>
 			<td>
@@ -96,7 +105,7 @@ foreach ( $languages as $language ) {
 			<tr>
 				<th><?php esc_html_e( 'We are going to prepare this page in', 'polylang' ); ?></th>
 			</tr>
-		<?php elseif ( false !== $home_page_language && count( $untranslated_languages ) <= 0 ) : ?>
+		<?php elseif ( ! empty( $home_page_language ) ) : ?>
 			<tr>
 				<th>
 					<span class="dashicons dashicons-info"></span>

--- a/modules/wizard/view-wizard-step-languages.php
+++ b/modules/wizard/view-wizard-step-languages.php
@@ -5,14 +5,15 @@
  * @package Polylang
  *
  * @since 2.7
+ *
+ * @var PLL_Admin_Model $model
+ * @var array           $options
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly.
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly.
 
-$existing_languages = $this->model->get_languages_list();
-$default_language   = count( $existing_languages ) > 0 ? $this->options['default_lang'] : null;
+$existing_languages = $model->get_languages_list();
+$default_language   = count( $existing_languages ) > 0 ? $options['default_lang'] : null;
 $languages_list = array_diff_key(
 	PLL_Settings::get_predefined_languages(),
 	wp_list_pluck( $existing_languages, 'locale', 'locale' )

--- a/modules/wizard/view-wizard-step-last.php
+++ b/modules/wizard/view-wizard-step-last.php
@@ -7,9 +7,7 @@
  * @since 2.7
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly.
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly.
 
 ?>
 <h2><?php esc_html_e( "You're ready to translate your contents!", 'polylang' ); ?></h2>

--- a/modules/wizard/view-wizard-step-media.php
+++ b/modules/wizard/view-wizard-step-media.php
@@ -7,12 +7,10 @@
  * @since 2.7
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly.
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly.
 
 $default_options = PLL_Install::get_default_options();
-$options = wp_parse_args( get_option( 'polylang' ), $default_options );
+$options = wp_parse_args( (array) get_option( 'polylang' ), $default_options );
 $media_support = $options['media_support'];
 
 $help_screenshot = '/modules/wizard/images/media-screen' . ( is_rtl() ? '-rtl' : '' ) . '.png';

--- a/modules/wizard/view-wizard-step-untranslated-contents.php
+++ b/modules/wizard/view-wizard-step-untranslated-contents.php
@@ -5,13 +5,13 @@
  * @package Polylang
  *
  * @since 2.7
+ *
+ * @var PLL_Admin_Model $model
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly.
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly.
 
-$languages_list = $this->model->get_languages_list();
+$languages_list = $model->get_languages_list();
 ?>
 <h2><?php esc_html_e( 'Content without language', 'polylang' ); ?></h2>
 <p>

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Main class for Polylang wizard.
  *
@@ -26,7 +28,7 @@ class PLL_Wizard {
 	/**
 	 * List of steps.
 	 *
-	 * @var array $steps {
+	 * @var array[] $steps {
 	 *     @type string   $name    I18n string which names the step.
 	 *     @type callable $view    The callback function use to display the step content.
 	 *     @type callable $handler The callback function use to process the step after it is submitted.
@@ -272,6 +274,10 @@ class PLL_Wizard {
 	 */
 	public function display_wizard_page() {
 		set_current_screen( 'pll-wizard' );
+		do_action( 'admin_enqueue_scripts' );
+		$steps          = $this->steps;
+		$current_step   = $this->step;
+		$styles         = $this->styles;
 		include __DIR__ . '/view-wizard-page.php';
 	}
 
@@ -512,6 +518,8 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function display_step_languages() {
+		$model   = $this->model;
+		$options = $this->options;
 		include __DIR__ . '/view-wizard-step-languages.php';
 	}
 
@@ -679,6 +687,7 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function display_step_untranslated_contents() {
+		$model = $this->model;
 		include __DIR__ . '/view-wizard-step-untranslated-contents.php';
 	}
 
@@ -742,6 +751,8 @@ class PLL_Wizard {
 	 * @return void
 	 */
 	public function display_step_home_page() {
+		$model   = $this->model;
+		$options = $this->options;
 		include __DIR__ . '/view-wizard-step-home-page.php';
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: admin/admin-base.php
 
 		-
-			message: "#^Cannot call method edit_post_translation_link\\(\\) on PLL_Admin_Links\\|null\\.$#"
-			count: 2
-			path: admin/admin-classic-editor.php
-
-		-
 			message: "#^Parameter \\#2 \\$lang of method PLL_Translated_Object\\:\\:get_translation\\(\\) expects PLL_Language\\|string, PLL_Language\\|false given\\.$#"
 			count: 1
 			path: admin/admin-classic-editor.php
@@ -137,11 +132,6 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$term_id on PLL_Language\\|null\\.$#"
-			count: 1
-			path: admin/admin-filters-term.php
-
-		-
-			message: "#^Cannot call method edit_term_translation_link\\(\\) on PLL_Admin_Links\\|null\\.$#"
 			count: 1
 			path: admin/admin-filters-term.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,7 +13,7 @@ parameters:
 		- settings/
 	excludePaths:
 		- **/load.php
-		- **/view*.php
+#		- **/view*.php
 		- include/widget-calendar.php
 		- install/plugin-updater.php
 	checkMissingIterableValueType: false

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * A class for the Polylang settings pages, accessible from @see PLL().
  *
@@ -306,6 +308,8 @@ class PLL_Settings extends PLL_Admin_Base {
 		}
 
 		// Displays the page
+		$modules    = $this->modules;
+		$active_tab = $this->active_tab;
 		include __DIR__ . '/view-languages.php';
 	}
 
@@ -368,7 +372,7 @@ class PLL_Settings extends PLL_Admin_Base {
 	 *
 	 * @since 2.3
 	 *
-	 * @return string[] {
+	 * @return string[][] {
 	 *   @type string $code     ISO 639-1 language code.
 	 *   @type string $locale   WordPress locale.
 	 *   @type string $name     Native language name.

--- a/settings/view-languages.php
+++ b/settings/view-languages.php
@@ -3,22 +3,22 @@
  * Displays the Languages admin panel
  *
  * @package Polylang
+ *
+ * @var string $active_tab
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly
 
 require ABSPATH . 'wp-admin/options-head.php'; // Displays the errors messages as when we were a child of options-general.php
 ?>
 <div class="wrap">
 	<h1><?php echo esc_html( $GLOBALS['title'] ); ?></h1>
 	<?php
-	switch ( $this->active_tab ) {
+	switch ( $active_tab ) {
 		case 'lang':     // Languages tab
 		case 'strings':  // String translations tab
 		case 'settings': // Settings tab
-			include __DIR__ . '/view-tab-' . $this->active_tab . '.php';
+			include __DIR__ . '/view-tab-' . $active_tab . '.php';
 			// Intentional fall-through to upgrade to fire the action below.
 
 		default:
@@ -28,7 +28,7 @@ require ABSPATH . 'wp-admin/options-head.php'; // Displays the errors messages a
 			 *
 			 * @since 1.5.1
 			 */
-			do_action( 'pll_settings_active_tab_' . $this->active_tab );
+			do_action( 'pll_settings_active_tab_' . $active_tab );
 			break;
 	}
 	?>

--- a/settings/view-tab-lang.php
+++ b/settings/view-tab-lang.php
@@ -3,11 +3,11 @@
  * Displays the languages tab in Polylang settings
  *
  * @package Polylang
+ *
+ * @var PLL_Table_Languages $list_table
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly
 ?>
 <div id="col-container">
 	<div id="col-right">

--- a/settings/view-tab-settings.php
+++ b/settings/view-tab-settings.php
@@ -3,17 +3,17 @@
  * Displays the settings tab in Polylang settings
  *
  * @package Polylang
+ *
+ * @var PLL_Settings_Module[] $modules
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly
 ?>
 <div class="form-wrap">
 	<?php
 	wp_nonce_field( 'pll_options', '_pll_nonce' );
 	$list_table = new PLL_Table_Settings();
-	$list_table->prepare_items( $this->modules );
+	$list_table->prepare_items( $modules );
 	$list_table->display();
 	?>
 </div>

--- a/settings/view-tab-strings.php
+++ b/settings/view-tab-strings.php
@@ -3,11 +3,11 @@
  * Displays the strings translations tab in Polylang settings
  *
  * @package Polylang
+ *
+ * @var PLL_Table_String $string_table
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Don't access directly
-}
+defined( 'ABSPATH' ) || exit; // Don't access directly
 ?>
 <div class="form-wrap">
 	<form id="string-translation" method="post" action="<?php echo esc_url( add_query_arg( 'noheader', 'true' ) ); ?>">


### PR DESCRIPTION
Same as https://github.com/polylang/polylang-pro/pull/2077 initiated on Polylang Pro

We can document `$this` outside a class since PHPStan [0.12.30](https://github.com/phpstan/phpstan/releases/tag/0.12.30) and completed in PHPStan [0.12.67](https://github.com/phpstan/phpstan/releases/tag/0.12.67). See complete discussion in https://github.com/phpstan/phpstan/issues/351

However it seems there is still an issue if this class has private or protected properties See However it seems there still has an issue if this class has private or protected properties.

It explains why I chose to assign these properties as local variable and document them in views instead of `$this` espacially in the wizard module.