### PR TITLE
Use determine_locale() instead of get_locale() to get HTML language attributes correctly on the log in page

### DIFF
--- a/include/filters.php
+++ b/include/filters.php
@@ -74,7 +74,7 @@ class PLL_Filters {
 		add_filter( 'get_previous_post_where', array( $this, 'posts_where' ), 10, 5 );
 		add_filter( 'get_next_post_where', array( $this, 'posts_where' ), 10, 5 );
 
-		// Converts the locale to a valid W3C locale except on log in page.
+		// Converts the locale to a valid W3C locale.
 		add_filter( 'language_attributes', array( $this, 'language_attributes' ) );
 
 		// Translate the site title in emails sent to users
@@ -332,13 +332,7 @@ class PLL_Filters {
 	 * @return string
 	 */
 	public function language_attributes( $output ) {
-		if (
-			isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow']
-			&& ( ! empty( $_GET['wp_lang'] ) || ! empty( $_COOKIE['wp_lang'] ) )  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		) {
-			return $output;
-		}
-		if ( $language = $this->model->get_language( is_admin() ? get_user_locale() : get_locale() ) ) {
+		if ( $language = $this->model->get_language( is_admin() ? get_user_locale() : determine_locale() ) ) {
 			$output = str_replace( '"' . get_bloginfo( 'language' ) . '"', '"' . $language->get_locale( 'display' ) . '"', $output );
 		}
 		return $output;

--- a/include/filters.php
+++ b/include/filters.php
@@ -74,7 +74,7 @@ class PLL_Filters {
 		add_filter( 'get_previous_post_where', array( $this, 'posts_where' ), 10, 5 );
 		add_filter( 'get_next_post_where', array( $this, 'posts_where' ), 10, 5 );
 
-		// Converts the locale to a valid W3C locale
+		// Converts the locale to a valid W3C locale except on log in page.
 		add_filter( 'language_attributes', array( $this, 'language_attributes' ) );
 
 		// Translate the site title in emails sent to users
@@ -332,6 +332,12 @@ class PLL_Filters {
 	 * @return string
 	 */
 	public function language_attributes( $output ) {
+		if (
+			isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow']
+			&& ( ! empty( $_GET['wp_lang'] ) || ! empty( $_COOKIE['wp_lang'] ) )  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		) {
+			return $output;
+		}
 		if ( $language = $this->model->get_language( is_admin() ? get_user_locale() : get_locale() ) ) {
 			$output = str_replace( '"' . get_bloginfo( 'language' ) . '"', '"' . $language->get_locale( 'display' ) . '"', $output );
 		}

--- a/include/filters.php
+++ b/include/filters.php
@@ -332,10 +332,13 @@ class PLL_Filters {
 	 * @return string
 	 */
 	public function language_attributes( $output ) {
-		if ( $language = $this->model->get_language( is_admin() ? get_user_locale() : determine_locale() ) ) {
-			$output = str_replace( '"' . get_bloginfo( 'language' ) . '"', '"' . $language->get_locale( 'display' ) . '"', $output );
+		$language = $this->model->get_language( is_admin() ? get_user_locale() : determine_locale() );
+
+		if ( ! $language ) {
+			return $output;
 		}
-		return $output;
+
+		return str_replace( '"' . get_bloginfo( 'language' ) . '"', '"' . $language->get_locale( 'display' ) . '"', $output );
 	}
 
 	/**

--- a/include/filters.php
+++ b/include/filters.php
@@ -332,7 +332,7 @@ class PLL_Filters {
 	 * @return string
 	 */
 	public function language_attributes( $output ) {
-		$language = $this->model->get_language( is_admin() ? get_user_locale() : determine_locale() );
+		$language = $this->model->get_language( determine_locale() );
 
 		if ( ! $language ) {
 			return $output;

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -264,7 +264,7 @@ class Filters_Test extends PLL_UnitTestCase {
 	/**
 	 * @ticket #2420
 	 * @see https://github.com/polylang/polylang-pro/issues/2420
-	*/
+	 */
 	public function test_language_attributes_for_login_page() {
 		$this->frontend->curlang = self::$model->get_language( 'de' );
 		new PLL_Frontend_Filters( $this->frontend );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -261,6 +261,20 @@ class Filters_Test extends PLL_UnitTestCase {
 		language_attributes();
 	}
 
+	/**
+	 * @ticket #2420
+	 * @see https://github.com/polylang/polylang-pro/issues/2420
+	*/
+	public function test_language_attributes_for_login_page() {
+		$this->frontend->curlang = self::$model->get_language( 'de' );
+		new PLL_Frontend_Filters( $this->frontend );
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_GET['wp_lang']    = 'fr_FR';
+
+		$this->expectOutputString( 'lang="fr-FR"' );
+		language_attributes();
+	}
+
 	public function test_save_post() {
 		$this->frontend->posts = new PLL_CRUD_Posts( $this->frontend );
 		$this->frontend->curlang = self::$model->get_language( 'en' );


### PR DESCRIPTION
fixes https://github.com/polylang/polylang-pro/issues/2420

## What?

It's seems that `determine_locale()`  WordPress function already manage `wp_lang` dropdown & cookie for the log in page.
See 
https://github.com/WordPress/WordPress/blob/6.8.2/wp-login.php#L393
and
https://github.com/WordPress/WordPress/blob/6.8.2/wp-login.php#L538

In `determine_locale()` WordPress handles specifically the login page See https://github.com/WordPress/WordPress/blob/6.8.2/wp-includes/l10n.php#L140-L148 and, in this case, prevents from passing to `get_locale()` function on which Polylang is hooked https://github.com/WordPress/WordPress/blob/6.8.2/wp-includes/l10n.php#L165-L167

> [!NOTE]
> On login page `WP::main()` method isn't called. So Polylang language cookie is never set when the page is called directly without having visit a frontend page before because we are hooked on `wp` action.
> See  https://github.com/polylang/polylang/blob/3.7.3/frontend/choose-lang.php#L69

## How?
- ~Adds a condition not to filter language attributes in this case.~
- Uses `determine_locale()` instead of `get_locale()` to correctly set the HTML language attribute to the W3C format if the language exists in Polylang. If the language doesn't exist in Polylang then it keeps the WordPress value which comes from translations See https://github.com/WordPress/WordPress/blob/6.8.2/wp-includes/general-template.php#L890-L894

> [!NOTE]
> Note that here if the value isn't translated, it is also `determine_locale()` which is used
