### PR TITLE
Hide the `hide_current` checkbox if `dropdown` is checked

### DIFF
--- a/admin/admin-nav-menu.php
+++ b/admin/admin-nav-menu.php
@@ -101,7 +101,7 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		}
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'pll_nav_menu', plugins_url( '/js/build/nav-menu' . $suffix . '.js', POLYLANG_ROOT_FILE ), array( 'jquery' ), POLYLANG_VERSION );
+		wp_enqueue_script( 'pll_nav_menu', plugins_url( "/js/build/nav-menu{$suffix}.js", POLYLANG_ROOT_FILE ), array(), POLYLANG_VERSION );
 
 		$data = array(
 			'strings' => PLL_Switcher::get_switcher_options( 'menu', 'string' ), // The strings for the options

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -5,110 +5,110 @@
  */
 
 const pllNavMenu = {
+	/* global pll_data */
+	/**
+	 * The element wrapping the menu elements.
+	 *
+	 * @member {HTMLElement|null}
+	 */
+	wrapper: null,
+
 	/**
 	 * Init.
 	 */
 	init: () => {
-		const handlers = [
-			pllNavMenu.printMetabox.attachEvent,
-			pllNavMenu.ensureContent.attachEvent,
-			pllNavMenu.showHideRows.attachEvent,
-		];
-
 		if ( document.readyState !== 'loading' ) {
-			handlers.forEach( ( handler ) => handler() );
+			pllNavMenu.ready();
 		} else {
-			handlers.forEach( ( handler ) =>
-				document.addEventListener( 'DOMContentLoaded', handler )
-			);
+			document.addEventListener( 'DOMContentLoaded', pllNavMenu.ready );
 		}
 	},
 
 	/**
-	 * Attaches an event to an element.
-	 *
-	 * @param {string} elemId   The HTML id of the element to attach the event to.
-	 * @param {string} type     A case-sensitive string representing the event type to listen for.
-	 * @param {Object} listener The callback to fire on that event.
+	 * Called when the DOM is ready. Attaches the events to the wrapper.
 	 */
-	maybeAttachEvent: ( elemId, type, listener ) => {
-		const wrapper = document.getElementById( elemId );
+	ready: () => {
+		pllNavMenu.wrapper = document.getElementById( 'menu-to-edit' );
 
-		if ( wrapper ) {
-			wrapper.addEventListener( type, listener );
+		if ( ! pllNavMenu.wrapper ) {
+			return;
 		}
+
+		pllNavMenu.wrapper.addEventListener( 'click', pllNavMenu.printMetabox );
+		pllNavMenu.wrapper.addEventListener( 'change', pllNavMenu.ensureContent );
+		pllNavMenu.wrapper.addEventListener( 'change', pllNavMenu.showHideRows );
 	},
 
 	printMetabox: {
 		/**
-		 * Attaches an event to `#menu-to-edit` to print our checkboxes in the language switcher.
+		 * Event callback that prints our checkboxes in the language switcher.
+		 *
+		 * @param {Event} event The event.
 		 */
-		attachEvent: () => {
-			pllNavMenu.maybeAttachEvent( 'menu-to-edit', 'click', ( event ) => {
-				if ( ! event.target.classList.contains( 'item-edit' ) ) {
-					// Not clicking on a Edit arrow button.
-					return;
+		handleEvent: ( event ) => {
+			if ( ! event.target.classList.contains( 'item-edit' ) ) {
+				// Not clicking on a Edit arrow button.
+				return;
+			}
+
+			const metabox = event.target.closest( '.menu-item' ).querySelector( '.menu-item-settings' );
+
+			if ( ! metabox?.id ) {
+				// Should not happen.
+				return;
+			}
+
+			if ( ! metabox.querySelectorAll( 'input[value="#pll_switcher"][type=text]' ).length ) {
+				// Not our metabox, or already replaced.
+				return;
+			}
+
+			// Remove default fields we don't need.
+			for ( const el of metabox.querySelectorAll( 'p:not(.field-move)' ) ) {
+				el.remove();
+			}
+
+			const t      = pllNavMenu.printMetabox;
+			const itemId = Number( metabox.id.replace( 'menu-item-settings-', '' ) );
+
+			metabox.append( t.createHiddenInput( 'title', itemId, pll_data.title ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			metabox.append( t.createHiddenInput( 'url', itemId, '#pll_switcher' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			metabox.append( t.createHiddenInput( 'detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+
+			const ids          = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // Reverse order.
+			const isValDefined = typeof( pll_data.val[ itemId ] ) !== 'undefined';
+
+			ids.forEach( ( optionName ) => {
+				// Create the checkbox's wrapper.
+				const inputWrapper = t.createElement( 'p', { class: 'description' } );
+
+				if ( 'hide_current' === optionName && isValDefined && 1 === pll_data.val[ itemId ].dropdown ) {
+					// Hide the `hide_current` checkbox if `dropdown` is checked.
+					inputWrapper.classList.add( 'hidden' );
 				}
 
-				const metabox = event.target.closest( '.menu-item' ).querySelector( '.menu-item-settings' );
+				metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 
-				if ( ! metabox?.id ) {
-					// Should not happen.
-					return;
-				}
+				// Create the checkbox's label.
+				const inputId = `edit-menu-item-${ optionName }-${ itemId }`;
+				const label   = t.createElement( 'label', { 'for': inputId } );
+				label.innerText = ` ${ pll_data.strings[ optionName ] }`;
 
-				if ( ! metabox.querySelectorAll( 'input[value="#pll_switcher"][type=text]' ).length ) {
-					// Not our metabox, or already replaced.
-					return;
-				}
+				inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
-				// Remove default fields we don't need.
-				for ( const el of metabox.querySelectorAll( 'p:not(.field-move)' ) ) {
-					el.remove();
-				}
-
-				const t      = pllNavMenu.printMetabox;
-				const itemId = Number( metabox.id.replace( 'menu-item-settings-', '' ) );
-
-				metabox.append( t.createHiddenInput( 'title', itemId, pll_data.title ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-				metabox.append( t.createHiddenInput( 'url', itemId, '#pll_switcher' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-				metabox.append( t.createHiddenInput( 'detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-
-				const ids          = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // Reverse order.
-				const isValDefined = typeof( pll_data.val[ itemId ] ) !== 'undefined';
-
-				ids.forEach( ( optionName ) => {
-					// Create the checkbox's wrapper.
-					const inputWrapper = t.createElement( 'p', { class: 'description' } );
-
-					if ( 'hide_current' === optionName && isValDefined && 1 === pll_data.val[ itemId ].dropdown ) {
-						// Hide the `hide_current` checkbox if `dropdown` is checked.
-						inputWrapper.classList.add( 'hidden' );
-					}
-
-					metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
-
-					// Create the checkbox's label.
-					const inputId = `edit-menu-item-${ optionName }-${ itemId }`;
-					const label   = t.createElement( 'label', { 'for': inputId } );
-					label.innerText = ` ${ pll_data.strings[ optionName ] }`;
-
-					inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-
-					// Create the checkbox.
-					const cb = t.createElement( 'input', {
-						type:  'checkbox',
-						id:    inputId,
-						name:  `menu-item-${ optionName }[${ itemId }]`,
-						value: 1,
-					} );
-
-					if ( ( isValDefined && 1 === pll_data.val[ itemId ][ optionName ] ) || ( ! isValDefined && 'show_names' === optionName ) ) { // `show_names` as default value.
-						cb.checked = true;
-					}
-
-					label.prepend( cb ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+				// Create the checkbox.
+				const cb = t.createElement( 'input', {
+					type:  'checkbox',
+					id:    inputId,
+					name:  `menu-item-${ optionName }[${ itemId }]`,
+					value: 1,
 				} );
+
+				if ( ( isValDefined && 1 === pll_data.val[ itemId ][ optionName ] ) || ( ! isValDefined && 'show_names' === optionName ) ) { // `show_names` as default value.
+					cb.checked = true;
+				}
+
+				label.prepend( cb ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 			} );
 		},
 
@@ -146,71 +146,71 @@ const pllNavMenu = {
 	},
 
 	ensureContent: {
+		regExpr: new RegExp( /^edit-menu-item-show_(names|flags)-(\d+)$/ ),
+
 		/**
-		 * Attaches an event to `#menu-to-edit` to disallow unchecking both `show_names` and `show_flags`.
+		 * Event callback that disallows unchecking both `show_names` and `show_flags`.
+		 *
+		 * @param {Event} event The event.
 		 */
-		attachEvent: () => {
-			const regExpr = new RegExp( /^edit-menu-item-show_(names|flags)-(\d+)$/ );
+		handleEvent: ( event ) => {
+			if ( ! event.target.id || event.target.checked ) {
+				// Now checked, nothing to do.
+				return;
+			}
 
-			pllNavMenu.maybeAttachEvent( 'menu-to-edit', 'change', ( event ) => {
-				if ( ! event.target.id || event.target.checked ) {
-					// Now checked, nothing to do.
-					return;
-				}
+			const matches = event.target.id.match( pllNavMenu.ensureContent.regExpr );
 
-				const matches = event.target.id.match( regExpr );
+			if ( ! matches ) {
+				// Not the checkbox we want.
+				return;
+			}
 
-				if ( ! matches ) {
-					// Not the checkbox we want.
-					return;
-				}
-
-				// Check the other checkbox.
-				const [ , type, id ] = matches;
-				const otherType = 'names' === type ? 'flags' : 'names';
-				document.getElementById( `edit-menu-item-show_${ otherType }-${ id }` ).checked = true;
-			} );
+			// Check the other checkbox.
+			const [ , type, id ] = matches;
+			const otherType = 'names' === type ? 'flags' : 'names';
+			document.getElementById( `edit-menu-item-show_${ otherType }-${ id }` ).checked = true;
 		},
 	},
 
 	showHideRows: {
+		regExpr: new RegExp( /^edit-menu-item-dropdown-(\d+)$/ ),
+
 		/**
-		 * Attaches an event to `#menu-to-edit` to show or hide the `hide_current` checkbox when `dropdown` is checked.
+		 * Event callback that shows or hides the `hide_current` checkbox when `dropdown` is checked.
+		 *
+		 * @param {Event} event The event.
 		 */
-		attachEvent: () => {
-			const regExpr = new RegExp( /^edit-menu-item-dropdown-(\d+)$/ );
+		handleEvent: ( event ) => {
+			if ( ! event.target.id ) {
+				// Not the checkbox we want.
+				return;
+			}
 
-			pllNavMenu.maybeAttachEvent( 'menu-to-edit', 'change', ( event ) => {
-				if ( ! event.target.id ) {
-					// Not the checkbox we want.
-					return;
-				}
+			const matches = event.target.id.match( pllNavMenu.showHideRows.regExpr );
 
-				const matches = event.target.id.match( regExpr );
+			if ( ! matches ) {
+				// Not the checkbox we want.
+				return;
+			}
 
-				if ( ! matches ) {
-					// Not the checkbox we want.
-					return;
-				}
+			const hideCb = document.getElementById( `edit-menu-item-hide_current-${ matches[1] }` );
 
-				const hideCb = document.getElementById( `edit-menu-item-hide_current-${ matches[1] }` );
+			if ( ! hideCb ) {
+				// Should not happen.
+				return;
+			}
 
-				if ( ! hideCb ) {
-					// Should not happen.
-					return;
-				}
+			const description = hideCb.closest( '.description' );
 
-				const description = hideCb.closest( '.description' );
+			// Hide or show.
+			description.classList.toggle( 'hidden', event.target.checked );
 
-				// Hide or show.
-				description.classList.toggle( 'hidden', event.target.checked );
-
-				if ( event.target.checked ) {
-					// Uncheck after hiding.
-					hideCb.checked = false;
-					hideCb.dispatchEvent( new Event( 'change' ) );
-				}
-			} );
+			if ( event.target.checked ) {
+				// Uncheck after hiding.
+				hideCb.checked = false;
+				hideCb.dispatchEvent( new Event( 'change' ) );
+			}
 		},
 	},
 };

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -74,7 +74,7 @@ const pllNavMenu = {
 
 			metabox.append( t.createHiddenInput( 'title', itemId, pll_data.title ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 			metabox.append( t.createHiddenInput( 'url', itemId, '#pll_switcher' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-			metabox.append( t.createHiddenInput( 'detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			metabox.append( t.createHiddenInput( 'pll-detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
 			const ids          = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // Reverse order.
 			const isValDefined = typeof( pll_data.val[ itemId ] ) !== 'undefined';
@@ -124,8 +124,8 @@ const pllNavMenu = {
 		createHiddenInput: ( id, itemId, value ) => {
 			return pllNavMenu.printMetabox.createElement( 'input', {
 				type:  'hidden',
-				id:    `edit-menu-item-pll-${ id }-${ itemId }`,
-				name:  `menu-item-pll-${ id }[${ itemId }]`,
+				id:    `edit-menu-item-${ id }-${ itemId }`,
+				name:  `menu-item-${ id }[${ itemId }]`,
 				value: value,
 			} );
 		},

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -5,7 +5,6 @@
  */
 
 const pllNavMenu = {
-	/* global pll_data */
 	/**
 	 * The element wrapping the menu elements.
 	 *

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -52,9 +52,9 @@ const pllNavMenu = {
 				const t      = pllNavMenu.printMetabox;
 				const itemId = Number( metabox.id.replace( 'menu-item-settings-', '' ) );
 
-				metabox.append( t.createHiddenInput( 'title', itemId, pll_data.title ) );
-				metabox.append( t.createHiddenInput( 'url', itemId, '#pll_switcher' ) );
-				metabox.append( t.createHiddenInput( 'detect', itemId, 1 ) );
+				metabox.append( t.createHiddenInput( 'title', itemId, pll_data.title ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+				metabox.append( t.createHiddenInput( 'url', itemId, '#pll_switcher' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+				metabox.append( t.createHiddenInput( 'detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
 				const ids          = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // Reverse order.
 				const isValDefined = typeof( pll_data.val[ itemId ] ) !== 'undefined';
@@ -68,14 +68,14 @@ const pllNavMenu = {
 						inputWrapper.classList.add( 'hidden' );
 					}
 
-					metabox.prepend( inputWrapper );
+					metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 
 					// Create the checkbox's label.
 					const inputId = `edit-menu-item-${ optionName }-${ itemId }`;
-					const label   = t.createElement( 'label', { for: inputId } );
+					const label   = t.createElement( 'label', { 'for': inputId } );
 					label.innerText = ` ${ pll_data.strings[ optionName ] }`;
 
-					inputWrapper.append( label );
+					inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
 					// Create the checkbox.
 					const cb = t.createElement( 'input', {
@@ -89,7 +89,7 @@ const pllNavMenu = {
 						cb.checked = true;
 					}
 
-					label.prepend( cb );
+					label.prepend( cb ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 				} );
 			} );
 		},

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -9,14 +9,18 @@ const pllNavMenu = {
 	 * Init.
 	 */
 	init: () => {
+		const handlers = [
+			pllNavMenu.printMetabox.attachEvent,
+			pllNavMenu.ensureContent.attachEvent,
+			pllNavMenu.showHideRows.attachEvent
+		];
+
 		if ( document.readyState !== 'loading' ) {
-			pllNavMenu.printMetabox.attachEvent();
-			pllNavMenu.ensureContent.attachEvent();
-			pllNavMenu.showHideRows.attachEvent();
+			handlers.forEach( handler => handler() );
 		} else {
-			document.addEventListener( 'DOMContentLoaded', pllNavMenu.printMetabox.attachEvent );
-			document.addEventListener( 'DOMContentLoaded', pllNavMenu.ensureContent.attachEvent );
-			document.addEventListener( 'DOMContentLoaded', pllNavMenu.showHideRows.attachEvent );
+			handlers.forEach( handler =>
+				document.addEventListener( 'DOMContentLoaded', handler )
+			);
 		}
 	},
 

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -63,11 +63,11 @@ const pllNavMenu = {
 			}
 
 			// Remove default fields we don't need.
-			for ( const el of metabox.children ) {
+			[ ...metabox.children ].forEach( ( el ) => {
 				if ( 'P' === el.nodeName && ! el.classList.contains( 'field-move' ) ) {
 					el.remove();
 				}
-			}
+			} );
 
 			const t      = pllNavMenu.printMetabox;
 			const itemId = Number( metabox.id.replace( 'menu-item-settings-', '' ) );

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -63,8 +63,10 @@ const pllNavMenu = {
 			}
 
 			// Remove default fields we don't need.
-			for ( const el of metabox.querySelectorAll( 'p:not(.field-move)' ) ) {
-				el.remove();
+			for ( const el of metabox.children ) {
+				if ( 'P' === el.nodeName && ! el.classList.contains( 'field-move' ) ) {
+					el.remove();
+				}
 			}
 
 			const t      = pllNavMenu.printMetabox;

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -182,13 +182,14 @@ const pllNavMenu = {
 					return;
 				}
 
+				const description = hideCb.closest( '.description' );
+
+				// Hide or show.
+				description.classList.toggle( 'hidden', event.target.checked );
+
 				if ( event.target.checked ) {
-					// Hide and uncheck.
-					hideCb.closest( '.description' ).classList.add( 'hidden' );
+					// Uncheck.
 					hideCb.checked = false;
-				} else {
-					// Show.
-					hideCb.closest( '.description' ).classList.remove( 'hidden' );
 				}
 			} );
 		}

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -30,7 +30,13 @@ const pllNavMenu = {
 		 */
 		attachEvent: () => {
 			/*global pll_data*/
-			document.getElementById( 'menu-to-edit' ).addEventListener( 'click', ( event ) => {
+			const wrapper = document.getElementById( 'menu-to-edit' );
+
+			if ( ! wrapper ) {
+				return;
+			}
+
+			wrapper.addEventListener( 'click', ( event ) => {
 				if ( ! event.target.classList.contains( 'item-edit' ) ) {
 					// Not clicking on a Edit arrow button.
 					return;
@@ -136,7 +142,13 @@ const pllNavMenu = {
 		 * Attaches an event to `#menu-to-edit` to disallow unchecking both `show_names` and `show_flags`.
 		 */
 		attachEvent: () => {
-			document.getElementById( 'menu-to-edit' ).addEventListener( 'change', ( event ) => {
+			const wrapper = document.getElementById( 'menu-to-edit' );
+
+			if ( ! wrapper ) {
+				return;
+			}
+
+			wrapper.addEventListener( 'change', ( event ) => {
 				if ( ! event.target.id || event.target.checked ) {
 					// Now checked, nothing to do.
 					return;
@@ -162,7 +174,13 @@ const pllNavMenu = {
 		 * Attaches an event to `#menu-to-edit` to show or hide the `hide_current` checkbox when `dropdown` is checked.
 		 */
 		attachEvent: () => {
-			document.getElementById( 'menu-to-edit' ).addEventListener( 'change', ( event ) => {
+			const wrapper = document.getElementById( 'menu-to-edit' );
+
+			if ( ! wrapper ) {
+				return;
+			}
+
+			wrapper.addEventListener( 'change', ( event ) => {
 				if ( ! event.target.id ) {
 					// Not the checkbox we want.
 					return;

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -49,11 +49,16 @@ jQuery(
 							);
 							$( this ).append( h ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
-							ids = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // reverse order
+							const ids          = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // reverse order
+							const isValDefined = typeof( pll_data.val[ item ] ) !== 'undefined';
 
 							// add the fields
 							for ( var i = 0, idsLength = ids.length; i < idsLength; i++ ) {
 								p = $( '<p>' ).attr( 'class', 'description' );
+								if ( 'hide_current' === ids[ i ] && isValDefined && 1 === pll_data.val[ item ].dropdown ) {
+									// Hide the `hide_current` checkbox if `dropdown` is checked.
+									p.addClass( 'hidden' );
+								}
 								// p is hardcoded just above by using attr method which is safe.
 								$( this ).prepend( p ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 								// item is a number part of id of parent menu item built by WordPress
@@ -68,7 +73,7 @@ jQuery(
 										value: 1
 									}
 								);
-								if ( ( typeof( pll_data.val[ item ] ) != 'undefined' && pll_data.val[ item ][ ids[ i ] ] == 1 ) || ( typeof( pll_data.val[ item ] ) == 'undefined' && ids[ i ] == 'show_names' ) ) { // show_names as default value
+								if ( ( isValDefined && pll_data.val[ item ][ ids[ i ] ] === 1 ) || ( ! isValDefined && ids[ i ] === 'show_names' ) ) { // show_names as default value
 									cb.prop( 'checked', true );
 								}
 								// See reasons above. Checkbox are totally hardcoded here with safe value
@@ -100,5 +105,28 @@ jQuery(
 				}
 			}
 		);
+
+		/**
+		 * Hide and uncheck the `hide_current` checkbox when `dropdown` is checked.
+		 * Display it when `dropdown` is unchecked.
+		 */
+		document.getElementById( 'menu-to-edit' ).addEventListener( 'change', ( event ) => {
+			if ( ! event.target.id || ! event.target.id.startsWith( 'edit-menu-item-dropdown-' ) ) {
+				return;
+			}
+
+			const hideCb = event.target.closest( '.menu-item-settings' ).querySelector( '[id^="edit-menu-item-hide_current-"]' );
+
+			if ( ! hideCb ) {
+				return;
+			}
+
+			if ( event.target.checked ) {
+				hideCb.checked = false;
+				hideCb.closest( '.description' ).classList.add( 'hidden' );
+			} else {
+				hideCb.closest( '.description' ).classList.remove( 'hidden' );
+			}
+		} );
 	}
 );

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -148,13 +148,15 @@ const pllNavMenu = {
 				return;
 			}
 
+			const regExpr = new RegExp( /^edit-menu-item-show_(names|flags)-(\d+)$/ );
+
 			wrapper.addEventListener( 'change', ( event ) => {
 				if ( ! event.target.id || event.target.checked ) {
 					// Now checked, nothing to do.
 					return;
 				}
 
-				const matches = event.target.id.match( new RegExp( /^edit-menu-item-show_(names|flags)-(\d+)$/ ) );
+				const matches = event.target.id.match( regExpr );
 
 				if ( ! matches ) {
 					// Not the checkbox we want.
@@ -180,13 +182,15 @@ const pllNavMenu = {
 				return;
 			}
 
+			const regExpr = new RegExp( /^edit-menu-item-dropdown-(\d+)$/ );
+
 			wrapper.addEventListener( 'change', ( event ) => {
 				if ( ! event.target.id ) {
 					// Not the checkbox we want.
 					return;
 				}
 
-				const matches = event.target.id.match( new RegExp( /^edit-menu-item-dropdown-(\d+)$/ ) );
+				const matches = event.target.id.match( regExpr );
 
 				if ( ! matches ) {
 					// Not the checkbox we want.

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -24,19 +24,27 @@ const pllNavMenu = {
 		}
 	},
 
+	/**
+	 * Attaches an event to an element.
+	 *
+	 * @param {string} elemId   The HTML id of the element to attach the event to.
+	 * @param {string} type     A case-sensitive string representing the event type to listen for.
+	 * @param {Object} listener The callback to fire on that event.
+	 */
+	maybeAttachEvent: ( elemId, type, listener ) => {
+		const wrapper = document.getElementById( elemId );
+
+		if ( wrapper ) {
+			wrapper.addEventListener( type, listener );
+		}
+	},
+
 	printMetabox: {
 		/**
 		 * Attaches an event to `#menu-to-edit` to print our checkboxes in the language switcher.
 		 */
 		attachEvent: () => {
-			/* global pll_data */
-			const wrapper = document.getElementById( 'menu-to-edit' );
-
-			if ( ! wrapper ) {
-				return;
-			}
-
-			wrapper.addEventListener( 'click', ( event ) => {
+			pllNavMenu.maybeAttachEvent( 'menu-to-edit', 'click', ( event ) => {
 				if ( ! event.target.classList.contains( 'item-edit' ) ) {
 					// Not clicking on a Edit arrow button.
 					return;
@@ -142,15 +150,9 @@ const pllNavMenu = {
 		 * Attaches an event to `#menu-to-edit` to disallow unchecking both `show_names` and `show_flags`.
 		 */
 		attachEvent: () => {
-			const wrapper = document.getElementById( 'menu-to-edit' );
-
-			if ( ! wrapper ) {
-				return;
-			}
-
 			const regExpr = new RegExp( /^edit-menu-item-show_(names|flags)-(\d+)$/ );
 
-			wrapper.addEventListener( 'change', ( event ) => {
+			pllNavMenu.maybeAttachEvent( 'menu-to-edit', 'change', ( event ) => {
 				if ( ! event.target.id || event.target.checked ) {
 					// Now checked, nothing to do.
 					return;
@@ -176,15 +178,9 @@ const pllNavMenu = {
 		 * Attaches an event to `#menu-to-edit` to show or hide the `hide_current` checkbox when `dropdown` is checked.
 		 */
 		attachEvent: () => {
-			const wrapper = document.getElementById( 'menu-to-edit' );
-
-			if ( ! wrapper ) {
-				return;
-			}
-
 			const regExpr = new RegExp( /^edit-menu-item-dropdown-(\d+)$/ );
 
-			wrapper.addEventListener( 'change', ( event ) => {
+			pllNavMenu.maybeAttachEvent( 'menu-to-edit', 'change', ( event ) => {
 				if ( ! event.target.id ) {
 					// Not the checkbox we want.
 					return;

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -12,13 +12,13 @@ const pllNavMenu = {
 		const handlers = [
 			pllNavMenu.printMetabox.attachEvent,
 			pllNavMenu.ensureContent.attachEvent,
-			pllNavMenu.showHideRows.attachEvent
+			pllNavMenu.showHideRows.attachEvent,
 		];
 
 		if ( document.readyState !== 'loading' ) {
-			handlers.forEach( handler => handler() );
+			handlers.forEach( ( handler ) => handler() );
 		} else {
-			handlers.forEach( handler =>
+			handlers.forEach( ( handler ) =>
 				document.addEventListener( 'DOMContentLoaded', handler )
 			);
 		}
@@ -92,7 +92,7 @@ const pllNavMenu = {
 						type:  'checkbox',
 						id:    inputId,
 						name:  `menu-item-${ optionName }[${ itemId }]`,
-						value: 1
+						value: 1,
 					} );
 
 					if ( ( isValDefined && 1 === pll_data.val[ itemId ][ optionName ] ) || ( ! isValDefined && 'show_names' === optionName ) ) { // `show_names` as default value.
@@ -117,7 +117,7 @@ const pllNavMenu = {
 				type:  'hidden',
 				id:    `edit-menu-item-pll-${ id }-${ itemId }`,
 				name:  `menu-item-pll-${ id }[${ itemId }]`,
-				value: value
+				value: value,
 			} );
 		},
 
@@ -134,7 +134,7 @@ const pllNavMenu = {
 				el.setAttribute( key, value );
 			}
 			return el;
-		}
+		},
 	},
 
 	ensureContent: {
@@ -168,7 +168,7 @@ const pllNavMenu = {
 				const otherType = 'names' === type ? 'flags' : 'names';
 				document.getElementById( `edit-menu-item-show_${ otherType }-${ id }` ).checked = true;
 			} );
-		}
+		},
 	},
 
 	showHideRows: {
@@ -215,8 +215,8 @@ const pllNavMenu = {
 					hideCb.dispatchEvent( new Event( 'change' ) );
 				}
 			} );
-		}
-	}
+		},
+	},
 };
 
 pllNavMenu.init();

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -190,6 +190,7 @@ const pllNavMenu = {
 				if ( event.target.checked ) {
 					// Uncheck.
 					hideCb.checked = false;
+					hideCb.dispatchEvent( new Event( 'change' ) );
 				}
 			} );
 		}

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -29,7 +29,7 @@ const pllNavMenu = {
 		 * Attaches an event to `#menu-to-edit` to print our checkboxes in the language switcher.
 		 */
 		attachEvent: () => {
-			/*global pll_data*/
+			/* global pll_data */
 			const wrapper = document.getElementById( 'menu-to-edit' );
 
 			if ( ! wrapper ) {
@@ -107,10 +107,10 @@ const pllNavMenu = {
 		/**
 		 * Creates and returns a `<input type=hidden"/>` element.
 		 *
-		 * @param {String}         id     An identifier for this input. It will be part of the final `id` attribute.
-		 * @param {Integerg}       itemId The ID of the menu element (post ID).
-		 * @param {String|Integer} value  The input's value.
-		 * @returns {HTMLElement}
+		 * @param {string}        id     An identifier for this input. It will be part of the final `id` attribute.
+		 * @param {number}        itemId The ID of the menu element (post ID).
+		 * @param {string|number} value  The input's value.
+		 * @return {HTMLElement} The input element.
 		 */
 		createHiddenInput: ( id, itemId, value ) => {
 			return pllNavMenu.printMetabox.createElement( 'input', {
@@ -124,9 +124,9 @@ const pllNavMenu = {
 		/**
 		 * Creates and returns an element.
 		 *
-		 * @param {String} type Element's type.
+		 * @param {string} type Element's type.
 		 * @param {Object} atts Element's attributes.
-		 * @returns {HTMLElement}
+		 * @return {HTMLElement} The element.
 		 */
 		createElement: ( type, atts ) => {
 			const el = document.createElement( type );

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -150,8 +150,9 @@ const pllNavMenu = {
 				}
 
 				// Check the other checkbox.
-				const other = 'names' === matches[1] ? 'flags' : 'names';
-				document.getElementById( `edit-menu-item-show_${ other }-${ matches[2] }` ).checked = true;
+				const [ , type, id ] = matches;
+				const otherType = 'names' === type ? 'flags' : 'names';
+				document.getElementById( `edit-menu-item-show_${ otherType }-${ id }` ).checked = true;
 			} );
 		}
 	},

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -34,7 +34,7 @@ const pllNavMenu = {
 
 				const metabox = event.target.closest( '.menu-item' ).querySelector( '.menu-item-settings' );
 
-				if ( ! metabox || ! metabox.id ) {
+				if ( ! metabox?.id ) {
 					// Should not happen.
 					return;
 				}

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -210,7 +210,7 @@ const pllNavMenu = {
 				description.classList.toggle( 'hidden', event.target.checked );
 
 				if ( event.target.checked ) {
-					// Uncheck.
+					// Uncheck after hiding.
 					hideCb.checked = false;
 					hideCb.dispatchEvent( new Event( 'change' ) );
 				}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2358.

In the menu editor, this PR hides (and uncheck) the `hide_current` checkbox if `dropdown` is checked.