### PR TITLE
Update to PHP 7.2 for nightlies

### DIFF
--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -58,7 +58,7 @@ jobs:
             is-multisite: 1
             allow-failure: false
           - wordpress-version: 'nightly'
-            php-version: '7.0'
+            php-version: '7.2'
             is-multisite: 0
             allow-failure: true
           - wordpress-version: 'nightly'


### PR DESCRIPTION
Fix unit tests.

> but WordPress 6.6-alpha-58021 requires at least 7.2.24.