### PR TITLE
`prepare_raw_data()` returns options instead of an empty array

### DIFF
--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -252,8 +252,8 @@ class PLL_Settings_Module {
 	 * @param array $options Raw values to save.
 	 * @return array
 	 */
-	protected function prepare_raw_data( array $options ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return array(); // It's responsibility of the child class to decide what is saved.
+	protected function prepare_raw_data( array $options ): array {
+		return $options;
 	}
 
 	/**


### PR DESCRIPTION
After discussing this, since the options are fully validated and sanitized, requiring `prepare_raw_data()` to return only the values in question makes less sense.
This prevents a bug with classes that "forget" to extend this method (options not saved).
[Related comment](https://github.com/polylang/polylang/pull/1481/files#r1618738580).