### PR TITLE
Fix doing_it_wrong bypass for tests with Polylang < 3.7

### DIFF
--- a/tests/phpunit/includes/doing-it-wrong-trait.php
+++ b/tests/phpunit/includes/doing-it-wrong-trait.php
@@ -40,6 +40,14 @@ trait PLL_Doing_It_Wrong_Trait {
 			return;
 		}
 
+		/*
+		 * Backward compatibility with Polylang < 3.7, useful to use the latest test library
+		 * when testing Polylang for WooCommerce with older versions of Polylang.
+		 */
+		if ( 'PLL_Model::get_languages_list()' === $function ) {
+			return;
+		}
+
 		parent::doing_it_wrong_run( $function, $message, $version );
 	}
 }


### PR DESCRIPTION
Follow up of #1503
This fixes errors in Polylang for WooCommerce tests with versions of Polylang < 3.7. 
```
Unexpected incorrect usage notice for PLL_Model::get_languages_list().
It must not be called before the hook 'pll_pre_init'. (This message was added in version 3.4.)
```
See https://github.com/polylang/polylang-wc/actions/runs/10055352573/job/28254391160