### PR TITLE
Fix "Language is defined from the content" front page

### DIFF
--- a/include/translated-post.php
+++ b/include/translated-post.php
@@ -85,11 +85,25 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 				'show_ui'            => false, // Hide the taxonomy on admin side, needed for WP 4.4.x.
 				'show_in_nav_menus'  => false, // No metabox for nav menus, needed for WP 4.4.x.
 				'publicly_queryable' => true, // Since WP 4.5.
-				'query_var'          => 'lang',
+				'query_var'          => 'lang', // See `add_language_taxonomy_query_var()`.
 				'rewrite'            => false, // Rewrite rules are added through filters when needed.
 				'_pll'               => true, // Polylang taxonomy.
 			)
 		);
+
+		add_action( 'setup_theme', array( $this, 'add_language_taxonomy_query_var' ) );
+	}
+
+	/**
+	 * Adds the language query var once the global `$wp` is available.
+	 *
+	 * @since 3.7
+	 * @see WP_Taxonomy::add_rewrite_rules()
+	 *
+	 * @return void
+	 */
+	public function add_language_taxonomy_query_var(): void {
+		$GLOBALS['wp']->add_query_var( 'lang' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -91,10 +91,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$GLOBALS['wp'] = new WP();
 
 		/*
-		 * Instead of using `_cleanup_query_vars()` to cleanup and repopulate query vars, trigger `setup_theme`.
+		 * Instead of using `_cleanup_query_vars()` to cleanup and repopulate query vars, trigger `setup_theme` and use
+		 * `create_initial_taxonomies()`.
 		 * See `PLL_Translated_Post::add_language_taxonomy_query_var()`.
 		 */
 		do_action( 'setup_theme' );
+		create_initial_taxonomies();
 
 		$GLOBALS['wp']->main( $parts['query'] );
 	}

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -189,32 +189,6 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'en', $this->frontend->curlang->slug );
 	}
 
-	/**
-	 * @see https://github.com/polylang/polylang-pro/issues/2294
-	 */
-	public function test_archive_not_initialized() {
-		$en = self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$model->term->set_language( $en, 'en' );
-
-		$fr = self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
-		self::$model->post->set_language( $fr, 'fr' );
-
-		// Remove the language taxonomy.
-		unregister_taxonomy( 'language' );
-		$this->remove_hooks( 'setup_theme', array( \PLL_Translated_Post::class, 'add_language_taxonomy_query_var' ) );
-
-		// Recreate the language taxonomy, in the same context as it would be created normally (understand: `$wp` is not set yet).
-		unset( $GLOBALS['wp'] );
-		$this->frontend->model->post = new \PLL_Translated_Post( $this->frontend->model );
-
-		// Remove the hook that adds the query var.
-		remove_action( 'setup_theme', array( $this->frontend->model->post, 'add_language_taxonomy_query_var' ) );
-
-		// Watch it fail: FR is asked but EN is the current language.
-		$this->go_to( home_url( '/fr/2007/' ) );
-		$this->assertEquals( 'en', $this->frontend->curlang->slug );
-	}
-
 	public function test_archive_with_default_permalinks() {
 		$GLOBALS['wp_rewrite']->set_permalink_structure( '' );
 

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -89,6 +89,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$GLOBALS['wp_the_query'] = new WP_Query();
 		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
 		$GLOBALS['wp'] = new WP();
+
 		/*
 		 * Instead of using `_cleanup_query_vars()` to cleanup and repopulate query vars, trigger `setup_theme`.
 		 * See `PLL_Translated_Post::add_language_taxonomy_query_var()`.

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -222,41 +222,4 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 
 		$this->assertEquals( 'rtl', wp_styles()->text_direction );
 	}
-
-	private function remove_hooks( $hook, $callback_to_remove ): void {
-		global $wp_filter;
-
-		if ( empty( $wp_filter[ $hook ] ) ) {
-			return;
-		}
-
-		foreach ( $wp_filter[ $hook ]->callbacks as $prio => $callbacks ) {
-			foreach ( $callbacks as $uniqid => $callback ) {
-				if ( ! is_array( $callback['function'] ) ) {
-					if ( $callback['function'] === $callback_to_remove ) {
-						unset( $wp_filter[ $hook ]->callbacks[ $prio ][ $uniqid ] );
-					}
-					continue;
-				}
-
-				if ( ! is_array( $callback_to_remove ) || $callback['function'][1] !== $callback_to_remove[1] ) {
-					continue;
-				}
-
-				if ( is_object( $callback['function'][0] ) && get_class( $callback['function'][0] ) === $callback_to_remove[0] ) {
-					unset( $wp_filter[ $hook ]->callbacks[ $prio ][ $uniqid ] );
-					continue;
-				}
-
-				if ( is_string( $callback['function'][0] ) && $callback['function'][0] === $callback_to_remove[0] ) {
-					unset( $wp_filter[ $hook ]->callbacks[ $prio ][ $uniqid ] );
-					continue;
-				}
-			}
-
-			if ( empty( $wp_filter[ $hook ]->callbacks[ $prio ] ) ) {
-				unset( $wp_filter[ $hook ]->callbacks[ $prio ] );
-			}
-		}
-	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2294.

## Issue

When the language is defined from the content, the home page and the CPT archive pages are not translated, they display content in default language. The home page even redirects to the default language home page.

## What happens

Props @Chouby for finding the cause of this issue.

When registering the language taxonomy in `PLL_Translated_Post::register_language_taxonomy()` since #1359, the global `$wp` doesn't exist yet, which leads `WP_Taxonomy::add_rewrite_rules()` to fail to add the query var [here](https://github.com/WordPress/WordPress/blob/00a39b7510b97b76c86768b0c0ba4ecb9797534b/wp-includes/class-wp-taxonomy.php#L503).

## Solution

The solution suggested here consists on re-add the query var when the global `$wp` is ready.