### PR TITLE
Fix a regression in usage of the `pll_flag` filter

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -373,7 +373,10 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * }
 	 */
 	public static function get_flag_information( $code ) {
-		$default_flag = array( 'url' => '' );
+		$default_flag = array(
+			'url' => '',
+			'src' => '',
+		);
 
 		// Polylang builtin flags.
 		if ( ! empty( $code ) && is_readable( POLYLANG_DIR . ( $file = '/flags/' . $code . '.png' ) ) ) {

--- a/include/language.php
+++ b/include/language.php
@@ -373,20 +373,20 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * }
 	 */
 	public static function get_flag_information( $code ) {
-		$flag = array( 'url' => '' );
+		$default_flag = array( 'url' => '' );
 
 		// Polylang builtin flags.
 		if ( ! empty( $code ) && is_readable( POLYLANG_DIR . ( $file = '/flags/' . $code . '.png' ) ) ) {
-			$flag['url'] = plugins_url( $file, POLYLANG_FILE );
+			$default_flag['url'] = plugins_url( $file, POLYLANG_FILE );
 
 			// If base64 encoded flags are preferred.
 			if ( pll_get_constant( 'PLL_ENCODED_FLAGS', true ) ) {
 				$imagesize = getimagesize( POLYLANG_DIR . $file );
 				if ( is_array( $imagesize ) ) {
-					list( $flag['width'], $flag['height'] ) = $imagesize;
+					list( $default_flag['width'], $default_flag['height'] ) = $imagesize;
 				}
-				$file_contents = file_get_contents( POLYLANG_DIR . $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-				$flag['src'] = 'data:image/png;base64,' . base64_encode( $file_contents ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				$file_contents       = file_get_contents( POLYLANG_DIR . $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$default_flag['src'] = 'data:image/png;base64,' . base64_encode( $file_contents ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			}
 		}
 
@@ -405,11 +405,11 @@ class PLL_Language extends PLL_Language_Deprecated {
 		 * }
 		 * @param string $code Flag code.
 		 */
-		$flag = apply_filters( 'pll_flag', $flag, $code );
+		$flag = apply_filters( 'pll_flag', $default_flag, $code );
 
 		$flag['url'] = esc_url_raw( $flag['url'] );
 
-		if ( empty( $flag['src'] ) ) {
+		if ( empty( $flag['src'] ) || ( $flag['src'] === $default_flag['src'] && $flag['url'] !== $default_flag['url'] ) ) {
 			$flag['src'] = esc_url( set_url_scheme( $flag['url'], 'relative' ) );
 		}
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2111

Before #690 it was possible to use the filter `pll_flag` to modify only `$flag["url']` without modifying `$flag['src']`. `$flag['src']` was indeed always computed after the filter was applied. The cited PR introduced a regression by prefilling `$flag['src']` before the filter is applied, thus making it necessary when modifying the url to modify `$flag['src']` too.

This PR recomputes `$flag['src']` if the url has been modified and `$flag['src']` has not been modified.