### PR TITLE
Hide "set language from content" option.

### DIFF
--- a/include/Options/Business/Force_Lang.php
+++ b/include/Options/Business/Force_Lang.php
@@ -51,7 +51,7 @@ class Force_Lang extends Abstract_Option {
 	protected function get_data_structure(): array {
 		return array(
 			'type' => 'integer',
-			'enum' => 'yes' === get_option( 'pll_set_language_from_content_available' ) ? array( 0, 1, 2, 3 ) : array( 1, 2, 3 ),
+			'enum' => 'yes' === get_option( 'pll_language_from_content_available' ) ? array( 0, 1, 2, 3 ) : array( 1, 2, 3 ),
 		);
 	}
 

--- a/include/Options/Business/Force_Lang.php
+++ b/include/Options/Business/Force_Lang.php
@@ -16,26 +16,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Force_Lang extends Abstract_Option {
 	/**
-	 * @var array
-	 */
-	private $enum = array( 1, 2, 3 );
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 3.7
-	 *
-	 * @param mixed $value Option value. Use `null` to set the default value.
-	 */
-	public function __construct( $value = null ) {
-		if ( true === get_option( 'pll_set_language_from_content_available', false ) ) {
-			$this->enum = array( 0, 1, 2, 3 );
-		}
-
-		parent::__construct( $value );
-	}
-
-	/**
 	 * Returns option key.
 	 *
 	 * @since 3.7
@@ -66,12 +46,12 @@ class Force_Lang extends Abstract_Option {
 	 *
 	 * @return array Partial schema.
 	 *
-	 * @phpstan-return array{type: 'integer', enum: list<0|1|2|3>}
+	 * @phpstan-return array{type: 'integer', enum: list<0|1|2|3>|list<1|2|3>}
 	 */
 	protected function get_data_structure(): array {
 		return array(
 			'type' => 'integer',
-			'enum' => $this->enum,
+			'enum' => 'yes' === get_option( 'pll_set_language_from_content_available' ) ? array( 0, 1, 2, 3 ) : array( 1, 2, 3 ),
 		);
 	}
 

--- a/include/Options/Business/Force_Lang.php
+++ b/include/Options/Business/Force_Lang.php
@@ -16,6 +16,26 @@ defined( 'ABSPATH' ) || exit;
  */
 class Force_Lang extends Abstract_Option {
 	/**
+	 * @var array
+	 */
+	private $enum = array( 1, 2, 3 );
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.7
+	 *
+	 * @param mixed $value Option value. Use `null` to set the default value.
+	 */
+	public function __construct( $value = null ) {
+		if ( true === get_option( 'pll_set_language_from_content_available', false ) ) {
+			$this->enum = array( 0, 1, 2, 3 );
+		}
+
+		parent::__construct( $value );
+	}
+
+	/**
 	 * Returns option key.
 	 *
 	 * @since 3.7
@@ -51,7 +71,7 @@ class Force_Lang extends Abstract_Option {
 	protected function get_data_structure(): array {
 		return array(
 			'type' => 'integer',
-			'enum' => array( 0, 1, 2, 3 ),
+			'enum' => $this->enum,
 		);
 	}
 

--- a/install/install.php
+++ b/install/install.php
@@ -102,11 +102,12 @@ class PLL_Install extends PLL_Install_Base {
 			$options['version'] = POLYLANG_VERSION;
 		}
 
-		$set_language_from_content_available = false;
-		if ( 0 === $options['force_lang'] && is_null( get_option( 'pll_set_language_from_content_available', null ) ) ) {
-			$set_language_from_content_available = true;
+		if ( false === get_option( 'pll_set_language_from_content_available' ) ) {
+			update_option(
+				'pll_set_language_from_content_available',
+				0 === $options['force_lang'] ? 'yes' : 'no'
+			);
 		}
-		update_option( 'pll_set_language_from_content_available', $set_language_from_content_available, true );
 
 		$options->save(); // Force save here to prevent any conflicts with another instance of `Options`.
 

--- a/install/install.php
+++ b/install/install.php
@@ -102,9 +102,9 @@ class PLL_Install extends PLL_Install_Base {
 			$options['version'] = POLYLANG_VERSION;
 		}
 
-		if ( false === get_option( 'pll_set_language_from_content_available' ) ) {
+		if ( false === get_option( 'pll_language_from_content_available' ) ) {
 			update_option(
-				'pll_set_language_from_content_available',
+				'pll_language_from_content_available',
 				0 === $options['force_lang'] ? 'yes' : 'no'
 			);
 		}

--- a/install/install.php
+++ b/install/install.php
@@ -102,6 +102,12 @@ class PLL_Install extends PLL_Install_Base {
 			$options['version'] = POLYLANG_VERSION;
 		}
 
+		$set_language_from_content_available = false;
+		if ( 0 === $options['force_lang'] && is_null( get_option( 'pll_set_language_from_content_available', null ) ) ) {
+			$set_language_from_content_available = true;
+		}
+		update_option( 'pll_set_language_from_content_available', $set_language_from_content_available, true );
+
 		$options->save(); // Force save here to prevent any conflicts with another instance of `Options`.
 
 		// Avoid 1 query on every pages if no wpml strings is registered

--- a/install/install.php
+++ b/install/install.php
@@ -102,14 +102,14 @@ class PLL_Install extends PLL_Install_Base {
 			$options['version'] = POLYLANG_VERSION;
 		}
 
+		$options->save(); // Force save here to prevent any conflicts with another instance of `Options`.
+
 		if ( false === get_option( 'pll_language_from_content_available' ) ) {
 			update_option(
 				'pll_language_from_content_available',
 				0 === $options['force_lang'] ? 'yes' : 'no'
 			);
 		}
-
-		$options->save(); // Force save here to prevent any conflicts with another instance of `Options`.
 
 		// Avoid 1 query on every pages if no wpml strings is registered
 		if ( ! get_option( 'polylang_wpml_strings' ) ) {

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -212,7 +212,7 @@ class PLL_Upgrade {
 	 */
 	protected function upgrade_3_7() {
 		update_option(
-			'pll_set_language_from_content_available',
+			'pll_language_from_content_available',
 			0 === $this->options['force_lang'] ? 'yes' : 'no'
 		);
 	}

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -211,11 +211,10 @@ class PLL_Upgrade {
 	 * @return void
 	 */
 	protected function upgrade_3_7() {
-		$set_language_from_content_available = false;
-		if ( 0 === $this->options['force_lang'] ) {
-			$set_language_from_content_available = true;
-		}
-		update_option( 'pll_set_language_from_content_available', $set_language_from_content_available, true );
+		update_option(
+			'pll_set_language_from_content_available',
+			0 === $this->options['force_lang'] ? 'yes' : 'no'
+		);
 	}
 
 	/**

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -104,7 +104,7 @@ class PLL_Upgrade {
 	 * @return void
 	 */
 	public function _upgrade() {
-		foreach ( array( '2.0.8', '2.1', '2.7', '3.4' ) as $version ) {
+		foreach ( array( '2.0.8', '2.1', '2.7', '3.4', '3.7' ) as $version ) {
 			if ( version_compare( $this->options['version'], $version, '<' ) ) {
 				$method_to_call = array( $this, 'upgrade_' . str_replace( '.', '_', $version ) );
 				if ( is_callable( $method_to_call ) ) {
@@ -200,6 +200,22 @@ class PLL_Upgrade {
 		$this->migrate_locale_fallback_to_language_description();
 
 		$this->migrate_strings_translations();
+	}
+
+	/**
+	 * Upgrades if the previous version is < 3.7.
+	 * Hides the "The language is set from content" option if it isn't the one selected.
+	 *
+	 * @since 3.7
+	 *
+	 * @return void
+	 */
+	protected function upgrade_3_7() {
+		$set_language_from_content_available = false;
+		if ( 0 === $this->options['force_lang'] ) {
+			$set_language_from_content_available = true;
+		}
+		update_option( 'pll_set_language_from_content_available', $set_language_from_content_available, true );
 	}
 
 	/**

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -51,18 +51,26 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function force_lang() {
-		?>
-		<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by the content or by domains.', 'polylang' ); ?></p>
-		<label>
-			<?php
-			printf(
-				'<input name="force_lang" type="radio" value="0" %s /> %s',
-				checked( $this->options['force_lang'], 0, false ),
-				esc_html__( 'The language is set from content', 'polylang' )
-			);
+		if ( true === get_option( 'pll_set_language_from_content_available', false ) ) {
 			?>
-		</label>
-		<p class="description"><?php esc_html_e( 'Posts, pages, categories and tags URLs will not be modified.', 'polylang' ); ?></p>
+			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by the content or by domains.', 'polylang' ); ?></p>
+			<label>
+				<?php
+				printf(
+					'<input name="force_lang" type="radio" value="0" %s /> %s',
+					checked( $this->options['force_lang'], 0, false ),
+					esc_html__( 'The language is set from content', 'polylang' )
+				);
+				?>
+			</label>
+			<p class="description"><?php esc_html_e( 'Posts, pages, categories and tags URLs will not be modified.', 'polylang' ); ?></p>
+			<?php
+		} else {
+			?>
+			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by domains.', 'polylang' ); ?></p>
+			<?php
+		}
+		?>
 		<label>
 			<?php
 			printf(

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -51,7 +51,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function force_lang() {
-		if ( 'yes' === get_option( 'pll_set_language_from_content_available' ) ) {
+		if ( 'yes' === get_option( 'pll_language_from_content_available' ) ) {
 			?>
 			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by the content or by domains.', 'polylang' ); ?></p>
 			<label>

--- a/settings/settings-url.php
+++ b/settings/settings-url.php
@@ -51,7 +51,7 @@ class PLL_Settings_Url extends PLL_Settings_Module {
 	 * @return void
 	 */
 	protected function force_lang() {
-		if ( true === get_option( 'pll_set_language_from_content_available', false ) ) {
+		if ( 'yes' === get_option( 'pll_set_language_from_content_available' ) ) {
 			?>
 			<p class="description"><?php esc_html_e( 'Some themes or plugins may not be fully compatible with the language defined by the content or by domains.', 'polylang' ); ?></p>
 			<label>

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -20,7 +20,6 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		global $wp_rewrite;
 
-		update_option( 'pll_set_language_from_content_available', true );
 		$options = self::create_options(
 			array(
 				'hide_default' => 1,

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -20,9 +20,15 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		global $wp_rewrite;
 
-		self::$model->options['hide_default'] = 1;
-		self::$model->options['force_lang'] = 0;
-		self::$model->options['browser'] = 0;
+		update_option( 'pll_set_language_from_content_available', true );
+		$options = self::create_options(
+			array(
+				'hide_default' => 1,
+				'force_lang'   => 0,
+				'browser'      => 0,
+				'default_lang' => 'en',
+			)
+		);
 
 		// switch to pretty permalinks
 		$wp_rewrite->init();
@@ -31,7 +37,8 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		create_initial_taxonomies();
 
-		$links_model = self::$model->get_links_model();
+		$model = new PLL_Model( $options );
+		$links_model = $model->get_links_model();
 		$links_model->init();
 
 		// flush rules

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -1,5 +1,7 @@
 <?php
 
+use WP_Syntex\Polylang\Options\Options;
+
 class Install_Test extends PLL_UnitTestCase {
 
 	public function test_activate() {
@@ -13,6 +15,16 @@ class Install_Test extends PLL_UnitTestCase {
 		$this->assertSame( 1, $options['force_lang'] );
 		$this->assertEmpty( $options['sync'] );
 		$this->assertSame( POLYLANG_VERSION, $options['version'] );
+	}
+
+	public function test_should_hide_set_language_from_content_on_activation() {
+		delete_option( 'polylang' );
+		do_action( 'activate_' . POLYLANG_BASENAME );
+
+		$options = new Options();
+
+		$this->assertFalse( get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertInstanceOf( WP_Error::class, $options->set( 'force_lang', 0 ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -23,7 +23,7 @@ class Install_Test extends PLL_UnitTestCase {
 
 		$options = new Options();
 
-		$this->assertFalse( get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 'no', get_option( 'pll_set_language_from_content_available' ) );
 		$this->assertInstanceOf( WP_Error::class, $options->set( 'force_lang', 0 ) );
 	}
 

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -23,7 +23,7 @@ class Install_Test extends PLL_UnitTestCase {
 
 		$options = new Options();
 
-		$this->assertSame( 'no', get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 'no', get_option( 'pll_language_from_content_available' ) );
 		$this->assertInstanceOf( WP_Error::class, $options->set( 'force_lang', 0 ) );
 	}
 

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -113,7 +113,6 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_language_from_post_content() {
-		update_option( 'pll_set_language_from_content_available', true );
 		$options = self::create_options(
 			array(
 				'hide_default' => 1,

--- a/tests/phpunit/tests/test-links-default.php
+++ b/tests/phpunit/tests/test-links-default.php
@@ -113,8 +113,18 @@ class Links_Default_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_language_from_post_content() {
-		self::$model->options['force_lang'] = 0;
-		$frontend = new PLL_Frontend( $this->links_model );
+		update_option( 'pll_set_language_from_content_available', true );
+		$options = self::create_options(
+			array(
+				'hide_default' => 1,
+				'force_lang'   => 0,
+				'browser'      => 0,
+				'default_lang' => 'en',
+			)
+		);
+		$model       = new PLL_Model( $options );
+		$links_model = $model->get_links_model();
+		$frontend    = new PLL_Frontend( $links_model );
 		new PLL_Filters_Links( $frontend );
 
 		$fr = self::factory()->post->create();

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -54,9 +54,9 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 	 * @param mixed       $value           The value to test.
 	 * @param int         $sanitized_value Sanitized value.
 	 * @param true|string $expected_valid  Validation result.
-	 * @param bool        $show_0          Tells if the choice `0` (i.e. "Language set from content") is available.
+	 * @param string      $show_0          Tells if the choice `0` (i.e. "Language set from content") is available, accepts `'yes'` or `'not'`.
 	 */
-	public function test_force_lang( $value, int $sanitized_value, $expected_valid, $show_0 = false ) {
+	public function test_force_lang( $value, int $sanitized_value, $expected_valid, $show_0 = 'no' ) {
 		update_option( 'pll_set_language_from_content_available', $show_0 );
 		$this->test_option( Business\Force_Lang::class, $value, $sanitized_value, $expected_valid );
 	}
@@ -235,13 +235,13 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 				'value'           => 0,
 				'sanitized_value' => 0,
 				'expected_valid'  => true,
-				'show_0'          => true,
+				'show_0'          => 'yes',
 			),
 			'0 hidden'     => array(
 				'value'           => 0,
 				'sanitized_value' => 0,
 				'expected_valid'  => 'rest_not_in_enum',
-				'show_0'          => false,
+				'show_0'          => 'no',
 			),
 			'in list'     => array(
 				'value'           => 2,

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -57,7 +57,7 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 	 * @param string      $show_0          Tells if the choice `0` (i.e. "Language set from content") is available, accepts `'yes'` or `'not'`.
 	 */
 	public function test_force_lang( $value, int $sanitized_value, $expected_valid, $show_0 = 'no' ) {
-		update_option( 'pll_set_language_from_content_available', $show_0 );
+		update_option( 'pll_language_from_content_available', $show_0 );
 		$this->test_option( Business\Force_Lang::class, $value, $sanitized_value, $expected_valid );
 	}
 

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -54,8 +54,10 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 	 * @param mixed       $value           The value to test.
 	 * @param int         $sanitized_value Sanitized value.
 	 * @param true|string $expected_valid  Validation result.
+	 * @param bool        $show_0          Tells if the choice `0` (i.e. "Language set from content") is available.
 	 */
-	public function test_force_lang( $value, int $sanitized_value, $expected_valid ) {
+	public function test_force_lang( $value, int $sanitized_value, $expected_valid, $show_0 = false ) {
+		update_option( 'pll_set_language_from_content_available', $show_0 );
 		$this->test_option( Business\Force_Lang::class, $value, $sanitized_value, $expected_valid );
 	}
 
@@ -229,6 +231,18 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 
 	public function force_lang_provider() {
 		return array(
+			'0 displayed'    => array(
+				'value'           => 0,
+				'sanitized_value' => 0,
+				'expected_valid'  => true,
+				'show_0'          => true,
+			),
+			'0 hidden'     => array(
+				'value'           => 0,
+				'sanitized_value' => 0,
+				'expected_valid'  => 'rest_not_in_enum',
+				'show_0'          => false,
+			),
 			'in list'     => array(
 				'value'           => 2,
 				'sanitized_value' => 2,

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -54,7 +54,7 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 	 * @param mixed       $value           The value to test.
 	 * @param int         $sanitized_value Sanitized value.
 	 * @param true|string $expected_valid  Validation result.
-	 * @param string      $show_0          Tells if the choice `0` (i.e. "Language set from content") is available, accepts `'yes'` or `'not'`.
+	 * @param string      $show_0          Tells if the choice `0` (i.e. "Language set from content") is available, accepts `'yes'` or `'no'`.
 	 */
 	public function test_force_lang( $value, int $sanitized_value, $expected_valid, $show_0 = 'no' ) {
 		update_option( 'pll_language_from_content_available', $show_0 );

--- a/tests/phpunit/tests/test-upgrade.php
+++ b/tests/phpunit/tests/test-upgrade.php
@@ -92,7 +92,7 @@ class Upgrade_Test extends PLL_UnitTestCase {
 
 		( new PLL_Upgrade( $options ) )->_upgrade();
 
-		$this->assertFalse( get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 'no', get_option( 'pll_set_language_from_content_available' ) );
 		$this->assertSame( 1, $options->get( 'force_lang' ) );
 	}
 
@@ -106,7 +106,7 @@ class Upgrade_Test extends PLL_UnitTestCase {
 
 		( new PLL_Upgrade( $options ) )->_upgrade();
 
-		$this->assertTrue( get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 'yes', get_option( 'pll_set_language_from_content_available' ) );
 		$this->assertSame( 0, $options->get( 'force_lang' ) );
 	}
 }

--- a/tests/phpunit/tests/test-upgrade.php
+++ b/tests/phpunit/tests/test-upgrade.php
@@ -9,6 +9,12 @@ class Upgrade_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 	}
 
+	public function tear_down() {
+		delete_option( 'pll_set_language_from_content_available' );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket #1664 see {https://github.com/polylang/polylang-pro/issues/1664}.
 	 */
@@ -74,5 +80,33 @@ class Upgrade_Test extends PLL_UnitTestCase {
 
 		$this->assertSameSets( $expected_transient, get_transient( 'pll_languages_list' ), 'Old pll_languages_list transient should have been deleted during upgrade.' );
 		$this->assertSame( POLYLANG_VERSION, $admin->options['version'], 'Polylang version should have been updated.' );
+	}
+
+	public function test_should_hide_language_defined_from_content_option_on_upgrade_to_3_7() {
+		$options = self::create_options(
+			array(
+				'force_lang' => 1,
+				'version'    => '3.6',
+			)
+		);
+
+		( new PLL_Upgrade( $options ) )->_upgrade();
+
+		$this->assertFalse( get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 1, $options->get( 'force_lang' ) );
+	}
+
+	public function test_should_not_hide_language_defined_from_content_option_on_upgrade_to_3_7() {
+		$options = self::create_options(
+			array(
+				'force_lang' => 0,
+				'version'    => '3.6',
+			)
+		);
+
+		( new PLL_Upgrade( $options ) )->_upgrade();
+
+		$this->assertTrue( get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 0, $options->get( 'force_lang' ) );
 	}
 }

--- a/tests/phpunit/tests/test-upgrade.php
+++ b/tests/phpunit/tests/test-upgrade.php
@@ -10,7 +10,7 @@ class Upgrade_Test extends PLL_UnitTestCase {
 	}
 
 	public function tear_down() {
-		delete_option( 'pll_set_language_from_content_available' );
+		delete_option( 'pll_language_from_content_available' );
 
 		parent::tear_down();
 	}
@@ -92,7 +92,7 @@ class Upgrade_Test extends PLL_UnitTestCase {
 
 		( new PLL_Upgrade( $options ) )->_upgrade();
 
-		$this->assertSame( 'no', get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 'no', get_option( 'pll_language_from_content_available' ) );
 		$this->assertSame( 1, $options->get( 'force_lang' ) );
 	}
 
@@ -106,7 +106,7 @@ class Upgrade_Test extends PLL_UnitTestCase {
 
 		( new PLL_Upgrade( $options ) )->_upgrade();
 
-		$this->assertSame( 'yes', get_option( 'pll_set_language_from_content_available' ) );
+		$this->assertSame( 'yes', get_option( 'pll_language_from_content_available' ) );
 		$this->assertSame( 0, $options->get( 'force_lang' ) );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -127,6 +127,7 @@ class PLL_Uninstall {
 		delete_option( 'polylang_wpml_strings' ); // Strings registered with icl_register_string
 		delete_option( 'polylang_licenses' );
 		delete_option( 'pll_dismissed_notices' );
+		delete_option( 'pll_language_from_content_available' );
 
 		// Delete transients
 		delete_transient( 'pll_languages_list' );


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/1921
Follows and replaces https://github.com/polylang/polylang/pull/1431
I created a new PR given this [comment](https://github.com/polylang/polylang/pull/1431#pullrequestreview-2218467606), which changes the way the option is hidden. Felt easier to me. Kudo to @Screenfeed for all the preliminary work and tests.

## How?
- Create a new raw option during install or upgrade, named `pll_set_language_from_content_available`.
- Set this option to `false` whenever it is a fresh install or an upgrade with `force_lang` not using "set language from content". Otherwise set the option to `true`.
- Use `pll_set_language_from_content_available` to hide `force_lang` choice corresponding to "set language from content" (i.e. `0`).