### PR TITLE
Avoids infinite loop when current_user_can() is called during get_terms filter

### DIFF
--- a/include/filters.php
+++ b/include/filters.php
@@ -361,7 +361,14 @@ class PLL_Filters {
 	 * @return int
 	 */
 	public function translate_page_for_privacy_policy( $id ) {
-		return empty( $this->curlang ) ? $id : $this->model->post->get( $id, $this->curlang );
+		static $once = false; // Avoid infinite loop.
+
+		if ( ! $once && ! empty( $this->curlang ) ) {
+			$once = true;
+			return $this->model->post->get( $id, $this->curlang );
+		}
+
+		return $id;
 	}
 
 	/**
@@ -376,7 +383,10 @@ class PLL_Filters {
 	 * @return array
 	 */
 	public function fix_privacy_policy_page_editing( $caps, $cap, $user_id, $args ) {
-		if ( in_array( $cap, array( 'edit_page', 'edit_post', 'delete_page', 'delete_post' ) ) ) {
+		static $once = true; // Avoid infinite loop.
+
+		if ( ! $once && in_array( $cap, array( 'edit_page', 'edit_post', 'delete_page', 'delete_post' ) ) ) {
+			$once = true;
 			$privacy_page = get_option( 'wp_page_for_privacy_policy' );
 			if ( $privacy_page && array_intersect( $args, $this->model->post->get_translations( $privacy_page ) ) ) {
 				$caps = array_merge( $caps, map_meta_cap( 'manage_privacy_options', $user_id ) );

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -132,22 +132,21 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_wp_page_for_privacy_policy_option_read_should_not_trigger_infinite_loop() {
-		new PLL_Context_Frontend();
-		// Needs a post to fully test current_user_can() function.
+		$this->pll_env = ( new PLL_Context_Frontend() )->get();
+
 		$post_id = self::factory()->post->create();
+
 		add_filter(
 			'get_terms',
-			function( $terms, $taxonomy, $query_vars, $query ) use( $post_id ) {
+			function ( $terms ) use ( $post_id ) {
+				// Use a real post id to fully check current_user_can() function.
 				current_user_can( 'edit_post', $post_id );
 				return $terms;
 			}
-			,
-			10,
-			4
 		);
 
 		$wp_page_for_privacy_policy_option = get_option( 'wp_page_for_privacy_policy' );
 
-		$this->assertTrue( true );
+		$this->assertSame( 0, $wp_page_for_privacy_policy_option );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters.php
+++ b/tests/phpunit/tests/test-admin-filters.php
@@ -130,4 +130,24 @@ class Admin_Filters_Test extends PLL_UnitTestCase {
 			}
 		);
 	}
+
+	public function test_wp_page_for_privacy_policy_option_read_should_not_trigger_infinite_loop() {
+		new PLL_Context_Frontend();
+		// Needs a post to fully test current_user_can() function.
+		$post_id = self::factory()->post->create();
+		add_filter(
+			'get_terms',
+			function( $terms, $taxonomy, $query_vars, $query ) use( $post_id ) {
+				current_user_can( 'edit_post', $post_id );
+				return $terms;
+			}
+			,
+			10,
+			4
+		);
+
+		$wp_page_for_privacy_policy_option = get_option( 'wp_page_for_privacy_policy' );
+
+		$this->assertTrue( true );
+	}
 }


### PR DESCRIPTION
Reported in Help Scout tickets:
- https://secure.helpscout.net/conversation/2612537760/29308?folderId=6991790
- https://secure.helpscout.net/conversation/2609801223/29268/?folderId=6991790
- https://secure.helpscout.net/conversation/2609169616/29248?folderId=6991790

It's due to a conflict with Content control plugin since its 2.3.0 release.

## What happens?
The issue occurs on frontend when the use is logged out.
Conflict with Content Control aka CC plugin and WordPress and Polylang.
 
- CC is hooked on `template_redirect` and execute a `current_user_can()` WordPress function with `edit_post` capability.
- During `current_user_can()`  process WordPress read the `wp_page_for_privacy_policy` option under the hood in the `map_meta_cap()` function. See https://github.com/WordPress/WordPress/blob/6.5.3/wp-includes/capabilities.php#L273
Called from `WP_User::has_cap()` method itself called in `user_can()` function itself called in `current_user_can()` function
- Polylang is hooked on `wp_page_for_privacy_policy` option read to translate it. See https://github.com/polylang/polylang/blob/3.6.2/include/filters.php#L364. Then calls `PLL_Translatable_Object::get_language()` which calls `PLL_Translatable_Object::get_object_term` which calls `wp_get_object_terms()` WordPress function and then `get_terms()` WordPress function.
- CC is also hooked on `get_terms` filter and excute again the same `current_user_can()` WordPress function with `edit_post` capability
- Then we restart at the first step. We are in the infinite loop.

## To reproduce
Can be reproduced with the snippet below:

```php
<?php
add_filter( 'get_terms', 'pll_get_terms_29308', 10, 4 );

function pll_get_terms_29308( $terms, $taxonomy, $query_vars, $query ) {
	current_user_can( 'edit_post', 1 );

	return $terms;
}

```
With this snippet the issue also occurs with a logged in user (Back and front end).
