### PR TITLE
Fix empty notice displayed if plugin upgrade notice is set but empty

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -115,7 +115,7 @@ class PLL_Admin extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function plugin_update_message( $plugin_data, $r ) {
-		if ( isset( $r->upgrade_notice ) ) {
+		if ( ! empty( $r->upgrade_notice ) ) {
 			printf( '<p style="margin: 3px 0 0 0; border-top: 1px solid #ddd; padding-top: 3px">%s</p>', esc_html( $r->upgrade_notice ) );
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2203
I keep the change as small as possible, although I've read [somewhere](https://developer.wordpress.org/reference/hooks/in_plugin_update_message-file/#comment-4512) that WP may not send upgrade notices anymore and see some major plugins (Woo, W3TC...) directly parsing the remote readme.txt to obtaine the expected feature.