### PR TITLE
`nav_menus` and `domains` options: also update `0` IDs

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -308,7 +308,7 @@ class Languages {
 			if ( ! empty( $nav_menus ) ) {
 				foreach ( $nav_menus as $theme => $locations ) {
 					foreach ( array_keys( $locations ) as $location ) {
-						if ( ! empty( $nav_menus[ $theme ][ $location ][ $old_slug ] ) ) {
+						if ( isset( $nav_menus[ $theme ][ $location ][ $old_slug ] ) ) {
 							$nav_menus[ $theme ][ $location ][ $slug ] = $nav_menus[ $theme ][ $location ][ $old_slug ];
 							unset( $nav_menus[ $theme ][ $location ][ $old_slug ] );
 						}

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -321,7 +321,7 @@ class Languages {
 			// Update domains.
 			$domains = $this->options->get( 'domains' );
 
-			if ( ! empty( $domains[ $old_slug ] ) ) {
+			if ( isset( $domains[ $old_slug ] ) ) {
 				$domains[ $slug ] = $domains[ $old_slug ];
 				unset( $domains[ $old_slug ] );
 				$this->options->set( 'domains', $domains );


### PR DESCRIPTION
Consider the `nav_menus` option containing this:

```php
array(
    'twentytwentyone' => array(
      'primary' => array(
        'fr' => 2738,
        'en' => 4317,
      ),
      'footer' => array(
        'fr' => 0,
        'en' => 0,
      ),
    ),
)
```

After modifying the `en` lang slug to `eng`:

```php
array(
    'twentytwentyone' => array(
      'primary' => array(
        'fr' => 2738,
        'eng' => 4317,
      ),
      'footer' => array(
        'fr' => 0,
        'en' => 0,
      ),
    ),
)
```

`['twentytwentyone']['footer']['en']` is not updated because it is `empty()`.

While not a big issue, this PR fixes this problem.