### PR TITLE
Introduces get_calendar() changes planned in WordPress 6.8

### DIFF
--- a/include/widget-calendar.php
+++ b/include/widget-calendar.php
@@ -192,7 +192,7 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 		}
 
 		// See how much we should pad in the beginning.
-		$pad = calendar_week_mod( gmdate( 'w', $unixmonth ) - $week_begins );
+		$pad = calendar_week_mod( (int) gmdate( 'w', $unixmonth ) - $week_begins );
 		if ( 0 != $pad ) {
 			$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 		}
@@ -231,12 +231,12 @@ class PLL_Widget_Calendar extends WP_Widget_Calendar {
 
 			$calendar_output .= '</td>';
 
-			if ( 6 == calendar_week_mod( gmdate( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+			if ( 6 == calendar_week_mod( (int) gmdate( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
 				$newrow = true;
 			}
 		}
 
-		$pad = 7 - calendar_week_mod( gmdate( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+		$pad = 7 - calendar_week_mod( (int) gmdate( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
 		if ( 0 != $pad && 7 != $pad ) {
 			$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
 		}

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -8,7 +8,7 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_calendar() {
-		$this->check_method( '01b136c86d6837211ada6651fba90e28', '6.3', 'get_calendar' );
+		$this->check_method( '3df7efc11b10675e98191a33bfafb71a', '6.8', 'get_calendar' );
 	}
 
 	public function test_wp_admin_bar() {


### PR DESCRIPTION
All is in the title reported by our tests 
See https://github.com/polylang/polylang/actions/runs/12138876766/job/33845244163?pr=1586

Changes introduced by https://github.com/WordPress/wordpress-develop/commit/ce4627f67feb608f8528f74709c8dc9aeed234e3#diff-1c6b59f268c3016f96c2f2ac62c15a4990045a68fd56aa2c36ef8e1853362bcb