### PR TITLE
Restrict option sanitization to the relevant string

### DIFF
--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -21,9 +21,9 @@ class PLL_Translate_Option {
 	/**
 	 * Sanitization callback.
 	 *
-	 * @var callable
+	 * @var string
 	 */
-	private $sanitize_callback = 'sanitize_option';
+	private $sanitize_callback;
 
 	/**
 	 * Hashes for registered strings for this option.
@@ -98,7 +98,7 @@ class PLL_Translate_Option {
 		add_action( 'update_option_' . $name, array( $this, 'update_option' ) );
 
 		// Sanitizes translated strings.
-		if ( ! empty( $args['sanitize_callback'] ) && is_callable( $args['sanitize_callback'] ) ) {
+		if ( ! empty( $args['sanitize_callback'] ) ) {
 			$this->sanitize_callback = $args['sanitize_callback'];
 		}
 		add_filter( 'pll_sanitize_string_translation', array( $this, 'sanitize_option' ), 10, 4 );
@@ -426,6 +426,11 @@ class PLL_Translate_Option {
 			return $value;
 		}
 
-		return call_user_func( $this->sanitize_callback, $value, $name, $context, $original );
+		if ( is_callable( $this->sanitize_callback ) ) {
+			return call_user_func( $this->sanitize_callback, $value, $name, $context, $original );
+		}
+
+		/** @var string */
+		return sanitize_option( $name, $value );
 	}
 }

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -14,9 +14,23 @@ class PLL_Translate_Option {
 	/**
 	 * Array of option keys to translate.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	private $keys;
+
+	/**
+	 * Sanitization callback.
+	 *
+	 * @var string
+	 */
+	private $sanitize_callback;
+
+	/**
+	 * Hashes for registered strings for this option.
+	 *
+	 * @var string[]
+	 */
+	private $hashes = array();
 
 	/**
 	 * Used to prevent filtering when retrieving the raw value of the option.
@@ -84,11 +98,10 @@ class PLL_Translate_Option {
 		add_action( 'update_option_' . $name, array( $this, 'update_option' ) );
 
 		// Sanitizes translated strings.
-		if ( empty( $args['sanitize_callback'] ) ) {
-			add_filter( 'pll_sanitize_string_translation', array( $this, 'sanitize_option' ), 10, 2 );
-		} else {
-			add_filter( 'pll_sanitize_string_translation', $args['sanitize_callback'], 10, 3 );
+		if ( ! empty( $args['sanitize_callback'] ) ) {
+			$this->sanitize_callback = $args['sanitize_callback'];
 		}
+		add_filter( 'pll_sanitize_string_translation', array( $this, 'sanitize_option' ), 10, 4 );
 	}
 
 	/**
@@ -216,8 +229,10 @@ class PLL_Translate_Option {
 					$this->register_string_recursive( $context, $n, $value, $key );
 				}
 			}
-		} else {
-			PLL_Admin_Strings::register_string( $option, $values, $context, true );
+		} elseif ( is_scalar( $values ) ) {
+			$string         = (string) $values;
+			$this->hashes[] = md5( "$string|$option|$context" );
+			PLL_Admin_Strings::register_string( $option, $string, $context, true );
 		}
 	}
 
@@ -395,17 +410,27 @@ class PLL_Translate_Option {
 	}
 
 	/**
-	 * Sanitizes the option value.
+	 * Sanitizes the string translation.
 	 *
 	 * @since 2.9
+	 * @since 3.7 Add $context and $orignal parameters.
 	 *
-	 * @param string $value The unsanitised value.
-	 * @param string $name  The name of the option.
+	 * @param string $value    The unsanitised string translation value.
+	 * @param string $name     The name registered for the string.
+	 * @param string $context  The context registered for the string.
+	 * @param string $original The original string to translate.
 	 * @return string Sanitized value.
 	 */
-	public function sanitize_option( $value, $name ) {
-		/** @var string $value */
-		$value = sanitize_option( $name, $value );
-		return $value;
+	public function sanitize_option( $value, $name, $context, $original ) {
+		if ( ! in_array( md5( "$original|$name|$context" ), $this->hashes, true ) ) {
+			return $value;
+		}
+
+		if ( is_callable( $this->sanitize_callback ) ) {
+			return call_user_func( $this->sanitize_callback, $value, $name, $context, $original );
+		}
+
+		/** @var string */
+		return sanitize_option( $name, $value );
 	}
 }

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -413,7 +413,7 @@ class PLL_Translate_Option {
 	 * Sanitizes the string translation.
 	 *
 	 * @since 2.9
-	 * @since 3.7 Add $context and $orignal parameters.
+	 * @since 3.7 Add $context and $original parameters.
 	 *
 	 * @param string $value    The unsanitised string translation value.
 	 * @param string $name     The name registered for the string.

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -21,7 +21,7 @@ class PLL_Translate_Option {
 	/**
 	 * Sanitization callback.
 	 *
-	 * @var string
+	 * @var callable|null
 	 */
 	private $sanitize_callback;
 
@@ -78,8 +78,8 @@ class PLL_Translate_Option {
 	 * @param array  $args {
 	 *    Optional. Array of arguments for registering the option.
 	 *
-	 *    @type string $context           The group in which the strings will be registered.
-	 *    @type string $sanitize_callback A callback function that sanitizes the option's value.
+	 *    @type string   $context           The group in which the strings will be registered.
+	 *    @type callable $sanitize_callback A callback function that sanitizes the option's value.
 	 * }
 	 */
 	public function __construct( $name, $keys = array(), $args = array() ) {

--- a/include/translate-option.php
+++ b/include/translate-option.php
@@ -21,9 +21,9 @@ class PLL_Translate_Option {
 	/**
 	 * Sanitization callback.
 	 *
-	 * @var string
+	 * @var callable
 	 */
-	private $sanitize_callback;
+	private $sanitize_callback = 'sanitize_option';
 
 	/**
 	 * Hashes for registered strings for this option.
@@ -98,7 +98,7 @@ class PLL_Translate_Option {
 		add_action( 'update_option_' . $name, array( $this, 'update_option' ) );
 
 		// Sanitizes translated strings.
-		if ( ! empty( $args['sanitize_callback'] ) ) {
+		if ( ! empty( $args['sanitize_callback'] ) && is_callable( $args['sanitize_callback'] ) ) {
 			$this->sanitize_callback = $args['sanitize_callback'];
 		}
 		add_filter( 'pll_sanitize_string_translation', array( $this, 'sanitize_option' ), 10, 4 );
@@ -426,11 +426,6 @@ class PLL_Translate_Option {
 			return $value;
 		}
 
-		if ( is_callable( $this->sanitize_callback ) ) {
-			return call_user_func( $this->sanitize_callback, $value, $name, $context, $original );
-		}
-
-		/** @var string */
-		return sanitize_option( $name, $value );
+		return call_user_func( $this->sanitize_callback, $value, $name, $context, $original );
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -546,11 +546,6 @@ parameters:
 			path: include/translate-option.php
 
 		-
-			message: "#^Parameter \\#2 \\$string of static method PLL_Admin_Strings\\:\\:register_string\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: include/translate-option.php
-
-		-
 			message: "#^Parameter \\#3 \\$args of function wp_insert_term expects array\\{alias_of\\?\\: string, description\\?\\: string, parent\\?\\: int, slug\\?\\: string\\}, array\\{description\\: mixed\\} given\\.$#"
 			count: 1
 			path: include/translated-object.php

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -390,17 +390,19 @@ class PLL_Table_String extends WP_List_Table {
 
 				foreach ( $translations as $key => $translation ) {
 					/**
-					 * Filter the string translation before it is saved in DB
-					 * Allows to sanitize strings registered with pll_register_string
+					 * Filters the string translation before it is saved in DB.
+					 * Allows to sanitize strings registered with pll_register_string().
 					 *
 					 * @since 1.6
 					 * @since 2.7 The translation passed to the filter is unslashed.
+					 * @since 3.7 Add original string as 4th parameter.
 					 *
 					 * @param string $translation The string translation.
 					 * @param string $name        The name as defined in pll_register_string.
 					 * @param string $context     The context as defined in pll_register_string.
+					 * @param string $original    The original string to translate.
 					 */
-					$translation = apply_filters( 'pll_sanitize_string_translation', $translation, $this->strings[ $key ]['name'], $this->strings[ $key ]['context'] );
+					$translation = apply_filters( 'pll_sanitize_string_translation', $translation, $this->strings[ $key ]['name'], $this->strings[ $key ]['context'], $this->strings[ $key ]['string'] );
 					$mo->add_entry(
 						$mo->make_entry(
 							$this->strings[ $key ]['string'],

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -417,4 +417,15 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'val_fr', get_option( 'my_option1' ), 'Translations should be kept after option update' );
 		$this->assertSame( 'val_fr', get_option( 'my_option2' ), 'Translations should be kept after option update' );
 	}
+
+	public function test_sanitization_should_no_apply_to_other_options() {
+		add_option( 'my_option1', 'val1' );
+		add_option( 'my_option2', 'val2' );
+
+		new PLL_Translate_Option( 'my_option1', array(), array( 'sanitize_callback' => '__return_empty_string' ) );
+		new PLL_Translate_Option( 'my_option2' );
+
+		$this->assertEmpty( apply_filters( 'pll_sanitize_string_translation', 'tr_val1', 'my_option1', 'Polylang', 'val1' ) ); // Sanitized.
+		$this->assertSame( 'tr_val2', apply_filters( 'pll_sanitize_string_translation', 'tr_val2', 'my_option2', 'Polylang', 'val2' ) ); // Not sanitized.
+	}
 }


### PR DESCRIPTION
Currently, an option sanitization callback is a applied to all string translations. If the callback doesn't make the necessary checks, this could lead to undesired changed to other strings translations.

First, a simple test is added to demonstrate the bug.

The proposed solution:
1. Add a new parameter to the filter `pll_sanitize_string_translation`: the string passed to `pll_register_string()`
2. For each option, store all registered strings in an array (in fact I propose to store md5 hashes). 
3. Use this array to check, in the method hooked to `pll_sanitize_string_translation`, that the string passed is included in the option.  