### PR TITLE
Allow numbers in language code

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Languages {
 	public const LOCALE_PATTERN = '^[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?$';
-	public const SLUG_PATTERN   = '^[a-z0-9_-]+$';
+	public const SLUG_PATTERN   = '^[a-z]+[a-z0-9_-]*$';
 
 	public const TRANSIENT_NAME = 'pll_languages_list';
 	private const CACHE_KEY     = 'languages';

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -798,7 +798,7 @@ class Languages {
 		}
 
 		// Validate slug characters.
-		if ( ! preg_match( '#^[a-z_-]+$#', $args['slug'] ) ) {
+		if ( ! preg_match( '#^[a-z0-9_-]+$#', $args['slug'] ) ) {
 			$errors->add( 'pll_invalid_slug', __( 'The language code contains invalid characters', 'polylang' ) );
 		}
 

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -21,6 +21,9 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.7
  */
 class Languages {
+	public const LOCALE_PATTERN = '^[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?$';
+	public const SLUG_PATTERN   = '^[a-z0-9_-]+$';
+
 	public const TRANSIENT_NAME = 'pll_languages_list';
 	private const CACHE_KEY     = 'languages';
 
@@ -793,12 +796,12 @@ class Languages {
 		$errors = new WP_Error();
 
 		// Validate locale with the same pattern as WP 4.3. See #28303.
-		if ( ! preg_match( '#^[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?$#', $args['locale'], $matches ) ) {
+		if ( ! preg_match( '#' . self::LOCALE_PATTERN . '#', $args['locale'], $matches ) ) {
 			$errors->add( 'pll_invalid_locale', __( 'Enter a valid WordPress locale', 'polylang' ) );
 		}
 
 		// Validate slug characters.
-		if ( ! preg_match( '#^[a-z0-9_-]+$#', $args['slug'] ) ) {
+		if ( ! preg_match( '#' . self::SLUG_PATTERN . '#', $args['slug'] ) ) {
 			$errors->add( 'pll_invalid_slug', __( 'The language code contains invalid characters', 'polylang' ) );
 		}
 

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Languages {
 	public const LOCALE_PATTERN = '^[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?$';
-	public const SLUG_PATTERN   = '^[a-z]+[a-z0-9_-]*$';
+	public const SLUG_PATTERN   = '^[a-z][a-z0-9_-]*$';
 
 	public const TRANSIENT_NAME = 'pll_languages_list';
 	private const CACHE_KEY     = 'languages';

--- a/include/Options/Business/Default_Lang.php
+++ b/include/Options/Business/Default_Lang.php
@@ -6,6 +6,7 @@
 namespace WP_Syntex\Polylang\Options\Business;
 
 use WP_Syntex\Polylang\Options\Primitive\Abstract_String;
+use WP_Syntex\Polylang\Model\Languages;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -35,11 +36,11 @@ class Default_Lang extends Abstract_String {
 	 *
 	 * @return array Partial schema.
 	 *
-	 * @phpstan-return array{type: 'string', pattern: '^[a-z_-]+$'}
+	 * @phpstan-return array{type: 'string', pattern: Languages::SLUG_PATTERN}
 	 */
 	protected function get_data_structure(): array {
 		$string_schema            = parent::get_data_structure();
-		$string_schema['pattern'] = '^[a-z_-]+$';
+		$string_schema['pattern'] = Languages::SLUG_PATTERN;
 
 		return $string_schema;
 	}

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -8,6 +8,7 @@ namespace WP_Syntex\Polylang\Options\Business;
 use WP_Error;
 use WP_Syntex\Polylang\Options\Abstract_Option;
 use WP_Syntex\Polylang\Options\Options;
+use WP_Syntex\Polylang\Model\Languages;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -59,7 +60,7 @@ class Domains extends Abstract_Option {
 		return array(
 			'type'                 => 'object', // Correspond to associative array in PHP, @see{https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#primitive-types}.
 			'patternProperties'    => array(
-				'^[a-z_-]+$' => array( // Language slug as key.
+				Languages::SLUG_PATTERN => array( // Language slug as key.
 					'type'   => 'string',
 					'format' => 'uri',
 				),

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -6,6 +6,8 @@
 namespace WP_Syntex\Polylang\Options\Business;
 
 use WP_Syntex\Polylang\Options\Abstract_Option;
+use WP_Syntex\Polylang\Model\Languages;
+
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,7 +58,7 @@ class Nav_Menus extends Abstract_Option {
 						'[\w-]+' => array( // Accepted characters for menu locations @see https://developer.wordpress.org/reference/classes/wp_rest_menu_locations_controller/register_routes/
 							'type'              => 'object',
 							'patternProperties' => array(
-								'[a-z_-]+' => array( // Language slug as key.
+								Languages::SLUG_PATTERN => array( // Language slug as key.
 									'type'    => 'integer',
 									'minimum' => 0, // A post ID.
 								),

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -111,10 +111,9 @@ class Languages extends WP_REST_Controller {
 				'allow_batch' => array( 'v1' => true ),
 			)
 		);
-
 		register_rest_route(
 			$this->namespace,
-			"/{$this->rest_base}/(?P<slug>[a-z_-]+)",
+			sprintf( '/%1$s/(?P<slug>%2$s)', $this->rest_base, trim( Languages_Model::SLUG_PATTERN, '^$' ) ),
 			array(
 				'args'   => array(
 					'slug'    => array(
@@ -462,13 +461,13 @@ class Languages extends WP_REST_Controller {
 				'slug'            => array(
 					'description' => __( 'Language code - preferably 2-letters ISO 639-1 (for example: en).', 'polylang' ),
 					'type'        => 'string',
-					'pattern'     => '[a-z_-]+',
+					'pattern'     => Languages_Model::SLUG_PATTERN,
 					'context'     => array( 'view', 'edit' ),
 				),
 				'locale'          => array(
 					'description' => __( 'WordPress Locale for the language (for example: en_US).', 'polylang' ),
 					'type'        => 'string',
-					'pattern'     => '[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?',
+					'pattern'     => Languages_Model::LOCALE_PATTERN,
 					'context'     => array( 'view', 'edit' ),
 					'required'    => true,
 				),
@@ -578,7 +577,7 @@ class Languages extends WP_REST_Controller {
 					'uniqueItems' => true,
 					'items'       => array(
 						'type'    => 'string',
-						'pattern' => '[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?',
+						'pattern' => Languages_Model::LOCALE_PATTERN,
 					),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -192,7 +192,7 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 				'expected_valid'  => 'rest_invalid_type',
 			),
 			'invalid key'      => array(
-				'value'           => array( 'en' => 'https://example.com', 'fr41' => 'https://example.net', 'de' => 'https://example.org' ),
+				'value'           => array( 'en' => 'https://example.com', 'fr_FR' => 'https://example.net', 'de' => 'https://example.org' ),
 				'sanitized_value' => array( 'en' => 'https://example.com', 'de' => 'https://example.org' ),
 				'expected_valid'  => 'rest_additional_properties_forbidden',
 			),
@@ -274,8 +274,8 @@ class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
 				'expected_valid'  => 'rest_invalid_type',
 			),
 			'invalid'    => array(
-				'value'           => 'fr41',
-				'sanitized_value' => 'fr41',
+				'value'           => 'fr_FR',
+				'sanitized_value' => 'fr_FR',
 				'expected_valid'  => 'rest_invalid_pattern',
 			),
 		);


### PR DESCRIPTION
`es-419` is a valid locale (Spanish for Latin America and Caribbean islands). It would make sense to use `es-419` as language code for this locale. Thus this PR allow numbers in language code. Interesting side effect: we will have the same characters allowed as in `sanitize_key()` that we use to sanitize language codes.

Furthermore, to avoid repeating ourselves, the PR introduces constants for the patterns validating the local and language slug. 