### PR TITLE
Reformat SQL queries for the  WP Importer

### DIFF
--- a/integrations/wp-importer/wp-import.php
+++ b/integrations/wp-importer/wp-import.php
@@ -128,20 +128,18 @@ class PLL_WP_Import extends WP_Import {
 			$translations = maybe_unserialize( $term['term_description'] );
 			foreach ( $translations as $slug => $old_id ) {
 				if ( $old_id && ! empty( $this->processed_terms[ $old_id ] ) && $lang = PLL()->model->get_language( $slug ) ) {
-					// Language relationship
-					$trs[] = $wpdb->prepare( '( %d, %d )', $this->processed_terms[ $old_id ], $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' ) );
+					// Language relationship.
+					$trs[] = array( $this->processed_terms[ $old_id ], $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' ) );
 
-					// Translation relationship
-					$trs[] = $wpdb->prepare( '( %d, %d )', $this->processed_terms[ $old_id ], get_term( $this->processed_terms[ $term['term_id'] ], 'term_translations' )->term_taxonomy_id );
+					// Translation relationship.
+					$trs[] = array( $this->processed_terms[ $old_id ], get_term( $this->processed_terms[ $term['term_id'] ], 'term_translations' )->term_taxonomy_id );
 				}
 			}
 		}
 
-		// Insert term_relationships
+		// Insert term_relationships.
 		if ( ! empty( $trs ) ) {
-			$trs = array_unique( $trs );
-
-			// Make sure we don't attempt to insert already existing term relationships
+			// Make sure we don't attempt to insert already existing term relationships.
 			$existing_trs = $wpdb->get_results(
 				"SELECT tr.object_id, tr.term_taxonomy_id FROM {$wpdb->term_relationships} AS tr
 				INNER JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
@@ -149,14 +147,21 @@ class PLL_WP_Import extends WP_Import {
 			);
 
 			foreach ( $existing_trs as $key => $tr ) {
-				$existing_trs[ $key ] = $wpdb->prepare( '( %d, %d )', $tr->object_id, $tr->term_taxonomy_id );
+				$existing_trs[ $key ] = array( $tr->object_id, $tr->term_taxonomy_id );
 			}
 
 			$trs = array_diff( $trs, $existing_trs );
 
 			if ( ! empty( $trs ) ) {
-				// PHPCS:ignore WordPress.DB.PreparedSQL.NotPrepared
-				$wpdb->query( "INSERT INTO {$wpdb->term_relationships} ( object_id, term_taxonomy_id ) VALUES " . implode( ',', $trs ) );
+				$wpdb->query(
+					$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+						sprintf(
+							"INSERT INTO {$wpdb->term_relationships} ( object_id, term_taxonomy_id ) VALUES %s",
+							implode( ',', array_fill( 0, count( $trs ), '( %d, %d )' ) )
+						),
+						array_merge( ...$trs )
+					)
+				);
 			}
 		}
 	}
@@ -185,16 +190,23 @@ class PLL_WP_Import extends WP_Import {
 			}
 
 			if ( ! empty( $new_translations ) ) {
-				$u['case'][] = $wpdb->prepare( 'WHEN %d THEN %s', $this->processed_terms[ $term['term_id'] ], maybe_serialize( $new_translations ) );
+				$u['case'][] = array( $this->processed_terms[ $term['term_id'] ], maybe_serialize( $new_translations ) );
 				$u['in'][] = (int) $this->processed_terms[ $term['term_id'] ];
 			}
 		}
 
 		if ( ! empty( $u ) ) {
 			$wpdb->query(
-				"UPDATE {$wpdb->term_taxonomy}
-				SET description = ( CASE term_id " . implode( ' ', $u['case'] ) . ' END ) ' . // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				'WHERE term_id IN ( ' . implode( ',', $u['in'] ) . ' )' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->prepare(
+					sprintf(
+						"UPDATE {$wpdb->term_taxonomy}
+						SET description = ( CASE term_id %s END )
+						WHERE term_id IN (%s)",
+						implode( ' ', array_fill( 0, count( $u['case'] ), 'WHEN %d THEN %s' ) ),
+						implode( ',', array_fill( 0, count( $u['in'] ), '%d' ) )
+					),
+					array_merge( array_merge( ...$u['case'] ), $u['in'] )
+				)
 			);
 		}
 	}

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -27,7 +27,6 @@ class WP_Importer_Test extends PLL_UnitTestCase {
 		global $wpdb;
 		// crude but effective: make sure there's no residual data in the main tables
 		foreach ( array( 'posts', 'postmeta', 'comments', 'terms', 'term_taxonomy', 'term_relationships', 'users', 'usermeta' ) as $table ) {
-			// PHPCS:ignore WordPress.DB.PreparedSQL
 			$wpdb->query( "DELETE FROM {$wpdb->$table}" );
 		}
 


### PR DESCRIPTION
Same as #1576 for the WordPress importer.

This PR reformats SQL queries prepare them in only one place when possible thus avoiding `phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared`.

In some cases this ignore comment is replaced by `phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber` as least as long as WPCS doesn't handle correctly the SQL syntax `INSERT INTO ... VALUES ...`.