### PR TITLE
Add cache to `PLL_MO` and string translations.

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -300,19 +300,8 @@ function pll_translate_string( $string, $lang ) {
 		return $string;
 	}
 
-	static $cache; // Cache object to avoid loading the same translations object several times.
-
-	if ( empty( $cache ) ) {
-		$cache = new PLL_Cache();
-	}
-
-	$mo = $cache->get( $lang->slug );
-
-	if ( ! $mo instanceof PLL_MO ) {
-		$mo = new PLL_MO();
-		$mo->import_from_db( $lang );
-		$cache->set( $lang->slug, $mo );
-	}
+	$mo = new PLL_MO();
+	$mo->import_from_db( $lang );
 
 	return $mo->translate( $string );
 }

--- a/include/mo.php
+++ b/include/mo.php
@@ -5,7 +5,7 @@
 
 /**
  * Manages strings translations storage.
- * An static cache is used internally to enhance performances,
+ * A static cache is used internally to enhance performances,
  * for it to work as expected, `import_from_db` and `export_to_db` must be called consecutively.
  *
  * @since 1.2

--- a/include/mo.php
+++ b/include/mo.php
@@ -6,7 +6,8 @@
 /**
  * Manages strings translations storage.
  * A static cache is used internally to enhance performances,
- * for it to work as expected, `import_from_db` and `export_to_db` must be called consecutively.
+ * for it to work as expected, use `import_from_db` for the cache to be used
+ * and `export_to_db` for the cache to be cleared.
  *
  * @since 1.2
  * @since 2.1 Stores the strings in a post meta instead of post content to avoid unserialize issues (See #63)

--- a/include/mo.php
+++ b/include/mo.php
@@ -76,7 +76,7 @@ class PLL_MO extends MO {
 			}
 		}
 
-		self::$cache[ $lang->slug ] = &$this->entries;
+		self::$cache[ $lang->slug ] = $this->entries;
 	}
 
 	/**
@@ -90,5 +90,49 @@ class PLL_MO extends MO {
 	public function delete_entry( $string ) {
 		unset( $this->entries[ $string ] );
 		unset( self::$cache[ $this->get_header( 'Language' ) ][ $string ] );
+	}
+
+	/**
+	 * Adds an entry to the MO structure and caches it.
+	 *
+	 * @since 3.7
+	 *
+	 * @param Translation_Entry|array $entry The entry to add.
+	 * @return bool True if the entry was added, false otherwise.
+	 */
+	public function add_entry( $entry ) {
+		if ( is_array( $entry ) ) {
+			$entry = new Translation_Entry( $entry );
+		}
+
+		if ( parent::add_entry( $entry ) ) {
+			self::$cache[ $this->get_header( 'Language' ) ][ $entry->key() ] = $entry;
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Adds or merges an entry to the MO structure and caches it.
+	 *
+	 * @since 3.7
+	 *
+	 * @param Translation_Entry|array $entry The entry to add.
+	 * @return bool True if the entry was added, false otherwise.
+	 */
+	public function add_entry_or_merge( $entry ) {
+		if ( is_array( $entry ) ) {
+			$entry = new Translation_Entry( $entry );
+		}
+
+		if ( parent::add_entry_or_merge( $entry ) ) {
+			self::$cache[ $this->get_header( 'Language' ) ][ $entry->key() ] = $this->entries[ $entry->key() ];
+
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/include/mo.php
+++ b/include/mo.php
@@ -116,10 +116,6 @@ class PLL_MO extends MO {
 	 * @return bool True if the entry was added, false otherwise.
 	 */
 	public function add_entry( $entry ) {
-		if ( is_array( $entry ) ) {
-			$entry = new Translation_Entry( $entry );
-		}
-
 		if ( parent::add_entry( $entry ) ) {
 			$language = $this->get_header( 'Language' );
 			if ( ! empty( $language ) ) {
@@ -141,10 +137,6 @@ class PLL_MO extends MO {
 	 * @return bool True if the entry was added, false otherwise.
 	 */
 	public function add_entry_or_merge( $entry ) {
-		if ( is_array( $entry ) ) {
-			$entry = new Translation_Entry( $entry );
-		}
-
 		if ( parent::add_entry_or_merge( $entry ) ) {
 			$language = $this->get_header( 'Language' );
 			if ( ! empty( $language ) ) {

--- a/include/mo.php
+++ b/include/mo.php
@@ -4,7 +4,9 @@
  */
 
 /**
- * Manages strings translations storage
+ * Manages strings translations storage.
+ * An static cache is used internally to enhance performances,
+ * for it to work as expected, `import_from_db` and `export_to_db` must be called consecutively.
  *
  * @since 1.2
  * @since 2.1 Stores the strings in a post meta instead of post content to avoid unserialize issues (See #63)
@@ -100,52 +102,5 @@ class PLL_MO extends MO {
 	 */
 	public function delete_entry( $string ) {
 		unset( $this->entries[ $string ] );
-
-		$language = $this->get_header( 'Language' );
-		if ( ! empty( $language ) ) {
-			self::$cache->set( $language, $this->entries );
-		}
-	}
-
-	/**
-	 * Adds an entry to the MO structure and caches it.
-	 *
-	 * @since 3.7
-	 *
-	 * @param Translation_Entry|array $entry The entry to add.
-	 * @return bool True if the entry was added, false otherwise.
-	 */
-	public function add_entry( $entry ) {
-		if ( parent::add_entry( $entry ) ) {
-			$language = $this->get_header( 'Language' );
-			if ( ! empty( $language ) ) {
-				self::$cache->set( $language, $this->entries );
-			}
-
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Adds or merges an entry to the MO structure and caches it.
-	 *
-	 * @since 3.7
-	 *
-	 * @param Translation_Entry|array $entry The entry to add.
-	 * @return bool True if the entry was added, false otherwise.
-	 */
-	public function add_entry_or_merge( $entry ) {
-		if ( parent::add_entry_or_merge( $entry ) ) {
-			$language = $this->get_header( 'Language' );
-			if ( ! empty( $language ) ) {
-				self::$cache->set( $language, $this->entries );
-			}
-
-			return true;
-		}
-
-		return false;
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -50,3 +50,9 @@ parameters:
 			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\): mixed, array\\{.+\\} given\\.$#"
 			count: 1
 			path: include/model.php
+
+		# Ignored because the cache is initialized in the constructor.
+		-
+			message: "#^Static property PLL_MO\\:\\:\\$cache \\(PLL_Cache\\<array\\>\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: include/mo.php

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -54,24 +54,6 @@ class Test_PLL_MO extends PLL_UnitTestCase {
 		$this->assertSame( 1, $db_calls );
 	}
 
-	public function test_cache_is_populated_when_adding_entries() {
-		$language = $this->pll_admin->model->languages->get( 'en' );
-		$mo = new PLL_MO();
-		$mo->import_from_db( $language );
-		$added = $mo->add_entry( $mo->make_entry( 'val', 'val_en' ) );
-
-		$this->assertTrue( $added );
-
-		$mo->export_to_db( $language );
-
-		unset( $mo );
-
-		$mo = new PLL_MO();
-		$mo->import_from_db( $language );
-
-		$this->assertSame( 'val_en', $mo->translate( 'val' ) );
-	}
-
 	public function test_cache_is_updated_when_deleting_entries() {
 		$language = $this->pll_admin->model->languages->get( 'en' );
 		$mo = new PLL_MO();

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -62,31 +62,7 @@ class Test_PLL_MO extends PLL_UnitTestCase {
 
 		$this->assertTrue( $added );
 
-		unset( $mo );
-
-		$mo = new PLL_MO();
-		$mo->import_from_db( $language );
-
-		$this->assertSame( 'val_en', $mo->translate( 'val' ) );
-	}
-
-	public function test_cache_is_populated_when_merging_entries() {
-		$language = $this->pll_admin->model->languages->get( 'en' );
-		$mo = new PLL_MO();
-		$mo->import_from_db( $language );
-		$added = $mo->add_entry( $mo->make_entry( 'val', 'val_en' ) );
-
-		$this->assertTrue( $added );
-
-		unset( $mo );
-
-		$mo = new PLL_MO();
-		$mo->import_from_db( $language );
-		$entry = $mo->make_entry( 'val', 'val_en' );
-		$entry->extracted_comments = 'test_comment';
-		$added = $mo->add_entry_or_merge( $entry );
-
-		$this->assertTrue( $added );
+		$mo->export_to_db( $language );
 
 		unset( $mo );
 
@@ -94,7 +70,6 @@ class Test_PLL_MO extends PLL_UnitTestCase {
 		$mo->import_from_db( $language );
 
 		$this->assertSame( 'val_en', $mo->translate( 'val' ) );
-		$this->assertSame( 'test_comment', $mo->entries['val']->extracted_comments );
 	}
 
 	public function test_cache_is_updated_when_deleting_entries() {

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -1,0 +1,121 @@
+<?php
+
+class Test_PLL_MO extends PLL_UnitTestCase {
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
+
+		$factory->language->create_many( 2 );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$options         = $this->create_options();
+		$model           = new PLL_Model( $options );
+		$links_model     = $model->get_links_model();
+		$this->pll_admin = new PLL_Admin( $links_model );
+	}
+
+	public function tear_down() {
+		$mo = new PLL_MO();
+		foreach ( $this->pll_admin->model->languages->get_list() as $lang ) {
+			// Flush the cache.
+			$mo->export_to_db( $lang );
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_cache_is_hit_when_reimporting_from_db() {
+		$language = $this->pll_admin->model->languages->get( 'en' );
+		$translations = array( 'val' => 'val_en', 'val2' => 'val2_en' );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		foreach ( $translations as $original => $translation ) {
+			$mo->add_entry( $mo->make_entry( $original, $translation ) );
+		}
+		$mo->export_to_db( $language );
+
+		$db_calls = 0;
+		add_filter(
+			'get_term_metadata',
+			function () use ( &$db_calls ) {
+				$db_calls++;
+				return null;
+			}
+		);
+
+		$a_mo = new PLL_MO();
+		$a_mo->import_from_db( $language );
+		$another_mo = new PLL_MO();
+		$another_mo->import_from_db( $language );
+
+		$this->assertEquals( $a_mo, $another_mo );
+		$this->assertSame( 1, $db_calls );
+	}
+
+	public function test_cache_is_populated_when_adding_entries() {
+		$language = $this->pll_admin->model->languages->get( 'en' );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$added = $mo->add_entry( $mo->make_entry( 'val', 'val_en' ) );
+
+		$this->assertTrue( $added );
+
+		unset( $mo );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+
+		$this->assertSame( 'val_en', $mo->translate( 'val' ) );
+	}
+
+	public function test_cache_is_populated_when_merging_entries() {
+		$language = $this->pll_admin->model->languages->get( 'en' );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$added = $mo->add_entry( $mo->make_entry( 'val', 'val_en' ) );
+
+		$this->assertTrue( $added );
+
+		unset( $mo );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$entry = $mo->make_entry( 'val', 'val_en' );
+		$entry->extracted_comments = 'test_comment';
+		$added = $mo->add_entry_or_merge( $entry );
+
+		$this->assertTrue( $added );
+
+		unset( $mo );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+
+		$this->assertSame( 'val_en', $mo->translate( 'val' ) );
+		$this->assertSame( 'test_comment', $mo->entries['val']->extracted_comments );
+	}
+
+	public function test_cache_is_updated_when_deleting_entries() {
+		$language = $this->pll_admin->model->languages->get( 'en' );
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$added = $mo->add_entry( $mo->make_entry( 'val', 'val_en' ) );
+
+		$this->assertTrue( $added );
+
+		unset( $mo );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+		$mo->delete_entry( 'val' );
+
+		unset( $mo );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $language );
+
+		$this->assertSame( 'val', $mo->translate( 'val' ) );
+	}
+}

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -417,25 +417,4 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'val_fr', get_option( 'my_option1' ), 'Translations should be kept after option update' );
 		$this->assertSame( 'val_fr', get_option( 'my_option2' ), 'Translations should be kept after option update' );
 	}
-
-	public function test_cache_is_hit() {
-		$this->translate_strings();
-
-		$db_calls = 0;
-		add_filter(
-			'get_term_metadata',
-			function () use ( &$db_calls ) {
-				$db_calls++;
-				return null;
-			}
-		);
-
-		$a_mo = new PLL_MO();
-		$a_mo->import_from_db( $this->pll_admin->model->languages->get( 'en' ) );
-		$another_mo = new PLL_MO();
-		$another_mo->import_from_db( $this->pll_admin->model->languages->get( 'en' ) );
-
-		$this->assertEquals( $a_mo, $another_mo );
-		$this->assertSame( 1, $db_calls );
-	}
 }


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2309
Replaces https://github.com/polylang/polylang/pull/1567
For the record, it has been decided to implement the cache ourselves since WordPress caches translations per locale (and we need it to be per language code).

## How?
- Create a new prop `PLL_MO::$cache` that stores imported strings from DB. It stores *only* `Translations::$entries`.
- Remove cached implemented in `pll_translate_string()`.
- Add a test to ensure the cache is hit.

> [!NOTE]
> Some more tests are needed, especially some ensuring removed/added entries are reflected in the cache.
> But I think the code can be reviewed in the meantime.