### PR TITLE
Fix REST Languages collection

### DIFF
--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -141,13 +141,14 @@ class Languages extends WP_REST_Controller {
 	 * @phpstan-param WP_REST_Request<T> $request
 	 */
 	public function get_items( $request ) {
-		$languages = array();
+		$response = array();
 
 		foreach ( $this->languages->get_list() as $language ) {
-			$languages[] = $this->prepare_item_for_response( $language, $request );
+			$language   = $this->prepare_item_for_response( $language, $request );
+			$response[] = $this->prepare_response_for_collection( $language );
 		}
 
-		return rest_ensure_response( $languages );
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-rest-languages.php
+++ b/tests/phpunit/tests/test-rest-languages.php
@@ -60,8 +60,6 @@ class REST_Languages_Test extends PLL_UnitTestCase {
 		$this->assertCount( 3, $data );
 
 		foreach ( $data as $response_data ) {
-			$this->assertInstanceOf( WP_REST_Response::class, $response_data );
-			$response_data = $response_data->get_data();
 			$this->assertIsArray( $response_data );
 			$this->assertArrayHasKey( 'locale', $response_data );
 			$this->assertContains( $response_data['locale'], $locales );


### PR DESCRIPTION
In #1505, we introduced a REST endpoint for languages. However the response of `get_items()` is malformed. It includes an array of `WP_REST_Response` when we expect an array of items. The call to [`prepare_response_for_collection()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/prepare_response_for_collection/) was forgotten.
The corresponding test is fixed as the expectation was wrong too. 