### PR TITLE
Fix admin bar search menu in WP 6.6

### DIFF
--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -97,6 +97,10 @@ class PLL_Frontend_Filters_Search {
 	public function add_admin_bar_menus() {
 		// Backward compatibility with WP < 6.6. The priority was 4 before this version, 9999 since then.
 		$priority = has_action( 'admin_bar_menu', 'wp_admin_bar_search_menu' );
+		if ( ! is_int( $priority ) ) {
+			return;
+		}
+
 		remove_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', $priority );
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_search_menu' ), $priority );
 	}

--- a/frontend/frontend-filters-search.php
+++ b/frontend/frontend-filters-search.php
@@ -88,15 +88,17 @@ class PLL_Frontend_Filters_Search {
 	}
 
 	/**
-	 * Adds the language information in admin bar search form
+	 * Adds the language information in the admin bar search form.
 	 *
 	 * @since 1.2
 	 *
 	 * @return void
 	 */
 	public function add_admin_bar_menus() {
-		remove_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', 4 );
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_search_menu' ), 4 );
+		// Backward compatibility with WP < 6.6. The priority was 4 before this version, 9999 since then.
+		$priority = has_action( 'admin_bar_menu', 'wp_admin_bar_search_menu' );
+		remove_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', $priority );
+		add_action( 'admin_bar_menu', array( $this, 'admin_bar_search_menu' ), $priority );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the admin bar search menu in WP 6.6. The issue is detected bt PHPunit tests https://github.com/polylang/polylang/actions/runs/9450742063/job/26030078708?pr=1488 and is due to a priority change. 
See https://core.trac.wordpress.org/ticket/60685 for the context.
