### PR TITLE
Remove rewrite when registering the language taxonomy

### DIFF
--- a/include/links-directory.php
+++ b/include/links-directory.php
@@ -41,12 +41,6 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		add_action( 'pll_prepare_rewrite_rules', array( $this, 'prepare_rewrite_rules' ) ); // Ensure it's hooked before `self::do_prepare_rewrite_rules()` is called.
 
 		parent::init();
-
-		if ( did_action( 'setup_theme' ) ) {
-			$this->add_permastruct();
-		} else {
-			add_action( 'setup_theme', array( $this, 'add_permastruct' ), 2 );
-		}
 	}
 
 	/**
@@ -147,20 +141,6 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 	}
 
 	/**
-	 * Optionally removes 'language' in permalinks so that we get http://www.myblog/en/ instead of http://www.myblog/language/en/.
-	 *
-	 * @since 1.2
-	 *
-	 * @return void
-	 */
-	public function add_permastruct() {
-		// Language information always in front of the uri ( 'with_front' => false ).
-		if ( $this->model->has_languages() ) {
-			add_permastruct( 'language', $this->options['rewrite'] ? '%language%' : 'language/%language%', array( 'with_front' => false ) );
-		}
-	}
-
-	/**
 	 * Prepares the rewrite rules filters.
 	 *
 	 * @since 0.8.1
@@ -177,8 +157,6 @@ class PLL_Links_Directory extends PLL_Links_Permalinks {
 		if ( ! $this->model->has_languages() || ! did_action( 'wp_loaded' ) || ! self::$can_filter_rewrite_rules ) {
 			return;
 		}
-
-		add_filter( 'language_rewrite_rules', '__return_empty_array' ); // Suppress the rules created by WordPress for our taxonomy.
 
 		foreach ( $this->get_rewrite_rules_filters_with_callbacks() as $rule => $callback ) {
 			add_filter( $rule, $callback );

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -192,7 +192,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 				'show_in_nav_menus'  => false, // No metabox for nav menus, needed for WP 4.4.x.
 				'publicly_queryable' => true, // Since WP 4.5.
 				'query_var'          => 'lang',
-				'rewrite'            => $this->model->options['force_lang'] < 2, // No rewrite for domains and sub-domains.
+				'rewrite'            => false, // Rewrite rules are added through filters when needed.
 				'_pll'               => true, // Polylang taxonomy.
 			)
 		);

--- a/tests/phpunit/tests/test-single-language.php
+++ b/tests/phpunit/tests/test-single-language.php
@@ -57,6 +57,9 @@ class Single_Language_Test extends PLL_UnitTestCase {
 		$model->post->register_taxonomy(); // needs this for 'lang' query var
 		$links_model = $model->get_links_model();
 		$links_model->init();
+
+		$wp_rewrite->flush_rules();
+
 		$pll = new PLL_Frontend( $links_model );
 		$pll->init();
 		$pll->model->clean_languages_cache();


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2112

#1359 was a bit too ambitious to reach 2 goals:
1. Remove the language rewrite
2. Remove one of the `register_taxonomy()` for the language taxonomy.

The second task requires a lot of test adaptions and the PR was put on hold to wait for the version 3.7 to look at Polylang Pro and Polylang for WooCommerce tests.

This new PR focuses on the first task (the most important). Only one test must be adapted in Polylang, None in Polylang Pro.
- Set the `rewrite` param to false.
- Remove all the code which fixed the language rewrite. 