### PR TITLE
Improvements proposal for the default term in backend

### DIFF
--- a/admin/admin-default-term.php
+++ b/admin/admin-default-term.php
@@ -10,18 +10,6 @@
  * @since 3.7 Extends `PLL_Default_Term`, most of the code is moved to it.
  */
 class PLL_Admin_Default_Term extends PLL_Default_Term {
-	/**
-	 * Constructor: setups properties.
-	 *
-	 * @since 3.1
-	 *
-	 * @param object $polylang The Polylang object.
-	 */
-	public function __construct( &$polylang ) {
-		$this->model      = &$polylang->model;
-		$this->curlang    = &$polylang->pref_lang;
-		$this->taxonomies = $this->model->get_translated_taxonomies();
-	}
 
 	/**
 	 * Setups filters and actions needed.
@@ -36,7 +24,7 @@ class PLL_Admin_Default_Term extends PLL_Default_Term {
 		foreach ( $this->taxonomies as $taxonomy ) {
 			if ( 'category' === $taxonomy ) {
 				// Adds the language column in the 'Terms' table.
-				add_filter( 'manage_' . $taxonomy . '_custom_column', array( $this, 'term_column' ), 10, 3 );
+				add_filter( 'pll_first_language_term_column', array( $this, 'first_language_column' ), 10, 2 );
 			}
 		}
 	}
@@ -44,35 +32,17 @@ class PLL_Admin_Default_Term extends PLL_Default_Term {
 	/**
 	 * Identifies the default term in the terms list table to disable the language dropdown in JS.
 	 *
-	 * @since 3.1
+	 * @since 3.7
 	 *
 	 * @param  string $out     The output.
-	 * @param  string $column  The custom column's name.
 	 * @param  int    $term_id The term id.
 	 * @return string          The HTML string.
 	 */
-	public function term_column( $out, $column, $term_id ) {
-		if ( $column === $this->get_first_language_column() && $this->is_default_term( $term_id ) ) {
+	public function first_language_column( $out, $term_id ) {
+		if ( $this->is_default_term( $term_id ) ) {
 			$out .= sprintf( '<div class="hidden" id="default_cat_%1$d">%1$d</div>', intval( $term_id ) );
 		}
 
 		return $out;
-	}
-
-	/**
-	 * Returns the first language column in the posts, pages and media library tables.
-	 *
-	 * @since 0.9
-	 *
-	 * @return string First language column name.
-	 */
-	protected function get_first_language_column() {
-		$columns = array();
-
-		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[] = 'language_' . $language->slug;
-		}
-
-		return empty( $columns ) ? '' : reset( $columns );
 	}
 }

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -88,20 +88,18 @@ class PLL_Admin_Filters_Columns {
 	}
 
 	/**
-	 * Returns the first language column in the posts, pages and media library tables
+	 * Returns the first language column in posts, pages, media, categories and tags tables.
 	 *
 	 * @since 0.9
 	 *
-	 * @return string first language column name
+	 * @return string first language column name.
 	 */
 	protected function get_first_language_column() {
-		$columns = array();
-
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[] = 'language_' . $language->slug;
+			return 'language_' . $language->slug;
 		}
 
-		return empty( $columns ) ? '' : reset( $columns );
+		return '';
 	}
 
 	/**
@@ -300,10 +298,6 @@ class PLL_Admin_Filters_Columns {
 			return $out;
 		}
 
-		if ( $column == $this->get_first_language_column() ) {
-			$out .= sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );
-		}
-
 		// Link to edit term ( or a translation )
 		if ( ( $id = $this->model->term->get( $term_id, $language ) ) && $term = get_term( $id, $taxonomy ) ) {
 			if ( $term instanceof WP_Term && $link = get_edit_term_link( $id, $taxonomy, $post_type ) ) {
@@ -339,6 +333,21 @@ class PLL_Admin_Filters_Columns {
 		// Link to add a new translation
 		else {
 			$out .= $this->links->new_term_translation_link( $term_id, $taxonomy, $post_type, $language );
+		}
+
+		if ( $column == $this->get_first_language_column() ) {
+			$out .= sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );
+
+			/**
+			 * Filters the output of the first language column in the terms list table.
+			 *
+			 * @since 3.7
+			 *
+			 * @param string $output  First language column output.
+			 * @param int    $term_id Term ID
+			 * @param string $lang    Language code.
+			 */
+			$out = apply_filters( 'pll_first_language_term_column', $out, $term_id, $lang->slug );
 		}
 
 		return $out;

--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -335,7 +335,7 @@ class PLL_Admin_Filters_Columns {
 			$out .= $this->links->new_term_translation_link( $term_id, $taxonomy, $post_type, $language );
 		}
 
-		if ( $column == $this->get_first_language_column() ) {
+		if ( $this->get_first_language_column() === $column ) {
 			$out .= sprintf( '<div class="hidden" id="lang_%d">%s</div>', intval( $term_id ), esc_html( $lang->slug ) );
 
 			/**
@@ -344,7 +344,7 @@ class PLL_Admin_Filters_Columns {
 			 * @since 3.7
 			 *
 			 * @param string $output  First language column output.
-			 * @param int    $term_id Term ID
+			 * @param int    $term_id Term ID.
 			 * @param string $lang    Language code.
 			 */
 			$out = apply_filters( 'pll_first_language_term_column', $out, $term_id, $lang->slug );

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -79,7 +79,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$default = (int) get_option( 'default_category' );
 
 		// with capability
-		$column = $this->pll_admin->default_term->term_column( '', 'language_en', $default );
+		$column = $this->pll_admin->filters_columns->term_column( '', 'language_en', $default );
 		$this->assertNotFalse( strpos( $column, 'default_cat' ) );
 	}
 
@@ -148,7 +148,7 @@ class Default_Term_Test extends PLL_UnitTestCase {
 
 		$this->assertEquals( 'en', $option_lang->slug );
 
-		$this->pll_admin->pref_lang = self::$model->get_language( 'es' );
+		$this->pll_admin->curlang = self::$model->get_language( 'es' );
 
 		$option = get_option( 'default_category' );
 		$option_lang = self::$model->term->get_language( $option );


### PR DESCRIPTION
Context: `PLL_Admin_Default_Term` is split in #1505.

- Introduces a new filter `pll_first_language_term_column` to filter specifically the output of the first language column in the terms list table. This allows to remove the method `get_first_language_column()` in `PLL_Admin_Default_term` which duplicates the same method in `PLL_Admin_Filters_Columns`.
- Simplifies the method `get_first_language_column()`.
- Removes the constructor of `PLL_Admin_Default_Term`. The only difference with the parent constructor was the current language assigned to`$tpref_lang` instead of `$curlang` but in fact both are the same in the terms list table which is the only screen where the class acts.
- Adapts 2 tests. 

Considering new the size of `PLL_Admin_Default_Term`, we could envisage to merge it back to `PLL_Default_Term`:
- Pro: Further reduces the code size
- Con: Doesn't separate the code specific to the backend.