### PR TITLE
Adds an event when the lang has been changed on `post_lang_choice`.

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -571,7 +571,12 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @return stdClass Converted `PLL_Language` object.
 	 */
 	public function to_std_class() {
-		return (object) $this->to_array();
+		$object = (object) $this->to_array();
+
+		// Sets the w3c locale as the main locale.
+		$object->locale = $this->get_locale( 'display' );
+
+		return $object;
 	}
 
 	/**

--- a/include/language.php
+++ b/include/language.php
@@ -571,12 +571,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @return stdClass Converted `PLL_Language` object.
 	 */
 	public function to_std_class() {
-		$object = (object) $this->to_array();
-
-		// Sets the w3c locale as the main locale.
-		$object->locale = $this->get_locale( 'display' );
-
-		return $object;
+		return (object) $this->to_array();
 	}
 
 	/**

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -122,12 +122,13 @@ class PLL_Switcher {
 		$out   = array();
 
 		foreach ( $this->links->model->get_languages_list( array( 'hide_empty' => $args['hide_if_empty'] ) ) as $language ) {
-			$id = (int) $language->term_id;
-			$order = (int) $language->term_group;
-			$slug = $language->slug;
-			$locale = $language->get_locale( 'display' );
+			$id           = (int) $language->term_id;
+			$order        = (int) $language->term_group;
+			$slug         = $language->slug;
+			$locale       = $language->get_locale( 'display' );
+			$w3c          = $language->get_locale( 'display' );
 			$item_classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
-			$classes = isset( $args['classes'] ) && is_array( $args['classes'] ) ?
+			$classes      = isset( $args['classes'] ) && is_array( $args['classes'] ) ?
 				array_merge(
 					$item_classes,
 					$args['classes']
@@ -183,7 +184,7 @@ class PLL_Switcher {
 				$first = false;
 			}
 
-			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes', 'link_classes' );
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'w3c', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes', 'link_classes' );
 		}
 
 		return $out;

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -127,6 +127,7 @@ class PLL_Switcher {
 			$slug         = $language->slug;
 			$locale       = $language->get_locale( 'display' );
 			$w3c          = $language->get_locale( 'display' );
+			$is_rtl       = $language->is_rtl;
 			$item_classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
 			$classes      = isset( $args['classes'] ) && is_array( $args['classes'] ) ?
 				array_merge(
@@ -184,7 +185,7 @@ class PLL_Switcher {
 				$first = false;
 			}
 
-			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'w3c', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes', 'link_classes' );
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'is_rtl', 'w3c', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes', 'link_classes' );
 		}
 
 		return $out;

--- a/include/switcher.php
+++ b/include/switcher.php
@@ -126,7 +126,6 @@ class PLL_Switcher {
 			$order        = (int) $language->term_group;
 			$slug         = $language->slug;
 			$locale       = $language->get_locale( 'display' );
-			$w3c          = $language->get_locale( 'display' );
 			$is_rtl       = $language->is_rtl;
 			$item_classes = array( 'lang-item', 'lang-item-' . $id, 'lang-item-' . esc_attr( $slug ) );
 			$classes      = isset( $args['classes'] ) && is_array( $args['classes'] ) ?
@@ -185,7 +184,7 @@ class PLL_Switcher {
 				$first = false;
 			}
 
-			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'is_rtl', 'w3c', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes', 'link_classes' );
+			$out[ $slug ] = compact( 'id', 'order', 'slug', 'locale', 'is_rtl', 'name', 'url', 'flag', 'current_lang', 'no_translation', 'classes', 'link_classes' );
 		}
 
 		return $out;

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -34,11 +34,12 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value_type = $args['value'];
 		$output .= sprintf(
-			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
+			"\t" . '<option value="%1$s"%2$s%3$s data-pll-lang="%5$s">%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
 			! empty( $element->w3c ) ? sprintf( ' lang="%s"', esc_attr( $element->w3c ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
-			esc_html( $element->name )
+			esc_html( $element->name ),
+			esc_html( wp_json_encode( $element ) )
 		);
 	}
 

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -36,7 +36,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 		$output .= sprintf(
 			"\t" . '<option value="%1$s"%2$s%3$s>%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
-			! empty( $element->locale ) ? sprintf( ' lang="%s"', esc_attr( $element->locale ) ) : '',
+			! empty( $element->w3c ) ? sprintf( ' lang="%s"', esc_attr( $element->w3c ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
 			esc_html( $element->name )
 		);

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -39,7 +39,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 			! empty( $element->w3c ) ? sprintf( ' lang="%s"', esc_attr( $element->w3c ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
 			esc_html( $element->name ),
-			esc_html( wp_json_encode( $element ) )
+			esc_html( (string) wp_json_encode( $element ) )
 		);
 	}
 

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -48,7 +48,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 			! empty( $element->locale ) ? sprintf( ' lang="%s"', esc_attr( $element->locale ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
 			esc_html( $element->name ),
-			esc_html( wp_json_encode( $data_lang ) )
+			esc_html( (string) wp_json_encode( $data_lang ) )
 		);
 	}
 

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -33,13 +33,22 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 	 */
 	public function start_el( &$output, $element, $depth = 0, $args = array(), $current_object_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$value_type = $args['value'];
+
+		// Some data from the language object to be passed as HTML data attributes for fetching in JS.
+		$data_lang = array(
+			'id'   => $element->id,
+			'name' => $element->name,
+			'slug' => $element->slug,
+			'dir'  => $element->is_rtl,
+		);
+
 		$output .= sprintf(
-			"\t" . '<option value="%1$s"%2$s%3$s data-pll-lang="%5$s">%4$s</option>' . "\n",
+			"\t" . '<option value="%1$s"%2$s%3$s data-lang="%5$s">%4$s</option>' . "\n",
 			'url' === $value_type ? esc_url( $element->$value_type ) : esc_attr( $element->$value_type ),
-			! empty( $element->w3c ) ? sprintf( ' lang="%s"', esc_attr( $element->w3c ) ) : '',
+			! empty( $element->locale ) ? sprintf( ' lang="%s"', esc_attr( $element->locale ) ) : '',
 			selected( isset( $args['selected'] ) && $args['selected'] === $element->$value_type, true, false ),
 			esc_html( $element->name ),
-			esc_html( (string) wp_json_encode( $element ) )
+			esc_html( wp_json_encode( $data_lang ) )
 		);
 	}
 

