### PR TITLE
Do not relate an object to a term if the term does not exist.

### DIFF
--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -144,7 +144,8 @@ class PLL_CRUD_Posts {
 	public function set_object_terms( $object_id, $terms, $tt_ids, $taxonomy ) {
 		static $avoid_recursion;
 
-		if ( $avoid_recursion || empty( $terms ) || ! is_array( $terms ) || ! $this->model->is_translated_taxonomy( $taxonomy ) ) {
+		if ( $avoid_recursion || empty( $terms ) || ! is_array( $terms ) || empty( $tt_ids )
+			|| ! $this->model->is_translated_taxonomy( $taxonomy ) ) {
 			return;
 		}
 

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -262,7 +262,7 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 		// Create a post with this category so that `get_terms()` returns terms (since `hide_empty` is `true` by default).
 		self::factory()->post->create( array( 'post_category' => array( $en_cat ) ) );
 
-		update_option( 'default_category', '999' );
+		update_option( 'default_category', $en_cat + 999 ); // Use this number to make sure the category doesn't exist.
 
 		// Simulate the request that create the post and assigns language.
 		$post = get_default_post_to_edit( 'post', true );

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -245,4 +245,34 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 		$this->assertCount( 1, $tags );
 		$this->assertSame( 'Common', reset( $tags )->name );
 	}
+
+	/**
+	 * Test a post creation with a non-existent default category to check that no category has been assigned to this post.
+	 *
+	 * @ticket 2248.
+	 * @see https://github.com/polylang/polylang-pro/issues/2249.
+	 */
+	public function test_save_post_when_no_default_category_set() {
+		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
+
+		// Create an english category.
+		$en_cat = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'English category' ) );
+		$this->pll_admin->model->term->set_language( $en_cat, 'en' );
+
+		// Create a post with this category so that `get_terms()` returns terms (since `hide_empty` is `true` by default).
+		self::factory()->post->create( array( 'post_category' => array( $en_cat ) ) );
+
+		update_option( 'default_category', '999' );
+
+		// Simulate the request that create the post and assigns language.
+		$post = get_default_post_to_edit( 'post', true );
+		$_REQUEST = $_POST = array(
+			'post_lang_choice' => 'en',
+			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
+			'post_ID'          => $post->ID,
+		);
+		edit_post();
+
+		$this->assertEmpty( wp_get_post_categories( $post->ID ) );
+	}
 }


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2249.

## What ?

All categories are assigned to a post when the set default category no longer exists.

See the mentioned ticket in the issue.

## Why ?

When a term no longer exists but is still set as a `default_category`, a `wp_set_object_terms` is still made to this non-existent term, so we end up with a term that doesn't exist in `PLL_Crud_Posts::set_object_terms()`. 

So in our `get_terms()` we'll get all existing terms, since `$tt_ids` is empty.

## Fix

Don't proceed further if `$tt_iids` is empty, which means the term(s) don't exist.
