### PR TITLE
Adds wrapper for `wp_insert_term` and `wp_update_term`.

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -561,7 +561,7 @@ function pll_count_posts( $lang, $args = array() ) {
 }
 
 /**
- * Wrapper of `wp_insert_term` with the language.
+ * Wraps `wp_insert_term` with language feature.
  *
  * @since 3.7
  *

--- a/include/api.php
+++ b/include/api.php
@@ -579,7 +579,7 @@ function pll_count_posts( $lang, $args = array() ) {
  * } $args
  */
 function pll_insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
-	return PLL()->model->term->insert_term( $term, $taxonomy, $language, $args );
+	return PLL()->model->term->insert( $term, $taxonomy, $language, $args );
 }
 
 /**
@@ -594,7 +594,7 @@ function pll_insert_term( string $term, string $taxonomy, PLL_Language $language
  * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
  */
 function pll_update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
-	return PLL()->model->term->update_term( $term_id, $taxonomy, $language, $args );
+	return PLL()->model->term->update( $term_id, $taxonomy, $language, $args );
 }
 
 

--- a/include/api.php
+++ b/include/api.php
@@ -583,7 +583,7 @@ function pll_insert_term( string $term, string $taxonomy, PLL_Language $language
  * @param int          $term_id  The ID of the term.
  * @param string       $taxonomy The taxonomy of the term.
  * @param PLL_Language $language The term language.
- * @param array        $args     The taxonomy of the term.
+ * @param array        $args     Array of arguments for updating a term.
  * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
  */
 function pll_update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {

--- a/include/api.php
+++ b/include/api.php
@@ -609,11 +609,12 @@ function pll_insert_term( string $term, string $taxonomy, $language, array $args
  *     @type string              $description  The term description. Default empty string.
  *     @type int                 $parent       The id of the parent term. Default 0.
  *     @type string              $slug         The term slug to use. Default empty string.
+ *     @type string              $name         The term name.
  *     @type PLL_Language|string $lang         The term language object or slug.
  *     @type string[]            $translations The translation group to assign to the term with language slug as keys and `term_id` as values.
  * }
  * @return array|WP_Error {
- *     An array of the new term data, `WP_Error` otherwise.
+ *     An array containing the `term_id` and `term_taxonomy_id`, `WP_Error` otherwise.
  *
  *     @type int        $term_id          The new term ID.
  *     @type int|string $term_taxonomy_id The new term taxonomy ID. Can be a numeric string.

--- a/include/api.php
+++ b/include/api.php
@@ -576,7 +576,7 @@ function pll_insert_term( string $term, string $taxonomy, PLL_Language $language
 }
 
 /**
- * Wrapper of `wp_update_term` with the language.
+ * Wraps `wp_update_term` with language feature.
  *
  * @since 3.7
  *

--- a/include/api.php
+++ b/include/api.php
@@ -570,6 +570,13 @@ function pll_count_posts( $lang, $args = array() ) {
  * @param PLL_Language $language The term language.
  * @param array|string $args     Array or query string of arguments for inserting a term.
  * @return array|WP_Error An array of the new term, WP_Error otherwise.
+ *
+ * @phpstan-param array{
+ *   alias_of?: string,
+ *   description?: string,
+ *   parent?: int,
+ *   slug?: string,
+ * } $args
  */
 function pll_insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 	return PLL()->model->term->insert_term( $term, $taxonomy, $language, $args );

--- a/include/api.php
+++ b/include/api.php
@@ -620,16 +620,6 @@ function pll_insert_term( string $term, string $taxonomy, $language, array $args
  * }
  */
 function pll_update_term( int $term_id, array $args = array() ) {
-	$language = isset( $args['lang'] ) ? PLL()->model->get_language( $args['lang'] ) : null;
-
-	if ( false === $language ) {
-		return new WP_Error( 'invalid_language', __( 'Please provide a valid language.', 'polylang' ) );
-	}
-
-	if ( $language instanceof PLL_Language ) {
-		$args['lang'] = $language;
-	}
-
 	return PLL()->model->term->update( $term_id, $args );
 }
 

--- a/include/api.php
+++ b/include/api.php
@@ -570,13 +570,6 @@ function pll_count_posts( $lang, $args = array() ) {
  * @param PLL_Language $language The term language.
  * @param array|string $args     Array or query string of arguments for inserting a term.
  * @return array|WP_Error An array of the new term, WP_Error otherwise.
- *
- * @phpstan-param array{
- *   alias_of?: string,
- *   description?: string,
- *   parent?: int,
- *   slug?: string,
- * } $args
  */
 function pll_insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 	return PLL()->model->term->insert( $term, $taxonomy, $language, $args );

--- a/include/api.php
+++ b/include/api.php
@@ -604,12 +604,13 @@ function pll_insert_term( string $term, string $taxonomy, $language, array $args
  * @param array $args {
  *     Optional. Array of arguments for updating a term.
  *
- *     @type string       $alias_of    Slug of the term to make this term an alias of.
- *                                     Default empty string. Accepts a term slug.
- *     @type string       $description The term description. Default empty string.
- *     @type int          $parent      The id of the parent term. Default 0.
- *     @type string       $slug        The term slug to use. Default empty string.
- *     @type PLL_Language $lang        The term language object.
+ *     @type string              $alias_of     Slug of the term to make this term an alias of.
+ *                                             Default empty string. Accepts a term slug.
+ *     @type string              $description  The term description. Default empty string.
+ *     @type int                 $parent       The id of the parent term. Default 0.
+ *     @type string              $slug         The term slug to use. Default empty string.
+ *     @type PLL_Language|string $lang         The term language object or slug.
+ *     @type string[]            $translations The translation group to assign to the term with language slug as keys and `term_id` as values.
  * }
  * @return array|WP_Error {
  *     An array of the new term data, `WP_Error` otherwise.
@@ -619,6 +620,16 @@ function pll_insert_term( string $term, string $taxonomy, $language, array $args
  * }
  */
 function pll_update_term( int $term_id, array $args = array() ) {
+	$language = isset( $args['lang'] ) ? PLL()->model->get_language( $args['lang'] ) : null;
+
+	if ( false === $language ) {
+		return new WP_Error( 'invalid_language', __( 'Please provide a valid language.', 'polylang' ) );
+	}
+
+	if ( $language instanceof PLL_Language ) {
+		$args['lang'] = $language;
+	}
+
 	return PLL()->model->term->update( $term_id, $args );
 }
 

--- a/include/api.php
+++ b/include/api.php
@@ -565,13 +565,33 @@ function pll_count_posts( $lang, $args = array() ) {
  *
  * @since 3.7
  *
- * @param string       $term     The term name to add.
- * @param string       $taxonomy The taxonomy to which to add the term.
- * @param PLL_Language $language The term language.
- * @param array|string $args     Array or query string of arguments for inserting a term.
- * @return array|WP_Error An array of the new term, WP_Error otherwise.
+ * @param string              $term     The term name to add.
+ * @param string              $taxonomy The taxonomy to which to add the term.
+ * @param PLL_Language|string $language The term language object or slug.
+ * @param array               $args {
+ *            Optional. Array of arguments for inserting a term.
+ *
+ *     @type string   $alias_of     Slug of the term to make this term an alias of.
+ *                                  Default empty string. Accepts a term slug.
+ *     @type string   $description  The term description. Default empty string.
+ *     @type int      $parent       The id of the parent term. Default 0.
+ *     @type string   $slug         The term slug to use. Default empty string.
+ *     @type string[] $translations The translation group to assign to the term with language slug as keys and `term_id` as values.
+ * }
+ * @return array|WP_Error {
+ *     An array of the new term data, `WP_Error` otherwise.
+ *
+ *     @type int        $term_id          The new term ID.
+ *     @type int|string $term_taxonomy_id The new term taxonomy ID. Can be a numeric string.
+ * }
  */
-function pll_insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
+function pll_insert_term( string $term, string $taxonomy, $language, array $args = array() ) {
+	$language = PLL()->model->get_language( $language );
+
+	if ( ! $language instanceof PLL_Language ) {
+		return new WP_Error( 'invalid_language', __( 'Please provide a valid language.', 'polylang' ) );
+	}
+
 	return PLL()->model->term->insert( $term, $taxonomy, $language, $args );
 }
 
@@ -580,14 +600,26 @@ function pll_insert_term( string $term, string $taxonomy, PLL_Language $language
  *
  * @since 3.7
  *
- * @param int          $term_id  The ID of the term.
- * @param string       $taxonomy The taxonomy of the term.
- * @param PLL_Language $language The term language.
- * @param array        $args     Array of arguments for updating a term.
- * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
+ * @param int   $term_id The ID of the term.
+ * @param array $args {
+ *     Optional. Array of arguments for updating a term.
+ *
+ *     @type string       $alias_of    Slug of the term to make this term an alias of.
+ *                                     Default empty string. Accepts a term slug.
+ *     @type string       $description The term description. Default empty string.
+ *     @type int          $parent      The id of the parent term. Default 0.
+ *     @type string       $slug        The term slug to use. Default empty string.
+ *     @type PLL_Language $lang        The term language object.
+ * }
+ * @return array|WP_Error {
+ *     An array of the new term data, `WP_Error` otherwise.
+ *
+ *     @type int        $term_id          The new term ID.
+ *     @type int|string $term_taxonomy_id The new term taxonomy ID. Can be a numeric string.
+ * }
  */
-function pll_update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
-	return PLL()->model->term->update( $term_id, $taxonomy, $language, $args );
+function pll_update_term( int $term_id, array $args = array() ) {
+	return PLL()->model->term->update( $term_id, $args );
 }
 
 

--- a/include/api.php
+++ b/include/api.php
@@ -561,6 +561,37 @@ function pll_count_posts( $lang, $args = array() ) {
 }
 
 /**
+ * Wrapper of `wp_insert_term` with the language.
+ *
+ * @since 3.7
+ *
+ * @param string       $term     The term name to add.
+ * @param string       $taxonomy The taxonomy to which to add the term.
+ * @param PLL_Language $language The term language.
+ * @param array|string $args     Array or query string of arguments for inserting a term.
+ * @return array|WP_Error An array of the new term, WP_Error otherwise.
+ */
+function pll_insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
+	return PLL()->model->term->insert_term( $term, $taxonomy, $language, $args );
+}
+
+/**
+ * Wrapper of `wp_update_term` with the language.
+ *
+ * @since 3.7
+ *
+ * @param int          $term_id  The ID of the term.
+ * @param string       $taxonomy The taxonomy of the term.
+ * @param PLL_Language $language The term language.
+ * @param array        $args     The taxonomy of the term.
+ * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
+ */
+function pll_update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
+	return PLL()->model->term->update_term( $term_id, $taxonomy, $language, $args );
+}
+
+
+/**
  * Allows to access the Polylang instance.
  * However, it is always preferable to use API functions
  * as internal methods may be changed without prior notice.

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -367,8 +367,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return $term;
 		}
 
-		$term_id = (int) $term['term_id'];
-		$this->model->term->set_language( $term_id, $language );
+		$this->model->term->set_language( (int) $term['term_id'], $language );
 
 		return $term;
 	}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -358,9 +358,8 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return $language;
 		};
 
-		$term_parent              = $args['parent'] ?? 0;
-		$get_inserted_term_parent = function () use ( $term_parent ) {
-			return $term_parent;
+		$get_inserted_term_parent = function () use ( $args ) {
+			return $args['parent'] ?? 0;
 		};
 
 		// Set term parent and language for suffixed slugs.
@@ -404,9 +403,8 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return new WP_Error( 'invalid_term', __( 'Empty Term.', 'polylang' ) );
 		}
 
-		$term_parent              = $term->parent;
-		$get_inserted_term_parent = function () use ( $term_parent ) {
-			return $term_parent;
+		$get_inserted_term_parent = function () use ( $term ) {
+			return $term->term_parent;
 		};
 
 		// Set term parent and language for suffixed slugs.

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -403,7 +403,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		}
 
 		$get_inserted_term_parent = function () use ( $term ) {
-			return $term->term_parent;
+			return $term->parent;
 		};
 
 		// Set term parent and language for suffixed slugs.

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -362,7 +362,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	public function insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 		$this->term_language = $language;
 
-		add_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20, 2 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 ); // After Polylang's filter.
 		$tr_term = wp_insert_term( $term, $taxonomy, $args );
 		remove_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 );
 
@@ -383,7 +383,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	public function update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
 		$this->term_language = $language;
 
-		add_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20, 2 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 ); // After Polylang's filter.
 		$tr_term = wp_update_term( $term_id, $taxonomy, $args );
 		remove_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 );
 

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -358,8 +358,19 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return $language;
 		};
 
+		$term_parent              = $args['parent'] ?? 0;
+		$get_inserted_term_parent = function () use ( $term_parent ) {
+			return $term_parent;
+		};
+
+		// Set term parent and language for suffixed slugs.
 		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
+
 		$term = wp_insert_term( $term, $taxonomy, $args );
+
+		// Clean up!
+		remove_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
 		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
 
 		if ( is_wp_error( $term ) ) {

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -349,7 +349,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param string       $term     The term name to add.
 	 * @param string       $taxonomy The taxonomy to which to add the term.
 	 * @param PLL_Language $language The term language.
-	 * @param array|string $args     The taxonomy of the term.
+	 * @param array|string $args     Array or query string of arguments for inserting a term.
 	 * @return array|WP_Error An array of the new term, WP_Error otherwise.
 	 *
 	 * @phpstan-param array{

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -391,7 +391,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param int          $term_id  The ID of the term.
 	 * @param string       $taxonomy The taxonomy of the term.
 	 * @param PLL_Language $language The term language.
-	 * @param array        $args     The taxonomy of the term.
+	 * @param array        $args     Array of arguments for updating a term.
 	 * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
 	 */
 	public function update(int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -65,13 +65,6 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	protected $tax_translations = 'term_translations';
 
 	/**
-	 * Term language.
-	 *
-	 * @var PLL_Language
-	 */
-	protected $term_language;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 1.8
@@ -367,11 +360,13 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * } $args
 	 */
 	public function insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
-		$this->term_language = $language;
+		$set_language_for_term_slug = function () use ( $language ) {
+			return $language;
+		};
 
-		add_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
 		$tr_term = wp_insert_term( $term, $taxonomy, $args );
-		remove_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 );
+		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
 
 		return $tr_term;
 	}
@@ -388,11 +383,13 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
 	 */
 	public function update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
-		$this->term_language = $language;
+		$set_language_for_term_slug = function () use ( $language ) {
+			return $language;
+		};
 
-		add_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
 		$tr_term = wp_update_term( $term_id, $taxonomy, $args );
-		remove_filter( 'pll_inserted_term_language', array( $this, 'set_language_for_term_slug' ), 20 );
+		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
 
 		return $tr_term;
 	}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -351,9 +351,8 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param PLL_Language $language The term language.
 	 * @param array|string $args     Array or query string of arguments for inserting a term.
 	 * @return array|WP_Error An array of the new term, WP_Error otherwise.
-	 *
 	 */
-	public function insert(string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
+	public function insert( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 		$set_language_for_term_slug = function () use ( $language ) {
 			return $language;
 		};
@@ -393,7 +392,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param array        $args     Array of arguments for updating a term.
 	 * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
 	 */
-	public function update(int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
+	public function update( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
 		$set_language_for_term_slug = function () use ( $language ) {
 			return $language;
 		};

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -422,18 +422,9 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return new WP_Error( 'invalid_term', __( 'Empty Term.', 'polylang' ) );
 		}
 
-		$new_language = ! empty( $args['lang'] ) ? $this->model->get_language( $args['lang'] ) : null;
+		$new_language = ! empty( $args['lang'] ) ? $this->model->get_language( $args['lang'] ) : $this->get_language( $term_id );
 		if ( false === $new_language ) {
 			return new WP_Error( 'invalid_language', __( 'Please provide a valid language.', 'polylang' ) );
-		}
-
-		$old_language = $this->get_language( $term_id );
-		if ( false === $old_language ) {
-			return new WP_Error( 'broken_language', __( 'Given term has a broken language.', 'polylang' ) );
-		}
-
-		if ( is_null( $new_language ) ) {
-			$new_language = $old_language;
 		}
 
 		$language_callback = $this->get_slug_management_language_callback( $new_language );
@@ -443,9 +434,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		$term = wp_update_term( $term->term_id, $term->taxonomy, $args );
 		$this->toggle_inserted_term_filters( $language_callback, $parent_callback );
 
-		if ( $old_language->slug !== $new_language->slug ) {
-			$this->set_language( $term_id, $new_language );
-		}
+		$this->set_language( $term_id, $new_language );
 
 		if ( ! empty( $args['translations'] ) ) {
 			$this->model->term->save_translations(

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -377,10 +377,10 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return $term;
 		}
 
-		$this->model->term->set_language( (int) $term['term_id'], $language );
+		$this->set_language( (int) $term['term_id'], $language );
 
 		if ( ! empty( $args['translations'] ) ) {
-			$this->model->term->save_translations(
+			$this->save_translations(
 				(int) $term['term_id'],
 				array_merge(
 					$args['translations'],
@@ -437,7 +437,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		$this->toggle_inserted_term_filters( $language, $parent );
 
 		if ( ! empty( $args['translations'] ) ) {
-			$this->model->term->save_translations(
+			$this->save_translations(
 				$term_id,
 				array_merge(
 					$args['translations'],

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -393,15 +393,4 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 
 		return $tr_term;
 	}
-
-	/**
-	 * Filters the currently inserted term language to suffix the term slug or not.
-	 *
-	 * @since 3.7
-	 *
-	 * @return PLL_Language Overridden language object.
-	 */
-	public function set_language_for_term_slug() {
-		return $this->term_language;
-	}
 }

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -342,7 +342,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
-	 * Wrapper of `wp_insert_term` with the language.
+	 * Wraps `wp_insert_term` with language feature.
 	 *
 	 * @since 3.7
 	 *
@@ -374,7 +374,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
-	 * Wrapper of `wp_update_term` with the language.
+	 * Wraps `wp_update_term` with language feature.
 	 *
 	 * @since 3.7
 	 *

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -363,14 +363,14 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		};
 
 		// Set term parent and language for suffixed slugs.
-		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug );
 		add_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
 
 		$term = wp_insert_term( $term, $taxonomy, $args );
 
 		// Clean up!
 		remove_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
-		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
+		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug );
 
 		if ( is_wp_error( $term ) ) {
 			// Something went wrong!
@@ -408,14 +408,14 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		};
 
 		// Set term parent and language for suffixed slugs.
-		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug );
 		add_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
 
 		$tr_term = wp_update_term( $term_id, $taxonomy, $args );
 
 		// Clean up!
 		remove_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
-		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
+		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug );
 
 		return $tr_term;
 	}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -365,10 +365,18 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		};
 
 		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
-		$tr_term = wp_insert_term( $term, $taxonomy, $args );
+		$term = wp_insert_term( $term, $taxonomy, $args );
 		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
 
-		return $tr_term;
+		if ( is_wp_error( $term ) ) {
+			// Something went wrong!
+			return $term;
+		}
+
+		$term_id = (int) $term['term_id'];
+		$this->model->term->set_language( $term_id, $language );
+
+		return $term;
 	}
 
 	/**

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -353,7 +353,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @return array|WP_Error An array of the new term, WP_Error otherwise.
 	 *
 	 */
-	public function insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
+	public function insert(string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 		$set_language_for_term_slug = function () use ( $language ) {
 			return $language;
 		};
@@ -394,7 +394,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param array        $args     The taxonomy of the term.
 	 * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
 	 */
-	public function update_term( int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
+	public function update(int $term_id, string $taxonomy, PLL_Language $language, array $args = array() ) {
 		$set_language_for_term_slug = function () use ( $language ) {
 			return $language;
 		};

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -423,7 +423,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		/** @var PLL_Language $language */
 		$language = $this->get_language( $term_id );
 		if ( ! empty( $args['lang'] ) ) {
-			$language = $this->model->get_language( $args['lang'] );
+			$language = $this->languages->get( $args['lang'] );
 			if ( ! $language instanceof PLL_Language ) {
 				return new WP_Error( 'invalid_language', __( 'Please provide a valid language.', 'polylang' ) );
 			}

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -395,8 +395,24 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return $language;
 		};
 
+		$term = get_term( $term_id );
+		if ( ! $term instanceof WP_Term ) {
+			return new WP_Error( 'invalid_term', __( 'Empty Term.', 'polylang' ) );
+		}
+
+		$term_parent              = $term->parent;
+		$get_inserted_term_parent = function () use ( $term_parent ) {
+			return $term_parent;
+		};
+
+		// Set term parent and language for suffixed slugs.
 		add_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 ); // After Polylang's filter.
+		add_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
+
 		$tr_term = wp_update_term( $term_id, $taxonomy, $args );
+
+		// Clean up!
+		remove_filter( 'pll_inserted_term_parent', $get_inserted_term_parent );
 		remove_filter( 'pll_inserted_term_language', $set_language_for_term_slug, 20 );
 
 		return $tr_term;

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -415,12 +415,13 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param array $args {
 	 *     Optional. Array of arguments for updating a term.
 	 *
-	 *     @type string       $alias_of    Slug of the term to make this term an alias of.
-	 *                                     Default empty string. Accepts a term slug.
-	 *     @type string       $description The term description. Default empty string.
-	 *     @type int          $parent      The id of the parent term. Default 0.
-	 *     @type string       $slug        The term slug to use. Default empty string.
-	 *     @type PLL_Language $lang        The term language object.
+	 *     @type string       $alias_of     Slug of the term to make this term an alias of.
+	 *                                      Default empty string. Accepts a term slug.
+	 *     @type string       $description  The term description. Default empty string.
+	 *     @type int          $parent       The id of the parent term. Default 0.
+	 *     @type string       $slug         The term slug to use. Default empty string.
+	 *     @type PLL_Language $lang         The term language object.
+	 *     @type string[]     $translations The translation group to assign to the term with language slug as keys and `term_id` as values.
 	 * }
 	 * @return array|WP_Error An array containing the `term_id` and `term_taxonomy_id`,
 	 *                        WP_Error otherwise.                  WP_Error otherwise.

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -356,8 +356,15 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param string       $term     The term name to add.
 	 * @param string       $taxonomy The taxonomy to which to add the term.
 	 * @param PLL_Language $language The term language.
-	 * @param array|string $args     Array or query string of arguments for inserting a term.
+	 * @param array|string $args     The taxonomy of the term.
 	 * @return array|WP_Error An array of the new term, WP_Error otherwise.
+	 *
+	 * @phpstan-param array{
+	 *   alias_of?: string,
+	 *   description?: string,
+	 *   parent?: int,
+	 *   slug?: string,
+	 * } $args
 	 */
 	public function insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 		$this->term_language = $language;

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -352,12 +352,6 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param array|string $args     Array or query string of arguments for inserting a term.
 	 * @return array|WP_Error An array of the new term, WP_Error otherwise.
 	 *
-	 * @phpstan-param array{
-	 *   alias_of?: string,
-	 *   description?: string,
-	 *   parent?: int,
-	 *   slug?: string,
-	 * } $args
 	 */
 	public function insert_term( string $term, string $taxonomy, PLL_Language $language, $args = array() ) {
 		$set_language_for_term_slug = function () use ( $language ) {

--- a/include/translated-term.php
+++ b/include/translated-term.php
@@ -370,9 +370,9 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		$language_callback = $this->get_slug_management_language_callback( $language );
 		$parent_callback   = $this->get_slug_management_parent_callback( $args['parent'] ?? 0 );
 
-		$this->toggle_slug_management( $language_callback, $parent_callback );
+		$this->toggle_inserted_term_filters( $language_callback, $parent_callback );
 		$term = wp_insert_term( $term, $taxonomy, $args );
-		$this->toggle_slug_management( $language_callback, $parent_callback );
+		$this->toggle_inserted_term_filters( $language_callback, $parent_callback );
 
 		if ( is_wp_error( $term ) ) {
 			// Something went wrong!
@@ -439,9 +439,9 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 		$language_callback = $this->get_slug_management_language_callback( $new_language );
 		$parent_callback   = $this->get_slug_management_parent_callback( $args['parent'] ?? $term->parent );
 
-		$this->toggle_slug_management( $language_callback, $parent_callback );
+		$this->toggle_inserted_term_filters( $language_callback, $parent_callback );
 		$term = wp_update_term( $term->term_id, $term->taxonomy, $args );
-		$this->toggle_slug_management( $language_callback, $parent_callback );
+		$this->toggle_inserted_term_filters( $language_callback, $parent_callback );
 
 		if ( $old_language->slug !== $new_language->slug ) {
 			$this->set_language( $term_id, $new_language );
@@ -463,7 +463,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	}
 
 	/**
-	 * Toggles Polylang term slug management.
+	 * Toggles Polylang term slug filters management.
 	 * Must be used before and after any term slug modification or insertion.
 	 *
 	 * @since 3.7
@@ -472,7 +472,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @param callable $parent_callback   The parent callback for term slug modification.
 	 * @return void
 	 */
-	private function toggle_slug_management( $language_callback, $parent_callback ): void {
+	private function toggle_inserted_term_filters( $language_callback, $parent_callback ): void {
 		static $enabled = false;
 
 		if ( $enabled ) {

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -11,11 +11,11 @@ class API_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		register_taxonomy( 'custom_tax', 'post' );
+		register_taxonomy( 'tr_custom_tax', 'post' );
 
 		$options             = array(
 			'default_lang' => 'en',
-			'taxonomies'   => array( 'custom_tax' ),
+			'taxonomies'   => array( 'tr_custom_tax' ),
 		);
 		$this->pll_env       = ( new PLL_Context_Frontend( array( 'options' => $options ) ) )->get();
 		$GLOBALS['polylang'] = $this->pll_env;
@@ -75,14 +75,16 @@ class API_Test extends PLL_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::pll_insert_term
+	 *
 	 * @testWith ["category", true, true]
 	 *           ["category", false, true]
 	 *           ["post_tag", false, true]
-	 *           ["custom_tax", false, true]
+	 *           ["tr_custom_tax", false, true]
 	 *           ["category", false, false]
 	 *           ["category", true, false]
 	 *           ["post_tag", false, false]
-	 *           ["custom_tax", false, false]
+	 *           ["tr_custom_tax", false, false]
 	 *
 	 * @param string $taxonomy
 	 * @return void
@@ -124,5 +126,33 @@ class API_Test extends PLL_UnitTestCase {
 
 			$this->assertSame( $expected_slug, $term->slug );
 		}
+	}
+
+	/**
+	 * @covers ::pll_insert_term
+	 *
+	 * @testWith ["category", "en", "term_exists"]
+	 *           ["post_tag", "en", "term_exists"]
+	 *           ["tr_custom_tax", "en", "term_exists"]
+	 *           ["category", "chti", "invalid_language"]
+	 *           ["post_tag", "chti", "invalid_language"]
+	 *           ["tr_custom_tax", "chti", "invalid_language"]
+	 *
+	 * @param string $taxonomy
+	 * @return void
+	 */
+	public function test_pll_insert_term_error_path( $taxonomy, $language, $error_code ) {
+		self::factory()->term->create_and_get(
+			array(
+				'name'     => 'Foo',
+				'taxonomy' => $taxonomy,
+				'lang'     => 'en',
+			)
+		);
+
+		$result = pll_insert_term( 'Foo', $taxonomy, $language );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $error_code, $result->get_error_code() );
 	}
 }

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -128,9 +128,6 @@ class API_Test extends PLL_UnitTestCase {
 			$translations[ $language ] = $result['term_id'];
 			$term                      = get_term( $result['term_id'], $taxonomy );
 
-			/*
-			 * @FIXME Polylang doesn't reuse parent slug and add a suffix with language slug instead...
-			 */
 			$suffix        = $with_parent || ! $is_default_lang ? "-{$language}" : '';
 			$expected_slug = "foo{$suffix}";
 

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -27,9 +27,6 @@ class API_Test extends PLL_UnitTestCase {
 		parent::tear_down();
 	}
 
-	/**
-	 * @covers ::pll_get_post
-	 */
 	public function test_pll_get_post() {
 		$posts = $this->factory()->post->create_translated(
 			array( 'lang' => 'en' ),
@@ -44,9 +41,6 @@ class API_Test extends PLL_UnitTestCase {
 		$this->assertSame( $posts['fr'], pll_get_post( $posts['en'] ) );
 	}
 
-	/**
-	 * @covers ::pll_get_term
-	 */
 	public function test_pll_get_term() {
 		$terms = $this->factory()->term->create_translated(
 			array( 'lang' => 'en' ),
@@ -65,8 +59,6 @@ class API_Test extends PLL_UnitTestCase {
 	 * @testWith ["post"]
 	 *           ["term"]
 	 *
-	 * @covers PLL_Translated_Object::get_translation
-	 *
 	 * @param string $type Type of object.
 	 */
 	public function test_translated_objects_get_translation( $type ) {
@@ -81,8 +73,6 @@ class API_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::pll_insert_term
-	 *
 	 * @testWith ["category", true, true]
 	 *           ["category", false, true]
 	 *           ["post_tag", false, true]
@@ -136,8 +126,6 @@ class API_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::pll_insert_term
-	 *
 	 * @testWith ["category", "en", "term_exists"]
 	 *           ["post_tag", "en", "term_exists"]
 	 *           ["tr_custom_tax", "en", "term_exists"]
@@ -166,8 +154,6 @@ class API_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::pll_update_term
-	 *
 	 * @testWith ["category", true, true, true]
 	 *           ["category", false, true, false]
 	 *           ["category", true, true, true]
@@ -273,8 +259,6 @@ class API_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::pll_update_term
-	 *
 	 * @testWith ["category", "en", "duplicate_term_slug"]
 	 *           ["post_tag", "en", "duplicate_term_slug"]
 	 *           ["tr_custom_tax", "en", "duplicate_term_slug"]

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -15,10 +15,9 @@ class API_Test extends PLL_UnitTestCase {
 
 		$options             = array(
 			'default_lang' => 'en',
-			'post_types'   => array( 'trcpt' ),
-			'taxonomies'   => array( 'trtax', 'trtax_with_no_namespace' ),
+			'taxonomies'   => array( 'custom_tax' ),
 		);
-		$this->pll_env       = ( new PLL_Context_Frontend( $options ) )->get();
+		$this->pll_env       = ( new PLL_Context_Frontend( array( 'options' => $options ) ) )->get();
 		$GLOBALS['polylang'] = $this->pll_env;
 	}
 
@@ -76,8 +75,8 @@ class API_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @testWith ["category", false, true]
-	 *           ["category", true, true]
+	 * @testWith ["category", true, true]
+	 *           ["category", false, true]
 	 *           ["post_tag", false, true]
 	 *           ["custom_tax", false, true]
 	 *           ["category", false, false]
@@ -100,6 +99,7 @@ class API_Test extends PLL_UnitTestCase {
 					array(
 						'name'     => $is_default_lang ? 'Foo' : "Foo {$language}",
 						'taxonomy' => $taxonomy,
+						'lang'     => $language,
 					)
 				);
 				$args['parent'] = $parent->term_id;
@@ -109,7 +109,7 @@ class API_Test extends PLL_UnitTestCase {
 				$args['translations'] = $translations;
 			}
 
-			$result = pll_insert_term( 'Foo', $taxonomy, $language );
+			$result = pll_insert_term( 'Foo', $taxonomy, $language, $args );
 
 			$this->assertIsArray( $result, "The term in {$this->pll_env->model->get_language( $language )->name} could not be created." );
 			$this->assertArrayHasKey( 'term_id', $result );
@@ -119,7 +119,7 @@ class API_Test extends PLL_UnitTestCase {
 			$term                      = get_term( $result['term_id'], $taxonomy );
 
 			$prefix = $with_parent ? "{$parent->slug}-" : ''; // @fixme Polylang doesn't reuse parent slug and add a suffix with language slug instead...
-			$suffix = ( $with_translations && ! $is_default_lang ) || $with_parent ? "-{$language}" : ''; // @fixme With the new API, the term slug is suffixed with language slug even if not in the same translation group...
+			$suffix = ! $is_default_lang ? "-{$language}" : '';
 			$expected_slug = "{$prefix}foo{$suffix}";
 
 			$this->assertSame( $expected_slug, $term->slug );

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -167,4 +167,151 @@ class API_Test extends PLL_UnitTestCase {
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( $error_code, $result->get_error_code() );
 	}
+
+	/**
+	 * @covers ::pll_update_term
+	 *
+	 * @testWith ["category", true, true, true]
+	 *           ["category", false, true, false]
+	 *           ["category", true, true, true]
+	 *           ["category", false, true, false]
+	 *           ["category", false, false, true]
+	 *           ["category", true, false, true]
+	 *           ["category", false, false, false]
+	 *           ["category", true, false, false]
+	 *           ["post_tag", false, true, true]
+	 *           ["post_tag", false, false, true]
+	 *           ["post_tag", false, true, false]
+	 *           ["post_tag", false, false, false]
+	 *           ["tr_custom_tax", false, true, true]
+	 *           ["tr_custom_tax", false, false, true]
+	 *           ["tr_custom_tax", false, true, false]
+	 *           ["tr_custom_tax", false, false, false]
+	 *
+	 * @param string $taxonomy          Taxonomy name.
+	 * @param bool   $with_parent       Whether or not the term has a parent.
+	 * @param bool   $with_language     Whether or not the term language should be updated.
+	 * @param bool   $with_translations Whether or not the term translations should be updated.
+	 * @return void
+	 */
+	public function test_pll_update_term_happy_path( $taxonomy, $with_parent, $with_language, $with_translations ) {
+		$tr_term_ids = self::factory()->term->create_translated(
+			array(
+				'name'     => 'The Foo',
+				'taxonomy' => $taxonomy,
+				'lang'     => 'en',
+			),
+			array(
+				'name'     => 'Le Foo',
+				'taxonomy' => $taxonomy,
+				'lang'     => 'fr',
+			)
+		);
+		$lonely_term = self::factory()->term->create_and_get( // Used to update translations.
+			array(
+				'name'     => 'Das Foo',
+				'taxonomy' => $taxonomy,
+				'lang'     => 'de',
+			)
+		);
+		$spanish = self::factory()->language->create_and_get(
+			array(
+				'slug'   => 'es',
+				'locale' => 'es_ES',
+			)
+		);
+
+		$en   = get_term( $tr_term_ids['en'] );
+		$fr   = get_term( $tr_term_ids['fr'] );
+		$args = array();
+
+		if ( $with_parent ) {
+			$parent = self::factory()->term->create_and_get(
+				array(
+					'name'     => 'Le Foo',
+					'taxonomy' => $taxonomy,
+					'lang'     => 'fr',
+				)
+			);
+			$args['parent'] = $parent->term_id;
+		}
+
+		if ( $with_translations ) {
+			$args['translations'] = array(
+				'de'                                   => $lonely_term->term_id,
+				$with_language ? $spanish->slug : 'fr' => $fr->term_id,
+			);
+		}
+
+		if ( $with_language ) {
+			$args['lang'] = $spanish->slug;
+		}
+
+		$args['slug'] = $with_translations ? $lonely_term->slug : $en->slug;
+
+		$result = pll_update_term( $fr->term_id, $args );
+
+		$this->assertIsArray( $result, 'The term in French could not be updated.' );
+		$this->assertArrayHasKey( 'term_id', $result );
+		$this->assertArrayHasKey( 'term_taxonomy_id', $result );
+
+		$updated_term = get_term( $result['term_id'], $taxonomy );
+		$term_lang     = $with_language ? $spanish->slug : 'fr';
+		$expected_slug = "{$args['slug']}-{$term_lang}";
+
+		$this->assertSame( $expected_slug, $updated_term->slug );
+
+		$expected_language = $with_language ? $spanish->slug : 'fr';
+
+		$this->assertSame( $expected_language, $this->pll_env->model->term->get_language( $updated_term->term_id )->slug, 'The term language is not the right one.' );
+
+		$expected_translations = $with_translations
+			? $args['translations']
+			: array(
+				'en'                                   => $en->term_id,
+				$with_language ? $spanish->slug : 'fr' => $fr->term_id,
+			);
+
+		$this->assertSameSetsWithIndex( $expected_translations, $this->pll_env->model->term->get_translations( $updated_term->term_id ), "The term doesn't have the right translations." );
+	}
+
+	/**
+	 * @covers ::pll_update_term
+	 *
+	 * @testWith ["category", "en", "duplicate_term_slug"]
+	 *           ["post_tag", "en", "duplicate_term_slug"]
+	 *           ["tr_custom_tax", "en", "duplicate_term_slug"]
+	 *           ["category", "chti", "invalid_language"]
+	 *           ["post_tag", "chti", "invalid_language"]
+	 *           ["tr_custom_tax", "chti", "invalid_language"]
+	 *
+	 * @param string $taxonomy   Taxonomy name.
+	 * @param string $language   Language slug.
+	 * @param string $error_code Error code.
+	 * @return void
+	 */
+	public function test_pll_update_term_error_path( $taxonomy, $language, $error_code ) {
+		$term_ids = self::factory()->term->create_translated(
+			array(
+				'name'     => 'The Foo',
+				'taxonomy' => $taxonomy,
+				'lang'     => 'en',
+			),
+			array(
+				'name'     => 'Le Foo',
+				'taxonomy' => $taxonomy,
+				'lang'     => 'fr',
+			)
+		);
+
+		$args = array(
+			'slug' => 'the-foo',
+			'lang' => $language,
+		);
+
+		$result = pll_update_term( $term_ids['fr'], $args );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $error_code, $result->get_error_code() );
+	}
 }

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -21,6 +21,12 @@ class API_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang'] = $this->pll_env;
 	}
 
+	public function tear_down() {
+		unregister_taxonomy( 'tr_custom_tax' );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @covers ::pll_get_post
 	 */

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -86,7 +86,9 @@ class API_Test extends PLL_UnitTestCase {
 	 *           ["post_tag", false, false]
 	 *           ["tr_custom_tax", false, false]
 	 *
-	 * @param string $taxonomy
+	 * @param string $taxonomy          Taxonomy name.
+	 * @param bool   $with_parent       Whether or not the term has a parent.
+	 * @param bool   $with_translations Whether or not the term has translations.
 	 * @return void
 	 */
 	public function test_pll_insert_term_happy_path( $taxonomy, $with_parent, $with_translations ) {
@@ -94,7 +96,7 @@ class API_Test extends PLL_UnitTestCase {
 		$translations = array();
 		foreach ( $languages as $i => $language ) {
 			$args            = array();
-			$is_default_lang = $i === 0;
+			$is_default_lang = 0 === $i;
 
 			if ( $with_parent ) {
 				$parent = self::factory()->term->create_and_get(
@@ -140,7 +142,9 @@ class API_Test extends PLL_UnitTestCase {
 	 *           ["post_tag", "chti", "invalid_language"]
 	 *           ["tr_custom_tax", "chti", "invalid_language"]
 	 *
-	 * @param string $taxonomy
+	 * @param string $taxonomy   Taxonomy name.
+	 * @param string $language   Language slug.
+	 * @param string $error_code Error code.
 	 * @return void
 	 */
 	public function test_pll_insert_term_error_path( $taxonomy, $language, $error_code ) {

--- a/tests/phpunit/tests/test-api.php
+++ b/tests/phpunit/tests/test-api.php
@@ -92,7 +92,7 @@ class API_Test extends PLL_UnitTestCase {
 	public function test_pll_insert_term_happy_path( $taxonomy, $with_parent, $with_translations ) {
 		$languages    = array( 'en', 'fr', 'de' );
 		$translations = array();
-		foreach( $languages as $i => $language ) {
+		foreach ( $languages as $i => $language ) {
 			$args            = array();
 			$is_default_lang = $i === 0;
 
@@ -120,9 +120,11 @@ class API_Test extends PLL_UnitTestCase {
 			$translations[ $language ] = $result['term_id'];
 			$term                      = get_term( $result['term_id'], $taxonomy );
 
-			$prefix = $with_parent ? "{$parent->slug}-" : ''; // @fixme Polylang doesn't reuse parent slug and add a suffix with language slug instead...
-			$suffix = ! $is_default_lang ? "-{$language}" : '';
-			$expected_slug = "{$prefix}foo{$suffix}";
+			/*
+			 * @FIXME Polylang doesn't reuse parent slug and add a suffix with language slug instead...
+			 */
+			$suffix        = $with_parent || ! $is_default_lang ? "-{$language}" : '';
+			$expected_slug = "foo{$suffix}";
 
 			$this->assertSame( $expected_slug, $term->slug );
 		}


### PR DESCRIPTION
Adds wrapper for `wp_insert_term` and `wp_update_term` with the language.

This allows term slug handling when adding or updating a term.

See https://github.com/polylang/polylang-pro/pull/2135.