--- a/include/walker-dropdown.php
+++ b/include/walker-dropdown.php
@@ -39,7 +39,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 			'id'   => $element->id,
 			'name' => $element->name,
 			'slug' => $element->slug,
-			'dir'  => $element->is_rtl,
+			'dir'  => $element->is_rtl ?? '',
 		);
 
 		$output .= sprintf(

--- a/include/walker.php
+++ b/include/walker.php
@@ -38,6 +38,9 @@ class PLL_Walker extends Walker {
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
 		if ( $element instanceof PLL_Language ) {
 			$element = $element->to_std_class();
+
+			// Sets the w3c locale as the main locale.
+			$element->locale = $element->w3c ?? $element->locale;
 		}
 
 		$element->parent = $element->id = 0; // Don't care about this.

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -200,6 +200,11 @@ jQuery(
 
 								pll.media.resetAllAttachmentsCollections();
 							}
+						).done( function () {
+								// Creates an event once the language has been successfully changed.
+								const on_lang_change_event = new Event( 'onLangChange' );
+								document.dispatchEvent( on_lang_change_event );
+							}
 						)
 					},
 					() => {} // Do nothing when promise is rejected by clicking the Cancel dialog button.

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -185,7 +185,7 @@ jQuery(
 									"onPostLangChoice",
 									{
 										detail: {
-											lang: JSON.parse( selectedOption.options[selectedOption.options.selectedIndex].getAttribute( 'data-pll-lang' ) )
+											lang: JSON.parse( selectedOption.options[selectedOption.options.selectedIndex].getAttribute( 'data-lang' ) )
 										},
 									}
 								);
@@ -213,7 +213,8 @@ jQuery(
 			( e ) => {
 				// Update the old language with the new one to be able to compare it in the next changing.
 				initializeLanguageOldValue();
-				// modifies the language in the tag cloud
+
+				// Modifies the language in the tag cloud.
 				$( '.tagcloud-link' ).each(
 					function () {
 						var id = $( this ).attr( 'id' );
@@ -221,13 +222,13 @@ jQuery(
 					}
 				);
 
+				// Modifies the text direction.
 				let dir = e.detail.lang.is_rtl ? 'rtl' : 'ltr'
-
-				// Modifies the text direction
 				$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
 				$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', e.detail.lang.locale ).attr( 'dir', dir );
 				$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
 
+				// Refresh media libraries.
 				pll.media.resetAllAttachmentsCollections();
 			}
 		);

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -202,8 +202,8 @@ jQuery(
 							}
 						).done( function () {
 								// Creates an event once the language has been successfully changed.
-								const on_lang_change_event = new Event( 'onLangChange' );
-								document.dispatchEvent( on_lang_change_event );
+								const onPostLangChoice = new Event( 'onPostLangChoice' );
+								document.dispatchEvent( onPostLangChoice );
 							}
 						)
 					},

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -124,9 +124,6 @@ jQuery(
 				// phpcs:disable PEAR.Functions.FunctionCallSignature.EmptyLine
 				dialogResult.then(
 					() => {
-						var lang  = selectedOption.options[selectedOption.options.selectedIndex].lang; // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
-						var dir   = $( '.pll-translation-column > span[lang="' + lang + '"]' ).attr( 'dir' ); // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
-
 						var data = {  // phpcs:ignore PEAR.Functions.FunctionCallSignature.Indent
 							action:     'post_lang_choice',
 							lang:       selectedOption.value,
@@ -188,11 +185,7 @@ jQuery(
 									"onPostLangChoice",
 									{
 										detail: {
-											lang: {
-												slug: selectedOption.value,
-												locale: lang
-											},
-											dir: dir,
+											lang: JSON.parse( selectedOption.options[selectedOption.options.selectedIndex].getAttribute( 'data-pll-lang' ) )
 										},
 									}
 								);
@@ -228,10 +221,12 @@ jQuery(
 					}
 				);
 
+				let dir = e.detail.lang.is_rtl ? 'rtl' : 'ltr'
+
 				// Modifies the text direction
-				$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + e.detail.dir );
-				$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', e.detail.lang.locale ).attr( 'dir', e.detail.dir );
-				$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', e.detail.dir );
+				$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
+				$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', e.detail.lang.locale ).attr( 'dir', dir );
+				$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
 
 				pll.media.resetAllAttachmentsCollections();
 			}

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -183,23 +183,6 @@ jQuery(
 									}
 								);
 
