### PR TITLE
Harmonize icon spacings

### DIFF
--- a/css/src/admin.css
+++ b/css/src/admin.css
@@ -225,6 +225,17 @@ td.column-default_lang .icon-default-lang:before,
 	width: 20px;
 }
 
+.components-panel #post-translations .pll-language-column {
+	width: 21px; /* 1px padding-left + 16px icon + 4px padding-right */
+	padding-right: 4px;
+}
+
+.components-panel #post-translations .pll-column-icon {
+	width: 26px;
+	padding: 1px;
+	text-align: center;
+}
+
 #post-translations .tr_lang {
 	width: 100%;
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2442.

## Icon sizes

1. Icons in classic editor's metabox are 20x20px.
2. Icons in block editor's metabox are 24x24px.

However, this is consistent with other icons for each interface: all icons in the classic editor are 20px and all icons in the block editor are 24px.

So there is no issue here, we're applying the icon size used by each interface.

## Icon spacing (in block editor)

The current value of `box-sizing: inherit` (`border-box`), makes that the table cell width includes the paddings.
For example:
```CSS
td {
	width: 20px;
	padding: 0 2px;
}
```

By doing this, the inner width of the cell is 16px: 20px - (2 x 2px). So if we put an icon that is more than 16px width, it will overflow out of the cell, reducing the visual spacing at the right.

### Solution

Make so that the inner width of the cell matches the icon width (which is 24px):
```CSS
td {
	width: 26px;
	padding: 1px;
}
```

For the cell containing the flag we apply the same strategy, except that the flags are smaller and we don't need the padding-left.

### Result

![Capture 2025-01-13 à 13 54 35](https://github.com/user-attachments/assets/75f0be19-0057-4c0c-ac75-9d3adb72ee76)
