### PR TITLE
Fix attachment page redirected to 404

### DIFF
--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -87,7 +87,7 @@ class PLL_Canonical {
 			$requested_url = pll_get_requested_url();
 		}
 
-		if ( ( is_single() || is_page() ) && ! is_front_page() ) {
+		if ( ( is_single() && ! is_attachment() ) || ( is_page() && ! is_front_page() ) ) {
 			$post = get_post();
 			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
 				$language = $this->model->post->get_language( (int) $post->ID );

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -87,7 +87,7 @@ class PLL_Canonical {
 			$requested_url = pll_get_requested_url();
 		}
 
-		if ( ( is_single() && ! is_attachment() ) || ( is_page() && ! is_front_page() ) ) {
+		if ( ( is_single() && ( ! is_attachment() || get_option( 'wp_attachment_pages_enabled' ) ) ) || ( is_page() && ! is_front_page() ) ) {
 			$post = get_post();
 			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
 				$language = $this->model->post->get_language( (int) $post->ID );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2431

For attachment, `is_single()` is true, so attachment pages enter our canonical redirect process.
However, when the option `wp_attachment_pages_enabled` is set to 0, the attachment pages are redirect to the file. In this case we should not interfere with the WordPress redirect. 

If anyone volunteers to write canonical tests for attachment pages...

NB: I did not find a way to set the `wp_attachment_pages_enabled` option value from WP backend. So in my tests, I set it directly from the DB.

See https://make.wordpress.org/core/2023/10/16/changes-to-attachment-pages/