### PR TITLE
Harmonize context checks in `PLL_Admin_Sync`

### DIFF
--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -223,4 +223,53 @@ class PLL_Admin_Links extends PLL_Links {
 		$language = $this->model->term->get_language( $term_id );
 		return $this->edit_translation_link( $link, $language );
 	}
+
+	/**
+	 * Returns some data (`from_post` and `new_lang`) from the current request.
+	 *
+	 * @since 3.7
+	 *
+	 * @param string $post_type A post type.
+	 * @return array {
+	 *     @type WP_Post      $from_post The source post.
+	 *     @type PLL_Language $new_lang  The target language.
+	 * }
+	 *
+	 * @phpstan-return array{}|array{from_post: WP_Post, new_lang: PLL_Language}|never
+	 */
+	public function get_data_from_new_post_translation_request( string $post_type ): array {
+		if ( ! isset( $GLOBALS['pagenow'], $_GET['_wpnonce'], $_GET['from_post'], $_GET['new_lang'], $_GET['post_type'] ) ) {
+			return array();
+		}
+
+		if ( 'post-new.php' !== $GLOBALS['pagenow'] ) {
+			return array();
+		}
+
+		if ( empty( $post_type ) || $post_type !== $_GET['post_type'] || ! $this->model->is_translated_post_type( $post_type ) ) {
+			return array();
+		}
+
+		// Capability check already done in post-new.php.
+		check_admin_referer( 'new-post-translation' );
+
+		$post_id   = (int) $_GET['from_post'];
+		$lang_slug = sanitize_key( $_GET['new_lang'] );
+
+		if ( $post_id <= 0 || empty( $lang_slug ) ) {
+			return array();
+		}
+
+		$post = get_post( $post_id );
+		$lang = $this->model->get_language( $lang_slug );
+
+		if ( empty( $post ) || empty( $lang ) ) {
+			return array();
+		}
+
+		return array(
+			'from_post' => $post,
+			'new_lang'  => $lang,
+		);
+	}
 }

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -254,7 +254,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @param array $post_data A post array.
 	 * @return array
 	 *
