### PR TITLE
Explicit implicitly nullable parameter

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -923,7 +923,7 @@ class PLL_Model {
 	 * @phpstan-param non-empty-string $name
 	 * @phpstan-param array<non-empty-string> $taxonomies
 	 */
-	protected function update_secondary_language_terms( $slug, $name, PLL_Language $language = null, array $taxonomies = array() ) {
+	protected function update_secondary_language_terms( $slug, $name, ?PLL_Language $language = null, array $taxonomies = array() ) {
 		$slug = 0 === strpos( $slug, 'pll_' ) ? $slug : "pll_$slug";
 
 		foreach ( $this->translatable_objects->get_secondary_translatable_objects() as $object ) {


### PR DESCRIPTION
PHP 8.4 will deprecate implicitly nullable parameter: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
I found only one occurrence in our code.
NB. This PR requires #1470 as nullable types require PHP 7.1. Tests with PHP 7/0 are expected to fail badly.