### PR TITLE
Don't allow setting `default_lang` value with non-existing language.

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -327,7 +327,10 @@ class Languages {
 		$description = $this->build_metas( $args );
 		wp_update_term( $lang->get_tax_prop( 'language', 'term_id' ), 'language', array( 'slug' => $slug, 'name' => $args['name'], 'description' => $description, 'term_group' => (int) $args['term_group'] ) );
 
-		// Update the default language option if necessary.
+		/*
+		 * Update the default language option if necessary.
+		 * This must happen after the term is saved (see `Options\Business\Default_Lang::sanitize()`).
+		 */
 		if ( $old_slug !== $slug && $lang->is_default ) {
 			$this->options['default_lang'] = $slug;
 		}

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -319,11 +319,6 @@ class Languages {
 				$this->options['domains'][ $slug ] = $this->options['domains'][ $old_slug ];
 				unset( $this->options['domains'][ $old_slug ] );
 			}
-
-			// Update the default language option if necessary.
-			if ( $lang->is_default ) {
-				$this->options['default_lang'] = $slug;
-			}
 		}
 
 		// And finally update the language itself.
@@ -331,6 +326,11 @@ class Languages {
 
 		$description = $this->build_metas( $args );
 		wp_update_term( $lang->get_tax_prop( 'language', 'term_id' ), 'language', array( 'slug' => $slug, 'name' => $args['name'], 'description' => $description, 'term_group' => (int) $args['term_group'] ) );
+
+		// Update the default language option if necessary.
+		if ( $old_slug !== $slug && $lang->is_default ) {
+			$this->options['default_lang'] = $slug;
+		}
 
 		// Refresh languages.
 		$this->clean_cache();

--- a/include/Options/Business/Default_Lang.php
+++ b/include/Options/Business/Default_Lang.php
@@ -76,6 +76,7 @@ class Default_Lang extends Abstract_String {
 			return $value;
 		}
 
+		/** @var string $value */
 		if ( ! get_term_by( 'slug', $value, 'language' ) ) {
 			return new WP_Error( 'pll_invalid_language', sprintf( 'The language slug \'%s\' is not a valid language.', $value ) );
 		}

--- a/include/Options/Business/Default_Lang.php
+++ b/include/Options/Business/Default_Lang.php
@@ -5,8 +5,10 @@
 
 namespace WP_Syntex\Polylang\Options\Business;
 
-use WP_Syntex\Polylang\Options\Primitive\Abstract_String;
+use WP_Error;
+use WP_Syntex\Polylang\Options\Options;
 use WP_Syntex\Polylang\Model\Languages;
+use WP_Syntex\Polylang\Options\Primitive\Abstract_String;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,5 +56,30 @@ class Default_Lang extends Abstract_String {
 	 */
 	protected function get_description(): string {
 		return __( 'Slug of the default language.', 'polylang' );
+	}
+
+	/**
+	 * Sanitizes option's value.
+	 * Can populate the `$errors` property with blocking and non-blocking errors: in case of non-blocking errors,
+	 * the value is sanitized and can be stored.
+	 *
+	 * @since 3.7
+	 *
+	 * @param array   $value   Value to sanitize.
+	 * @param Options $options All options.
+	 * @return string|WP_Error The sanitized value. An instance of `WP_Error` in case of error.
+	 */
+	protected function sanitize( $value, Options $options ) {
+		parent::sanitize( $value, $options );
+
+		if ( is_wp_error( $value ) ) {
+			return $value;
+		}
+
+		if ( ! get_term_by( 'slug', $value, 'language' ) ) {
+			return new WP_Error( 'invalid_language', sprintf( 'The language slug \'%s\' is not a valid language.', $value ) );
+		}
+
+		return $value;
 	}
 }

--- a/include/Options/Business/Default_Lang.php
+++ b/include/Options/Business/Default_Lang.php
@@ -6,8 +6,8 @@
 namespace WP_Syntex\Polylang\Options\Business;
 
 use WP_Error;
-use WP_Syntex\Polylang\Options\Options;
 use WP_Syntex\Polylang\Model\Languages;
+use WP_Syntex\Polylang\Options\Options;
 use WP_Syntex\Polylang\Options\Primitive\Abstract_String;
 
 defined( 'ABSPATH' ) || exit;
@@ -65,7 +65,7 @@ class Default_Lang extends Abstract_String {
 	 *
 	 * @since 3.7
 	 *
-	 * @param array   $value   Value to sanitize.
+	 * @param string  $value   Value to sanitize.
 	 * @param Options $options All options.
 	 * @return string|WP_Error The sanitized value. An instance of `WP_Error` in case of error.
 	 */

--- a/include/Options/Business/Default_Lang.php
+++ b/include/Options/Business/Default_Lang.php
@@ -70,14 +70,14 @@ class Default_Lang extends Abstract_String {
 	 * @return string|WP_Error The sanitized value. An instance of `WP_Error` in case of error.
 	 */
 	protected function sanitize( $value, Options $options ) {
-		parent::sanitize( $value, $options );
+		$value = parent::sanitize( $value, $options );
 
 		if ( is_wp_error( $value ) ) {
 			return $value;
 		}
 
 		if ( ! get_term_by( 'slug', $value, 'language' ) ) {
-			return new WP_Error( 'invalid_language', sprintf( 'The language slug \'%s\' is not a valid language.', $value ) );
+			return new WP_Error( 'pll_invalid_language', sprintf( 'The language slug \'%s\' is not a valid language.', $value ) );
 		}
 
 		return $value;

--- a/tests/phpunit/tests/Options/Abstract_Option/test-GetSchema.php
+++ b/tests/phpunit/tests/Options/Abstract_Option/test-GetSchema.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Options\Options;
+namespace WP_Syntex\Polylang\Tests\Integration\Options\Abstract_Option;
 
 use WP_Error;
 use PHPUnit_Adapter_TestCase;
@@ -9,7 +9,7 @@ use WP_Syntex\Polylang\Options\Business;
 /**
  * Test the schema of all classes extending {@see WP_Syntex\Polylang\Options\Abstract_Option}.
  */
-class OptionSchema_Test extends PHPUnit_Adapter_TestCase {
+class GetSchema_Test extends PHPUnit_Adapter_TestCase {
 	/**
 	 * @dataProvider boolean_provider
 	 *

--- a/tests/phpunit/tests/Options/Options/test-Set.php
+++ b/tests/phpunit/tests/Options/Options/test-Set.php
@@ -69,6 +69,15 @@ class Set_Test extends PLL_UnitTestCase {
 		$this->assertSameSetsWithIndex( $domains, $this->pll_env->model->options->get( 'domains' ) );
 	}
 
+	public function test_should_not_set_bad_default_language() {
+		$options = self::create_options();
+		$errors = $options->set( 'default_lang', 'bad-lang' );
+
+		$this->assertInstanceOf( WP_Error::class, $errors );
+		$this->assertTrue( $errors->has_errors() );
+		$this->assertSame( 'pll_invalid_language', $errors->get_error_code() );
+	}
+
 	/**
 	 * Callback used to filter the http requests.
 	 *

--- a/tests/phpunit/tests/test-option-schema.php
+++ b/tests/phpunit/tests/test-option-schema.php
@@ -1,11 +1,15 @@
 <?php
 
+namespace WP_Syntex\Polylang\Tests\Integration\Options\Options;
+
+use WP_Error;
+use PHPUnit_Adapter_TestCase;
 use WP_Syntex\Polylang\Options\Business;
 
 /**
  * Test the schema of all classes extending {@see WP_Syntex\Polylang\Options\Abstract_Option}.
  */
-class Option_Schema_Test extends PHPUnit_Adapter_TestCase {
+class OptionSchema_Test extends PHPUnit_Adapter_TestCase {
 	/**
 	 * @dataProvider boolean_provider
 	 *

--- a/tests/phpunit/tests/test-rest-request.php
+++ b/tests/phpunit/tests/test-rest-request.php
@@ -85,7 +85,7 @@ class Rest_Request_Test extends PLL_UnitTestCase {
 	 * }
 	 */
 	public function test_should_not_define_default_language_when_default_language_is_invalid( $data ) {
-		$this->pll_rest->model->options['default_lang'] = 'es';
+		$this->pll_rest->options = self::create_options( array( 'default_lang' => 'es' ) );
 
 		$request = new WP_REST_Request( $data['method'], $data['route'] );
 		$request->set_param( 'lang', 'it' );

--- a/tests/phpunit/tests/test-rest-settings.php
+++ b/tests/phpunit/tests/test-rest-settings.php
@@ -163,6 +163,15 @@ class REST_Settings_Test extends PLL_UnitTestCase {
 		$this->assertSame( 404, $response->get_status() );
 	}
 
+	public function test_should_not_update_default_language_with_bad_value() {
+		wp_set_current_user( self::$administrator );
+
+		$response = $this->dispatch_request( 'PATCH', array( 'default_lang' => 'bad-lang' ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'pll_invalid_language', $response->get_data()['code'] );
+	}
+
 	/**
 	 * Dispatches a request after setting some params.
 	 *


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2375

## Why?
Prevent setting bad default language value through REST.
I chose to manage the sanitization on option object (`Default_Lang`)  level, so any external code using this feature will benefit from it (e.g. Polylang CLI?).

## How?
- Implement `Default_Lang::sanitize()` and ensure term language with the given slug exists before updating the option.
- Update `default_lang` option in `Languages::update()` only once the langue term *is* really updated.
- Cover the expected behavior on option object level.
- Cover the expected behavior on REST response level.
- Fix `REST_Request_Test::test_should_define_default_language_when_language_is_invalid` test assigning bad default language using proper `create_option()` method.
