### PR TITLE
Adds a condition not to update page_on_front and page_for_posts options

### DIFF
--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -190,55 +190,6 @@ class PLL_Static_Pages {
 	}
 
 	/**
-	 * Translates the page on front option.
-	 *
-	 * @since 1.8
-	 * @since 3.3 Was previously defined in PLL_Frontend_Static_Pages.
-	 *
-	 * @param  int $page_id ID of the page on front.
-	 * @return int
-	 */
-	public function translate_page_on_front( $page_id ) {
-		if ( empty( $this->curlang->page_on_front ) ) {
-			return $page_id;
-		}
-
-		if ( doing_action( 'update_option_page_on_front' ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
-			/*
-			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
-			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
-			 */
-			return $page_id;
-		}
-
-		return $this->curlang->page_on_front;
-	}
-
-	/**
-	 * Translates the page for posts option.
-	 *
-	 * @since 1.8
-	 *
-	 * @param  int $page_id ID of the page for posts.
-	 * @return int
-	 */
-	public function translate_page_for_posts( $page_id ) {
-		if ( empty( $this->curlang->page_for_posts ) ) {
-			return $page_id;
-		}
-
-		if ( doing_action( 'update_option_page_for_posts' ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
-			/*
-			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
-			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
-			 */
-			return $page_id;
-		}
-
-		return $this->curlang->page_for_posts;
-	}
-
-	/**
 	 * Modifies the page link in case the front page is not in the default language.
 	 *
 	 * @since 0.7.2

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -178,7 +178,7 @@ class PLL_Static_Pages {
 			return $page_id;
 		}
 
-		if ( doing_action( 'update_option_page_on_front' ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
+		if ( doing_action( "update_option_{$option}" ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
 			/*
 			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
 			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -159,8 +159,8 @@ class PLL_Static_Pages {
 	 */
 	public function pll_language_defined() {
 		// Translates page for posts and page on front.
-		add_filter( 'option_page_on_front', array( $this, 'translate_page_id' ) );
-		add_filter( 'option_page_for_posts', array( $this, 'translate_page_id' ) );
+		add_filter( 'option_page_on_front', array( $this, 'translate_page_id' ), 10, 2 );
+		add_filter( 'option_page_for_posts', array( $this, 'translate_page_id' ), 10, 2 );
 	}
 
 	/**
@@ -168,11 +168,12 @@ class PLL_Static_Pages {
 	 *
 	 * @since 3.6 Replaces `translate_page_on_front()` and `translate_page_on_front()` methods.
 	 *
-	 * @param  int $page_id ID of the page on front or page for posts.
+	 * @param  int    $page_id ID of the page on front or page for posts.
+	 * @param  string $option Option name: `page_on_front` or `page_for_posts`.
 	 * @return int
 	 */
-	public function translate_page_id( $page_id ) {
-		$prop = str_replace( 'option_', '', current_filter() );
+	public function translate_page_id( $page_id, $option ) {
+		$prop = str_replace( 'option_', '', $option );
 
 		if ( empty( $this->curlang->{$prop} ) ) {
 			return $page_id;

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -159,8 +159,34 @@ class PLL_Static_Pages {
 	 */
 	public function pll_language_defined() {
 		// Translates page for posts and page on front.
-		add_filter( 'option_page_on_front', array( $this, 'translate_page_on_front' ) );
-		add_filter( 'option_page_for_posts', array( $this, 'translate_page_for_posts' ) );
+		add_filter( 'option_page_on_front', array( $this, 'translate_page_id' ) );
+		add_filter( 'option_page_for_posts', array( $this, 'translate_page_id' ) );
+	}
+
+	/**
+	 * Translates the page on front or page for posts option.
+	 *
+	 * @since 3.6 Replaces `translate_page_on_front()` and `translate_page_on_front()` methods.
+	 *
+	 * @param  int $page_id ID of the page on front or page for posts.
+	 * @return int
+	 */
+	public function translate_page_id( $page_id ) {
+		$prop = str_replace( 'option_', '', current_filter() );
+
+		if ( empty( $this->curlang->{$prop} ) ) {
+			return $page_id;
+		}
+
+		if ( doing_action( 'update_option_page_on_front' ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
+			/*
+			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
+			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
+			 */
+			return $page_id;
+		}
+
+		return $this->curlang->{$prop};
 	}
 
 	/**

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -182,6 +182,7 @@ class PLL_Static_Pages {
 			/*
 			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
 			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
+			 * Don't translate while updating the option itself.
 			 */
 			return $page_id;
 		}

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -173,9 +173,8 @@ class PLL_Static_Pages {
 	 * @return int
 	 */
 	public function translate_page_id( $page_id, $option ) {
-		$prop = str_replace( 'option_', '', $option );
 
-		if ( empty( $this->curlang->{$prop} ) ) {
+		if ( empty( $this->curlang->{$option} ) ) {
 			return $page_id;
 		}
 
@@ -188,7 +187,7 @@ class PLL_Static_Pages {
 			return $page_id;
 		}
 
-		return $this->curlang->{$prop};
+		return $this->curlang->{$option};
 	}
 
 	/**

--- a/include/static-pages.php
+++ b/include/static-pages.php
@@ -177,7 +177,7 @@ class PLL_Static_Pages {
 			return $page_id;
 		}
 
-		if ( doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
+		if ( doing_action( 'update_option_page_on_front' ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
 			/*
 			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
 			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.
@@ -201,7 +201,7 @@ class PLL_Static_Pages {
 			return $page_id;
 		}
 
-		if ( doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
+		if ( doing_action( 'update_option_page_for_posts' ) || doing_action( 'switch_blog' ) || doing_action( 'before_delete_post' ) || doing_action( 'wp_trash_post' ) ) {
 			/*
 			 * Don't attempt to translate in a 'switch_blog' action as there is a risk to call this function while initializing the languages cache.
 			 * Don't translate while deleting a post or it will mess up `_reset_front_page_settings_for_post()`.

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -776,4 +776,43 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 2178
+	 * @see https://github.com/polylang/polylang-pro/issues/2178
+	 *
+	 * @return void
+	 */
+	public function test_update_page_on_front_option_with_admin_language_filter_activated() {
+		$this->init_test( 'admin' );
+
+		// Create a new home page without translation to update `page_on_front` option later.
+		$en = self::factory()->post->create(
+			array(
+				'post_title'   => 'new home',
+				'post_type'    => 'page',
+				'post_content' => 'Home without translation',
+				'lang'         => 'en',
+			),
+		);
+
+		// Set the Polylang Admin language filter to English.
+		$this->pll_env->filter_lang = $this->pll_env->model->get_language( 'en' );
+		$this->pll_env->set_current_language();
+
+		$this->assertSame( self::$home_en, get_option( 'page_on_front' ), 'Expected the page on front in English to be ' . self::$home_en );
+
+		// Updates the `page_on_front` option with the untranslated new page.
+		update_option( 'page_on_front', $en );
+
+		// Checks the `page_on_front` property of the English language is correctly updated.
+		$this->assertSame( $en, $this->pll_env->model->get_language('en')->page_on_front, 'Expected `page_on_front` property of the English language to be ' . $en );
+
+		// Simulate another process after updating `page_on_front` option: refresh the edit option page for example.
+		$this->pll_env->filter_lang = $this->pll_env->model->get_language( 'en' );
+		$this->pll_env->set_current_language();
+
+		$this->assertSame( $en, get_option( 'page_on_front' ), 'Expected the page on front to be ' . $en );
+
+	}
 }

--- a/tests/phpunit/tests/test-static-pages.php
+++ b/tests/phpunit/tests/test-static-pages.php
@@ -793,7 +793,7 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 				'post_type'    => 'page',
 				'post_content' => 'Home without translation',
 				'lang'         => 'en',
-			),
+			)
 		);
 
 		// Set the Polylang Admin language filter to English.
@@ -806,13 +806,12 @@ class Static_Pages_Test extends PLL_UnitTestCase {
 		update_option( 'page_on_front', $en );
 
 		// Checks the `page_on_front` property of the English language is correctly updated.
-		$this->assertSame( $en, $this->pll_env->model->get_language('en')->page_on_front, 'Expected `page_on_front` property of the English language to be ' . $en );
+		$this->assertSame( $en, $this->pll_env->model->get_language( 'en' )->page_on_front, 'Expected `page_on_front` property of the English language to be ' . $en );
 
 		// Simulate another process after updating `page_on_front` option: refresh the edit option page for example.
 		$this->pll_env->filter_lang = $this->pll_env->model->get_language( 'en' );
 		$this->pll_env->set_current_language();
 
 		$this->assertSame( $en, get_option( 'page_on_front' ), 'Expected the page on front to be ' . $en );
-
 	}
 }

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -34,7 +34,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 
-		$return = $this->frontend->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+		$return = get_option( 'page_for_posts' );
 
 		$this->assertEquals( $en, $return );
 	}
@@ -54,7 +54,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-		$return = $this->frontend->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+		$return = get_option( 'page_for_posts' );
 
 		$this->assertEquals( $fr, $return );
 	}
@@ -69,7 +69,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-		$return = $this->frontend->static_pages->translate_page_for_posts( get_option( 'page_for_posts' ) );
+		$return = get_option( 'page_for_posts' );
 
 		$this->assertEquals( $en, $return );
 	}

