### PR TITLE
Fix false returned with pll_get_post()

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -64,9 +64,7 @@ class PLL_Cache {
 	 * @phpstan-return TCacheData
 	 */
 	public function set( $key, $data ) {
-		if ( ! doing_action( 'switch_blog' ) ) {
-			$this->cache[ $this->blog_id ][ $key ] = $data;
-		}
+		$this->cache[ $this->blog_id ][ $key ] = $data;
 		return $data;
 	}
 

--- a/include/cache.php
+++ b/include/cache.php
@@ -65,6 +65,7 @@ class PLL_Cache {
 	 */
 	public function set( $key, $data ) {
 		$this->cache[ $this->blog_id ][ $key ] = $data;
+		return $data
 	}
 
 	/**

--- a/include/cache.php
+++ b/include/cache.php
@@ -65,7 +65,6 @@ class PLL_Cache {
 	 */
 	public function set( $key, $data ) {
 		$this->cache[ $this->blog_id ][ $key ] = $data;
-		return $data;
 	}
 
 	/**


### PR DESCRIPTION
When I try to get a post_id of a page defined in another site using switch_to_blog($blog_id) and pll_get_post($post_id), the value returned was false instead of the existing id because the id was not defined in the cache object.