### PR TITLE
Update language slug in `domains` option

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -297,9 +297,6 @@ class Languages {
 			)
 		);
 
-		// Make sure the languages have the new slugs.
-		$this->clean_cache();
-
 		if ( $old_slug !== $slug ) {
 			// Update the language slug in translations.
 			$this->update_translations( $old_slug, $slug );

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -283,6 +283,23 @@ class Languages {
 		$slug     = $args['slug'];
 		$old_slug = $lang->slug;
 
+		// Update the language itself.
+		$this->update_secondary_language_terms( $args['slug'], $args['name'], $lang );
+
+		wp_update_term(
+			$lang->get_tax_prop( 'language', 'term_id' ),
+			'language',
+			array(
+				'slug'        => $slug,
+				'name'        => $args['name'],
+				'description' => $this->build_metas( $args ),
+				'term_group'  => (int) $args['term_group'],
+			)
+		);
+
+		// Make sure the languages have the new slugs.
+		$this->clean_cache();
+
 		if ( $old_slug !== $slug ) {
 			// Update the language slug in translations.
 			$this->update_translations( $old_slug, $slug );
@@ -302,7 +319,7 @@ class Languages {
 				}
 			}
 
-			// Update menus locations.
+			// Update menus locations in options.
 			$nav_menus = $this->options->get( 'nav_menus' );
 
 			if ( ! empty( $nav_menus ) ) {
@@ -318,7 +335,10 @@ class Languages {
 				$this->options->set( 'nav_menus', $nav_menus );
 			}
 
-			// Update domains.
+			/*
+			 * Update domains in options.
+			 * This must happen after the term is saved (see `Options\Business\Domains::sanitize()`).
+			 */
 			$domains = $this->options->get( 'domains' );
 
 			if ( ! empty( $domains[ $old_slug ] ) ) {
@@ -326,20 +346,14 @@ class Languages {
 				unset( $domains[ $old_slug ] );
 				$this->options->set( 'domains', $domains );
 			}
-		}
 
-		// And finally update the language itself.
-		$this->update_secondary_language_terms( $args['slug'], $args['name'], $lang );
-
-		$description = $this->build_metas( $args );
-		wp_update_term( $lang->get_tax_prop( 'language', 'term_id' ), 'language', array( 'slug' => $slug, 'name' => $args['name'], 'description' => $description, 'term_group' => (int) $args['term_group'] ) );
-
-		/*
-		 * Update the default language option if necessary.
-		 * This must happen after the term is saved (see `Options\Business\Default_Lang::sanitize()`).
-		 */
-		if ( $old_slug !== $slug && $lang->is_default ) {
-			$this->options['default_lang'] = $slug;
+			/*
+			 * Update the default language option if necessary.
+			 * This must happen after the term is saved (see `Options\Business\Default_Lang::sanitize()`).
+			 */
+			if ( $lang->is_default ) {
+				$this->options->set( 'default_lang', $slug );
+			}
 		}
 
 		// Refresh languages.

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -120,6 +120,7 @@ class Domains extends Abstract_Option {
 			if ( array_key_exists( $lang->slug, $value ) ) {
 				// Use the new value.
 				$all_values[ $lang->slug ] = $value[ $lang->slug ];
+				unset( $value[ $lang->slug ] );
 			} else {
 				// Use previous value.
 				$all_values[ $lang->slug ] = $this->value[ $lang->slug ] ?? '';
@@ -129,6 +130,30 @@ class Domains extends Abstract_Option {
 				// The value is empty.
 				$missing_langs[] = $lang->name;
 			}
+		}
+
+		// Detect invalid language slugs.
+		if ( ! empty( $value ) ) {
+			// Non-blocking error.
+			$value = array_keys( $value );
+
+			$this->errors->add(
+				'pll_unknown_domain_languages',
+				sprintf(
+					/* translators: %s is a list of language slugs. */
+					_n( 'The language %s is unknown and has been discarded.', 'The languages %s are unknown and have been discarded.', count( $value ), 'polylang' ),
+					wp_sprintf_l(
+						'%l',
+						array_map(
+							function ( $slug ) {
+								return "<code>{$slug}</code>";
+							},
+							$value
+						)
+					)
+				),
+				'warning'
+			);
 		}
 
 		if ( 3 === $options->get( 'force_lang' ) && ! empty( $missing_langs ) ) {

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -105,11 +105,18 @@ class Domains extends Abstract_Option {
 		}
 
 		/** @phpstan-var array<non-falsy-string, string> $value */
-		$all_values    = array(); // Previous and new values.
-		$missing_langs = array(); // Lang names corresponding to the empty values.
+		$all_values     = array(); // Previous and new values.
+		$missing_langs  = array(); // Lang names corresponding to the empty values.
+		$language_terms = get_terms(
+			array(
+				'taxonomy'   => 'language',
+				'hide_empty' => false,
+			)
+		);
+		$language_terms = is_array( $language_terms ) ? $language_terms : array();
 
 		// Detect empty values, fill missing keys with previous values.
-		foreach ( $polylang->model->get_languages_list() as $lang ) {
+		foreach ( $language_terms as $lang ) {
 			if ( array_key_exists( $lang->slug, $value ) ) {
 				// Use the new value.
 				$all_values[ $lang->slug ] = $value[ $lang->slug ];

--- a/tests/phpunit/tests/Options/Options/test-Set.php
+++ b/tests/phpunit/tests/Options/Options/test-Set.php
@@ -79,7 +79,7 @@ class Set_Test extends PLL_UnitTestCase {
 			'en'       => 'https://good-url.com',
 			'bad-lang' => 'https://good-url.org',
 		);
-		$errors  = $this->pll_env->model->options->set( 'domains', $domains );
+		$this->pll_env->model->options->set( 'domains', $domains );
 		$domains = $this->pll_env->model->options->get( 'domains' );
 
 		$this->assertArrayHasKey( 'en', $domains );

--- a/tests/phpunit/tests/Options/Options/test-Set.php
+++ b/tests/phpunit/tests/Options/Options/test-Set.php
@@ -79,8 +79,11 @@ class Set_Test extends PLL_UnitTestCase {
 			'en'       => 'https://good-url.com',
 			'bad-lang' => 'https://good-url.org',
 		);
-		$this->pll_env->model->options->set( 'domains', $domains );
+		$errors  = $this->pll_env->model->options->set( 'domains', $domains );
 		$domains = $this->pll_env->model->options->get( 'domains' );
+
+		$this->assertCount( 1, $errors->get_error_codes() );
+		$this->assertSame( 'pll_unknown_domain_languages', $errors->get_error_code() );
 
 		$this->assertArrayHasKey( 'en', $domains );
 		$this->assertSame( 'https://good-url.com', $domains['en'] );


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2397.

In `Model\Languages::update()`, the `domains` option must be set AFTER the language terms are updated. Otherwise, this would prevent the option's sanitization cannot work, since we loop through the languages: their slug must be updated.

## Bonus 1

In `Business\Domains::sanitize()`, `$polylang->model->get_languages_list()` has been replaced by `get_terms()`, so we're sure to fetch the updated data.

## Bonus 2

Trying to pass a domain with an unknown language slug now adds a non-blocking error.