### PR TITLE
Make sure language slugs in the `nav_menus` option correspond to existing languages

### DIFF
--- a/include/Options/Abstract_Option.php
+++ b/include/Options/Abstract_Option.php
@@ -228,6 +228,31 @@ abstract class Abstract_Option {
 	abstract protected function get_description(): string;
 
 	/**
+	 * Tells if the languages list is ready.
+	 * If not ready, a "doing it wrong" notice is fired.
+	 *
+	 * @since 3.7
+	 *
+	 * @param string $method The name of the method using this. Used in the error message.
+	 * @return bool
+	 */
+	protected function are_languages_ready( string $method ): bool {
+		global $polylang;
+
+		if ( empty( $polylang ) || ! $polylang->model->languages->are_ready() ) {
+			// Access to global `$polylang` is required.
+			_doing_it_wrong(
+				esc_html( $method ),
+				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
+				'3.7'
+			);
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Returns a list of language terms.
 	 *
 	 * @since 3.7

--- a/include/Options/Abstract_Option.php
+++ b/include/Options/Abstract_Option.php
@@ -228,31 +228,6 @@ abstract class Abstract_Option {
 	abstract protected function get_description(): string;
 
 	/**
-	 * Tells if the languages list is ready.
-	 * If not ready, a "doing it wrong" notice is fired.
-	 *
-	 * @since 3.7
-	 *
-	 * @param string $method The name of the method using this. Used in the error message.
-	 * @return bool
-	 */
-	protected function are_languages_ready( string $method ): bool {
-		global $polylang;
-
-		if ( empty( $polylang ) || ! $polylang->model->languages->are_ready() ) {
-			// Access to global `$polylang` is required.
-			_doing_it_wrong(
-				esc_html( $method ),
-				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
-				'3.7'
-			);
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Returns a list of language terms.
 	 *
 	 * @since 3.7

--- a/include/Options/Abstract_Option.php
+++ b/include/Options/Abstract_Option.php
@@ -232,22 +232,15 @@ abstract class Abstract_Option {
 	 *
 	 * @since 3.7
 	 *
-	 * @param string $fields Optional. Term fields to query for (see `WP_Term_Query` for possible values). Default is `'all'`.
 	 * @return array
 	 *
-	 * @phpstan-param 'all'|'all_with_object_id'|'names'|'slugs'|'id=>name'|'id=>slug'|'ids'|'tt_ids' $fields
-	 * @phpstan-return (
-	 *     $fields is 'all'|'all_with_object_id' ? list<WP_Term> : (
-	 *         $fields is 'names'|'slugs'|'id=>name'|'id=>slug' ? array<int, string> : array<int, int>
-	 *     )
-	 * )
+	 * @phpstan-return list<WP_Term>
 	 */
-	protected function get_language_terms( string $fields = 'all' ): array {
+	protected function get_language_terms(): array {
 		$language_terms = get_terms(
 			array(
 				'taxonomy'   => 'language',
 				'hide_empty' => false,
-				'fields'     => $fields,
 			)
 		);
 		return is_array( $language_terms ) ? $language_terms : array();

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -107,13 +107,7 @@ class Domains extends Abstract_Option {
 		/** @phpstan-var array<non-falsy-string, string> $value */
 		$all_values     = array(); // Previous and new values.
 		$missing_langs  = array(); // Lang names corresponding to the empty values.
-		$language_terms = get_terms(
-			array(
-				'taxonomy'   => 'language',
-				'hide_empty' => false,
-			)
-		);
-		$language_terms = is_array( $language_terms ) ? $language_terms : array();
+		$language_terms = $this->get_language_terms();
 
 		// Detect empty values, fill missing keys with previous values.
 		foreach ( $language_terms as $lang ) {
@@ -135,25 +129,7 @@ class Domains extends Abstract_Option {
 		// Detect invalid language slugs.
 		if ( ! empty( $value ) ) {
 			// Non-blocking error.
-			$value = array_keys( $value );
-
-			$this->errors->add(
-				'pll_unknown_domain_languages',
-				sprintf(
-					/* translators: %s is a list of language slugs. */
-					_n( 'The language %s is unknown and has been discarded.', 'The languages %s are unknown and have been discarded.', count( $value ), 'polylang' ),
-					wp_sprintf_l(
-						'%l',
-						array_map(
-							function ( $slug ) {
-								return "<code>{$slug}</code>";
-							},
-							$value
-						)
-					)
-				),
-				'warning'
-			);
+			$this->add_unknown_languages_warning( array_keys( $value ) );
 		}
 
 		if ( 3 === $options->get( 'force_lang' ) && ! empty( $missing_langs ) ) {

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -85,13 +85,6 @@ class Domains extends Abstract_Option {
 	 * @phpstan-return DomainsValue|WP_Error
 	 */
 	protected function sanitize( $value, Options $options ) {
-		/** @phpstan-var DomainsValue */
-		$current_value = $this->get();
-
-		if ( ! $this->are_languages_ready( __METHOD__ ) ) {
-			return $current_value;
-		}
-
 		// Sanitize new URLs.
 		$value = parent::sanitize( $value, $options );
 
@@ -100,6 +93,8 @@ class Domains extends Abstract_Option {
 			return $value;
 		}
 
+		/** @phpstan-var DomainsValue */
+		$current_value = $this->get();
 		/** @phpstan-var DomainsValue $value */
 		$all_values     = array(); // Previous and new values.
 		$missing_langs  = array(); // Lang names corresponding to the empty values.

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -85,18 +85,10 @@ class Domains extends Abstract_Option {
 	 * @phpstan-return DomainsValue|WP_Error
 	 */
 	protected function sanitize( $value, Options $options ) {
-		global $polylang;
-
 		/** @phpstan-var DomainsValue */
 		$current_value = $this->get();
 
-		if ( empty( $polylang ) || ! $polylang->model->are_languages_ready() ) {
-			// Access to global `$polylang` is required.
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
-				'3.7'
-			);
+		if ( ! $this->are_languages_ready( __METHOD__ ) ) {
 			return $current_value;
 		}
 

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -17,6 +17,8 @@ defined( 'ABSPATH' ) || exit;
  * /!\ Sanitization depends on `force_lang`: this option must be set AFTER `force_lang`.
  *
  * @since 3.7
+ *
+ * @phpstan-type DomainsValue array<non-falsy-string, string>
  */
 class Domains extends Abstract_Option {
 	/**
@@ -80,12 +82,12 @@ class Domains extends Abstract_Option {
 	 * @param Options $options All options.
 	 * @return array|WP_Error The sanitized value. An instance of `WP_Error` in case of blocking error.
 	 *
-	 * @phpstan-return array<non-falsy-string, string>|WP_Error
+	 * @phpstan-return DomainsValue|WP_Error
 	 */
 	protected function sanitize( $value, Options $options ) {
 		global $polylang;
 
-		/** @phpstan-var array<non-falsy-string, string> */
+		/** @phpstan-var DomainsValue */
 		$current_value = $this->get();
 
 		if ( empty( $polylang ) || ! $polylang->model->are_languages_ready() ) {
@@ -106,7 +108,7 @@ class Domains extends Abstract_Option {
 			return $value;
 		}
 
-		/** @phpstan-var array<non-falsy-string, string> $value */
+		/** @phpstan-var DomainsValue $value */
 		$all_values     = array(); // Previous and new values.
 		$missing_langs  = array(); // Lang names corresponding to the empty values.
 		$language_terms = $this->get_language_terms();
@@ -175,7 +177,7 @@ class Domains extends Abstract_Option {
 			}
 		}
 
-		/** @phpstan-var array<non-falsy-string, string> */
+		/** @phpstan-var DomainsValue */
 		return $all_values;
 	}
 

--- a/include/Options/Business/Domains.php
+++ b/include/Options/Business/Domains.php
@@ -85,6 +85,9 @@ class Domains extends Abstract_Option {
 	protected function sanitize( $value, Options $options ) {
 		global $polylang;
 
+		/** @phpstan-var array<non-falsy-string, string> */
+		$current_value = $this->get();
+
 		if ( empty( $polylang ) || ! $polylang->model->are_languages_ready() ) {
 			// Access to global `$polylang` is required.
 			_doing_it_wrong(
@@ -92,8 +95,7 @@ class Domains extends Abstract_Option {
 				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
 				'3.7'
 			);
-			/** @phpstan-var array<non-falsy-string, string> */
-			return $this->get();
+			return $current_value;
 		}
 
 		// Sanitize new URLs.
@@ -117,7 +119,7 @@ class Domains extends Abstract_Option {
 				unset( $value[ $lang->slug ] );
 			} else {
 				// Use previous value.
-				$all_values[ $lang->slug ] = $this->value[ $lang->slug ] ?? '';
+				$all_values[ $lang->slug ] = $current_value[ $lang->slug ] ?? '';
 			}
 
 			if ( empty( $all_values[ $lang->slug ] ) ) {

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -97,15 +97,7 @@ class Nav_Menus extends Abstract_Option {
 	 * @phpstan-return NavMenusValue|WP_Error
 	 */
 	protected function sanitize( $value, Options $options ) {
-		global $polylang;
-
-		if ( empty( $polylang ) || ! $polylang->model->are_languages_ready() ) {
-			// Access to global `$polylang` is required.
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
-				'3.7'
-			);
+		if ( ! $this->are_languages_ready( __METHOD__ ) ) {
 			/** @phpstan-var NavMenusValue */
 			return $this->get();
 		}

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -124,7 +124,7 @@ class Nav_Menus extends Abstract_Option {
 			return $value;
 		}
 
-		$unknown_langs  = array();
+		$all_langs      = array();
 		$language_terms = wp_list_pluck( $this->get_language_terms(), 'slug' );
 
 		foreach ( $value as $theme_slug => $menu_ids_by_location ) {
@@ -139,12 +139,12 @@ class Nav_Menus extends Abstract_Option {
 				}
 
 				// Detect unknown languages.
-				$unknown_langs = array_merge( $unknown_langs, $menu_ids );
+				$all_langs = array_merge( $all_langs, $menu_ids );
 			}
 		}
 
 		/** @phpstan-var NavMenusValue $value */
-		$unknown_langs = array_diff_key( $unknown_langs, array_flip( $language_terms ) );
+		$unknown_langs = array_diff_key( $all_langs, array_flip( $language_terms ) );
 
 		// Detect invalid language slugs.
 		if ( ! empty( $unknown_langs ) ) {

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -5,7 +5,9 @@
 
 namespace WP_Syntex\Polylang\Options\Business;
 
+use WP_Error;
 use WP_Syntex\Polylang\Options\Abstract_Option;
+use WP_Syntex\Polylang\Options\Options;
 use WP_Syntex\Polylang\Model\Languages;
 
 
@@ -15,6 +17,14 @@ defined( 'ABSPATH' ) || exit;
  * Class defining navigation menus array option.
  *
  * @since 3.7
+ *
+ * @phpstan-type Value array<
+ *     non-falsy-string,
+ *     array<
+ *         non-falsy-string,
+ *         array<non-falsy-string, int<0, max>>
+ *     >
+ * >
  */
 class Nav_Menus extends Abstract_Option {
 	/**
@@ -71,6 +81,78 @@ class Nav_Menus extends Abstract_Option {
 			),
 			'additionalProperties' => false,
 		);
+	}
+
+	/**
+	 * Sanitizes option's value.
+	 * Can populate the `$errors` property with blocking and non-blocking errors: in case of non-blocking errors,
+	 * the value is sanitized and can be stored.
+	 *
+	 * @since 3.7
+	 *
+	 * @param array   $value   Value to sanitize.
+	 * @param Options $options All options.
+	 * @return array|WP_Error The sanitized value. An instance of `WP_Error` in case of blocking error.
+	 *
+	 * @phpstan-return Value|WP_Error
+	 */
+	protected function sanitize( $value, Options $options ) {
+		global $polylang;
+
+		if ( empty( $polylang ) || ! $polylang->model->are_languages_ready() ) {
+			// Access to global `$polylang` is required.
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
+				'3.7'
+			);
+			/** @phpstan-var Value */
+			return $this->get();
+		}
+
+		// Sanitize new value.
+		$value = parent::sanitize( $value, $options );
+
+		if ( is_wp_error( $value ) ) {
+			// Blocking error.
+			return $value;
+		}
+
+		/** @phpstan-var Value $value */
+		if ( empty( $value ) ) {
+			// Nothing to validate.
+			return $value;
+		}
+
+		$unknown_langs  = array();
+		$language_terms = $this->get_language_terms( 'slugs' );
+
+		foreach ( $value as $theme_slug => $menu_ids_by_location ) {
+			foreach ( $menu_ids_by_location as $location => $menu_ids ) {
+				// Make sure the language slugs correspond to an existing language.
+				$value[ $theme_slug ][ $location ] = array();
+
+				foreach ( $language_terms as $lang_slug ) {
+					if ( ! empty( $menu_ids[ $lang_slug ] ) ) {
+						$value[ $theme_slug ][ $location ][ $lang_slug ] = $menu_ids[ $lang_slug ];
+					}
+				}
+
+				// Detect unknown languages.
+				$unknown_langs = array_merge( $unknown_langs, $menu_ids );
+			}
+		}
+
+		/** @phpstan-var Value $value */
+		$unknown_langs = array_diff_key( $unknown_langs, array_flip( $language_terms ) );
+
+		// Detect invalid language slugs.
+		if ( ! empty( $unknown_langs ) ) {
+			// Non-blocking error.
+			$this->add_unknown_languages_warning( array_keys( $unknown_langs ) );
+		}
+
+		return $value;
 	}
 
 	/**

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -125,8 +125,7 @@ class Nav_Menus extends Abstract_Option {
 		}
 
 		$unknown_langs  = array();
-		$language_terms = $this->get_language_terms();
-		$language_terms = \wp_list_pluck( $language_terms, 'slug' );
+		$language_terms = wp_list_pluck( $this->get_language_terms(), 'slug' );
 
 		foreach ( $value as $theme_slug => $menu_ids_by_location ) {
 			foreach ( $menu_ids_by_location as $location => $menu_ids ) {

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -97,11 +97,6 @@ class Nav_Menus extends Abstract_Option {
 	 * @phpstan-return NavMenusValue|WP_Error
 	 */
 	protected function sanitize( $value, Options $options ) {
-		if ( ! $this->are_languages_ready( __METHOD__ ) ) {
-			/** @phpstan-var NavMenusValue */
-			return $this->get();
-		}
-
 		// Sanitize new value.
 		$value = parent::sanitize( $value, $options );
 

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -125,7 +125,8 @@ class Nav_Menus extends Abstract_Option {
 		}
 
 		$unknown_langs  = array();
-		$language_terms = $this->get_language_terms( 'slugs' );
+		$language_terms = $this->get_language_terms();
+		$language_terms = \wp_list_pluck( $language_terms, 'slug' );
 
 		foreach ( $value as $theme_slug => $menu_ids_by_location ) {
 			foreach ( $menu_ids_by_location as $location => $menu_ids ) {

--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.7
  *
- * @phpstan-type Value array<
+ * @phpstan-type NavMenusValue array<
  *     non-falsy-string,
  *     array<
  *         non-falsy-string,
@@ -94,7 +94,7 @@ class Nav_Menus extends Abstract_Option {
 	 * @param Options $options All options.
 	 * @return array|WP_Error The sanitized value. An instance of `WP_Error` in case of blocking error.
 	 *
-	 * @phpstan-return Value|WP_Error
+	 * @phpstan-return NavMenusValue|WP_Error
 	 */
 	protected function sanitize( $value, Options $options ) {
 		global $polylang;
@@ -106,7 +106,7 @@ class Nav_Menus extends Abstract_Option {
 				esc_html( sprintf( 'The option \'%s\' cannot be set before the hook \'pll_init\'.', static::key() ) ),
 				'3.7'
 			);
-			/** @phpstan-var Value */
+			/** @phpstan-var NavMenusValue */
 			return $this->get();
 		}
 
@@ -118,7 +118,7 @@ class Nav_Menus extends Abstract_Option {
 			return $value;
 		}
 
-		/** @phpstan-var Value $value */
+		/** @phpstan-var NavMenusValue $value */
 		if ( empty( $value ) ) {
 			// Nothing to validate.
 			return $value;
@@ -143,7 +143,7 @@ class Nav_Menus extends Abstract_Option {
 			}
 		}
 
-		/** @phpstan-var Value $value */
+		/** @phpstan-var NavMenusValue $value */
 		$unknown_langs = array_diff_key( $unknown_langs, array_flip( $language_terms ) );
 
 		// Detect invalid language slugs.

--- a/tests/phpunit/tests/Options/Options/test-Set.php
+++ b/tests/phpunit/tests/Options/Options/test-Set.php
@@ -126,14 +126,14 @@ class Set_Test extends PLL_UnitTestCase {
 				'primary' => array(
 					'en' => 0, // Overwrites `22`.
 					'fr' => 2, // Overwrites `7`.
-					'es' => 2738, // Added.
+					'es' => 2738, // Added because not present in `$settings`.
 					'de' => 4317, // Unknown language, not added.
 				),
-				'custom'  => array( // Added.
+				'custom'  => array( // Added because not present in `$settings`.
 					'es' => 269,
 				),
 			),
-			'twentyseventeen' => array( // Not modified.
+			'twentyseventeen' => array( // Not modified because identical in `$settings`.
 				'top'    => array(
 					'en' => 26,
 				),

--- a/tests/phpunit/tests/Options/Options/test-Set.php
+++ b/tests/phpunit/tests/Options/Options/test-Set.php
@@ -83,7 +83,7 @@ class Set_Test extends PLL_UnitTestCase {
 		$domains = $this->pll_env->model->options->get( 'domains' );
 
 		$this->assertCount( 1, $errors->get_error_codes() );
-		$this->assertSame( 'pll_unknown_domain_languages', $errors->get_error_code() );
+		$this->assertSame( 'pll_unknown_domains_languages', $errors->get_error_code() );
 
 		$this->assertArrayHasKey( 'en', $domains );
 		$this->assertSame( 'https://good-url.com', $domains['en'] );

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -26,6 +26,10 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_nav_menu_locations() {
+		$pll_admin           = new PLL_Admin( $this->links_model );
+		$GLOBALS['polylang'] = $pll_admin;
+		$pll_admin->model->set_languages_ready();
+
 		// get the primary location of the current theme
 		$locations = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
@@ -73,9 +77,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 			)
 		);
 
-
 		// assign our menus to locations
-		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->create_nav_menu_locations();
 
@@ -121,6 +123,10 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	public function test_delete_nav_menu() {
 		$theme = get_option( 'stylesheet' );
 
+		$pll_admin           = new PLL_Admin( $this->links_model );
+		$GLOBALS['polylang'] = $pll_admin;
+		$pll_admin->model->set_languages_ready();
+
 		// get the primary location of the current theme
 		$locations = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
@@ -130,7 +136,6 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$menu_fr = wp_create_nav_menu( 'menu_fr' );
 
 		// assign our menus to locations
-		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->create_nav_menu_locations();
 
@@ -142,8 +147,10 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$nav_menu->update_nav_menu_locations( $nav_menu_locations ); // our filter update_nav_menu_locations does not run due to security checks
-
-		$this->assertEquals( array( 'en' => $menu_en, 'fr' => $menu_fr ), $pll_admin->options['nav_menus'][ $theme ][ $primary_location ] );
+		$this->assertSameSetsWithIndex(
+			array( 'en' => $menu_en, 'fr' => $menu_fr ),
+			$pll_admin->options['nav_menus'][ $theme ][ $primary_location ]
+		);
 
 		// setup filters
 		$nav_menu->admin_init();
@@ -151,10 +158,17 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		// delete a nav_menu
 		wp_delete_nav_menu( $menu_en );
 
-		$this->assertEquals( array( 'fr' => $menu_fr ), $pll_admin->options['nav_menus'][ $theme ][ $primary_location ] );
+		$this->assertSameSetsWithIndex(
+			array( 'fr' => $menu_fr ),
+			$pll_admin->options['nav_menus'][ $theme ][ $primary_location ]
+		);
 	}
 
 	public function test_auto_add_pages_to_menu() {
+		$pll_admin           = new PLL_Admin( $this->links_model );
+		$GLOBALS['polylang'] = $pll_admin;
+		$pll_admin->model->set_languages_ready();
+
 		// create 2 menus
 		$menu_en = wp_create_nav_menu( 'menu_en' );
 		$menu_fr = wp_create_nav_menu( 'menu_fr' );
@@ -169,7 +183,6 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		);
 
 		// assign our menus to locations
-		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->create_nav_menu_locations();
 
@@ -208,6 +221,10 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	}
 
 	protected function setup_nav_menus( $options ) {
+		$pll_admin           = new PLL_Admin( $this->links_model );
+		$GLOBALS['polylang'] = $pll_admin;
+		$pll_admin->model->set_languages_ready();
+
 		// create posts
 		$en = self::factory()->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -238,7 +255,6 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$primary_location = reset( $locations );
 
 		// assign our menus to locations
-		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->create_nav_menu_locations();
 
@@ -336,6 +352,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$frontend->curlang = self::$model->get_language( 'en' );
 		$frontend->links = new PLL_Frontend_Links( $frontend );
 		$frontend->nav_menu = new PLL_Frontend_Nav_Menu( $frontend );
+		$frontend->model->set_languages_ready();
 
 		$GLOBALS['polylang'] = $frontend; // FIXME we still use PLL() in PLL_Frontend_Nav_Menu
 
@@ -401,11 +418,14 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	public function test_set_theme_mod_from_edit_menus_tab() {
 		wp_set_current_user( 1 );
 
+		$pll_admin           = new PLL_Admin( $this->links_model );
+		$GLOBALS['polylang'] = $pll_admin;
+		$pll_admin->model->set_languages_ready();
+
 		// Get the primary location of the current theme
 		$locations = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
-		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->admin_init(); // Setup filters
 		$nav_menu->create_nav_menu_locations();
@@ -433,11 +453,14 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 	public function test_set_theme_mod_from_manage_locations_tab() {
 		wp_set_current_user( 1 );
 
+		$pll_admin           = new PLL_Admin( $this->links_model );
+		$GLOBALS['polylang'] = $pll_admin;
+		$pll_admin->model->set_languages_ready();
+
 		// Get the primary location of the current theme
 		$locations = array_keys( get_registered_nav_menus() );
 		$primary_location = reset( $locations );
 
-		$pll_admin = new PLL_Admin( $this->links_model );
 		$nav_menu = new PLL_Admin_Nav_Menu( $pll_admin );
 		$nav_menu->admin_init(); // Setup filters
 		$nav_menu->create_nav_menu_locations();


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2413.

This PR validates the language slugs in the `nav_menus` option by making sure they correspond to existing languages.

Some code has been factorized in `Abstract_Option`, to be used in `Domains` and `Nav_Menus`.

Also, a bug has been fixed in `Domains::sanitize()`: the property `Abstract_Option::$value` is `private` and cannot be used in child-classes.

`Nav_Menus::sanitize()` keeps the previous sub-values if they are not provided by the new ones. This means the whole value must be sent to it to prevent unintantional removals.