### PR TITLE
Use 2 constants for locale and slug patterns

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -21,8 +21,11 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.7
  */
 class Languages {
-	public const LOCALE_PATTERN = '^[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?$';
-	public const SLUG_PATTERN   = '^[a-z][a-z0-9_-]*$';
+	public const INNER_LOCALE_PATTERN = '[a-z]{2,3}(?:_[A-Z]{2})?(?:_[a-z0-9]+)?';
+	public const INNER_SLUG_PATTERN   = '[a-z][a-z0-9_-]*';
+
+	public const LOCALE_PATTERN = '^' . self::INNER_LOCALE_PATTERN . '$';
+	public const SLUG_PATTERN   = '^' . self::INNER_SLUG_PATTERN . '$';
 
 	public const TRANSIENT_NAME = 'pll_languages_list';
 	private const CACHE_KEY     = 'languages';

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -113,7 +113,7 @@ class Languages extends WP_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			sprintf( '/%1$s/(?P<slug>%2$s)', $this->rest_base, trim( Languages_Model::SLUG_PATTERN, '^$' ) ),
+			sprintf( '/%1$s/(?P<slug>%2$s)', $this->rest_base, Languages_Model::INNER_SLUG_PATTERN ),
 			array(
 				'args'   => array(
 					'slug'    => array(


### PR DESCRIPTION
Follow up of #1546.

Use 2 different constants instead of trimming the first and last characters when the pattern is included in a larger one.
See also https://github.com/polylang/polylang-pro/pull/2279#pullrequestreview-2328186474  