### PR TITLE
Missing namespace in `Abstract_Screen` classname in `pll_use_block_editor_plugin()`.

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -126,7 +126,7 @@ function pll_use_block_editor_plugin() {
 	 *
 	 * @param bool $use_plugin True when loading the block editor plugin.
 	 */
-	return class_exists( 'Abstract_Screen' ) && apply_filters( 'pll_use_block_editor_plugin', ! defined( 'PLL_USE_BLOCK_EDITOR_PLUGIN' ) || PLL_USE_BLOCK_EDITOR_PLUGIN );
+	return class_exists( 'WP_Syntex\Polylang_Pro\Editors\Screens\Abstract_Screen' ) && apply_filters( 'pll_use_block_editor_plugin', ! defined( 'PLL_USE_BLOCK_EDITOR_PLUGIN' ) || PLL_USE_BLOCK_EDITOR_PLUGIN );
 }
 
 /**


### PR DESCRIPTION
## What?
Follows and fix https://github.com/polylang/polylang/pull/1524 where the FQCN was missing.