### PR TITLE
Update GitHub Actions workflow.

### DIFF
--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run PHPUnit tests
         uses: polylang/actions/phpunit@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Check out the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run PHPCS and PHPStan tests
       uses: polylang/actions/static-analysis@main


### PR DESCRIPTION
## Why?
Get rid of deprecated notice in actions runner UI.

## How?
- Update actions/checkout to V4.