### PR TITLE
Fix new issues reported by phpstan

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -155,6 +155,16 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	}
 
 	/**
+	 * Dummy method to display the 3 tabs pages: languages, strings translations, settings.
+	 * Must be overwritten in child class.
+	 *
+	 * @since 3.7
+	 *
+	 * @return void
+	 */
+	public function languages_page() {}
+
+	/**
 	 * Setup js scripts & css styles ( only on the relevant pages )
 	 *
 	 * @since 0.6

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -156,7 +156,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 	/**
 	 * Dummy method to display the 3 tabs pages: languages, strings translations, settings.
-	 * Must be overwritten in child class.
+	 * Overwritten in `PLL_Settings`.
 	 *
 	 * @since 3.7
 	 *

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -404,7 +404,8 @@ class PLL_Translate_Option {
 	 * @return string Sanitized value.
 	 */
 	public function sanitize_option( $value, $name ) {
+		/** @var string $value */
 		$value = sanitize_option( $name, $value );
-		return is_scalar( $value ) ? (string) $value : '';
+		return $value;
 	}
 }

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -404,6 +404,7 @@ class PLL_Translate_Option {
 	 * @return string Sanitized value.
 	 */
 	public function sanitize_option( $value, $name ) {
-		return sanitize_option( $name, $value );
+		$value = sanitize_option( $name, $value );
+		return is_scalar( $value ) ? (string) $value : '';
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,7 +26,7 @@ parameters:
 			path: admin/admin-base.php
 
 		-
-			message: "#^Parameter \\#6 \\$callback of function add_submenu_page expects callable\\(\\)\\: mixed, array\\{\\$this\\(PLL_Admin_Base\\), 'languages_page'\\} given\\.$#"
+			message: "#^Parameter \\#6 \\$callback of function add_submenu_page expects ''\\|\\(callable\\(\\)\\: mixed\\), array\\{\\$this\\(PLL_Admin_Base\\), 'languages_page'\\} given\\.$#"
 			count: 1
 			path: admin/admin-base.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: admin/admin-base.php
 
 		-
-			message: "#^Parameter \\#6 \\$callback of function add_submenu_page expects ''\\|\\(callable\\(\\)\\: mixed\\), array\\{\\$this\\(PLL_Admin_Base\\), 'languages_page'\\} given\\.$#"
-			count: 1
-			path: admin/admin-base.php
-
-		-
 			message: "#^Property PLL_Admin_Base\\:\\:\\$curlang \\(PLL_Language\\|null\\) does not accept PLL_Language\\|false\\.$#"
 			count: 2
 			path: admin/admin-base.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -40,9 +40,3 @@ parameters:
 			message: "#^Call to static method encode\\(\\) on an unknown class Requests_IDNAEncoder\\.$#"
 			count: 1
 			path: include/links-domain.php
-
-		# Ignored by waiting WordPress documentation enhancement https://core.trac.wordpress.org/ticket/60563
-		-
-			message: "#^Property WP_Query::\\$tax_query \\(WP_Tax_Query\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: frontend/canonical.php


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2088.

1. Fix baseline for `add_submenu_page()`: https://github.com/php-stubs/wordpress-stubs/commit/794559556de631c52b98349890956d306ac38884
2. Remove exclusion about the property `$tax_query`: https://core.trac.wordpress.org/changeset/57761
3. Fix use of `sanitize_option()`: https://github.com/WordPress/WordPress/commit/b9638e6b00ed2cc03dc3ee8cc0c5cc987bc2db23 and https://github.com/php-stubs/wordpress-stubs/commit/379f17a90c01498d4c99a0d15aab6e7aa6a2c840#diff-4dc94858ed12d457b90cbe75a4151de2b69d60a4693fc574a0bf8d4b71923f31R109833.