--- a/tests/phpunit/tests/test-translate-page-for-posts.php
+++ b/tests/phpunit/tests/test-translate-page-for-posts.php
@@ -34,9 +34,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 
-		$return = get_option( 'page_for_posts' );
-
-		$this->assertEquals( $en, $return );
+		$this->assertSame( $en, get_option( 'page_for_posts' ) );
 	}
 
 	public function test_translate_page_for_posts_on_secondary_language() {
@@ -54,9 +52,7 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-		$return = get_option( 'page_for_posts' );
-
-		$this->assertEquals( $fr, $return );
+		$this->assertSame( $fr, get_option( 'page_for_posts' ) );
 	}
 
 	public function test_translate_page_for_posts_when_page_for_posts_has_no_translations() {
@@ -69,8 +65,6 @@ class Translate_Page_For_Posts_Test extends PLL_UnitTestCase {
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
 
-		$return = get_option( 'page_for_posts' );
-
-		$this->assertEquals( $en, $return );
+		$this->assertSame( $en, get_option( 'page_for_posts' ) );
 	}
 }


### PR DESCRIPTION
fixes https://github.com/polylang/polylang-pro/issues/2178

## What?
When updating WordPress static page `page_on_front` (or `page_for_posts`) option this option is correctly updated in DB but not in the `languages_list` Polylang transient for the concerned language.

- start updating `page_on_front` option with the Polylang language admin filter set to a specific language.
- when Polylang initializes, it gets `page_on_front` option from the Polylang language filter (`filter_lang` property) which is gotten from `languages_list` transient.
- it sets current language with the filter language.
- WordPress updates the `page_on_front` option in DB
- Polylang deletes its `languages_list` transient by calling `PLL_Static_Pages::clean_cache()` to make it updatable.
- then Poylang runs `PLL_Static_Pages::init()` to get the new `page_on_front` option value.
- then Polylang runs `PLL_Static_Pages::translate_page_on_front()` hooked on `option_page_on_front` action.
- As Polylang current language `page_on_front` property isn't empty and we aren't in one of the 3 actions '`switch_blog`', '`before_delete_post`' or '`wp_trash_post`', the returned value is Polylang current language `page_on_front` property instead of the new `page_on_front` option value in DB.

## How?
Adds a condition not to update `page_on_front` and `page_for_posts` options with translated ids when these options are being updated i.e. when doing respectively `update_option_page_on_front` or `update_option_page_for_posts` action.