### PR TITLE
Use parallel processing and cache for PHPCS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,8 @@
 	<arg name="extensions" value="php,js" />
 	<arg name="colors"/>
 	<arg value="ps"/>
+	<arg name="parallel" value="20"/>
+	<arg name="cache"/>
 
 	<file>.</file>
 


### PR DESCRIPTION
All is in the title. On my laptop, the parallel processing decreases the time to check from 38 s to 6s.
On GitHub the time goes from 32s in the previous PR to 15s in this PR. Not that much.