### PR TITLE
Use empty string instead of duplicate for non-translated strings.

### DIFF
--- a/include/mo.php
+++ b/include/mo.php
@@ -74,4 +74,29 @@ class PLL_MO extends MO {
 	public function delete_entry( $string ) {
 		unset( $this->entries[ $string ] );
 	}
+
+	/**
+	 * Translates a string or returns false if the translation is not found.
+	 * Contrary to `self::translate()`, this method doesn't fallback to the source string.
+	 *
+	 * @since 3.7
+	 *
+	 * @param string $source The source string to translate.
+	 * @return string|false The translated string or false if not found.
+	 */
+	public function translate_or_fail( string $source ) {
+		$entry = $this->translate_entry(
+			new Translation_Entry(
+				array(
+					'singular' => $source,
+				)
+			)
+		);
+
+		if ( ! $entry instanceof Translation_Entry || empty( $entry->translations ) ) {
+			return false;
+		}
+
+		return $entry->translations[0];
+	}
 }

--- a/include/mo.php
+++ b/include/mo.php
@@ -77,19 +77,19 @@ class PLL_MO extends MO {
 
 	/**
 	 * Translates a string or returns false if the translation is not found.
-	 * Contrary to `self::translate()`, this method doesn't fallback to the source string.
+	 * Contrary to `self::translate()`, this method doesn't fallback to the source string but returns empty string instead.
 	 *
 	 * @since 3.7
 	 *
 	 * @param string $source The source string to translate.
-	 * @return string|false The translated string or false if not found.
+	 * @return string The translated string or empty string if not found.
 	 */
-	public function translate_or_fail( string $source ) {
+	public function translate_if_any( string $source ) {
 		$entry = new Translation_Entry( array( 'singular' => $source ) );
 		$entry = $this->translate_entry( $entry );
 
 		if ( ! $entry instanceof Translation_Entry || empty( $entry->translations ) ) {
-			return false;
+			return '';
 		}
 
 		return $entry->translations[0];

--- a/include/mo.php
+++ b/include/mo.php
@@ -85,13 +85,8 @@ class PLL_MO extends MO {
 	 * @return string|false The translated string or false if not found.
 	 */
 	public function translate_or_fail( string $source ) {
-		$entry = $this->translate_entry(
-			new Translation_Entry(
-				array(
-					'singular' => $source,
-				)
-			)
-		);
+		$entry = new Translation_Entry( array( 'singular' => $source ) );
+		$entry = $this->translate_entry( $entry );
 
 		if ( ! $entry instanceof Translation_Entry || empty( $entry->translations ) ) {
 			return false;

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -229,7 +229,7 @@ class PLL_Upgrade {
 		$options = new Options();
 		$model   = new PLL_Model( $options );
 
-		foreach ( $model->get_languages_list() as $language ) { // @todo Do not use Polylang functions here.
+		foreach ( $model->get_languages_list() as $language ) {
 			$mo = new PLL_MO();
 			$mo->import_from_db( $language );
 

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -300,8 +300,16 @@ class PLL_Table_String extends WP_List_Table {
 		// Kept for the end as it is a slow process
 		foreach ( $languages as $language ) {
 			foreach ( $this->items as $key => $row ) {
-				$this->items[ $key ]['translations'][ $language->slug ] = $mo[ $language->slug ]->translate( $row['string'] );
-				$this->items[ $key ]['row'] = $key; // Store the row number for convenience
+				$entry = new Translation_Entry(
+					array(
+						'singular' => $row['string'],
+					)
+				);
+
+				$entry                                                  = $mo[ $language->slug ]->translate_entry( $entry );
+				$translation                                            = $entry && ! empty( $entry->translations ) ? $entry->translations[0] : '';
+				$this->items[ $key ]['translations'][ $language->slug ] = $translation;
+				$this->items[ $key ]['row']                             = $key; // Store the row number for convenience
 			}
 		}
 	}
@@ -407,7 +415,7 @@ class PLL_Table_String extends WP_List_Table {
 					$mo->add_entry(
 						$mo->make_entry(
 							$this->strings[ $key ]['string'],
-							$translation === $this->strings[ $key ]['string'] ? '' : $translation
+							$translation
 						)
 					);
 				}

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -141,9 +141,7 @@ class PLL_Table_String extends WP_List_Table {
 				esc_attr( $key ),
 				esc_attr( $item['row'] ),
 				esc_html( $languages[ $key ] ),
-				format_to_edit(
-					$translation === $item['string'] ? '' : $translation
-				) // Don't interpret special chars.
+				format_to_edit( $translation ) // Don't interpret special chars.
 			);
 		}
 

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -300,16 +300,7 @@ class PLL_Table_String extends WP_List_Table {
 		// Kept for the end as it is a slow process
 		foreach ( $languages as $language ) {
 			foreach ( $this->items as $key => $row ) {
-				$entry = new Translation_Entry(
-					array(
-						'singular' => $row['string'],
-					)
-				);
-
-				$entry       = $mo[ $language->slug ]->translate_entry( $entry );
-				$translation = $entry && ! empty( $entry->translations ) ? $entry->translations[0] : '';
-
-				$this->items[ $key ]['translations'][ $language->slug ] = $translation;
+				$this->items[ $key ]['translations'][ $language->slug ] = (string) $mo[ $language->slug ]->translate_or_fail( $row['string'] );
 				$this->items[ $key ]['row']                             = $key; // Store the row number for convenience
 			}
 		}

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -196,14 +196,16 @@ class PLL_Table_String extends WP_List_Table {
 	 *
 	 * @since 2.6
 	 *
-	 * @param PLL_MO[] $mos An array of PLL_MO objects.
-	 * @param string   $s   Searched string.
+	 * @param PLL_Language[] $languages An array of language objects.
+	 * @param string         $s         Searched string.
 	 * @return string[] Found strings.
 	 */
-	protected function search_in_translations( $mos, $s ) {
+	protected function search_in_translations( $languages, $s ) {
 		$founds = array();
 
-		foreach ( $mos as $mo ) {
+		foreach ( $languages as $language ) {
+			$mo = new PLL_MO();
+			$mo->import_from_db( $language );
 			foreach ( wp_list_pluck( $mo->entries, 'translations' ) as $string => $translation ) {
 				if ( false !== stripos( $translation[0], $s ) ) {
 					$founds[] = $string;
@@ -250,13 +252,6 @@ class PLL_Table_String extends WP_List_Table {
 			$languages = $this->languages;
 		}
 
-		// Load translations
-		$mo = array();
-		foreach ( $languages as $language ) {
-			$mo[ $language->slug ] = new PLL_MO();
-			$mo[ $language->slug ]->import_from_db( $language );
-		}
-
 		$data = $this->strings;
 
 		// Filter by selected group
@@ -269,7 +264,7 @@ class PLL_Table_String extends WP_List_Table {
 
 		if ( ! empty( $s ) ) {
 			// Search in translations
-			$in_translations = $this->search_in_translations( $mo, $s );
+			$in_translations = $this->search_in_translations( $languages, $s );
 
 			foreach ( $data as $key => $row ) {
 				if ( stripos( $row['name'], $s ) === false && stripos( $row['string'], $s ) === false && ! in_array( $row['string'], $in_translations ) ) {
@@ -299,8 +294,10 @@ class PLL_Table_String extends WP_List_Table {
 		// Translate strings
 		// Kept for the end as it is a slow process
 		foreach ( $languages as $language ) {
+			$mo = new PLL_MO();
+			$mo->import_from_db( $language );
 			foreach ( $this->items as $key => $row ) {
-				$this->items[ $key ]['translations'][ $language->slug ] = (string) $mo[ $language->slug ]->translate_or_fail( $row['string'] );
+				$this->items[ $key ]['translations'][ $language->slug ] = (string) $mo->translate_or_fail( $row['string'] );
 				$this->items[ $key ]['row']                             = $key; // Store the row number for convenience
 			}
 		}

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -297,7 +297,7 @@ class PLL_Table_String extends WP_List_Table {
 			$mo = new PLL_MO();
 			$mo->import_from_db( $language );
 			foreach ( $this->items as $key => $row ) {
-				$this->items[ $key ]['translations'][ $language->slug ] = (string) $mo->translate_or_fail( $row['string'] );
+				$this->items[ $key ]['translations'][ $language->slug ] = $mo->translate_if_any( $row['string'] );
 				$this->items[ $key ]['row']                             = $key; // Store the row number for convenience
 			}
 		}

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -141,7 +141,9 @@ class PLL_Table_String extends WP_List_Table {
 				esc_attr( $key ),
 				esc_attr( $item['row'] ),
 				esc_html( $languages[ $key ] ),
-				format_to_edit( $translation ) // Don't interpret special chars.
+				format_to_edit(
+					$translation === $item['string'] ? '' : $translation
+				) // Don't interpret special chars.
 			);
 		}
 
@@ -404,7 +406,12 @@ class PLL_Table_String extends WP_List_Table {
 					 * @param string $context     The context as defined in pll_register_string.
 					 */
 					$translation = apply_filters( 'pll_sanitize_string_translation', $translation, $this->strings[ $key ]['name'], $this->strings[ $key ]['context'] );
-					$mo->add_entry( $mo->make_entry( $this->strings[ $key ]['string'], $translation ) );
+					$mo->add_entry(
+						$mo->make_entry(
+							$this->strings[ $key ]['string'],
+							$translation === $this->strings[ $key ]['string'] ? '' : $translation
+						)
+					);
 				}
 
 				// Clean database ( removes all strings which were registered some day but are no more )

--- a/settings/table-string.php
+++ b/settings/table-string.php
@@ -306,8 +306,9 @@ class PLL_Table_String extends WP_List_Table {
 					)
 				);
 
-				$entry                                                  = $mo[ $language->slug ]->translate_entry( $entry );
-				$translation                                            = $entry && ! empty( $entry->translations ) ? $entry->translations[0] : '';
+				$entry       = $mo[ $language->slug ]->translate_entry( $entry );
+				$translation = $entry && ! empty( $entry->translations ) ? $entry->translations[0] : '';
+
 				$this->items[ $key ]['translations'][ $language->slug ] = $translation;
 				$this->items[ $key ]['row']                             = $key; // Store the row number for convenience
 			}

--- a/tests/phpunit/tests/test-upgrade.php
+++ b/tests/phpunit/tests/test-upgrade.php
@@ -109,4 +109,54 @@ class Upgrade_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'yes', get_option( 'pll_language_from_content_available' ) );
 		$this->assertSame( 0, $options->get( 'force_lang' ) );
 	}
+
+	public function test_should_clean_up_strings_translations_on_upgrade_to_3_7() {
+		$fr = $this->factory()->language->create_and_get(
+			array( 'locale' => 'fr_FR' )
+		);
+		update_term_meta(
+			$fr->term_id,
+			'_pll_strings_translations',
+			array(
+				array( 'Hello', 'Hello' ),
+				array( 'World', 'World' ),
+			)
+		);
+
+		$en = $this->factory()->pll_model->languages->get( 'en' );
+		update_term_meta(
+			$en->term_id,
+			'_pll_strings_translations',
+			array(
+				array( 'Hello', 'Hello' ),
+				array( 'World', 'World' ),
+			)
+		);
+
+		$options = self::create_options(
+			array( 'version' => '3.6' )
+		);
+
+		( new PLL_Upgrade( $options ) )->_upgrade();
+
+		$raw_strings_fr = get_term_meta( $fr->term_id, '_pll_strings_translations', true );
+		$raw_strings_en = get_term_meta( $en->term_id, '_pll_strings_translations', true );
+
+		$this->assertSame(
+			array(
+				array( 'Hello', '' ),
+				array( 'World', '' ),
+			),
+			$raw_strings_fr,
+			'Strings translations should have been cleaned up.'
+		);
+		$this->assertSame(
+			array(
+				array( 'Hello', '' ),
+				array( 'World', '' ),
+			),
+			$raw_strings_en,
+			'Strings translations should have been cleaned up.'
+		);
+	}
 }


### PR DESCRIPTION
## What?
Fixes partially https://github.com/polylang/polylang-pro/issues/2308.
Removes non-translated strings from the dashboard. Use empty string instead.

## How
- Ensure to use empty string on display
- Force to empty string when adding entries
- Migration from Polylang < 3.7 to ensure steady behavior.