### PR TITLE
Reformat uninstall.php and avoid phpcs ignore

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -3,20 +3,20 @@
  * @package Polylang
  */
 
-if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { // If uninstall not called from WordPress exit
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { // If uninstall not called from WordPress exit.
 	exit;
 }
 
 /**
- * Manages Polylang uninstallation
- * The goal is to remove ALL Polylang related data in db
+ * Manages Polylang uninstallation.
+ * The goal is to remove ALL Polylang related data in db.
  *
  * @since 0.5
  */
 class PLL_Uninstall {
 
 	/**
-	 * Constructor: manages uninstall for multisite
+	 * Constructor: manages uninstall for multisite.
 	 *
 	 * @since 0.5
 	 */
@@ -28,22 +28,20 @@ class PLL_Uninstall {
 			return;
 		}
 
-		// Check if it is a multisite uninstall - if so, run the uninstall function for each blog id
+		// Check if it is a multisite uninstall - if so, run the uninstall function for each blog id.
 		if ( is_multisite() ) {
 			foreach ( $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" ) as $blog_id ) {
 				switch_to_blog( $blog_id );
 				$this->uninstall();
 			}
 			restore_current_blog();
-		}
-		else {
+		} else {
 			$this->uninstall();
 		}
 	}
 
 	/**
-	 * Removes ALL plugin data
-	 * only when the relevant option is active
+	 * Removes ALL plugin data.
 	 *
 	 * @since 0.5
 	 */
@@ -52,22 +50,42 @@ class PLL_Uninstall {
 
 		do_action( 'pll_uninstall' );
 
-		// Need to register the taxonomies
-		$pll_taxonomies = array( 'language', 'term_language', 'post_translations', 'term_translations' );
+		// We need to register the taxonomies.
+		$pll_taxonomies = array(
+			'language',
+			'term_language',
+			'post_translations',
+			'term_translations',
+		);
+
 		foreach ( $pll_taxonomies as $taxonomy ) {
-			register_taxonomy( $taxonomy, null, array( 'label' => false, 'public' => false, 'query_var' => false, 'rewrite' => false ) );
+			register_taxonomy(
+				$taxonomy,
+				null,
+				array(
+					'label'     => false,
+					'public'    => false,
+					'query_var' => false,
+					'rewrite'   => false,
+				)
+			);
 		}
 
-		$languages = get_terms( array( 'taxonomy' => 'language', 'hide_empty' => false ) );
+		$languages = get_terms(
+			array(
+				'taxonomy'   => 'language',
+				'hide_empty' => false,
+			)
+		);
 
-		// Delete users options
+		// Delete users options.
 		delete_metadata( 'user', 0, 'pll_filter_content', '', true );
 		delete_metadata( 'user', 0, 'pll_dismissed_notices', '', true ); // Legacy meta.
 		foreach ( $languages as $lang ) {
 			delete_metadata( 'user', 0, "description_{$lang->slug}", '', true );
 		}
 
-		// Delete menu language switchers
+		// Delete menu language switchers.
 		$ids = get_posts(
 			array(
 				'post_type'   => 'nav_menu_item',
@@ -86,7 +104,13 @@ class PLL_Uninstall {
 		 * Backward compatibility with Polylang < 3.4.
 		 * Delete the legacy strings translations.
 		 */
-		register_post_type( 'polylang_mo', array( 'rewrite' => false, 'query_var' => false ) );
+		register_post_type(
+			'polylang_mo',
+			array(
+				'rewrite'   => false,
+				'query_var' => false,
+			)
+		);
 		$ids = get_posts(
 			array(
 				'post_type'   => 'polylang_mo',
@@ -100,36 +124,43 @@ class PLL_Uninstall {
 			wp_delete_post( $id, true );
 		}
 
-		// Delete all what is related to languages and translations
+		// Delete all what is related to languages and translations.
 		$term_ids = array();
 		$tt_ids   = array();
 
-		foreach ( get_terms( array( 'taxonomy' => $pll_taxonomies, 'hide_empty' => false ) ) as $term ) {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $pll_taxonomies,
+				'hide_empty' => false,
+			)
+		);
+
+		foreach ( $terms as $term ) {
 			$term_ids[] = (int) $term->term_id;
-			$tt_ids[] = (int) $term->term_taxonomy_id;
+			$tt_ids[]   = (int) $term->term_taxonomy_id;
 		}
 
 		if ( ! empty( $term_ids ) ) {
 			$term_ids = array_unique( $term_ids );
-			$wpdb->query( "DELETE FROM {$wpdb->terms} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( "DELETE FROM {$wpdb->term_taxonomy} WHERE term_id IN ( " . implode( ',', $term_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( "DELETE FROM {$wpdb->termmeta} WHERE term_id IN ( " . implode( ',', $term_ids ) . " ) AND meta_key='_pll_strings_translations'" ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( sprintf( "DELETE FROM {$wpdb->terms} WHERE term_id IN (%s)", implode( ',', array_fill( 0, count( $term_ids ), '%d' ) ) ), $term_ids ) );
+			$wpdb->query( $wpdb->prepare( sprintf( "DELETE FROM {$wpdb->term_taxonomy} WHERE term_id IN (%s)", implode( ',', array_fill( 0, count( $term_ids ), '%d' ) ) ), $term_ids ) );
+			$wpdb->query( $wpdb->prepare( sprintf( "DELETE FROM {$wpdb->termmeta} WHERE term_id IN (%s) AND meta_key='_pll_strings_translations'", implode( ',', array_fill( 0, count( $term_ids ), '%d' ) ) ), $term_ids ) );
 		}
 
 		if ( ! empty( $tt_ids ) ) {
 			$tt_ids = array_unique( $tt_ids );
-			$wpdb->query( "DELETE FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN ( " . implode( ',', $tt_ids ) . ' )' ); // PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( sprintf( "DELETE FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN (%s)", implode( ',', array_fill( 0, count( $tt_ids ), '%d' ) ) ), $tt_ids ) );
 		}
 
-		// Delete options
+		// Delete options.
 		delete_option( 'polylang' );
-		delete_option( 'widget_polylang' ); // Automatically created by WP
-		delete_option( 'polylang_wpml_strings' ); // Strings registered with icl_register_string
+		delete_option( 'widget_polylang' ); // Automatically created by WP.
+		delete_option( 'polylang_wpml_strings' ); // Strings registered with icl_register_string.
 		delete_option( 'polylang_licenses' );
 		delete_option( 'pll_dismissed_notices' );
 		delete_option( 'pll_language_from_content_available' );
 
-		// Delete transients
+		// Delete transients.
 		delete_transient( 'pll_languages_list' );
 	}
 }


### PR DESCRIPTION
The main purpose is to remove 4 `PHPCS:ignore WordPress.DB.PreparedSQL`.
I took the opportunity to reformat the code to pass most of the WPCS included some currently excluded in the main rules.