### PR TITLE
Don't use textdomains until `after_setup_theme` in 3.7 code

### DIFF
--- a/include/Options/Business/Sync.php
+++ b/include/Options/Business/Sync.php
@@ -37,11 +37,12 @@ class Sync extends Abstract_List {
 	 *
 	 * @return array Partial schema.
 	 *
-	 * @phpstan-return array{type: 'array', items: array{type: SchemaType, enum: non-empty-array<non-falsy-string>}}
+	 * @phpstan-return array{type: 'array', items: array{type: SchemaType, enum: non-empty-list<non-falsy-string>}}
 	 */
 	protected function get_data_structure(): array {
-		/** @phpstan-var non-empty-array<non-falsy-string> */
+		add_filter( 'lang_dir_for_domain', '__return_false' ); // Prevents loading the translations too early.
 		$enum = array_keys( \PLL_Settings_Sync::list_metas_to_sync() );
+		remove_filter( 'lang_dir_for_domain', '__return_false' );
 		return array(
 			'type'  => 'array',
 			'items' => array(

--- a/modules/sync/settings-sync.php
+++ b/modules/sync/settings-sync.php
@@ -95,6 +95,8 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 	 * @since 1.0
 	 *
 	 * @return string[] Array synchronization options.
+	 *
+	 * @phpstan-return non-empty-array<non-falsy-string, string>
 	 */
 	public static function list_metas_to_sync() {
 		return array(


### PR DESCRIPTION
This follows #1550 and focuses only on PLL 3.7 code.

Since WP 6.7-beta, any call to `__()`, `load_*_textdomains()` and `_load_textdomain_just_in_time()` before the hook `after_setup_theme` ends with a `_doing_it_wrong()` notice.

This is caused by [this commit](https://github.com/WordPress/WordPress/commit/48f12f72df8bb2c11570158d32e7fa2e6f5dcea6) about [this ticket](https://core.trac.wordpress.org/ticket/44937).

In this PR:
1. `Options\Business\Sync::get_data_structure()` calls `PLL_Settings_Sync::list_metas_to_sync()`, which contains several `__()`. Ponctually filtering `lang_dir_for_domain` with `__return_false()` prevents `__()` to call `_load_textdomain_just_in_time()`. Props @Chouby for [the idea](https://github.com/polylang/polylang/pull/1550#discussion_r1784670861).