### PR TITLE
Make add_all_meta_actions() and remove_all_meta_actions() method accessible

### DIFF
--- a/modules/sync/sync-metas.php
+++ b/modules/sync/sync-metas.php
@@ -72,7 +72,7 @@ abstract class PLL_Sync_Metas {
 	 *
 	 * @return void
 	 */
-	protected function remove_all_meta_actions() {
+	public function remove_all_meta_actions() {
 		$this->remove_add_meta_action();
 
 		remove_filter( "update_{$this->meta_type}_metadata", array( $this, 'update_metadata' ), 999 );
@@ -100,7 +100,7 @@ abstract class PLL_Sync_Metas {
 	 *
 	 * @return void
 	 */
-	protected function add_all_meta_actions() {
+	public function add_all_meta_actions() {
 		$this->restore_add_meta_action();
 
 		add_filter( "update_{$this->meta_type}_metadata", array( $this, 'update_metadata' ), 999, 5 ); // Very late in case a filter prevents the meta to be updated


### PR DESCRIPTION
To be able to fix https://github.com/polylang/polylang-pro/issues/2083 with the https://github.com/polylang/polylang-pro/pull/2104 PR both of `add_all_meta_actions()` and `remove_all_meta_actions()` methods have to be accessible outside `PLL_Sync_Metas` class.

This is what propose this PR