### PR TITLE
Fix search block filter

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -69,7 +69,7 @@ class PLL_Frontend_Filters_Search {
 
 		if ( $this->links_model->using_permalinks ) {
 			// Take care to modify only the url in the <form> tag.
-			preg_match( '#<form[\s\S]+?>#', $form, $matches );
+			preg_match( '#<form.+?>#s', $form, $matches );
 			$old = reset( $matches );
 			if ( empty( $old ) ) {
 				return $form;

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -69,7 +69,7 @@ class PLL_Frontend_Filters_Search {
 
 		if ( $this->links_model->using_permalinks ) {
 			// Take care to modify only the url in the <form> tag.
-			preg_match( '#<form.+?>#', $form, $matches );
+			preg_match( '#<form[\s\S]+?>#', $form, $matches );
 			$old = reset( $matches );
 			if ( empty( $old ) ) {
 				return $form;

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -76,8 +76,6 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		$form_no_button      = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"no-button","buttonUseIcon":true,"align":"left"} /-->' );
 		$form_button_only    = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true,"align":"left"} /-->' );
 
-		$form = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true} /-->' );
-
 		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form );
 		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form_button_outside );
 		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form_button_inside );

--- a/tests/phpunit/tests/test-search-form.php
+++ b/tests/phpunit/tests/test-search-form.php
@@ -70,9 +70,19 @@ class Search_Form_Test extends PLL_UnitTestCase {
 		global $wp_rewrite;
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
-		$form = do_blocks( '<!-- wp:search /-->' );
+		$form                = do_blocks( '<!-- wp:search /-->' );
+		$form_button_outside = do_blocks( '<!-- wp:search {"showLabel":false,"buttonUseIcon":true,"align":"left"} /-->' );
+		$form_button_inside  = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"button-inside","buttonUseIcon":true,"align":"left"} /-->' );
+		$form_no_button      = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"no-button","buttonUseIcon":true,"align":"left"} /-->' );
+		$form_button_only    = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true,"align":"left"} /-->' );
+
+		$form = do_blocks( '<!-- wp:search {"showLabel":false,"buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true} /-->' );
 
 		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form );
+		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form_button_outside );
+		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form_button_inside );
+		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form_no_button );
+		$this->assertStringContainsString( 'action="' . home_url( '/fr/' ) . '"', $form_button_only );
 
 		$wp_rewrite->set_permalink_structure( '' );
 		$this->frontend->links_model = self::$model->get_links_model();


### PR DESCRIPTION
Reported in HS [#28291](https://secure.helpscout.net/conversation/2556149296/28291?folderId=6991790) ticket

## Why?
Because `<form>` tag generated for the search block only rendered as a button has some carriage return between `<form` and `>`.
So the regular expression `#<form.+?>#` doesn't match anything because the `>` character is never reached.
See https://github.com/polylang/polylang/blob/3.6/frontend/frontend-filters-search.php#L72

## How?
Use `#<form.+?>#s` regular expression instead to be able to match any character including carriage return character by considering the string as a single line.
