### PR TITLE
Use the test block-theme instead of Twenty Twenty Two

### DIFF
--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -1,7 +1,5 @@
 <?php
 class Admin_Test extends PLL_UnitTestCase {
-	protected static $stylesheet;
-
 	/**
 	 * @param WP_UnitTest_Factory $factory
 	 */
@@ -10,8 +8,6 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
-
-		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
 	}
 
 	public function set_up() {
@@ -25,7 +21,7 @@ class Admin_Test extends PLL_UnitTestCase {
 
 		remove_action( 'customize_register', array( $this, 'whatever' ) );
 
-		switch_theme( self::$stylesheet );
+		switch_theme( 'default' ); // Restore the default theme.
 	}
 
 	public function test_admin_bar_menu() {
@@ -54,16 +50,10 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_remove_customize_submenu_with_block_base_theme() {
-		$block_base_theme = wp_get_theme( 'twentytwentytwo' );
-		if ( ! $block_base_theme->exists() ) {
-			self::markTestSkipped( 'This test requires twenty twenty two' );
-		}
-
-		global $submenu;
-		switch_theme( 'twentytwentytwo' );
-
-		global $_wp_theme_features;
+		global $submenu, $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
+
+		switch_theme( 'block-theme' );
 
 		$links_model         = self::$model->get_links_model();
 		$pll_admin           = new PLL_Admin( $links_model );
@@ -75,9 +65,7 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_remove_customize_submenu_with_non_block_base_theme() {
-		global $submenu;
-
-		global $_wp_theme_features;
+		global $submenu, $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
 
 		$links_model         = self::$model->get_links_model();
@@ -90,16 +78,10 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_do_not_remove_customize_submenu_with_block_base_theme_if_a_plugin_use_it() {
-		$block_base_theme = wp_get_theme( 'twentytwentytwo' );
-		if ( ! $block_base_theme->exists() ) {
-			self::markTestSkipped( 'This test requires twenty twenty two' );
-		}
-
-		global $submenu;
-		switch_theme( 'twentytwentytwo' );
-
-		global $_wp_theme_features;
+		global $submenu, $_wp_theme_features;
 		unset( $_wp_theme_features['widgets'] );
+
+		switch_theme( 'block-theme' );
 
 		$links_model         = self::$model->get_links_model();
 		$pll_admin           = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-frontend.php
+++ b/tests/phpunit/tests/test-frontend.php
@@ -3,42 +3,23 @@
 
 class Frontend_Test extends PLL_UnitTestCase {
 
-	protected static $editor;
-	protected static $stylesheet;
-
-	/**
-	 * @param WP_UnitTest_Factory $factory
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
-
-		self::$editor = $factory->user->create( array( 'role' => 'administrator' ) );
-
-		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
-	}
-
 	public function set_up() {
 		parent::set_up();
 
-		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can tests
+		wp_set_current_user( 1 ); // Set a user to pass current_user_can tests.
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 
-		switch_theme( self::$stylesheet );
+		switch_theme( 'default' );
 	}
 
 	public function test_remove_customize_admin_bar_with_block_base_theme() {
 		global $wp_admin_bar;
 
-		$block_base_theme = wp_get_theme( 'twentytwentytwo' );
-		if ( ! $block_base_theme->exists() ) {
-			self::markTestSkipped( 'This test requires twenty twenty two' );
-		}
-
-		switch_theme( 'twentytwentytwo' );
-		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
+		switch_theme( 'block-theme' );
+		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
 
 		$links_model = self::$model->get_links_model();
 		$frontend = new PLL_Frontend( $links_model );
@@ -53,7 +34,7 @@ class Frontend_Test extends PLL_UnitTestCase {
 
 	public function test_remove_customize_admin_bar_with_non_block_base_theme() {
 		global $wp_admin_bar;
-		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar
+		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
 
 		$links_model = self::$model->get_links_model();
 		$frontend = new PLL_Frontend( $links_model );


### PR DESCRIPTION
Twenty Twenty Two has been removed fro WP 6.7. Tests using it are then skipped. See https://github.com/polylang/polylang/actions/runs/11935773152/job/33267859373

In this PR I use the block theme provided by the WordPress test framework to replace Twenty Twenty in our tests.
Additionally I simplify the test as there is no need the save the default theme as we know what it is.
Frontend tests are further simplified. No need to create a new administrator user have the user 1 is already available.