### PR TITLE
Remove backward compatibility with WP < 6.2

### DIFF
--- a/admin/admin-block-editor.php
+++ b/admin/admin-block-editor.php
@@ -48,11 +48,7 @@ class PLL_Admin_Block_Editor {
 			return $preload_paths;
 		}
 
-		// Backward compatibility with WP < 6.0 where `WP_Block_Editor_Context::$name` doesn't exist yet.
-		if (
-			( property_exists( $context, 'name' ) && 'core/edit-post' !== $context->name )
-			|| ! $context->post instanceof WP_Post
-		) {
+		if ( 'core/edit-post' !== $context->name ) {
 			// Do nothing if not post editor.
 			return $preload_paths;
 		}

--- a/include/links-domain.php
+++ b/include/links-domain.php
@@ -107,12 +107,8 @@ class PLL_Links_Domain extends PLL_Links_Abstract_Domain {
 			// The function idn_to_ascii() is much faster than the WordPress method.
 			if ( function_exists( 'idn_to_ascii' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
 				$hosts[ $lang ] = idn_to_ascii( $host, 0, INTL_IDNA_VARIANT_UTS46 );
-			} elseif ( class_exists( 'WpOrg\Requests\IdnaEncoder' ) ) {
-				// Since WP 6.2.
-				$hosts[ $lang ] = \WpOrg\Requests\IdnaEncoder::encode( $host );
 			} else {
-				// Backward compatibility with WP < 6.2.
-				$hosts[ $lang ] = Requests_IDNAEncoder::encode( $host );
+				$hosts[ $lang ] = \WpOrg\Requests\IdnaEncoder::encode( $host ); // Since WP 6.2.
 			}
 		}
 

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -284,17 +284,11 @@ abstract class PLL_Translatable_Object {
 			}
 		}
 
-		// Stores it the way WP expects it. Set an empty cache if no term was found in the taxonomy.
-		$store_only_term_ids = version_compare( $wp_version, '6.0', '>=' );
-
 		foreach ( $this->tax_to_cache as $tax ) {
 			if ( empty( $terms[ $tax ] ) ) {
 				$to_cache = array();
-			} elseif ( $store_only_term_ids ) {
-				$to_cache = array( $terms[ $tax ]->term_id );
 			} else {
-				// Backward compatibility with WP < 6.0.
-				$to_cache = array( $terms[ $tax ] );
+				$to_cache = array( $terms[ $tax ]->term_id );
 			}
 
 			wp_cache_add( $id, $to_cache, "{$tax}_relationships" );


### PR DESCRIPTION
- `Requests_IDNAEncoder` replaced by `WpOrg\Requests\IdnaEncoder`
- Object term cache storing ids instead of terms
- Use `WP_Block_Editor_Context::$name` 