### PR TITLE
Filter locale on REST context

### DIFF
--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -134,10 +134,10 @@ class PLL_REST_Request extends PLL_Base {
 	 * @return string
 	 */
 	public function get_locale( $locale ) {
-		if ( ! empty( $this->curlang ) ) {
-			return $this->curlang->locale;
+		if ( empty( $this->curlang ) ) {
+			return $locale;
 		}
 
-		return $locale;
+		return $this->curlang->locale;
 	}
 }

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -62,6 +62,8 @@ class PLL_REST_Request extends PLL_Base {
 		}
 
 		$this->model->set_languages_ready();
+
+		add_filter( 'locale', array( $this, 'get_locale' ) );
 	}
 
 	/**
@@ -121,5 +123,20 @@ class PLL_REST_Request extends PLL_Base {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Returns the locale based on current language.
+	 *
+	 * @since 3.7
+	 *
+	 * @return string
+	 */
+	public function get_locale( $locale ) {
+		if ( ! empty( $this->curlang ) ) {
+			return $this->curlang->locale;
+		}
+
+		return $locale;
 	}
 }

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -62,7 +62,6 @@ class PLL_REST_Request extends PLL_Base {
 		}
 
 		$this->model->set_languages_ready();
-
 	}
 
 	/**

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -63,7 +63,6 @@ class PLL_REST_Request extends PLL_Base {
 
 		$this->model->set_languages_ready();
 
-		add_filter( 'locale', array( $this, 'get_locale' ) );
 	}
 
 	/**
@@ -79,6 +78,8 @@ class PLL_REST_Request extends PLL_Base {
 		if ( ! $this->model->has_languages() ) {
 			return;
 		}
+
+		add_filter( 'locale', array( $this, 'get_locale' ) );
 
 		add_filter( 'rest_pre_dispatch', array( $this, 'set_language' ), 10, 3 );
 

--- a/include/rest-request.php
+++ b/include/rest-request.php
@@ -130,6 +130,7 @@ class PLL_REST_Request extends PLL_Base {
 	 *
 	 * @since 3.7
 	 *
+	 * @param string $locale The current ID.
 	 * @return string
 	 */
 	public function get_locale( $locale ) {


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-wc/issues/787.

Filter locale on **REST** context to set the right current language user meta.

**_Needs https://github.com/polylang/polylang/pull/1395 to work because of `do_action( 'change_locale', $new_locale );` which reload the WC localisation files._**