### PR TITLE
Introduce get_data_from_new_media_translation_request()

### DIFF
--- a/admin/admin-filters-media.php
+++ b/admin/admin-filters-media.php
@@ -27,16 +27,14 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 
 		$this->posts = &$polylang->posts;
 
-		// Adds the language field and translations tables in the 'Edit Media' panel
+		// Adds the language field and translations tables in the 'Edit Media' panel.
 		add_filter( 'attachment_fields_to_edit', array( $this, 'attachment_fields_to_edit' ), 10, 2 );
 
-		// Adds actions related to languages when creating, saving or deleting media
+		// Adds actions related to languages when creating, saving or deleting media.
 		add_filter( 'attachment_fields_to_save', array( $this, 'save_media' ), 10, 2 );
 
-		// Creates a media translation
-		if ( isset( $_GET['action'], $_GET['new_lang'], $_GET['from_media'] ) && 'translate_media' === $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			add_action( 'admin_init', array( $this, 'translate_media' ) );
-		}
+		// Maybe creates a media translation.
+		add_action( 'admin_init', array( $this, 'translate_media' ) );
 	}
 
 	/**
@@ -50,8 +48,8 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 	 * @return array Modified list of form fields.
 	 */
 	public function attachment_fields_to_edit( $fields, $post ) {
-		if ( 'post.php' == $GLOBALS['pagenow'] ) {
-			return $fields; // Don't add anything on edit media panel for WP 3.5+ since we have the metabox
+		if ( 'post.php' === $GLOBALS['pagenow'] ) {
+			return $fields; // Don't add anything on edit media panel for WP 3.5+ since we have the metabox.
 		}
 
 		$post_id = $post->ID;
@@ -76,30 +74,29 @@ class PLL_Admin_Filters_Media extends PLL_Admin_Filters_Post_Base {
 	}
 
 	/**
-	 * Creates a media translation
+	 * Maybe creates a media translation.
 	 *
 	 * @since 0.9
 	 *
 	 * @return void
 	 */
 	public function translate_media() {
-		if ( isset( $_GET['from_media'], $_GET['new_lang'] ) ) {
-			// Security check
-			check_admin_referer( 'translate_media' );
-			$post_id = (int) $_GET['from_media'];
+		$data = $this->links->get_data_from_new_media_translation_request();
+		if ( empty( $data ) ) {
+			return;
+		}
 
-			// Bails if the translations already exists
-			// See https://wordpress.org/support/topic/edit-translation-in-media-attachments?#post-7322303
-			// Or if the source media does not exist
-			if ( $this->model->post->get_translation( $post_id, sanitize_key( $_GET['new_lang'] ) ) || ! get_post( $post_id ) ) {
-				wp_safe_redirect( wp_get_referer() );
-				exit;
-			}
+		$post_id = $data['from_post']->ID;
 
-			$tr_id = $this->model->post->create_media_translation( $post_id, sanitize_key( $_GET['new_lang'] ) );
-			wp_safe_redirect( admin_url( sprintf( 'post.php?post=%d&action=edit', $tr_id ) ) ); // WP 3.5+
+		// Bails if the translations already exists.
+		if ( $this->model->post->get_translation( $post_id, $data['new_lang'] ) ) {
+			wp_safe_redirect( wp_get_referer() );
 			exit;
 		}
+
+		$tr_id = $this->model->post->create_media_translation( $post_id, $data['new_lang'] );
+		wp_safe_redirect( admin_url( sprintf( 'post.php?post=%d&action=edit', $tr_id ) ) ); // WP 3.5+.
+		exit;
 	}
 
 	/**

--- a/admin/admin-filters-post-base.php
+++ b/admin/admin-filters-post-base.php
@@ -15,7 +15,7 @@ abstract class PLL_Admin_Filters_Post_Base {
 	public $model;
 
 	/**
-	 * @var PLL_Links|null
+	 * @var PLL_Admin_Links
 	 */
 	public $links;
 

--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -256,25 +256,7 @@ class PLL_Admin_Links extends PLL_Links {
 
 		// Capability check already done in post-new.php.
 		check_admin_referer( 'new-post-translation' );
-
-		$post_id   = (int) $_GET['from_post'];
-		$lang_slug = sanitize_key( $_GET['new_lang'] );
-
-		if ( $post_id <= 0 || empty( $lang_slug ) ) {
-			return array();
-		}
-
-		$post = get_post( $post_id );
-		$lang = $this->model->get_language( $lang_slug );
-
-		if ( empty( $post ) || empty( $lang ) ) {
-			return array();
-		}
-
-		return array(
-			'from_post' => $post,
-			'new_lang'  => $lang,
-		);
+		return $this->get_objects_from_new_post_translation_request( (int) $_GET['from_post'], sanitize_key( $_GET['new_lang'] ) );
 	}
 
 	/**
@@ -283,13 +265,13 @@ class PLL_Admin_Links extends PLL_Links {
 	 * @since 3.7
 	 *
 	 * @return array {
-	 *     @type WP_Post      $from_post The source post.
+	 *     @type WP_Post      $from_post The source media.
 	 *     @type PLL_Language $new_lang  The target language.
 	 * }
 	 *
 	 * @phpstan-return array{}|array{from_post: WP_Post, new_lang: PLL_Language}|never
 	 */
-	public function get_data_from_new_media_translation_request() {
+	public function get_data_from_new_media_translation_request(): array {
 		if ( ! $this->options['media_support'] ) {
 			return array();
 		}
@@ -299,10 +281,24 @@ class PLL_Admin_Links extends PLL_Links {
 		}
 
 		check_admin_referer( 'translate_media' );
+		return $this->get_objects_from_new_post_translation_request( (int) $_GET['from_media'], sanitize_key( $_GET['new_lang'] ) );
+	}
 
-		$post_id   = (int) $_GET['from_media'];
-		$lang_slug = sanitize_key( $_GET['new_lang'] );
-
+	/**
+	 * Returns the objects given the post ID and language slug provided in the new post translation request.
+	 *
+	 * @since 3.7
+	 *
+	 * @param int    $post_id   The original Post ID provided.
+	 * @param string $lang_slug The new translation language provided
+	 * @return array {
+	 *     @type WP_Post      $from_post The source post.
+	 *     @type PLL_Language $new_lang  The target language.
+	 * }
+	 *
+	 * @phpstan-return array{}|array{from_post: WP_Post, new_lang: PLL_Language}|never
+	 */
+	private function get_objects_from_new_post_translation_request( int $post_id, string $lang_slug ): array {
 		if ( $post_id <= 0 || empty( $lang_slug ) ) {
 			return array();
 		}


### PR DESCRIPTION
Follows up #1532 
This PR introduces the new method `PLL_Admin_Links::get_data_from_new_media_translation_request()` similar to `PLL_Admin_Links::get_data_from_new_post_translation_request()` but for media.