### PR TITLE
Disable the warning for static page translation when page translations are deactivated

### DIFF
--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -26,15 +26,35 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 
 		$this->links = &$polylang->links;
 
-		// Add post state for translations of the front page and posts page
+		add_action( 'pll_init', array( $this, 'init_page_hooks' ), 1000 ); // Hook late to allow other sources to filter `'pll_get_post_types'` easily.
+	}
+
+	/**
+	 * Launches hooks related to the `page` post type.
+	 *
+	 * @since 3.7
+	 *
+	 * @param PLL_Base $polylang The Polylang object.
+	 * @return void
+	 */
+	public function init_page_hooks( PLL_Base $polylang ): void {
+		$post_types = $polylang->model->post->get_translated_object_types();
+
+		if ( ! in_array( 'page', $post_types, true ) ) {
+			// No need of the following if the pages are not translated.
+			return;
+		}
+
+		// Add post state for translations of the front page and posts page.
 		add_filter( 'display_post_states', array( $this, 'display_post_states' ), 10, 2 );
 
-		// Refreshes the language cache when a static front page or page for for posts has been translated.
+		// Refresh the language cache when a static front page or page for for posts has been translated.
 		add_action( 'pll_save_post', array( $this, 'pll_save_post' ), 10, 3 );
 
-		// Prevents WP resetting the option
+		// Prevent WP resetting the option.
 		add_filter( 'pre_update_option_show_on_front', array( $this, 'update_show_on_front' ), 10, 2 );
 
+		// Add a notice to translate the static front page if it is not translated in all languages.
 		add_action( 'admin_notices', array( $this, 'notice_must_translate' ) );
 	}
 
@@ -92,7 +112,7 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Add a notice to translate the static front page if it is not translated in all languages
+	 * Adds a notice to translate the static front page if it is not translated in all languages.
 	 * This is especially useful after a new language is created.
 	 * The notice is not dismissible and displayed on the Languages pages and the list of pages.
 	 *

--- a/admin/admin-static-pages.php
+++ b/admin/admin-static-pages.php
@@ -15,6 +15,11 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	protected $links;
 
 	/**
+	 * @var PLL_Translated_Post
+	 */
+	protected $post;
+
+	/**
 	 * Constructor: setups filters and actions.
 	 *
 	 * @since 1.8
@@ -25,8 +30,9 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 		parent::__construct( $polylang );
 
 		$this->links = &$polylang->links;
+		$this->post  = &$polylang->model->post;
 
-		add_action( 'pll_init', array( $this, 'init_page_hooks' ), 1000 ); // Hook late to allow other sources to filter `'pll_get_post_types'` easily.
+		add_action( 'after_setup_theme', array( $this, 'init_page_hooks' ), 1000 ); // Hook late to allow other sources to filter `'pll_get_post_types'` easily.
 	}
 
 	/**
@@ -34,13 +40,10 @@ class PLL_Admin_Static_Pages extends PLL_Static_Pages {
 	 *
 	 * @since 3.7
 	 *
-	 * @param PLL_Base $polylang The Polylang object.
 	 * @return void
 	 */
-	public function init_page_hooks( PLL_Base $polylang ): void {
-		$post_types = $polylang->model->post->get_translated_object_types();
-
-		if ( ! in_array( 'page', $post_types, true ) ) {
+	public function init_page_hooks(): void {
+		if ( ! in_array( 'page', $this->post->get_translated_object_types(), true ) ) {
 			// No need of the following if the pages are not translated.
 			return;
 		}

--- a/tests/phpunit/tests/test-admin-static-pages.php
+++ b/tests/phpunit/tests/test-admin-static-pages.php
@@ -1,0 +1,103 @@
+<?php
+
+class Admin_Static_Pages_Test extends PLL_UnitTestCase {
+	protected static $home_en;
+
+	/**
+	 * @param PLL_UnitTest_Factory $factory
+	 * @return void
+	 */
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
+
+		$factory->language->create_many( 2 );
+		self::$model->options['default_lang'] = 'en'; // Otherwise static model isn't aware of the created languages...
+
+		self::$home_en = $factory->post->create(
+			array(
+				'post_title'   => 'home',
+				'post_type'    => 'page',
+				'post_content' => 'en1<!--nextpage-->en2',
+				'lang'         => 'en',
+			)
+		);
+
+		self::$model->clean_languages_cache();
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', self::$home_en );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$home_en, true );
+
+		parent::wpTearDownAfterClass();
+	}
+
+	/**
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $translate_page_post_type True to translate the `page` post type.
+	 * @return void
+	 */
+	public function test_front_page_not_translated_warning( bool $translate_page_post_type ): void {
+		wp_set_current_user( 1 );
+
+		// Needed by `LL_Admin_Static_Pages::notice_must_translate()`.
+		$GLOBALS['hook_suffix'] = 'toplevel_page_mlang';
+		set_current_screen();
+
+		if ( ! $translate_page_post_type ) {
+			// Don't translate the `page` post type.
+			add_filter(
+				'pll_get_post_types',
+				function ( $post_types ) {
+					return array_diff( $post_types, array( 'page' ) );
+				}
+			);
+		}
+
+		$links_model   = self::$model->get_links_model();
+		$this->pll_env = new PLL_Admin( $links_model );
+
+		$this->pll_env->init();
+
+		$post_types = $this->pll_env->model->post->get_translated_object_types();
+
+		if ( ! $translate_page_post_type ) {
+			$this->assertArrayNotHasKey( 'page', $post_types );
+		} else {
+			$this->assertArrayHasKey( 'page', $post_types );
+		}
+
+		ob_start();
+		do_action( 'after_setup_theme' );
+		do_action( 'admin_notices' );
+		$notices = ob_get_clean();
+
+		if ( ! $translate_page_post_type ) {
+			// No warning notice if we don't translate the pages.
+			$this->assertStringNotContainsString( '/post-new.php?post_type=page', $notices );
+			return;
+		}
+
+		// Make sure there is something (our notice) that displays a link to create a translation.
+		$this->assertStringContainsString( '/post-new.php?post_type=page', $notices );
+
+		$this->assertNotFalse( preg_match( '@href="([^"]+/post-new\.php[^"]+)"@', $notices, $matches ) );
+		$query_str = wp_parse_url( html_entity_decode( $matches[1] ), PHP_URL_QUERY );
+		$this->assertIsString( $query_str );
+		wp_parse_str( $query_str, $query_arr );
+
+		$expected = array(
+			'post_type' => 'page',
+			'from_post' => (string) self::$home_en,
+			'new_lang'  => 'fr',
+		);
+		$this->assertSameSetsWithIndex(
+			$expected,
+			array_intersect_key( $query_arr, $expected )
+		);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2296.

If the `page` post type is removed from the list of translatable post types, we shouldn't display the "translate your static front page" warning notice.

It can be done by adding this:
```php
add_filter(
	'pll_get_post_types',
	function ( $post_types ) {
		return array_diff( $post_types, array( 'page' ) );
	}
);
```

This PR prevents this notice (and other related hooks) if the `page` post type is not translated.