### PR TITLE
Fix API documentation.

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -114,7 +114,7 @@ function pll_default_language( $field = 'slug' ) {
  *
  * @param int                 $post_id Post ID.
  * @param PLL_Language|string $lang    Optional language (object or slug), defaults to the current language.
- * @return int|false The translation post ID if exists, otherwise the passed ID. False if the passed object has no language or if the language doesn't exist.
+ * @return int|false The translation post ID if exists, 0 if not translated. False if the passed object has no language or if the language doesn't exist.
  *
  * @phpstan-return int<0, max>|false
  */
@@ -138,7 +138,7 @@ function pll_get_post( $post_id, $lang = '' ) {
  *
  * @param int                 $term_id Term ID.
  * @param PLL_Language|string $lang    Optional language (object or slug), defaults to the current language.
- * @return int|false The translation term ID if exists, otherwise the passed ID. False if the passed object has no language or if the language doesn't exist.
+ * @return int|false The translation term ID if exists, 0 if not translated. False if the passed object has no language or if the language doesn't exist.
  *
  * @phpstan-return int<0, max>|false
  */
@@ -450,7 +450,7 @@ function pll_save_term_translations( $arr ) {
  *                      Pass `\OBJECT` constant to get the language object. A composite value can be used for language
  *                      term property values, in the form of `{language_taxonomy_name}:{property_name}` (see
  *                      {@see PLL_Language::get_tax_prop()} for the possible values). Ex: `term_language:term_taxonomy_id`.
- * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that post.
+ * @return string|int|false|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that post.
  *
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (
@@ -480,7 +480,7 @@ function pll_get_post_language( $post_id, $field = 'slug' ) {
  *                      Pass `\OBJECT` constant to get the language object. A composite value can be used for language
  *                      term property values, in the form of `{language_taxonomy_name}:{property_name}` (see
  *                      {@see PLL_Language::get_tax_prop()} for the possible values). Ex: `term_language:term_taxonomy_id`.
- * @return string|int|bool|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that term.
+ * @return string|int|false|string[]|PLL_Language The requested field or object for the post language, `false` if no language is associated to that term.
  *
  * @phpstan-return (
  *     $field is \OBJECT ? PLL_Language : (

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -320,7 +320,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 *
 	 * @param int                     $id   Object ID.
 	 * @param PLL_Language|string|int $lang Language (object, slug, or term ID).
-	 * @return int The translation object ID if exists, otherwise the passed ID. `0` if the passed object has no language.
+	 * @return int The translation object ID if exists. `0` if the passed object has no language or if not translated.
 	 *
 	 * @phpstan-return int<0, max>
 	 */

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Test class for Polylang public API.
+ */
+class API_Test extends PLL_UnitTestCase {
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		$factory->language->create_many( 3 );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->pll_env       = ( new PLL_Context_Frontend() )->get();
+		$GLOBALS['polylang'] = $this->pll_env;
+	}
+
+	public function test_pll_get_post() {
+		$posts = $this->factory()->post->create_translated(
+			array( 'lang' => 'en' ),
+			array( 'lang' => 'fr' )
+		);
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'fr' );
+
+		$this->assertSame( $posts['en'], pll_get_post( $posts['en'], 'en' ) );
+		$this->assertSame( $posts['fr'], pll_get_post( $posts['en'], 'fr' ) );
+		$this->assertSame( 0, pll_get_post( $posts['en'], 'de' ) );
+		$this->assertSame( $posts['fr'], pll_get_post( $posts['en'] ) );
+	}
+
+	public function test_pll_get_term() {
+		$terms = $this->factory()->term->create_translated(
+			array( 'lang' => 'en' ),
+			array( 'lang' => 'fr' )
+		);
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'fr' );
+
+		$this->assertSame( $terms['en'], pll_get_term( $terms['en'], 'en' ) );
+		$this->assertSame( $terms['fr'], pll_get_term( $terms['en'], 'fr' ) );
+		$this->assertSame( 0, pll_get_term( $terms['en'], 'de' ) );
+		$this->assertSame( $terms['fr'], pll_get_term( $terms['en'] ) );
+	}
+}


### PR DESCRIPTION
## What?
`pll_get_post()` and `pll_get_term()` documentation is not accurate.
Indeed, the passed ID is never returned when not translated in the given language (or current one). Instead `0` is returned.
Before 3.4, we used to return `false` and thus we should keep returning falsy value to avoid breaking changes.

## How?
- Fix the doc for `pll_get_post()` and `pll_get_term()`.
- Fix the doc for `PLL_Translated_Object::get()`.
- Add some tests to ensure `pll_get_post()` and `pll_get_term()` returned types are correct.