### PR TITLE
Ignore coverage folder from the webpack build process and distributing process

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
 # Files to exclude from the distribution.
 
 bin/
+coverage/
 css/src/
 js/src/
 node_modules/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ function configureWebpack( options ){
 
 	const commonFoldersToIgnore = [
 		'node_modules/**',
+		'coverage/**',
 		'vendor/**',
 		'tmp/**',
 		'tests/**',


### PR DESCRIPTION
Follow up https://github.com/polylang/polylang-pro/pull/2448

Even if there is no `composer update` command in this repository unlike in Polylang pro repository, it's possible to run
`/vendor/bin/phpunit --coverage-html coverage` which creates this folder containing some javascript and css files.

So, as in Polylang Pro, we need to ignore this folder from our build processes.
It's what this PR proposes.

Below files concerned by the webpack build process when the `coverage/` folder isn't ignore.

```shell
dirname: /home/manu/Documents/Boulot/code/polylang
js files to minify: [
  './coverage/_js/file.js',
  './js/src/admin.js',
  './js/src/block-editor.js',
  './js/src/classic-editor.js',
  './js/src/nav-menu.js',
  './js/src/post.js',
  './js/src/term.js',
  './js/src/user.js',
  './js/src/widgets.js',
  './modules/wizard/js/languages-step.js'
]
css files to minify: [
  './coverage/_css/custom.css',
  './coverage/_css/octicons.css',
  './coverage/_css/style.css',
  './css/src/admin.css',
  './css/src/dialog.css',
  './css/src/selectmenu.css',
  './modules/wizard/css/wizard.css'
]
```