### PR TITLE
Restore current language management in multisite.

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -64,9 +64,8 @@ class PLL_Cache {
 	 * @phpstan-return TCacheData
 	 */
 	public function set( $key, $data ) {
-		if ( ! doing_action( 'switch_blog' ) ) {
-			$this->cache[ $this->blog_id ][ $key ] = $data;
-		}
+		$this->cache[ $this->blog_id ][ $key ] = $data;
+
 		return $data;
 	}
 

--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -146,7 +146,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 			 */
 			$post_types = (array) apply_filters( 'pll_get_post_types', $post_types, false );
 
-			if ( did_action( 'after_setup_theme' ) ) {
+			if ( did_action( 'after_setup_theme' ) && ! doing_action( 'switch_blog' ) ) {
 				$this->model->cache->set( 'post_types', $post_types );
 			}
 		}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -214,7 +214,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			 */
 			$taxonomies = (array) apply_filters( 'pll_get_taxonomies', $taxonomies, false );
 
-			if ( did_action( 'after_setup_theme' ) && ! doing_action( 'switch_blog' )  ) {
+			if ( did_action( 'after_setup_theme' ) && ! doing_action( 'switch_blog' ) ) {
 				$this->model->cache->set( 'taxonomies', $taxonomies );
 			}
 		}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -214,7 +214,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			 */
 			$taxonomies = (array) apply_filters( 'pll_get_taxonomies', $taxonomies, false );
 
-			if ( did_action( 'after_setup_theme' ) ) {
+			if ( did_action( 'after_setup_theme' ) && ! doing_action( 'switch_blog' )  ) {
 				$this->model->cache->set( 'taxonomies', $taxonomies );
 			}
 		}

--- a/tests/phpunit/includes/testcase-multisites.php
+++ b/tests/phpunit/includes/testcase-multisites.php
@@ -186,6 +186,8 @@ abstract class PLL_Multisites_TestCase extends WP_UnitTestCase {
 		$pll_admin->init();
 		$wp_rewrite->flush_rules();
 
+		$this->create_fixtures_for_blog( $blog, $pll_admin, $languages );
+
 		restore_current_blog();
 	}
 
@@ -211,7 +213,21 @@ abstract class PLL_Multisites_TestCase extends WP_UnitTestCase {
 		$plugins = get_option( 'active_plugins', array() );
 		update_option( 'active_plugins', array_diff( $plugins, $this->get_plugin_names() ) ); // Ensure Polylang plugins are deactivated.
 
+		$this->create_fixtures_for_blog( $blog );
+
 		restore_current_blog();
+	}
+
+	/**
+	 * Allows child classes to create fixtures for a given blog.
+	 *
+	 * @param WP_Site        $blog      Current site object.
+	 * @param PLL_Admin|null $pll_admin Polylang admin object, null if deactivated.
+	 * @param array          $languages Array of blog languages data, empty if none.
+	 * @return void
+	 */
+	protected function create_fixtures_for_blog( WP_Site $blog, $pll_admin = null, array $languages = array() ) {
+		// Not current class job.
 	}
 
 	/**

--- a/tests/phpunit/tests/test-switch-blog-custom-code.php
+++ b/tests/phpunit/tests/test-switch-blog-custom-code.php
@@ -36,7 +36,7 @@ if ( is_multisite() ) :
 						$languages[0]['slug'] => $post->ID,
 						$languages[1]['slug'] => $tr_post->ID,
 					)
-					);
+				);
 			}
 		}
 

--- a/tests/phpunit/tests/test-switch-blog-custom-code.php
+++ b/tests/phpunit/tests/test-switch-blog-custom-code.php
@@ -1,0 +1,145 @@
+<?php
+
+if ( is_multisite() ) :
+
+	/**
+	 * Test class for custom code in multisite.
+	 */
+	class Switch_Blog_Custom_Code_Test extends PLL_Multisites_TestCase {
+		/**
+		 * Posts by blogs, stores only posts in default language if applicable.
+		 *
+		 * @var WP_Post[]
+		 */
+		private $posts = array();
+
+		/**
+		 * Creates posts for a given blog.
+		 *
+		 * @param WP_Site        $blog      Current site object.
+		 * @param PLL_Admin|null $pll_admin Polylang admin object, null if deactivated.
+		 * @param array          $languages Array of blog languages data, empty if none.
+		 * @return void
+		 */
+		protected function create_fixtures_for_blog( WP_Site $blog, $pll_admin = null, array $languages = array() ) {
+			$post = $this->factory()->post->create_and_get();
+
+			$this->posts[ (int) $blog->blog_id ] = $post;
+
+			if ( $pll_admin instanceof PLL_Admin && ! empty( $languages ) ) {
+				// Current blog has Polylang activated, let's create multilingual fixtures.
+				$pll_admin->model->post->set_language( $post->ID, $languages[0]['slug'] );
+				$tr_post = $this->factory()->post->create_and_get();
+				$pll_admin->model->post->save_translations(
+					$post->ID,
+					array(
+						$languages[0]['slug'] => $post->ID,
+						$languages[1]['slug'] => $tr_post->ID,
+					)
+					);
+			}
+		}
+
+		public function test_switch_blog_with_custom_code() {
+			$pll_frontend = $this->get_pll_frontend_env();
+			$pll_frontend->curlang = $pll_frontend->model->get_language( 'en' ); // English is a common language for blogs with Polylang activated, @see {PLL_Multisites_TestCase::set_up()}.
+			do_action( 'pll_language_defined' );
+			do_action_ref_array( 'pll_init', array( &$pll_frontend ) );
+			$GLOBALS['polylang'] = $pll_frontend;
+
+			/*
+			 * Test blog with Polylang activated and pretty permalink with language as directory.
+			 */
+			switch_to_blog( (int) $this->blog_with_pll_directory->blog_id );
+
+			$home = get_home_url();
+
+			$this->assertNotEmpty( $home );
+
+			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+
+			$post_id = pll_get_post( $this->posts[ (int) $this->blog_with_pll_directory->blog_id ]->ID );
+
+			$this->assertNotFalse( $post_id );
+			$this->assertSame( $this->posts[ (int) $this->blog_with_pll_directory->blog_id ]->ID, $post_id );
+
+			restore_current_blog();
+
+			/*
+			 * Test blog with Polylang activated and pretty permalink with language as domains.
+			 */
+			switch_to_blog( (int) $this->blog_with_pll_domains->blog_id );
+
+			$home = get_home_url();
+
+			$this->assertNotEmpty( $home );
+
+			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+
+			$post_id = pll_get_post( $this->posts[ (int) $this->blog_with_pll_domains->blog_id ]->ID );
+
+			$this->assertNotFalse( $post_id );
+			$this->assertSame( $this->posts[ (int) $this->blog_with_pll_domains->blog_id ]->ID, $post_id );
+
+			restore_current_blog();
+
+			/*
+			 * Test blog with Polylang activated and plain permalink.
+			 */
+			switch_to_blog( (int) $this->blog_with_pll_plain_links->blog_id );
+
+			$home = get_home_url();
+
+			$this->assertNotEmpty( $home );
+
+			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+
+			$post_id = pll_get_post( $this->posts[ (int) $this->blog_with_pll_plain_links->blog_id ]->ID );
+
+			$this->assertNotFalse( $post_id );
+			$this->assertSame( $this->posts[ (int) $this->blog_with_pll_plain_links->blog_id ]->ID, $post_id );
+
+			restore_current_blog();
+
+			/*
+			 * Test blog with Polylang deactivated and pretty permalink.
+			 */
+			switch_to_blog( (int) $this->blog_without_pll_pretty_links->blog_id );
+
+			$home = get_home_url();
+
+			$this->assertNotEmpty( $home );
+
+			// Even though Polylang is deactivated on the current blog, the current language must be kept.
+			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+
+			$post_id = pll_get_post( $this->posts[ (int) $this->blog_without_pll_pretty_links->blog_id ]->ID );
+
+			$this->assertNotFalse( $post_id );
+			// No language, no post.
+			$this->assertSame( 0, $post_id );
+
+			restore_current_blog();
+
+			/*
+			 * Test blog with Polylang deactivated and plain permalink.
+			 */
+
+			switch_to_blog( (int) $this->blog_without_pll_plain_links->blog_id );
+
+			$home = get_home_url();
+
+			$this->assertNotEmpty( $home );
+
+			// Even though Polylang is deactivated on the current blog, the current language must be kept.
+			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+
+			$post_id = pll_get_post( $this->posts[ (int) $this->blog_without_pll_plain_links->blog_id ]->ID );
+
+			$this->assertNotFalse( $post_id );
+			// No language, no post.
+			$this->assertSame( 0, $post_id );
+		}
+	}
+
+endif;

--- a/tests/phpunit/tests/test-switch-blog-custom-code.php
+++ b/tests/phpunit/tests/test-switch-blog-custom-code.php
@@ -64,7 +64,6 @@ if ( is_multisite() ) :
 
 				$post_id = pll_get_post( $this->posts[ $this->{$blog}->blog_id ]->ID );
 
-				$this->assertNotFalse( $post_id );
 				$this->assertSame( $this->posts[ $this->{$blog}->blog_id ]->ID, $post_id );
 
 				restore_current_blog();
@@ -87,7 +86,6 @@ if ( is_multisite() ) :
 
 				$post_id = pll_get_post( $this->posts[ $this->{$blog}->blog_id ]->ID );
 
-				$this->assertNotFalse( $post_id );
 				// No language, no post.
 				$this->assertSame( 0, $post_id );
 

--- a/tests/phpunit/tests/test-switch-blog-custom-code.php
+++ b/tests/phpunit/tests/test-switch-blog-custom-code.php
@@ -30,6 +30,7 @@ if ( is_multisite() ) :
 				// Current blog has Polylang activated, let's create multilingual fixtures.
 				$pll_admin->model->post->set_language( $post->ID, $languages[0]['slug'] );
 				$tr_post = $this->factory()->post->create_and_get();
+				$pll_admin->model->post->set_language( $tr_post->ID, $languages[1]['slug'] );
 				$pll_admin->model->post->save_translations(
 					$post->ID,
 					array(

--- a/tests/phpunit/tests/test-switch-blog-custom-code.php
+++ b/tests/phpunit/tests/test-switch-blog-custom-code.php
@@ -24,7 +24,7 @@ if ( is_multisite() ) :
 		protected function create_fixtures_for_blog( WP_Site $blog, $pll_admin = null, array $languages = array() ) {
 			$post = $this->factory()->post->create_and_get();
 
-			$this->posts[ (int) $blog->blog_id ] = $post;
+			$this->posts[ $blog->blog_id ] = $post;
 
 			if ( $pll_admin instanceof PLL_Admin && ! empty( $languages ) ) {
 				// Current blog has Polylang activated, let's create multilingual fixtures.
@@ -49,97 +49,50 @@ if ( is_multisite() ) :
 			$GLOBALS['polylang'] = $pll_frontend;
 
 			/*
-			 * Test blog with Polylang activated and pretty permalink with language as directory.
+			 * Switch between blogs with Polylang activated.
 			 */
-			switch_to_blog( (int) $this->blog_with_pll_directory->blog_id );
+			$blogs = array( 'blog_with_pll_directory', 'blog_with_pll_domains', 'blog_with_pll_plain_links' );
 
-			$home = get_home_url();
+			foreach ( $blogs as $blog ) {
+				switch_to_blog( (int) $this->{$blog}->blog_id );
 
-			$this->assertNotEmpty( $home );
+				$home = get_home_url();
 
-			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+				$this->assertNotEmpty( $home );
 
-			$post_id = pll_get_post( $this->posts[ (int) $this->blog_with_pll_directory->blog_id ]->ID );
+				$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
 
-			$this->assertNotFalse( $post_id );
-			$this->assertSame( $this->posts[ (int) $this->blog_with_pll_directory->blog_id ]->ID, $post_id );
+				$post_id = pll_get_post( $this->posts[ $this->{$blog}->blog_id ]->ID );
 
-			restore_current_blog();
+				$this->assertNotFalse( $post_id );
+				$this->assertSame( $this->posts[ $this->{$blog}->blog_id ]->ID, $post_id );
+
+				restore_current_blog();
+			}
 
 			/*
-			 * Test blog with Polylang activated and pretty permalink with language as domains.
+			 * Switch between blogs with Polylang deactivated.
 			 */
-			switch_to_blog( (int) $this->blog_with_pll_domains->blog_id );
+			$blogs = array( 'blog_without_pll_pretty_links', 'blog_without_pll_plain_links' );
 
-			$home = get_home_url();
+			foreach ( $blogs as $blog ) {
+				switch_to_blog( (int) $this->{$blog}->blog_id );
 
-			$this->assertNotEmpty( $home );
+				$home = get_home_url();
 
-			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
+				$this->assertNotEmpty( $home );
 
-			$post_id = pll_get_post( $this->posts[ (int) $this->blog_with_pll_domains->blog_id ]->ID );
+				// Even though Polylang is deactivated on the current blog, the current language must be kept.
+				$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
 
-			$this->assertNotFalse( $post_id );
-			$this->assertSame( $this->posts[ (int) $this->blog_with_pll_domains->blog_id ]->ID, $post_id );
+				$post_id = pll_get_post( $this->posts[ $this->{$blog}->blog_id ]->ID );
 
-			restore_current_blog();
+				$this->assertNotFalse( $post_id );
+				// No language, no post.
+				$this->assertSame( 0, $post_id );
 
-			/*
-			 * Test blog with Polylang activated and plain permalink.
-			 */
-			switch_to_blog( (int) $this->blog_with_pll_plain_links->blog_id );
-
-			$home = get_home_url();
-
-			$this->assertNotEmpty( $home );
-
-			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
-
-			$post_id = pll_get_post( $this->posts[ (int) $this->blog_with_pll_plain_links->blog_id ]->ID );
-
-			$this->assertNotFalse( $post_id );
-			$this->assertSame( $this->posts[ (int) $this->blog_with_pll_plain_links->blog_id ]->ID, $post_id );
-
-			restore_current_blog();
-
-			/*
-			 * Test blog with Polylang deactivated and pretty permalink.
-			 */
-			switch_to_blog( (int) $this->blog_without_pll_pretty_links->blog_id );
-
-			$home = get_home_url();
-
-			$this->assertNotEmpty( $home );
-
-			// Even though Polylang is deactivated on the current blog, the current language must be kept.
-			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
-
-			$post_id = pll_get_post( $this->posts[ (int) $this->blog_without_pll_pretty_links->blog_id ]->ID );
-
-			$this->assertNotFalse( $post_id );
-			// No language, no post.
-			$this->assertSame( 0, $post_id );
-
-			restore_current_blog();
-
-			/*
-			 * Test blog with Polylang deactivated and plain permalink.
-			 */
-
-			switch_to_blog( (int) $this->blog_without_pll_plain_links->blog_id );
-
-			$home = get_home_url();
-
-			$this->assertNotEmpty( $home );
-
-			// Even though Polylang is deactivated on the current blog, the current language must be kept.
-			$this->assertInstanceOf( PLL_Language::class, $pll_frontend->curlang );
-
-			$post_id = pll_get_post( $this->posts[ (int) $this->blog_without_pll_plain_links->blog_id ]->ID );
-
-			$this->assertNotFalse( $post_id );
-			// No language, no post.
-			$this->assertSame( 0, $post_id );
+				restore_current_blog();
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?
Fixes #1455 
Fixes #1452 

Current language has been lost during `switch_to_blog()` since #1415. This is because languages data is not cached anymore, thus current language has to be recalculated each time a function needing it is called (leading to infinite loop in specific cases, `get_home_url()` for instance).

## How?
- Revert #1415.
- Still fix what #1415 was fixing by skipping cache for translated CPT and taxonomies during `switch_blog`.
- Add tests, unfortunately I didn't manage to reproduce the infinite loop with `get_home_url()` in these tests...