### PR TITLE
Require PHP 7.2

### DIFF
--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -42,27 +42,23 @@ jobs:
       matrix:
         include:
           - wordpress-version: '6.2.x'
+            php-version: '7.4'
+            is-multisite: 0
+            allow-failure: false
+          - wordpress-version: 'latest'
             php-version: '7.2'
             is-multisite: 0
             allow-failure: false
           - wordpress-version: 'latest'
-            php-version: '7.0'
+            php-version: '8.1'
             is-multisite: 0
             allow-failure: false
           - wordpress-version: 'latest'
             php-version: '8.0'
-            is-multisite: 0
-            allow-failure: false
-          - wordpress-version: 'latest'
-            php-version: '7.2'
             is-multisite: 1
             allow-failure: false
           - wordpress-version: 'nightly'
-            php-version: '7.0'
-            is-multisite: 0
-            allow-failure: true
-          - wordpress-version: 'nightly'
-            php-version: '8.0'
+            php-version: '7.2'
             is-multisite: 0
             allow-failure: true
           - wordpress-version: 'nightly'

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"homepage": "https://polylang.pro",
 	"type": "wordpress-plugin",
 	"require": {
-		"php": ">=7.0"
+		"php": ">=7.2"
 	},
 	"require-dev": {
 		"wpsyntex/polylang-phpstan": "^1.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
 
 	<file>.</file>
 
-	<config name="testVersion" value="7.0-"/><!-- PHPCompatibilityWP -->
+	<config name="testVersion" value="7.2-"/><!-- PHPCompatibilityWP -->
 	<config name="minimum_supported_wp_version" value="6.2"/>
 
 	<rule ref="PHPCompatibilityWP"/>

--- a/polylang.php
+++ b/polylang.php
@@ -55,7 +55,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 	// Go on loading the plugin
 	define( 'POLYLANG_VERSION', '3.7-dev' );
 	define( 'PLL_MIN_WP_VERSION', '6.2' );
-	define( 'PLL_MIN_PHP_VERSION', '7.0' );
+	define( 'PLL_MIN_PHP_VERSION', '7.2' );
 
 	define( 'POLYLANG_FILE', __FILE__ );
 	define( 'POLYLANG_DIR', __DIR__ );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://polylang.pro
 Tags: multilingual, translate, translation, language, localization
 Requires at least: 6.2
 Tested up to: 6.5
-Requires PHP: 7.0
+Requires PHP: 7.2
 Stable tag: 3.6.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -76,7 +76,7 @@ Wherever third party code has been used, credit has been given in the code’s c
 
 == Installation ==
 
-1. Make sure you are using WordPress 6.2 or later and that your server is running PHP 7.0 or later (same requirement as WordPress itself).
+1. Make sure you are using WordPress 6.2 or later and that your server is running PHP 7.2 or later (same requirement as WordPress itself).
 1. If you tried other multilingual plugins, deactivate them before activating Polylang, otherwise, you may get unexpected results!
 1. Install and activate the plugin as usual from the 'Plugins' menu in WordPress.
 1. The [setup wizard](https://polylang.pro/doc/setup-wizard/) is automatically launched to help you get started more easily with Polylang by configuring the main features.


### PR DESCRIPTION
[WordPress 6.6 will require PHP 7.2](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/). Let's bump our min PHP version too.

I updated the test matrix with this in mind:
- Min WP supported version + recommended corresponding PHP version
- Latest WP version + min PHP supported version
- Latest WP version + max corresponding PHP version supported with exceptions
- Latest WP version in mutlisite + a different PHP version
- WP nightly + min PHP supported version
- WP nightly + max corresponding PHP version beta supported

I removed the job with WP nightly + PHP 8.0 as I don't believe that it brings much compered to WP nightly + PHP 8.3 which fully passes for months. 

For PHP version supported by WP: https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/