### PR TITLE
Make REST settings context agnostic.

### DIFF
--- a/include/Options/Abstract_Option.php
+++ b/include/Options/Abstract_Option.php
@@ -17,8 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @phpstan-type SchemaType 'string'|'null'|'number'|'integer'|'boolean'|'array'|'object'
  * @phpstan-type Schema array{
- *     type: SchemaType,
- *     context: array<non-falsy-string>
+ *     type: SchemaType
  * }
  */
 abstract class Abstract_Option {
@@ -152,7 +151,6 @@ abstract class Abstract_Option {
 		$this->schema = array_merge(
 			array(
 				'description' => $this->get_description(),
-				'context'     => array( 'edit' ),
 				'default'     => $this->get_default(),
 			),
 			$this->get_data_structure()

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -51,7 +51,7 @@ class Settings extends Abstract_Controller {
 			"/{$this->rest_base}",
 			array(
 				'args'        => array(
-					'context' => $this->get_context_param( array( 'default' => 'edit' ) ),
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -164,6 +164,9 @@ class Settings extends Abstract_Controller {
 				$response[ $option ] = $value;
 			}
 		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$response = $this->filter_response_by_context( $response, $context );
 
 		/** @var WP_REST_Response */
 		return rest_ensure_response( $response );

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -50,9 +50,6 @@ class Settings extends Abstract_Controller {
 			$this->namespace,
 			"/{$this->rest_base}",
 			array(
-				'args'        => array(
-					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
-				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
@@ -102,7 +99,7 @@ class Settings extends Abstract_Controller {
 		$schema  = $this->options->get_schema();
 		$options = array_intersect_key(
 			$request->get_params(),
-			rest_get_endpoint_args_for_schema( $schema, WP_REST_Server::EDITABLE ) // Remove `context` and fields with `readonly`.
+			rest_get_endpoint_args_for_schema( $schema, WP_REST_Server::EDITABLE ) // Remove fields with `readonly`.
 		);
 
 		foreach ( $options as $option_name => $new_value ) {
@@ -164,9 +161,6 @@ class Settings extends Abstract_Controller {
 				$response[ $option ] = $value;
 			}
 		}
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$response = $this->filter_response_by_context( $response, $context );
 
 		/** @var WP_REST_Response */
 		return rest_ensure_response( $response );

--- a/tests/phpunit/tests/test-rest-settings.php
+++ b/tests/phpunit/tests/test-rest-settings.php
@@ -144,16 +144,17 @@ class REST_Settings_Test extends PLL_UnitTestCase {
 	 * @param string $method
 	 * @return void
 	 */
-	public function test_wrong_context( string $method ) {
+	public function test_context_param_should_be_ignored( string $method ) {
 		wp_set_current_user( self::$administrator );
 
-		// Context 'view'.
 		$response = $this->dispatch_request( $method, array( 'context' => 'view' ) );
-		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
-		// Context 'embed'.
 		$response = $this->dispatch_request( $method, array( 'context' => 'embed' ) );
-		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
+
+		$response = $this->dispatch_request( $method, array( 'context' => 'edit' ) );
+		$this->assertSame( 200, $response->get_status() );
 	}
 
 	public function test_unknown_method() {
@@ -161,15 +162,6 @@ class REST_Settings_Test extends PLL_UnitTestCase {
 
 		$response = $this->dispatch_request( 'DELETE' );
 		$this->assertSame( 404, $response->get_status() );
-	}
-
-	public function test_get_settings_with_no_context() {
-		wp_set_current_user( self::$administrator );
-
-		$response = $this->dispatch_request();
-
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame( 'Invalid parameter(s): context', $response->get_data()['message'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-rest-settings.php
+++ b/tests/phpunit/tests/test-rest-settings.php
@@ -163,6 +163,15 @@ class REST_Settings_Test extends PLL_UnitTestCase {
 		$this->assertSame( 404, $response->get_status() );
 	}
 
+	public function test_get_settings_with_no_context() {
+		wp_set_current_user( self::$administrator );
+
+		$response = $this->dispatch_request();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'Invalid parameter(s): context', $response->get_data()['message'] );
+	}
+
 	/**
 	 * Dispatches a request after setting some params.
 	 *


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2376

## How?
- Remove `context` parameter from options schema.
- Remove checks for context in `Settings`.
- Adapt tests accordingly.
