### PR TITLE
Don't fire `change_locale` too soon

### DIFF
--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -75,14 +75,16 @@ class PLL_OLT_Manager {
 		load_default_textdomain( $new_locale );
 
 		// Act only if the language has not been set early (before default textdomain loading and $wp_locale creation).
-		if ( did_action( 'after_setup_theme' ) ) {
+		if ( ! empty( $GLOBALS['wp_locale'] ) ) {
 			// Reinitializes wp_locale for weekdays and months.
 			unset( $GLOBALS['wp_locale'] );
 			$GLOBALS['wp_locale'] = new WP_Locale();
 		}
 
-		/** This action is documented in wp-includes/class-wp-locale-switcher.php */
-		do_action( 'change_locale', $new_locale );
+		if ( ! empty( $GLOBALS['wp_locale_switcher'] ) ) {
+			/** This action is documented in wp-includes/class-wp-locale-switcher.php */
+			do_action( 'change_locale', $new_locale );
+		}
 
 		do_action_deprecated( 'pll_translate_labels', array(), '3.7', 'change_locale' );
 	}


### PR DESCRIPTION
We must be sure that the action `change_locale` cannot be fired before WordPress could fire it itself. Follow up of #1395.
Also test the existence of the global `$wp_locale` to re-initialize it instead of the action `after_setup_theme`.

## Context
WooCommerce: latest
Polylang Pro: master
Polylang for WooCommerce: master

### Fatal triggered

```
[27-May-2024 15:00:24 UTC] PHP Fatal error:  Uncaught Error: Call to a member function is_switched() on null in C:\wamp64\www\wordpress-support\wp-includes\l10n.php:1779
Stack trace:
#0 C:\polylang\polylang-wc\include\emails.php(264): is_locale_switched()
#1 C:\wamp64\www\wordpress-support\wp-includes\class-wp-hook.php(324): PLLWC_Emails->change_locale('en_US')
#2 C:\wamp64\www\wordpress-support\wp-includes\class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#3 C:\wamp64\www\wordpress-support\wp-includes\plugin.php(517): WP_Hook->do_action(Array)
#4 C:\polylang\polylang-pro\vendor\wpsyntex\polylang\include\olt-manager.php(86): do_action('change_locale', 'en_US')
#5 C:\wamp64\www\wordpress-support\wp-includes\class-wp-hook.php(324): PLL_OLT_Manager->load_textdomains('')
#6 C:\wamp64\www\wordpress-support\wp-includes\class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#7 C:\wamp64\www\wordpress-support\wp-includes\plugin.php(517): WP_Hook->do_action(Array)
#8 C:\polylang\polylang-pro\vendor\wpsyntex\polylang\admin\admin-base.php(436): do_action('pll_no_language...')
#9 C:\polylang\polylang-pro\vendor\wpsyntex\polylang\admin\admin-base.php(470): PLL_Admin_Base->set_current_language()
#10 C:\wamp64\www\wordpress-support\wp-includes\class-wp-hook.php(324): PLL_Admin_Base->init_user('')
#11 C:\wamp64\www\wordpress-support\wp-includes\class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#12 C:\wamp64\www\wordpress-support\wp-includes\plugin.php(517): WP_Hook->do_action(Array)
#13 C:\wamp64\www\wordpress-support\wp-settings.php(575): do_action('setup_theme')
#14 C:\wamp64\www\wordpress-support\wp-config.php(113): require_once('C:\\wamp64\\www\\w...')
#15 C:\wamp64\www\wordpress-support\wp-load.php(50): require_once('C:\\wamp64\\www\\w...')
#16 C:\wamp64\www\wordpress-support\wp-admin\admin-ajax.php(22): require_once('C:\\wamp64\\www\\w...')
#17 {main}
  thrown in C:\wamp64\www\wordpress-support\wp-includes\l10n.php on line 1779

```

Steps to reproduce
- Configure WP_DEGUG = true
- Activate the three required extensions
- Go to Languages / Settings
- Open machine translation module in Languages / Settings 
- Set DeepL API key and save
- Refresh the Languages / Settings page
- See there is the fatal error in wp-content/debug.log file and there is no DeepL consumption data in machine translation module settings
![image](https://github.com/polylang/polylang/assets/1003778/05c2bb69-e141-4bd6-8e1e-da059f4c8bfe)
The ajax response is also in error
![image](https://github.com/polylang/polylang/assets/1003778/c4d2c3e1-bd3c-4700-a2b4-60bf884522cd)
- Click on the `Check connection to DeepL` button
- See the same fatal error in wp-content/debug.log file, The DeepL API key field is on error without any message and the ajax response is also on error
![image](https://github.com/polylang/polylang/assets/1003778/5224736b-ee19-4180-b053-bb96a683acb2)
![image](https://github.com/polylang/polylang/assets/1003778/9fdb39b2-b969-4c94-b772-a9cca9513ef5)

