### PR TITLE
Fix issue reported by PHPStan (`rest_route` as an array)

### DIFF
--- a/include/class-polylang.php
+++ b/include/class-polylang.php
@@ -112,7 +112,7 @@ class Polylang {
 		// And also test rest_route query string parameter is not empty for plain permalinks.
 		$query_string = array();
 		wp_parse_str( (string) wp_parse_url( pll_get_requested_url(), PHP_URL_QUERY ), $query_string );
-		$rest_route = isset( $query_string['rest_route'] ) ? trim( $query_string['rest_route'], '/' ) : false;
+		$rest_route = isset( $query_string['rest_route'] ) && is_string( $query_string['rest_route'] ) ? trim( $query_string['rest_route'], '/' ) : false;
 
 		return 0 === strpos( $req_uri, rest_get_url_prefix() . '/' ) || ! empty( $rest_route );
 	}


### PR DESCRIPTION
This fixes the following issue reported by PHPStan:

```
 ------ --------------------------------------------------------------------------- 
  Line   include/class-polylang.php                                                 
 ------ --------------------------------------------------------------------------- 
  :115   Parameter #1 $string of function trim expects string, array|string given.  
 ------ ---------------------------------------------------------------------------
```