### PR TITLE
WPCS 3.1

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -431,7 +431,7 @@ class PLL_Model {
 	 */
 	public function is_filtered_taxonomy( $tax ) {
 		$taxonomies = $this->get_filtered_taxonomies( false );
-		return ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) || in_array( $tax, $taxonomies ) );
+		return ( ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) ) || in_array( $tax, $taxonomies ) );
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -431,7 +431,7 @@ class PLL_Model {
 	 */
 	public function is_filtered_taxonomy( $tax ) {
 		$taxonomies = $this->get_filtered_taxonomies( false );
-		return ( ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) ) || in_array( $tax, $taxonomies ) );
+		return ( is_array( $tax ) && array_intersect( $tax, $taxonomies ) ) || in_array( $tax, $taxonomies );
 	}
 
 	/**

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -167,7 +167,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 */
 	public function is_translated_object_type( $object_type ) {
 		$post_types = $this->get_translated_object_types( false );
-		return ( is_array( $object_type ) && array_intersect( $object_type, $post_types ) || in_array( $object_type, $post_types ) || 'any' === $object_type && ! empty( $post_types ) );
+		return ( ( is_array( $object_type ) && array_intersect( $object_type, $post_types ) ) || in_array( $object_type, $post_types ) || ( 'any' === $object_type && ! empty( $post_types ) ) );
 	}
 
 	/**

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -167,7 +167,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 */
 	public function is_translated_object_type( $object_type ) {
 		$post_types = $this->get_translated_object_types( false );
-		return ( ( is_array( $object_type ) && array_intersect( $object_type, $post_types ) ) || in_array( $object_type, $post_types ) || ( 'any' === $object_type && ! empty( $post_types ) ) );
+		return ( is_array( $object_type ) && array_intersect( $object_type, $post_types ) ) || in_array( $object_type, $post_types ) || ( 'any' === $object_type && ! empty( $post_types ) );
 	}
 
 	/**

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -104,7 +104,7 @@ class PLL_Wizard {
 	public function redirect_to_wizard() {
 		if ( get_transient( 'pll_activation_redirect' ) ) {
 			$do_redirect = true;
-			if ( ( isset( $_GET['page'] ) && 'mlang_wizard' === sanitize_key( $_GET['page'] ) || isset( $_GET['activate-multi'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ( isset( $_GET['page'] ) && 'mlang_wizard' === sanitize_key( $_GET['page'] ) ) || isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				delete_transient( 'pll_activation_redirect' );
 				$do_redirect = false;
 			}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,22 +67,6 @@
 		</properties>
 	</rule>
 
-	<rule ref="WordPress.Security.EscapeOutput">
-		<properties>
-			<property name="customAutoEscapedFunctions" type="array">
-				<element value="sanitize_locale_name"/>
-			</property>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.Security.ValidatedSanitizedInput">
-		<properties>
-			<property name="customUnslashingSanitizingFunctions" type="array">
-				<element value="sanitize_locale_name"/>
-			</property>
-		</properties>
-	</rule>
-
 	<!--
 	#############################################################################
 	Global exclusions for tests.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,6 +67,14 @@
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customUnslashingSanitizingFunctions" type="array">
+				<element value="wp_verify_nonce"/>
+			</property>
+		</properties>
+	</rule>
+
 	<!--
 	#############################################################################
 	Global exclusions for tests.


### PR DESCRIPTION
- Remove `sanitize_locale_name()` from custom properties now that's correctly handled by WPCS.
- Fix new errors reported
`Mixing different binary boolean operators within an expression without using parentheses to clarify precedence is not allowed.`

I also added `wp_verify_nonce()` to the `customUnslashingSanitizingFunctions`.