### PR TITLE
Rector-ize up to PHP 7.2

### DIFF
--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -137,7 +137,7 @@ class PLL_Admin_Default_Term {
 		$cat = wp_insert_term( $cat_name, $taxonomy, array( 'slug' => $cat_slug ) );
 
 		// check that the term was not previously created ( in case the language was deleted and recreated )
-		$cat = isset( $cat->error_data['term_exists'] ) ? $cat->error_data['term_exists'] : $cat['term_id'];
+		$cat = $cat->error_data['term_exists'] ?? $cat['term_id'];
 
 		// set language
 		$this->model->term->set_language( (int) $cat, $lang );

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -446,6 +446,6 @@ class PLL_Admin_Filters_Columns {
 	 * @return string
 	 */
 	protected function get_flag_html( $language ) {
-		return $language->flag ? $language->flag : sprintf( '<abbr>%s</abbr>', esc_html( $language->slug ) );
+		return $language->flag ?: sprintf( '<abbr>%s</abbr>', esc_html( $language->slug ) );
 	}
 }

--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -177,17 +177,17 @@ class PLL_Admin_Notices {
 	public function display_notices() {
 		if ( current_user_can( 'manage_options' ) ) {
 			// Core notices
-			if ( defined( 'WOOCOMMERCE_VERSION' ) && ! defined( 'PLLWC_VERSION' ) && $this->can_display_notice( 'pllwc' ) && ! $this->is_dismissed( 'pllwc' ) ) {
+			if ( defined( 'WOOCOMMERCE_VERSION' ) && ! defined( 'PLLWC_VERSION' ) && $this->can_display_notice( 'pllwc' ) && ! static::is_dismissed('pllwc') ) {
 				$this->pllwc_notice();
 			}
 
-			if ( ! defined( 'POLYLANG_PRO' ) && $this->can_display_notice( 'review' ) && ! $this->is_dismissed( 'review' ) && ! empty( $this->options['first_activation'] ) && time() > $this->options['first_activation'] + 15 * DAY_IN_SECONDS ) {
+			if ( ! defined( 'POLYLANG_PRO' ) && $this->can_display_notice( 'review' ) && ! static::is_dismissed('review') && ! empty( $this->options['first_activation'] ) && time() > $this->options['first_activation'] + 15 * DAY_IN_SECONDS ) {
 				$this->review_notice();
 			}
 
 			// Custom notices
-			foreach ( $this->get_notices() as $notice => $html ) {
-				if ( $this->can_display_notice( $notice ) && ! $this->is_dismissed( $notice ) ) {
+			foreach ( static::get_notices() as $notice => $html ) {
+				if ( $this->can_display_notice( $notice ) && ! static::is_dismissed($notice) ) {
 					?>
 					<div class="pll-notice notice notice-info">
 						<?php

--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -177,17 +177,17 @@ class PLL_Admin_Notices {
 	public function display_notices() {
 		if ( current_user_can( 'manage_options' ) ) {
 			// Core notices
-			if ( defined( 'WOOCOMMERCE_VERSION' ) && ! defined( 'PLLWC_VERSION' ) && $this->can_display_notice( 'pllwc' ) && ! static::is_dismissed('pllwc') ) {
+			if ( defined( 'WOOCOMMERCE_VERSION' ) && ! defined( 'PLLWC_VERSION' ) && $this->can_display_notice( 'pllwc' ) && ! static::is_dismissed( 'pllwc' ) ) {
 				$this->pllwc_notice();
 			}
 
-			if ( ! defined( 'POLYLANG_PRO' ) && $this->can_display_notice( 'review' ) && ! static::is_dismissed('review') && ! empty( $this->options['first_activation'] ) && time() > $this->options['first_activation'] + 15 * DAY_IN_SECONDS ) {
+			if ( ! defined( 'POLYLANG_PRO' ) && $this->can_display_notice( 'review' ) && ! static::is_dismissed( 'review' ) && ! empty( $this->options['first_activation'] ) && time() > $this->options['first_activation'] + 15 * DAY_IN_SECONDS ) {
 				$this->review_notice();
 			}
 
 			// Custom notices
 			foreach ( static::get_notices() as $notice => $html ) {
-				if ( $this->can_display_notice( $notice ) && ! static::is_dismissed($notice) ) {
+				if ( $this->can_display_notice( $notice ) && ! static::is_dismissed( $notice ) ) {
 					?>
 					<div class="pll-notice notice notice-info">
 						<?php

--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -37,7 +37,7 @@ class PLL_Admin_Strings {
 	 */
 	public static function init() {
 		// default strings translations sanitization
-		add_filter( 'pll_sanitize_string_translation', array( __CLASS__, 'sanitize_string_translation' ), 10, 2 );
+		add_filter( 'pll_sanitize_string_translation', array( self::class, 'sanitize_string_translation' ), 10, 2 );
 	}
 
 	/**

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -63,7 +63,7 @@ defined( 'ABSPATH' ) || exit;
 				?>
 			</td>
 		</tr>
-<?php
+		<?php
 	}
 	?>
 </table>

--- a/admin/view-translations-post.php
+++ b/admin/view-translations-post.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 		?>
 		<tr>
-			<th class = "pll-language-column"><?php echo $language->flag ? $language->flag : esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></th>
+			<th class = "pll-language-column"><?php echo $language->flag ?: esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></th>
 			<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<td class = "pll-edit-column pll-column-icon"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<?php
@@ -63,7 +63,7 @@ defined( 'ABSPATH' ) || exit;
 				?>
 			</td>
 		</tr>
-		<?php
+<?php
 	}
 	?>
 </table>

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -13,13 +13,13 @@ if ( isset( $term_id ) ) {
 	// Edit term form ?>
 	<th scope="row"><?php esc_html_e( 'Translations', 'polylang' ); ?></th>
 	<td>
-<?php
+	<?php
 }
 else {
 	// Add term form
 	?>
 	<p><?php esc_html_e( 'Translations', 'polylang' ); ?></p>
-<?php
+	<?php
 }
 ?>
 <table class="widefat term-translations"  id="<?php echo isset( $term_id ) ? 'edit' : 'add'; ?>-term-translations">
@@ -63,7 +63,7 @@ else {
 				?>
 				<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 				<td class = "pll-edit-column"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
-<?php
+				<?php
 			}
 			?>
 			<td class = "pll-translation-column">
@@ -84,7 +84,7 @@ else {
 				?>
 			</td>
 		</tr>
-<?php
+		<?php
 	} // End foreach
 	?>
 </table>
@@ -94,5 +94,5 @@ if ( isset( $term_id ) ) {
 	// Edit term form
 	?>
 	</td>
-<?php
+	<?php
 }

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -13,13 +13,13 @@ if ( isset( $term_id ) ) {
 	// Edit term form ?>
 	<th scope="row"><?php esc_html_e( 'Translations', 'polylang' ); ?></th>
 	<td>
-	<?php
+<?php
 }
 else {
 	// Add term form
 	?>
 	<p><?php esc_html_e( 'Translations', 'polylang' ); ?></p>
-	<?php
+<?php
 }
 ?>
 <table class="widefat term-translations"  id="<?php echo isset( $term_id ) ? 'edit' : 'add'; ?>-term-translations">
@@ -49,7 +49,7 @@ else {
 		?>
 		<tr>
 			<th class = "pll-language-column">
-				<span class = "pll-translation-flag"><?php echo $language->flag ? $language->flag : esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span>
+				<span class = "pll-translation-flag"><?php echo $language->flag ?: esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span>
 				<?php
 				printf(
 					'<span class="pll-language-name%1$s">%2$s</span>',
@@ -63,7 +63,7 @@ else {
 				?>
 				<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 				<td class = "pll-edit-column"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
-				<?php
+<?php
 			}
 			?>
 			<td class = "pll-translation-column">
@@ -84,7 +84,7 @@ else {
 				?>
 			</td>
 		</tr>
-		<?php
+<?php
 	} // End foreach
 	?>
 </table>
@@ -94,5 +94,5 @@ if ( isset( $term_id ) ) {
 	// Edit term form
 	?>
 	</td>
-	<?php
+<?php
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"automattic/vipwpcs": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"behat/behat": "^3.7|^3.8",
-		"yoast/wp-test-utils": "^1.0.0"
+		"yoast/wp-test-utils": "^1.0.0",
+		"rector/rector": "^1.1"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
 		"rector-dry": "vendor/bin/rector process --dry-run",
 		"lint": [
 			"@cs",
-			"@stan"
+			"@stan",
+			"@rector-dry"
 		],
 		"rector": "vendor/bin/rector process",
 		"build": "bin/build.sh",

--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,12 @@
 		"test":"vendor/bin/phpunit",
 		"cs":"vendor/bin/phpcs",
 		"stan": "vendor/bin/phpstan analyze --memory-limit=1500M",
+		"rector-dry": "vendor/bin/rector process --dry-run",
 		"lint": [
 			"@cs",
 			"@stan"
 		],
+		"rector": "vendor/bin/rector process",
 		"build": "bin/build.sh",
 		"dist": "bin/distribute.sh"
 	},
@@ -50,7 +52,9 @@
 		"test":"Runs PHPUnit tests.",
 		"cs":"Runs PHPCS linter.",
 		"stan": "Runs PHPStan analysis.",
+		"rector-dry": "Runs a preview of Rector.",
 		"lint": "Runs both PHPCS and PHPStan.",
+		"rector": "Runs Rector.",
 		"build": "Builds the project.",
 		"dist": "Make the zip file to distribute the project release."
 	},

--- a/frontend/accept-language.php
+++ b/frontend/accept-language.php
@@ -11,7 +11,7 @@
  * @since 3.0
  */
 class PLL_Accept_Language {
-	const SUBTAG_PATTERNS = array(
+	public const SUBTAG_PATTERNS = array(
 		'language' => '(\b[a-z]{2,3}|[a-z]{4}|[a-z]{5-8}\b)',
 		'language-extension' => '(?:-(\b[a-z]{3}){1,3}\b)?',
 		'script' => '(?:-(\b[a-z]{4})\b)?',
@@ -107,6 +107,6 @@ class PLL_Accept_Language {
 	 * @return string
 	 */
 	public function get_subtag( $name ) {
-		return isset( $this->subtags[ $name ] ) ? $this->subtags[ $name ] : '';
+		return $this->subtags[ $name ] ?? '';
 	}
 }

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -264,6 +264,6 @@ class PLL_Canonical {
 
 		$wp_query = $backup_wp_query;
 
-		return $redirect_url ? $redirect_url : $url;
+		return $redirect_url ?: $url;
 	}
 }

--- a/frontend/choose-lang-content.php
+++ b/frontend/choose-lang-content.php
@@ -96,7 +96,7 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 		 *
 		 * @param PLL_Language|false $lang Language object or false if none was found.
 		 */
-		return apply_filters( 'pll_get_current_language', isset( $lang ) ? $lang : false );
+		return apply_filters( 'pll_get_current_language', $lang ?? false );
 	}
 
 	/**

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -266,11 +266,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 			return $query->queried_object_id;
 		}
 
-		if ( isset( $query->query_vars['page_id'] ) ) {
-			return $query->query_vars['page_id'];
-		}
-
-		return 0; // No page queried.
+		return $query->query_vars['page_id'] ?? 0; // No page queried.
 	}
 
 	/**

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -250,7 +250,7 @@ class PLL_Frontend extends PLL_Base {
 		}
 
 		$lang          = $this->model->get_language( $restore_curlang );
-		$this->curlang = $lang ? $lang : $this->model->get_default_language();
+		$this->curlang = $lang ?: $this->model->get_default_language();
 		if ( empty( $this->curlang ) ) {
 			return;
 		}

--- a/include/api.php
+++ b/include/api.php
@@ -119,7 +119,7 @@ function pll_default_language( $field = 'slug' ) {
  * @phpstan-return int<0, max>
  */
 function pll_get_post( $post_id, $lang = '' ) {
-	$lang = $lang ? $lang : pll_current_language();
+	$lang = $lang ?: pll_current_language();
 
 	if ( empty( $lang ) ) {
 		return 0;
@@ -143,7 +143,7 @@ function pll_get_post( $post_id, $lang = '' ) {
  * @phpstan-return int<0, max>
  */
 function pll_get_term( $term_id, $lang = '' ) {
-	$lang = $lang ? $lang : pll_current_language();
+	$lang = $lang ?: pll_current_language();
 
 	if ( empty( $lang ) ) {
 		return 0;

--- a/include/cache.php
+++ b/include/cache.php
@@ -81,7 +81,7 @@ class PLL_Cache {
 	 * @phpstan-return TCacheData|false
 	 */
 	public function get( $key ) {
-		return isset( $this->cache[ $this->blog_id ][ $key ] ) ? $this->cache[ $this->blog_id ][ $key ] : false;
+		return $this->cache[ $this->blog_id ][ $key ] ?? false;
 	}
 
 	/**

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -236,7 +236,7 @@ class PLL_CRUD_Terms {
 	 * @return void
 	 */
 	public function set_tax_query_lang( $query ) {
-		$this->tax_query_lang = isset( $query->query_vars['lang'] ) ? $query->query_vars['lang'] : '';
+		$this->tax_query_lang = $query->query_vars['lang'] ?? '';
 	}
 
 	/**

--- a/include/db-tools.php
+++ b/include/db-tools.php
@@ -22,7 +22,7 @@ class PLL_Db_Tools {
 	 * @return string A comma separated list of values.
 	 */
 	public static function prepare_values_list( $values ) {
-		$values = array_map( array( __CLASS__, 'prepare_value' ), (array) $values );
+		$values = array_map( array( self::class, 'prepare_value' ), (array) $values );
 
 		return implode( ',', $values );
 	}

--- a/include/language-deprecated.php
+++ b/include/language-deprecated.php
@@ -17,7 +17,7 @@ abstract class PLL_Language_Deprecated {
 	 *
 	 * @var string[][]
 	 */
-	const DEPRECATED_TERM_PROPERTIES = array(
+	public const DEPRECATED_TERM_PROPERTIES = array(
 		'term_taxonomy_id'    => array( 'language', 'term_taxonomy_id' ),
 		'count'               => array( 'language', 'count' ),
 		'tl_term_id'          => array( 'term_language', 'term_id' ),
@@ -32,7 +32,7 @@ abstract class PLL_Language_Deprecated {
 	 *
 	 * @var string[]
 	 */
-	const DEPRECATED_URL_PROPERTIES = array(
+	public const DEPRECATED_URL_PROPERTIES = array(
 		'home_url'   => 'get_home_url',
 		'search_url' => 'get_search_url',
 	);
@@ -122,8 +122,8 @@ abstract class PLL_Language_Deprecated {
 		// Protected or private property.
 		$visibility = $ref->isPrivate() ? 'private' : 'protected';
 		$trace      = debug_backtrace(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection, WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
-		$file       = isset( $trace[0]['file'] ) ? $trace[0]['file'] : '';
-		$line       = isset( $trace[0]['line'] ) ? $trace[0]['line'] : 0;
+		$file       = $trace[0]['file'] ?? '';
+		$line       = $trace[0]['line'] ?? 0;
 		trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			esc_html(
 				sprintf(

--- a/include/language.php
+++ b/include/language.php
@@ -314,7 +314,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-return int<0, max>
 	 */
 	public function get_tax_prop( $taxonomy_name, $prop_name ) {
-		return isset( $this->term_props[ $taxonomy_name ][ $prop_name ] ) ? $this->term_props[ $taxonomy_name ][ $prop_name ] : 0;
+		return $this->term_props[ $taxonomy_name ][ $prop_name ] ?? 0;
 	}
 
 	/**
@@ -662,11 +662,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 			return $this->get_tax_prop( $matches['tax'], $matches['field'] );
 		}
 
-		// Any other public property.
-		if ( isset( $this->$property ) ) {
-			return $this->$property;
-		}
-
-		return false;
+		return $this->$property ?? false;
 	}
 }

--- a/include/links-subdomain.php
+++ b/include/links-subdomain.php
@@ -85,7 +85,7 @@ class PLL_Links_Subdomain extends PLL_Links_Abstract_Domain {
 		$hosts = array();
 		foreach ( $this->model->get_languages_list() as $lang ) {
 			$host = wp_parse_url( $this->home_url( $lang ), PHP_URL_HOST );
-			$hosts[ $lang->slug ] = $host ? $host : '';
+			$hosts[ $lang->slug ] = $host ?: '';
 		}
 		return $hosts;
 	}

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -9,7 +9,7 @@
  * @since 1.2
  */
 class PLL_Switcher {
-	const DEFAULTS = array(
+	public const DEFAULTS = array(
 		'dropdown'               => 0, // Display as list and not as dropdown.
 		'echo'                   => 1, // Echoes the list.
 		'hide_if_empty'          => 1, // Hides languages with no posts (or pages).
@@ -133,7 +133,7 @@ class PLL_Switcher {
 					$args['classes']
 				) :
 				$item_classes;
-			$link_classes = isset( $args['link_classes'] ) ? $args['link_classes'] : array();
+			$link_classes = $args['link_classes'] ?? array();
 			$current_lang = $this->get_current_language( $args ) === $slug;
 
 			if ( $current_lang ) {

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -72,7 +72,7 @@ class PLL_Translate_Option {
 		$this->cache = new PLL_Cache();
 
 		// Registers the strings.
-		$context = isset( $args['context'] ) ? $args['context'] : 'Polylang';
+		$context = $args['context'] ?? 'Polylang';
 		$this->register_string_recursive( $context, $name, get_option( $name ), $keys );
 
 		// Translates the strings.

--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -320,7 +320,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 
 		$translations = $this->get_translations( $id );
 
-		return isset( $translations[ $lang->slug ] ) ? $translations[ $lang->slug ] : 0;
+		return $translations[ $lang->slug ] ?? 0;
 	}
 
 	/**

--- a/include/walker.php
+++ b/include/walker.php
@@ -57,13 +57,13 @@ class PLL_Walker extends Walker {
 	 */
 	protected function maybe_fix_walk_args( &$max_depth, &$args ) {
 		if ( ! is_array( $max_depth ) ) {
-			$args = isset( $args[0] ) ? $args[0] : array();
+			$args = $args[0] ?? array();
 			return;
 		}
 
 		// Backward compatibility with Polylang < 2.6.7
 		_doing_it_wrong(
-			__CLASS__ . '::walk()',
+			self::class . '::walk()',
 			'The method expects an integer as second parameter.',
 			'2.6.7'
 		);

--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -508,9 +508,9 @@ class PLL_Plugin_Updater {
 		$api_params = array(
 			'edd_action'  => 'get_version',
 			'license'     => ! empty( $this->api_data['license'] ) ? $this->api_data['license'] : '',
-			'item_name'   => isset( $this->api_data['item_name'] ) ? $this->api_data['item_name'] : false,
-			'item_id'     => isset( $this->api_data['item_id'] ) ? $this->api_data['item_id'] : false,
-			'version'     => isset( $this->api_data['version'] ) ? $this->api_data['version'] : false,
+			'item_name'   => $this->api_data['item_name'] ?? false,
+			'item_id'     => $this->api_data['item_id'] ?? false,
+			'version'     => $this->api_data['version'] ?? false,
 			'slug'        => $this->slug,
 			'author'      => $this->api_data['author'],
 			'url'         => home_url(),

--- a/install/t15s.php
+++ b/install/t15s.php
@@ -16,7 +16,7 @@ class PLL_T15S {
 	 *
 	 * @var string
 	 */
-	const TRANSIENT_KEY_PLUGIN = 't15s-registry-plugins';
+	public const TRANSIENT_KEY_PLUGIN = 't15s-registry-plugins';
 
 	/**
 	 * Project directory slug
@@ -58,7 +58,7 @@ class PLL_T15S {
 		$this->slug    = $slug;
 		$this->api_url = $api_url;
 
-		add_action( 'init', array( __CLASS__, 'register_clean_translations_cache' ), 9999 );
+		add_action( 'init', array( self::class, 'register_clean_translations_cache' ), 9999 );
 		add_filter( 'translations_api', array( $this, 'translations_api' ), 10, 3 );
 		add_filter( 'site_transient_update_plugins', array( $this, 'site_transient_update_plugins' ) );
 	}
@@ -137,8 +137,8 @@ class PLL_T15S {
 	 * @return void
 	 */
 	public static function register_clean_translations_cache() {
-		add_action( 'set_site_transient_update_plugins', array( __CLASS__, 'clean_translations_cache' ) );
-		add_action( 'delete_site_transient_update_plugins', array( __CLASS__, 'clean_translations_cache' ) );
+		add_action( 'set_site_transient_update_plugins', array( self::class, 'clean_translations_cache' ) );
+		add_action( 'delete_site_transient_update_plugins', array( self::class, 'clean_translations_cache' ) );
 	}
 
 	/**

--- a/integrations/wpseo/wpseo.php
+++ b/integrations/wpseo/wpseo.php
@@ -405,7 +405,7 @@ class PLL_WPSEO {
 			} elseif ( 'post-type-archive' === $indexable->object_type && pll_is_translated_post_type( $indexable->object_sub_type ) ) {
 				$indexable->permalink = get_post_type_archive_link( $indexable->object_sub_type );
 				$breadcrumb_title = WPSEO_Options::get( 'bctitle-ptarchive-' . $indexable->object_sub_type );
-				$breadcrumb_title = $breadcrumb_title ? $breadcrumb_title : $indexable->breadcrumb_title; // The option may be empty.
+				$breadcrumb_title = $breadcrumb_title ?: $indexable->breadcrumb_title; // The option may be empty.
 				$indexable->breadcrumb_title = pll__( $breadcrumb_title );
 			} elseif ( 'term' === $indexable->object_type && pll_is_translated_taxonomy( $indexable->object_sub_type ) ) {
 				$indexable->permalink = get_term_link( $indexable->object_id );

--- a/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -138,8 +138,8 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	public function get_sitemap_type_data() {
 		$sitemap_data = array();
 
-		add_filter( 'wp_sitemaps_posts_query_args', array( __CLASS__, 'query_args' ) );
-		add_filter( 'wp_sitemaps_taxonomies_query_args', array( __CLASS__, 'query_args' ) );
+		add_filter( 'wp_sitemaps_posts_query_args', array( self::class, 'query_args' ) );
+		add_filter( 'wp_sitemaps_taxonomies_query_args', array( self::class, 'query_args' ) );
 
 		$object_subtypes = $this->get_object_subtypes();
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -215,7 +215,7 @@ class PLL_Sync {
 						if ( $tr_term instanceof WP_Term && ! ( $term->parent && empty( $tr_parent ) ) ) {
 							$wpdb->update(
 								$wpdb->term_taxonomy,
-								array( 'parent' => $tr_parent ? $tr_parent : 0 ),
+								array( 'parent' => $tr_parent ?: 0 ),
 								array( 'term_taxonomy_id' => $tr_term->term_taxonomy_id )
 							);
 

--- a/modules/wpml/wpml-api.php
+++ b/modules/wpml/wpml-api.php
@@ -53,7 +53,7 @@ class PLL_WPML_API {
 		 * Retrieving Language Information for Content.
 		 */
 		add_filter( 'wpml_post_language_details', 'wpml_get_language_information', 10, 2 );
-		add_action( 'wpml_switch_language', array( __CLASS__, 'wpml_switch_language' ), 10, 2 );
+		add_action( 'wpml_switch_language', array( self::class, 'wpml_switch_language' ), 10, 2 );
 		add_filter( 'wpml_element_language_code', array( $this, 'wpml_element_language_code' ), 10, 2 );
 		// wpml_element_language_details           => not applicable.
 

--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -445,7 +445,7 @@ class PLL_WPML_Config {
 			$this->parsing_rules = $this->extract_blocks_parsing_rules();
 		}
 
-		return isset( $this->parsing_rules[ $rule_tag ] ) ? $this->parsing_rules[ $rule_tag ] : array();
+		return $this->parsing_rules[ $rule_tag ] ?? array();
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,6 +27,7 @@
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
 		<exclude name="Universal.Operators.StrictComparisons" />
+		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound"/>
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned"/>
 		<exclude name="WordPress.CodeAnalysis.AssignmentInTernaryCondition.FoundInTernaryCondition"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -167,6 +167,7 @@
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>tmp/*</exclude-pattern>
 	<exclude-pattern>webpack.config.js</exclude-pattern>
+	<exclude-pattern>rector.php</exclude-pattern>
 
 	<!-- Specific to Polylang -->
 	<exclude-pattern>install/plugin-updater.php</exclude-pattern>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+
+return RectorConfig::configure()
+	->withPaths(
+		[
+			__DIR__ . '/admin',
+			__DIR__ . '/frontend',
+			__DIR__ . '/include',
+			__DIR__ . '/install',
+			__DIR__ . '/integrations',
+			__DIR__ . '/modules',
+			__DIR__ . '/settings',
+			__DIR__ . '/tests',
+			__DIR__ . '/polylang.php',
+			__DIR__ . '/uninstall.php',
+		]
+	)
+	->withSets(
+		[
+			LevelSetList::UP_TO_PHP_72,
+		]
+	)
+	->withSkip(
+		[
+			LongArrayToShortArrayRector::class,
+		]
+	);

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\Php71\Rector\List_\ListToArrayDestructRector;
 
 return RectorConfig::configure()
 	->withPaths(
@@ -29,5 +30,6 @@ return RectorConfig::configure()
 	->withSkip(
 		[
 			LongArrayToShortArrayRector::class,
+			ListToArrayDestructRector::class,
 		]
 	);

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -97,7 +97,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 		<table id="pll-domains-table" class="form-table" <?php echo 3 == $this->options['force_lang'] ? '' : 'style="display: none;"'; ?>>
 			<?php
 			foreach ( $this->model->get_languages_list() as  $lg ) {
-				$url = $this->options['domains'][ $lg->slug ] ?? ($lg->is_default ? $this->links_model->home : '');
+				$url = $this->options['domains'][ $lg->slug ] ?? ( $lg->is_default ? $this->links_model->home : '' );
 				printf(
 					'<tr><td><label for="pll-domain[%1$s]">%2$s</label></td>' .
 					'<td><input name="domains[%1$s]" id="pll-domain[%1$s]" type="text" value="%3$s" class="regular-text code" aria-required="true" /></td></tr>',

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -97,7 +97,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 		<table id="pll-domains-table" class="form-table" <?php echo 3 == $this->options['force_lang'] ? '' : 'style="display: none;"'; ?>>
 			<?php
 			foreach ( $this->model->get_languages_list() as  $lg ) {
-				$url = isset( $this->options['domains'][ $lg->slug ] ) ? $this->options['domains'][ $lg->slug ] : ( $lg->is_default ? $this->links_model->home : '' );
+				$url = $this->options['domains'][ $lg->slug ] ?? ($lg->is_default ? $this->links_model->home : '');
 				printf(
 					'<tr><td><label for="pll-domain[%1$s]">%2$s</label></td>' .
 					'<td><input name="domains[%1$s]" id="pll-domain[%1$s]" type="text" value="%3$s" class="regular-text code" aria-required="true" /></td></tr>',
@@ -189,7 +189,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 			// That's nice to display the right home urls but don't forget that the page on front may have no language yet
 			$lang = $this->model->post->get_language( $this->page_on_front );
 			/** @var PLL_Language $lang */
-			$lang = $lang ? $lang : $this->model->get_default_language();
+			$lang = $lang ?: $this->model->get_default_language();
 			printf(
 				/* translators: %1$s example url when the option is active. %2$s example url when the option is not active */
 				esc_html__( 'Example: %1$s instead of %2$s', 'polylang' ),

--- a/tests/phpunit/includes/mocks-trait.php
+++ b/tests/phpunit/includes/mocks-trait.php
@@ -19,7 +19,7 @@ trait PLL_Mocks_Trait {
 		Functions\when( 'pll_get_constant' )->alias(
 			function ( $constant_name, $default = null ) use ( $constants ) {
 				if ( array_key_exists( $constant_name, $constants ) ) {
-					return null !== $constants[ $constant_name ] ? $constants[ $constant_name ] : $default;
+					return $constants[ $constant_name ] ?? $default;
 				}
 
 				return defined( $constant_name ) ? constant( $constant_name ) : $default;

--- a/tests/phpunit/includes/polyfill-testcase.php
+++ b/tests/phpunit/includes/polyfill-testcase.php
@@ -28,10 +28,8 @@ abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 		$wpdb->db_connect();
 		ini_set( 'display_errors', 1 ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Disallowed
 
-		$class = static::class;
-
-		if ( method_exists( $class, 'wpSetUpBeforeClass' ) ) {
-			call_user_func( array( $class, 'wpSetUpBeforeClass' ), static::factory() );
+		if ( method_exists( static::class, 'wpSetUpBeforeClass' ) ) {
+			call_user_func( array( static::class, 'wpSetUpBeforeClass' ), static::factory() );
 		}
 
 		self::commit_transaction();

--- a/tests/phpunit/includes/polyfill-testcase.php
+++ b/tests/phpunit/includes/polyfill-testcase.php
@@ -28,7 +28,7 @@ abstract class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 		$wpdb->db_connect();
 		ini_set( 'display_errors', 1 ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Disallowed
 
-		$class = get_called_class();
+		$class = static::class;
 
 		if ( method_exists( $class, 'wpSetUpBeforeClass' ) ) {
 			call_user_func( array( $class, 'wpSetUpBeforeClass' ), static::factory() );

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -55,7 +55,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		}
 		$parts = wp_parse_url( $url );
 		if ( isset( $parts['scheme'] ) ) {
-			$req = isset( $parts['path'] ) ? $parts['path'] : '';
+			$req = $parts['path'] ?? '';
 			if ( isset( $parts['query'] ) ) {
 				$req .= '?' . $parts['query'];
 				// parse the url query vars into $_GET

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -73,7 +73,7 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		}
 		$parts = wp_parse_url( $url );
 		if ( isset( $parts['scheme'] ) ) {
-			$req = isset( $parts['path'] ) ? $parts['path'] : '';
+			$req = $parts['path'] ?? '';
 			if ( isset( $parts['query'] ) ) {
 				$req .= '?' . $parts['query'];
 				// parse the url query vars into $_GET

--- a/tests/phpunit/tests/test-links-domain.php
+++ b/tests/phpunit/tests/test-links-domain.php
@@ -48,12 +48,12 @@ class Links_Domain_Test extends PLL_Domain_UnitTestCase {
 		$url = 'http://example.org.fr';
 
 		$this->assertEquals( 'http://example.org.fr', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
-		$this->assertEquals( 'http://example.org', $this->links_model->remove_language_from_link( $url, self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( 'http://example.org', $this->links_model->remove_language_from_link( $url ) );
 
 		$url = 'http://example.org.fr/test/';
 
 		$this->assertEquals( 'http://example.org.fr/test/', $this->links_model->add_language_to_link( $url, self::$model->get_language( 'fr' ) ) );
-		$this->assertEquals( 'http://example.org/test/', $this->links_model->remove_language_from_link( $url, self::$model->get_language( 'fr' ) ) );
+		$this->assertEquals( 'http://example.org/test/', $this->links_model->remove_language_from_link( $url ) );
 	}
 
 	public function test_permalink_and_shortlink() {

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -699,8 +699,8 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 	public function test_page_deletion_without_translations() {
 		// Delete translations.
 		self::$model->post->delete_translation( self::$home_en );
-		self::$model->post->delete_translation( self::$home_de, true );
-		self::$model->post->delete_translation( self::$posts_en, true );
+		self::$model->post->delete_translation( self::$home_de );
+		self::$model->post->delete_translation( self::$posts_en );
 
 		$this->init_test( 'admin' );
 


### PR DESCRIPTION
Follow up the @szepeviktor work in #1476 

- Adds the latest Rector release (1.1.0) and configure it.
- Excludes short array syntax Rector rule because we decided not to use it and as WordPress do.
- Excludes destructuring assignment, espacially replacement of `list()` instruction in our tests and because it uses short array syntax.
- Excludes PHPCS shorthand ternary operator (Elvis operator) rule.

## Rector
Dry run with no code modification

```
vendor/bin/rector process --dry-run
```
Run with code modifications

```
vendor/bin/rector process
```

- Full documentation: https://getrector.com/documentation/
- Rules documentation: https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md

## Going further
Make it accessible for all our repositories by sharing it in our `wp-phpunit` package.