### PR TITLE
Remove `no_default_cat` property from schema in editable language requests.

### DIFF
--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -637,7 +637,7 @@ class Languages extends Abstract_Controller {
 	 * @return array Endpoint arguments.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
-		$schema = $this->get_item_schema()
+		$schema = $this->get_item_schema();
 		if ( WP_REST_Server::CREATABLE !== $method ) {
 			unset( $schema['properties']['no_default_cat'] );
 		}

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -629,13 +629,11 @@ class Languages extends Abstract_Controller {
 
 	/**
 	 * Retrieves an array of endpoint arguments from the item schema for the controller.
-	 * Ensures that the `no_default_cat` property is not returned for `EDITABLE` requests.
+	 * Ensures that the `no_default_cat` property is returned only for `CREATABLE` requests.
 	 *
 	 * @since 3.7
 	 *
-	 * @param string $method Optional. HTTP method of the request. The arguments for `CREATABLE` requests are
-	 *                       checked for required values and may fall-back to a given default, this is not done
-	 *                       on `EDITABLE` requests. Default WP_REST_Server::CREATABLE.
+	 * @param string $method Optional. HTTP method of the request. Default WP_REST_Server::CREATABLE.
 	 * @return array Endpoint arguments.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -637,14 +637,11 @@ class Languages extends Abstract_Controller {
 	 * @return array Endpoint arguments.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
-		if ( WP_REST_Server::EDITABLE === $method ) {
-			$edit_schema = $this->get_item_schema();
-			unset( $edit_schema['properties']['no_default_cat'] );
-
-			return rest_get_endpoint_args_for_schema( $edit_schema, $method );
+		$schema = $this->get_item_schema()
+		if ( WP_REST_Server::CREATABLE !== $method ) {
+			unset( $schema['properties']['no_default_cat'] );
 		}
-
-		return parent::get_endpoint_args_for_item_schema( $method );
+		return rest_get_endpoint_args_for_schema( $schema, $method );
 	}
 
 	/**

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -628,6 +628,28 @@ class Languages extends Abstract_Controller {
 	}
 
 	/**
+	 * Retrieves an array of endpoint arguments from the item schema for the controller.
+	 * Ensures that the `no_default_cat` property is not returned for `EDITABLE` requests.
+	 *
+	 * @since 3.7
+	 *
+	 * @param string $method Optional. HTTP method of the request. The arguments for `CREATABLE` requests are
+	 *                       checked for required values and may fall-back to a given default, this is not done
+	 *                       on `EDITABLE` requests. Default WP_REST_Server::CREATABLE.
+	 * @return array Endpoint arguments.
+	 */
+	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
+		if ( WP_REST_Server::EDITABLE === $method ) {
+			$edit_schema = $this->get_item_schema();
+			unset( $edit_schema['properties']['no_default_cat'] );
+
+			return rest_get_endpoint_args_for_schema( $edit_schema, $method );
+		}
+
+		return parent::get_endpoint_args_for_item_schema( $method );
+	}
+
+	/**
 	 * Prepares one language for create or update operation.
 	 *
 	 * @since 3.7


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2382
The issue can be seen with either route `OPTIONS https://mysite.site/wp-json/pll/v1/languages` or  `GET https://mysite.site/wp-json/pll/v1/`.

## How?
- Override `get_endpoint_args_for_item_schema()` and remove `no_default_cat` property from the schema only for `EDITABLE` requests.
- Cover the behavior in `REST_langues_Test::test_no_default_cat_arg()`.
- Took the opportunity to improve `REST_langues_Test::test_create_language()` by testing with different `no_default_cat` values.