### PR TITLE
Exclude `PLL_Plugin_Updater` from Typos and Rector tools

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@ extend-exclude = [
     ".git/",
     ".phpunit.result.cache",
     "flags/??.png",
+	"install/plugin-updater.php",
     "node_modules/",
     "settings/flags.php",
     "settings/languages.php",

--- a/rector.php
+++ b/rector.php
@@ -31,5 +31,6 @@ return RectorConfig::configure()
 		[
 			LongArrayToShortArrayRector::class,
 			ListToArrayDestructRector::class,
+			__DIR__ . '/install/plugin-updater.php',
 		]
 	);


### PR DESCRIPTION
This PR prevents issues reported in [this comment](https://github.com/polylang/polylang/pull/1563#issuecomment-2410660688).

<img width="868" alt="image" src="https://github.com/user-attachments/assets/16b49444-6d90-4359-8fdd-7002daf49352">
<img width="639" alt="image" src="https://github.com/user-attachments/assets/6f032dd1-0142-43e0-842e-446685265f34">

Since the class `PLL_Plugin_Updater` is not from us, but a copy/paste from EDD, the solution suggested here is to exclude it from Typos and Rector tools.