### PR TITLE
Don't add translation entry when the translated string is empty

### DIFF
--- a/include/mo.php
+++ b/include/mo.php
@@ -85,7 +85,7 @@ class PLL_MO extends MO {
 		foreach ( $strings as $msg ) {
 			$entry = $this->make_entry( $msg[0], $msg[1] );
 
-			if ( '' !== $entry->singular ) {
+			if ( '' !== $entry->singular && '' !== $msg[1] ) {
 				$this->add_entry( $entry );
 			}
 		}

--- a/include/mo.php
+++ b/include/mo.php
@@ -83,9 +83,13 @@ class PLL_MO extends MO {
 		}
 
 		foreach ( $strings as $msg ) {
+			if ( '' === $msg[0] || '' === $msg[1] ) {
+				continue;
+			}
+
 			$entry = $this->make_entry( $msg[0], $msg[1] );
 
-			if ( '' !== $entry->singular && '' !== $msg[1] ) {
+			if ( '' !== $entry->singular ) {
 				$this->add_entry( $entry );
 			}
 		}

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -289,4 +289,18 @@ class Strings_Test extends PLL_UnitTestCase {
 		$mo->import_from_db( $lang );
 		$this->assertSame( array( 'test', 'test 2' ), array_keys( $mo->entries ) );
 	}
+
+	public function test_translate_untranslated_string_should_return_original_string() {
+		$pll_admin = new PLL_Admin( $this->links_model );
+		$pll_admin->init();
+
+		$lang = self::$model->get_language( 'en' );
+		$mo   = new PLL_MO();
+		$mo->add_entry( $mo->make_entry( 'test', '' ) );
+		$mo->export_to_db( $lang );
+
+		do_action( 'pll_language_defined' );
+
+		$this->assertSame( 'test', __( 'test', 'pll_string' ) ); // PHPCS:ignore WordPress.WP.I18n
+	}
 }

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -291,15 +291,14 @@ class Strings_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_translate_untranslated_string_should_return_original_string() {
-		$pll_admin = new PLL_Admin( $this->links_model );
-		$pll_admin->init();
-
 		$lang = self::$model->get_language( 'en' );
 		$mo   = new PLL_MO();
 		$mo->add_entry( $mo->make_entry( 'test', '' ) );
 		$mo->export_to_db( $lang );
 
-		do_action( 'pll_language_defined' );
+		$pll_admin = new PLL_Admin( $this->links_model );
+		$pll_admin->init();
+		do_action( 'setup_theme' );
 
 		$this->assertSame( 'test', __( 'test', 'pll_string' ) ); // PHPCS:ignore WordPress.WP.I18n
 	}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2368

## What?
This issue was revealed by new ACF compatibility and reported in https://github.com/polylang/polylang-pro/issues/2368.
However it is a more general issue.

## Why?
The issue appears since #1574 and as explained in [#2368 comment](https://github.com/polylang/polylang-pro/issues/2368#issuecomment-2514194399), it shows that WordPress translation process replaces any string of Polylang `pll_string` textdomain by its empty translated string instead of keeping the original string.

Because the entry key exists
https://github.com/WordPress/WordPress/blob/6.7.1/wp-includes/pomo/translations.php#L135
the value is returned as the translated string
https://github.com/WordPress/WordPress/blob/6.7.1/wp-includes/pomo/translations.php#L155
(`$translated->translations[0]` instead of `$singular`)

## How?
Add a condition not to add a translation entry in the `pll_string` domain when the source string or its translated string are empty.