-								// Update the old language with the new one to be able to compare it in the next changing.
-								initializeLanguageOldValue();
-								// modifies the language in the tag cloud
-								$( '.tagcloud-link' ).each(
-									function () {
-										var id = $( this ).attr( 'id' );
-										tagBox.get( id );
-									}
-								);
-
-								// Modifies the text direction
-								$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
-								$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
-								$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
-
-								pll.media.resetAllAttachmentsCollections();
-
 								// Creates an event once the language has been successfully changed.
 								const onPostLangChoice = new Event( 'onPostLangChoice' );
 								document.dispatchEvent( onPostLangChoice );
@@ -217,6 +200,29 @@ jQuery(
 
 					return ! title && ! content && ! excerpt;
 				}
+			}
+		);
+
+		// Listen to `onPostLangChoice` to perform actions after the language has been changed.
+		document.addEventListener(
+			'onPostLangChoice',
+			() => {
+				// Update the old language with the new one to be able to compare it in the next changing.
+				initializeLanguageOldValue();
+				// modifies the language in the tag cloud
+				$( '.tagcloud-link' ).each(
+					function () {
+						var id = $( this ).attr( 'id' );
+						tagBox.get( id );
+					}
+				);
+
+				// Modifies the text direction
+				$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
+				$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
+				$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
+
+				pll.media.resetAllAttachmentsCollections();
 			}
 		);
 

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -184,7 +184,18 @@ jQuery(
 								);
 
 								// Creates an event once the language has been successfully changed.
-								const onPostLangChoice = new Event( 'onPostLangChoice' );
+								const onPostLangChoice = new CustomEvent(
+									"onPostLangChoice",
+									{
+										detail: {
+											lang: {
+												slug: selectedOption.value,
+												locale: lang
+											},
+											dir: dir,
+										},
+									}
+								);
 								document.dispatchEvent( onPostLangChoice );
 							}
 						)
@@ -206,7 +217,7 @@ jQuery(
 		// Listen to `onPostLangChoice` to perform actions after the language has been changed.
 		document.addEventListener(
 			'onPostLangChoice',
-			() => {
+			( e ) => {
 				// Update the old language with the new one to be able to compare it in the next changing.
 				initializeLanguageOldValue();
 				// modifies the language in the tag cloud
@@ -218,9 +229,9 @@ jQuery(
 				);
 
 				// Modifies the text direction
-				$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + dir );
-				$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', lang ).attr( 'dir', dir );
-				$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
+				$( 'body' ).removeClass( 'pll-dir-rtl' ).removeClass( 'pll-dir-ltr' ).addClass( 'pll-dir-' + e.detail.dir );
+				$( '#content_ifr' ).contents().find( 'html' ).attr( 'lang', e.detail.lang.locale ).attr( 'dir', e.detail.dir );
+				$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', e.detail.dir );
 
 				pll.media.resetAllAttachmentsCollections();
 			}

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -199,8 +199,7 @@ jQuery(
 								$( '#content_ifr' ).contents().find( 'body' ).attr( 'dir', dir );
 
 								pll.media.resetAllAttachmentsCollections();
-							}
-						).done( function () {
+
 								// Creates an event once the language has been successfully changed.
 								const onPostLangChoice = new Event( 'onPostLangChoice' );
 								document.dispatchEvent( onPostLangChoice );


### PR DESCRIPTION
See https://github.com/polylang/polylang-pro/pull/2243.

Adds a custom event `onPostLangChoice` with `lang` and `dir` as data (and use them when we can in the listener).

Moreover, fixed a small issue where the `w3c` locale was not passed as it should be in the language switcher (and so add it to the language elements).
