### PR TITLE
Fix nav menus option schema

### DIFF
--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -50,13 +50,13 @@ class Nav_Menus extends Abstract_Option {
 		return array(
 			'type'                 => 'object', // Correspond to associative array in PHP, @see{https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#primitive-types}.
 			'patternProperties'    => array(
-				'^\\w+$' => array( // Any word characters as key, correspond to a theme slug.
+				'[^\/:<>\*\?"\|]+' => array( // Excludes invalid directory name caharacters @see https://developer.wordpress.org/reference/classes/wp_rest_themes_controller/register_routes/
 					'type'                 => 'object',
 					'patternProperties'    => array(
-						'^\\w+$' => array( // Any word characters as key, correspond to a nav menu location.
+						'[\w-]+' => array( // Accepted characters for menu locations @see https://developer.wordpress.org/reference/classes/wp_rest_menu_locations_controller/register_routes/
 							'type'              => 'object',
 							'patternProperties' => array(
-								'^[a-z_-]+$' => array( // Language slug as key.
+								'[a-z_-]+' => array( // Language slug as key.
 									'type'    => 'integer',
 									'minimum' => 0, // A post ID.
 								),

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -50,7 +50,7 @@ class Nav_Menus extends Abstract_Option {
 		return array(
 			'type'                 => 'object', // Correspond to associative array in PHP, @see{https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#primitive-types}.
 			'patternProperties'    => array(
-				'[^\/:<>\*\?"\|]+' => array( // Excludes invalid directory name caharacters @see https://developer.wordpress.org/reference/classes/wp_rest_themes_controller/register_routes/
+				'[^\/:<>\*\?"\|]+' => array( // Excludes invalid directory name characters @see https://developer.wordpress.org/reference/classes/wp_rest_themes_controller/register_routes/
 					'type'                 => 'object',
 					'patternProperties'    => array(
 						'[\w-]+' => array( // Accepted characters for menu locations @see https://developer.wordpress.org/reference/classes/wp_rest_menu_locations_controller/register_routes/

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -45,36 +45,23 @@ class Nav_Menus extends Abstract_Option {
 	 * @since 3.7
 	 *
 	 * @return array Partial schema.
-	 *
-	 * @phpstan-return array{
-	 *     type: 'object',
-	 *     patternProperties: array{
-	 *         '^\w+$': array{
-	 *             type: 'object',
-	 *             context: list<'edit'>,
-	 *             patternProperties: array{
-	 *                 '^[a-z_-]+$': array{
-	 *                     type: 'integer',
-	 *                     minimum: 0
-	 *                 }
-	 *             },
-	 *             additionalProperties: false
-	 *         }
-	 *     },
-	 *     additionalProperties: false
-	 * }
 	 */
 	protected function get_data_structure(): array {
 		return array(
 			'type'                 => 'object', // Correspond to associative array in PHP, @see{https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#primitive-types}.
 			'patternProperties'    => array(
 				'^\\w+$' => array( // Any word characters as key, correspond to a theme slug.
-					'type'              => 'object',
-					'context'           => array( 'edit' ),
-					'patternProperties' => array(
-						'^[a-z_-]+$' => array( // Language slug as key.
-							'type'    => 'integer',
-							'minimum' => 0, // A post ID.
+					'type'                 => 'object',
+					'patternProperties'    => array(
+						'^\\w+$' => array( // Any word characters as key, correspond to a nav menu location.
+							'type'              => 'object',
+							'patternProperties' => array(
+								'^[a-z_-]+$' => array( // Language slug as key.
+									'type'    => 'integer',
+									'minimum' => 0, // A post ID.
+								),
+							),
+							'additionalProperties' => false,
 						),
 					),
 					'additionalProperties' => false,

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -306,22 +306,30 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'valid'                       => array(
 				'value'           => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						'fr' => 4,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 4,
+						),
 					),
 					'twentybarbaz' => array(
-						'fr' => 12,
-						'de' => 27,
+						'primary' => array(
+							'fr' => 12,
+							'de' => 27,
+						),
 					),
 				),
 				'sanitized_value' => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						'fr' => 4,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 4,
+						),
 					),
 					'twentybarbaz' => array(
-						'fr' => 12,
-						'de' => 27,
+						'primary' => array(
+							'fr' => 12,
+							'de' => 27,
+						),
 					),
 				),
 				'expected_valid'  => true,
@@ -334,8 +342,10 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'invalid theme'               => array(
 				'value'           => array(
 					'' => array(
-						'en' => 7,
-						'fr' => 4,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 4,
+						),
 					),
 				),
 				'sanitized_value' => array(),
@@ -344,14 +354,18 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'theme wrong type'            => array(
 				'value'           => array(
 					8 => array(
-						'en' => 7,
-						'fr' => 4,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 4,
+						),
 					),
 				),
 				'sanitized_value' => array(
 					8 => array(
-						'en' => 7,
-						'fr' => 4,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 4,
+						),
 					),
 				),
 				'expected_valid'  => true, // Passes because php casts `8` as a string automatically, thanks to type Juggling.
@@ -368,13 +382,17 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'invalid locale'              => array(
 				'value'           => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						''   => 4,
+						'primary' => array(
+							'en' => 7,
+							''   => 4,
+						),
 					),
 				),
 				'sanitized_value' => array(
 					'twentyfoobar' => array(
-						'en' => 7,
+						'primary' => array(
+							'en' => 7,
+						),
 					),
 				),
 				'expected_valid'  => 'rest_additional_properties_forbidden',
@@ -382,14 +400,18 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'invalid post ID'             => array(
 				'value'           => array(
 					'twentyfoobar' => array(
-						'en' => 0,
-						'fr' => -4,
+						'primary' => array(
+							'en' => 0,
+							'fr' => -4,
+						),
 					),
 				),
 				'sanitized_value' => array(
 					'twentyfoobar' => array(
-						'en' => 0,
-						'fr' => -4,
+						'primary' => array(
+							'en' => 0,
+							'fr' => -4,
+						),
 					),
 				),
 				'expected_valid'  => 'rest_out_of_bounds',
@@ -397,14 +419,18 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'post ID string'              => array(
 				'value'           => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						'fr' => '4',
+						'primary' => array(
+							'en' => 7,
+							'fr' => '4',
+						),
 					),
 				),
 				'sanitized_value' => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						'fr' => 4,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 4,
+						),
 					),
 				),
 				'expected_valid'  => true,
@@ -412,14 +438,18 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 			'post ID wrong type'          => array(
 				'value'           => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						'fr' => array(),
+						'primary' => array(
+							'en' => 7,
+							'fr' => array(),
+						),
 					),
 				),
 				'sanitized_value' => array(
 					'twentyfoobar' => array(
-						'en' => 7,
-						'fr' => 0,
+						'primary' => array(
+							'en' => 7,
+							'fr' => 0,
+						),
 					),
 				),
 				'expected_valid'  => 'rest_invalid_type',


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2212
The schema was missing the locations keys in the complex object `[themes][locations][languages] => menu_id`.
I removed the context as it is already added globally.
I removed the `phpstan-return` as it doesn't help.
Tests are modified accordingly.

