### PR TITLE
Translate strings with php files

### DIFF
--- a/include/base.php
+++ b/include/base.php
@@ -55,15 +55,17 @@ abstract class PLL_Base {
 		$this->model = &$links_model->model;
 		$this->options = &$this->model->options;
 
-		$GLOBALS['l10n_unloaded']['pll_string'] = true; // Short-circuit _load_textdomain_just_in_time() for 'pll_string' domain in WP 4.6+
-
 		add_action( 'widgets_init', array( $this, 'widgets_init' ) );
 
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
+		// Actions bellow not needed anymore?
 		// User defined strings translations
-		add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
-		add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
-		add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
-		add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 10, 0 ); // Password reset email.
+		// add_action( 'pll_language_defined', array( $this, 'load_strings_translations' ), 5 );
+		// add_action( 'change_locale', array( $this, 'load_strings_translations' ) ); // Since WP 4.7
+		// add_action( 'personal_options_update', array( $this, 'load_strings_translations' ), 1, 0 ); // Before WP, for confirmation request when changing the user email.
+		// add_action( 'lostpassword_post', array( $this, 'load_strings_translations' ), 10, 0 ); // Password reset email.
+		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
+
 		// Switch_to_blog
 		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 2 );
 	}

--- a/include/cache.php
+++ b/include/cache.php
@@ -77,7 +77,6 @@ class PLL_Cache {
 	 * @param string $key Cache key.
 	 * @return mixed
 	 *
-	 * @phpstan-param non-empty-string $key
 	 * @phpstan-return TCacheData|false
 	 */
 	public function get( $key ) {

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -104,20 +104,16 @@ class PLL_Translate_Option {
 			return $value;
 		}
 
-		if ( empty( $GLOBALS['l10n']['pll_string'] ) || ! $GLOBALS['l10n']['pll_string'] instanceof PLL_MO ) {
-			return $value;
-		}
-
-		$lang = $GLOBALS['l10n']['pll_string']->get_header( 'Language' );
-
-		if ( ! is_string( $lang ) || '' === $lang ) {
-			return $value;
-		}
-
-		$cache = $this->cache->get( $lang );
+		// `WP_Translation_Controller` knows only locales...
+		$locale = WP_Translation_Controller::get_instance()->get_locale();
+		$cache  = $this->cache->get( $locale );
 		if ( false === $cache ) {
+			// `_load_text_domain_just_in_time()` will be called eventually.
 			$cache = $this->translate_string_recursive( $value, $this->keys );
-			$this->cache->set( $lang, $cache );
+
+			if ( ! empty( $locale ) ) {
+				$this->cache->set( $locale, $cache );
+			}
 		}
 
 		return $cache;


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is a proof of concept and is offering a starting point to see things clearer.

## What?
Fixes https://github.com/polylang/polylang-pro/issues/2309
Change the way strings from `pll_string` domain are loaded and saved.
Let's use new l10n WordPress PHP files. 

## Why?
- Going as far as we can to improve performance.
- Benefit from WordPress `WP_Translation_Controller` to manages translations for us.

## How?
- Read from file when loading strings in `PLL_Table_String`.
- Generate array of string and put it in a PHP file when saving strings in `PLL_Table_String`.
- Small adjustments in `PLL_Translate_Option`
- Disable hooks that loads string translations. It should be done automatically when the locale is switched.

> [!NOTE]
> PHPUnit tests are expected to fail.

> [!WARNING]
> I've disabled hooks without testing thoroughly, some hooks might need adjustments instead of deactivation.
>
> Also, I think there is a limitation with the code I propose regarding languages sharing the same locale.
> Indeed, l10n PHP files are loaded per locales. But Polylang translated string are made per languages.

