### PR TITLE
Flush rewrite rules when specific options are updated in REST.

### DIFF
--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -103,6 +103,10 @@ class Settings extends Abstract_Controller {
 		);
 
 		foreach ( $options as $option_name => $new_value ) {
+			if ( $new_value === $this->options->get( $option_name ) ) {
+				continue;
+			}
+
 			$result = $this->options->set( $option_name, $new_value );
 
 			if ( $result->has_errors() ) {

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -103,14 +103,15 @@ class Settings extends Abstract_Controller {
 		);
 
 		foreach ( $options as $option_name => $new_value ) {
-			if ( $new_value === $this->options->get( $option_name ) ) {
-				continue;
-			}
-
-			$result = $this->options->set( $option_name, $new_value );
+			$previous_value = $this->options->get( $option_name );
+			$result         = $this->options->set( $option_name, $new_value );
 
 			if ( $result->has_errors() ) {
 				$errors->merge_from( $result );
+				continue;
+			}
+
+			if ( $previous_value === $this->options->get( $option_name ) ) {
 				continue;
 			}
 

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -111,7 +111,7 @@ class Settings extends Abstract_Controller {
 				continue;
 			}
 
-			if ( $previous_value === $this->options->get( $option_name ) ) {
+			if ( $this->options->get( $option_name ) === $previous_value ) {
 				continue;
 			}
 

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -107,6 +107,12 @@ class Settings extends Abstract_Controller {
 
 			if ( $result->has_errors() ) {
 				$errors->merge_from( $result );
+				continue;
+			}
+
+			$options_with_flush = array( 'rewrite', 'force_lang', 'hide_default' );
+			if ( in_array( $option_name, $options_with_flush, true ) ) {
+				flush_rewrite_rules();
 			}
 		}
 

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -115,9 +115,11 @@ class Settings extends Abstract_Controller {
 				continue;
 			}
 
-			$options_with_flush = array( 'rewrite', 'force_lang', 'hide_default' );
-			if ( in_array( $option_name, $options_with_flush, true ) ) {
-				flush_rewrite_rules();
+			switch ( $option_name ) {
+				case 'rewrite':
+				case 'force_lang':
+				case 'hide_default':
+					flush_rewrite_rules();
 			}
 		}
 

--- a/tests/phpunit/tests/test-rest-settings.php
+++ b/tests/phpunit/tests/test-rest-settings.php
@@ -208,7 +208,6 @@ class REST_Settings_Test extends PLL_UnitTestCase {
 		$frontend->init();
 		$rules_after_update = $wp_rewrite->rewrite_rules();
 
-		$this->assertNotSame( $rules_prior_to_update, $rules_after_update );
 		$this->assertArrayHasKey( 'language/(en|fr)/?$', $rules_after_update );
 	}
 


### PR DESCRIPTION
## What?
There is an issue when updating some links related options through REST. For instance, updating `rewrite` options doesn't flush rewrite rules then breaks the frontend.

## How?
- Flush rewrite rules when options such as `rewrite`, `force_lang` or `hide_default` is updated in REST.
- Add a tests for `rewrite` case, tell me if more is needed.