-	 * @phpstan-return array{}|array{from_post_id: int<0,max>, new_lang: string}
+	 * @phpstan-return array{}|array{from_post_id: int<0,max>, new_lang: string}|never
 	 */
 	public static function get_data_from_request( array $post_data ): array {
 		if ( ! isset( $GLOBALS['pagenow'], $_GET['_wpnonce'], $_GET['from_post'], $_GET['new_lang'], $_GET['post_type'], $post_data['post_type'] ) ) {
@@ -270,10 +270,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 		}
 
 		// Capability check already done in post-new.php.
-		if ( ! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'new-post-translation' ) ) {
-			return array();
-		}
-
+		check_admin_referer( 'new-post-translation' );
 		return array(
 			'from_post_id' => $_GET['from_post'] >= 1 ? abs( (int) $_GET['from_post'] ) : 0,
 			'new_lang'     => sanitize_key( $_GET['new_lang'] ),

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -256,7 +256,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 *
 	 * @phpstan-return array{}|array{from_post_id: int<0,max>, new_lang: string}
 	 */
-	private function get_data_from_request( array $post_data ): array {
+	public static function get_data_from_request( array $post_data ): array {
 		if ( ! isset( $GLOBALS['pagenow'], $_GET['_wpnonce'], $_GET['from_post'], $_GET['new_lang'], $_GET['post_type'], $post_data['post_type'] ) ) {
 			return array();
 		}
@@ -269,7 +269,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 			return array();
 		}
 
-		if ( $post_data['post_type'] !== $_GET['post_type'] || ! $this->model->is_translated_post_type( $post_data['post_type'] ) ) {
+		if ( $post_data['post_type'] !== $_GET['post_type'] || ! pll_is_translated_post_type( $post_data['post_type'] ) ) {
 			return array();
 		}
 

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -273,6 +273,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 			return array();
 		}
 
+		// Capability check already done in post-new.php.
 		if ( ! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'new-post-translation' ) ) {
 			return array();
 		}

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -36,7 +36,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return int
 	 */
 	public function wp_insert_post_parent( $post_parent, $post_id, $postarr ) {
-		$context_data = $this->get_data_from_request( $postarr['post_type'] ?? '' );
+		$context_data = static::get_data_from_request( $postarr['post_type'] ?? '' );
 
 		if ( empty( $context_data ) ) {
 			return $post_parent;
@@ -67,7 +67,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return array
 	 */
 	public function wp_insert_post_data( $data ) {
-		$context_data = $this->get_data_from_request( $data['post_type'] ?? '' );
+		$context_data = static::get_data_from_request( $data['post_type'] ?? '' );
 
 		if ( empty( $context_data ) ) {
 			return $data;
@@ -103,7 +103,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 			return $is_block_editor;
 		}
 
-		$context_data = $this->get_data_from_request( $post->post_type );
+		$context_data = static::get_data_from_request( $post->post_type );
 
 		if ( empty( $context_data ) || ! empty( $done[ $context_data['from_post']->ID ] ) ) {
 			return $is_block_editor;
@@ -139,7 +139,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 		global $wpdb;
 
 		$postarr      = parent::get_fields_to_sync( $post );
-		$context_data = $this->get_data_from_request( $post->post_type );
+		$context_data = static::get_data_from_request( $post->post_type );
 
 		// For new drafts, save the date now otherwise it is overridden by WP. Thanks to JoryHogeveen. See #32.
 		if ( ! empty( $context_data ) && in_array( 'post_date', $this->options['sync'], true ) ) {

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -265,10 +265,6 @@ class PLL_Admin_Sync extends PLL_Sync {
 			return array();
 		}
 
-		if ( ! is_string( $_GET['_wpnonce'] ) || ! is_numeric( $_GET['from_post'] ) || ! is_string( $_GET['new_lang'] ) ) {
-			return array();
-		}
-
 		if ( $post_data['post_type'] !== $_GET['post_type'] || ! pll_is_translated_post_type( $post_data['post_type'] ) ) {
 			return array();
 		}

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -36,7 +36,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return int
 	 */
 	public function wp_insert_post_parent( $post_parent, $post_id, $postarr ) {
-		$context_data = $this->check_context( $postarr );
+		$context_data = $this->get_data_from_request( $postarr );
 
 		if ( empty( $context_data ) ) {
 			return $post_parent;
@@ -67,7 +67,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return array
 	 */
 	public function wp_insert_post_data( $data ) {
-		$context_data = $this->check_context( $data );
+		$context_data = $this->get_data_from_request( $data );
 
 		if ( empty( $context_data ) ) {
 			return $data;
@@ -105,7 +105,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 		global $post;
 		static $done = array();
 
-		$context_data = $this->check_context( (array) $post );
+		$context_data = $this->get_data_from_request( (array) $post );
 
 		if ( empty( $context_data ) || ! empty( $done[ $context_data['from_post_id'] ] ) ) {
 			return $is_block_editor;
@@ -141,7 +141,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 		global $wpdb;
 
 		$postarr      = parent::get_fields_to_sync( $post );
-		$context_data = $this->check_context( (array) $post );
+		$context_data = $this->get_data_from_request( (array) $post );
 
 		// For new drafts, save the date now otherwise it is overridden by WP. Thanks to JoryHogeveen. See #32.
 		if ( ! empty( $context_data ) && in_array( 'post_date', $this->options['sync'], true ) ) {
@@ -247,7 +247,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	}
 
 	/**
-	 * Checks the context, and returns the value of `from_post_id` and `new_lang`.
+	 * Returns some data (`from_post_id` and `new_lang`) from the current request.
 	 *
 	 * @since 3.7
 	 *
@@ -256,7 +256,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 *
 	 * @phpstan-return array{}|array{from_post_id: int<0,max>, new_lang: string}
 	 */
-	private function check_context( array $post_data ): array {
+	private function get_data_from_request( array $post_data ): array {
 		if ( ! isset( $GLOBALS['pagenow'], $_GET['_wpnonce'], $_GET['from_post'], $_GET['new_lang'], $_GET['post_type'], $post_data['post_type'] ) ) {
 			return array();
 		}

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -140,28 +140,11 @@ class PLL_Admin_Sync extends PLL_Sync {
 	protected function get_fields_to_sync( $post ) {
 		global $wpdb;
 
-		$postarr = parent::get_fields_to_sync( $post );
-
-		if ( isset( $GLOBALS['post_type'] ) ) {
-			$post_type = $GLOBALS['post_type'];
-		} elseif ( isset( $_REQUEST['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			// 2nd case for quick edit.
-			$post_type = sanitize_key( $_REQUEST['post_type'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-
-		// Make sure not to impact media translations when creating them at the same time as post
-		if ( in_array( 'post_parent', $this->options['sync'], true ) && ( ! isset( $post_type ) || $post_type !== $post->post_type ) ) {
-			unset( $postarr['post_parent'] );
-		}
-
+		$postarr      = parent::get_fields_to_sync( $post );
 		$context_data = $this->check_context( (array) $post );
 
-		if ( empty( $context_data ) ) {
-			return $postarr;
-		}
-
 		// For new drafts, save the date now otherwise it is overridden by WP. Thanks to JoryHogeveen. See #32.
-		if ( in_array( 'post_date', $this->options['sync'], true ) ) {
+		if ( ! empty( $context_data ) && in_array( 'post_date', $this->options['sync'], true ) ) {
 			unset( $postarr['post_date'] );
 			unset( $postarr['post_date_gmt'] );
 
@@ -177,6 +160,18 @@ class PLL_Admin_Sync extends PLL_Sync {
 					array( 'ID' => $post->ID )
 				);
 			}
+		}
+
+		if ( isset( $GLOBALS['post_type'] ) ) {
+			$post_type = $GLOBALS['post_type'];
+		} elseif ( isset( $_REQUEST['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// 2nd case for quick edit.
+			$post_type = sanitize_key( $_REQUEST['post_type'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		// Make sure not to impact media translations when creating them at the same time as post
+		if ( in_array( 'post_parent', $this->options['sync'], true ) && ( ! isset( $post_type ) || $post_type !== $post->post_type ) ) {
+			unset( $postarr['post_parent'] );
 		}
 
 		return $postarr;

--- a/tests/phpunit/tests/test-media.php
+++ b/tests/phpunit/tests/test-media.php
@@ -27,6 +27,7 @@ class Media_Test extends PLL_UnitTestCase {
 		$this->pll_admin                = new PLL_Admin( $links_model );
 		$this->pll_admin->filters_media = new PLL_Admin_Filters_Media( $this->pll_admin );
 		$this->pll_admin->posts         = new PLL_CRUD_Posts( $this->pll_admin );
+		$this->pll_admin->links         = new PLL_Admin_Links( $this->pll_admin );
 		$this->pll_admin->sync          = new PLL_Admin_Sync( $this->pll_admin );
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );  // don't create intermediate sizes to save time
 	}

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -28,7 +28,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
 
 		$links_model = self::$model->get_links_model();
-		$this->pll_admin = new PLL_Admin( $links_model );
+		$this->pll_admin        = new PLL_Admin( $links_model );
+		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 	}
 
 	public function test_copy_taxonomies() {
@@ -191,9 +192,8 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$to = self::factory()->post->create();
 
-		$GLOBALS['polylang'] = $this->pll_admin;
-		$GLOBALS['pagenow']  = 'post-new.php';
-		$GLOBALS['post']     = get_post( $to );
+		$GLOBALS['pagenow'] = 'post-new.php';
+		$GLOBALS['post'] = get_post( $to );
 
 		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
@@ -234,8 +234,7 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$to = self::factory()->post->create( array( 'post_type' => 'page' ) );
 
-		$GLOBALS['polylang'] = $this->pll_admin;
-		$GLOBALS['post']     = get_post( $to );
+		$GLOBALS['post'] = get_post( $to );
 
 		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
@@ -490,8 +489,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		self::$model->options['sync'] = array( 'post_date' ); // Sync publish date
 
-		$GLOBALS['polylang'] = $this->pll_admin;
-		$GLOBALS['pagenow']  = 'post-new.php';
+		$GLOBALS['pagenow'] = 'post-new.php';
 
 		$_REQUEST = $_GET = array(
 			'post_type' => 'post',
@@ -559,8 +557,7 @@ class Sync_Test extends PLL_UnitTestCase {
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
 		);
 
-		$GLOBALS['polylang'] = $this->pll_admin;
-		$GLOBALS['pagenow']  = 'post-new.php';
+		$GLOBALS['pagenow'] = 'post-new.php';
 
 		$to = self::factory()->post->create();
 

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -191,8 +191,9 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$to = self::factory()->post->create();
 
-		$GLOBALS['pagenow'] = 'post-new.php';
-		$GLOBALS['post'] = get_post( $to );
+		$GLOBALS['polylang'] = $this->pll_admin;
+		$GLOBALS['pagenow']  = 'post-new.php';
+		$GLOBALS['post']     = get_post( $to );
 
 		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
@@ -233,7 +234,8 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$to = self::factory()->post->create( array( 'post_type' => 'page' ) );
 
-		$GLOBALS['post'] = get_post( $to );
+		$GLOBALS['polylang'] = $this->pll_admin;
+		$GLOBALS['post']     = get_post( $to );
 
 		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
 
@@ -488,7 +490,9 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		self::$model->options['sync'] = array( 'post_date' ); // Sync publish date
 
-		$GLOBALS['pagenow'] = 'post-new.php';
+		$GLOBALS['polylang'] = $this->pll_admin;
+		$GLOBALS['pagenow']  = 'post-new.php';
+
 		$_REQUEST = $_GET = array(
 			'post_type' => 'post',
 			'from_post' => $from,
@@ -555,7 +559,8 @@ class Sync_Test extends PLL_UnitTestCase {
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
 		);
 
-		$GLOBALS['pagenow'] = 'post-new.php';
+		$GLOBALS['polylang'] = $this->pll_admin;
+		$GLOBALS['pagenow']  = 'post-new.php';
 
 		$to = self::factory()->post->create();
 

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -490,6 +490,7 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		$GLOBALS['pagenow'] = 'post-new.php';
 		$_REQUEST = $_GET = array(
+			'post_type' => 'post',
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
@@ -548,6 +549,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$_REQUEST = $_GET = array(
+			'post_type' => 'post',
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -183,6 +183,7 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 
 		$_REQUEST = $_GET = array(
+			'post_type' => 'post',
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -133,7 +133,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertSame( array( 'a_json_meta' => 'json' ), $encodings );
 
 		// Copy.
-		$sync = new PLL_Admin_Sync( $pll_admin );
+		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
+		$sync             = new PLL_Admin_Sync( $pll_admin );
 		$sync->post_metas->copy( $from, $to, 'fr' ); // Copy.
 
 		$this->assertEquals( 1, get_post_meta( $to, 'quantity', true ) );
@@ -185,7 +186,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
 
 		// Copy
-		$sync = new PLL_Admin_Sync( $pll_admin );
+		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
+		$sync             = new PLL_Admin_Sync( $pll_admin );
 		$sync->term_metas->copy( $from, $to, 'fr' ); // copy
 
 		$this->assertEquals( 'A', get_term_meta( $to, 'term_meta_A', true ) );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2087.

This PR harmonizes the way the context (`$_GET['from_post']`, etc) is validated in `PLL_Admin_Sync`'s methods, by introducing the method `check_context()`.
The new method is public and static, so it can be reused in PLL Pro and PLLWC.

Some tests have been fixed to set `$_GET['post_type']`.