### PR TITLE
Use `wp_add_inline_script()` to add our cookie script.

### DIFF
--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -72,16 +72,14 @@ class PLL_Cache_Compat {
 
 		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
 
-		$script = "<script{$type_attr}>\n{$js}\n</script>\n";
-
 		/**
-		 * Filters the content of the script tag that creates the cookie.
+		 * Filters the script tag that creates the cookie.
 		 *
 		 * @since 3.7
 		 *
 		 * @param string $script The Script tag and content.
 		 */
-		echo apply_filters( 'pll_cookie_script', $script ); // phpcs:ignore WordPress.Security.EscapeOutput
+		echo apply_filters( 'pll_cookie_script', "<script{$type_attr}>\n{$js}\n</script>\n" ); // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
 	/**

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -71,8 +71,8 @@ class PLL_Cache_Compat {
 		);
 
 		// Need to register prior to enqueue empty script and add extra code to it.
-		wp_register_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION );
-		wp_enqueue_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION, true );
+		wp_register_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION, true );
+		wp_enqueue_script( 'pll_cookie_script' );
 		wp_add_inline_script( 'pll_cookie_script', $js );
 	}
 

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -17,7 +17,7 @@ class PLL_Cache_Compat {
 	 */
 	public function init() {
 		if ( PLL_COOKIE ) {
-			add_action( 'wp_print_footer_scripts', array( $this, 'add_cookie_script' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'add_cookie_script' ) );
 		}
 
 		// Since version 3.0.5, WP Rocket does not serve the cached page if our cookie is not set
@@ -70,16 +70,9 @@ class PLL_Cache_Compat {
 			esc_js( $expiration )
 		);
 
-		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
-
-		/**
-		 * Filters the script tag that creates the cookie.
-		 *
-		 * @since 3.7
-		 *
-		 * @param string $script The Script tag and content.
-		 */
-		echo apply_filters( 'pll_cookie_script', "<script{$type_attr}>\n{$js}\n</script>\n" ); // phpcs:ignore WordPress.Security.EscapeOutput
+		wp_register_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION );
+		wp_enqueue_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION, true );
+		wp_add_inline_script( 'pll_cookie_script', $js );
 	}
 
 	/**

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -70,6 +70,7 @@ class PLL_Cache_Compat {
 			esc_js( $expiration )
 		);
 
+		// Need to register the script to enqueue and add extra code to it.
 		wp_register_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION );
 		wp_enqueue_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION, true );
 		wp_add_inline_script( 'pll_cookie_script', $js );

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -34,6 +34,8 @@ class PLL_Cache_Compat {
 	 * This functions allows to create the cookie in javascript as a workaround.
 	 *
 	 * @since 2.3
+	 *
+	 * @return string The script that creates the cookie.
 	 */
 	public function add_cookie_script() {
 		// Embeds should not set the cookie.
@@ -70,7 +72,16 @@ class PLL_Cache_Compat {
 
 		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
 
-		echo "<script{$type_attr}>\n{$js}\n</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+		$script = "<script{$type_attr}>\n{$js}\n</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+
+		/**
+		 * Filters the content of the script tag that creates the cookie.
+		 *
+		 * @since 3.7
+		 *
+		 * @param string $script The Script tag and content.
+		 */
+		echo apply_filters( 'pll_cookie_script', $script );
 	}
 
 	/**

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -72,7 +72,7 @@ class PLL_Cache_Compat {
 
 		$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
 
-		$script = "<script{$type_attr}>\n{$js}\n</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+		$script = "<script{$type_attr}>\n{$js}\n</script>\n";
 
 		/**
 		 * Filters the content of the script tag that creates the cookie.
@@ -81,7 +81,7 @@ class PLL_Cache_Compat {
 		 *
 		 * @param string $script The Script tag and content.
 		 */
-		echo apply_filters( 'pll_cookie_script', $script );
+		echo apply_filters( 'pll_cookie_script', $script ); // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
 	/**

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -35,7 +35,7 @@ class PLL_Cache_Compat {
 	 *
 	 * @since 2.3
 	 *
-	 * @return string The script that creates the cookie.
+	 * @return void
 	 */
 	public function add_cookie_script() {
 		// Embeds should not set the cookie.

--- a/integrations/cache/cache-compat.php
+++ b/integrations/cache/cache-compat.php
@@ -70,7 +70,7 @@ class PLL_Cache_Compat {
 			esc_js( $expiration )
 		);
 
-		// Need to register the script to enqueue and add extra code to it.
+		// Need to register prior to enqueue empty script and add extra code to it.
 		wp_register_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION );
 		wp_enqueue_script( 'pll_cookie_script', '', array(), POLYLANG_VERSION, true );
 		wp_add_inline_script( 'pll_cookie_script', $js );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2469.

Finally, we decided to use `wp_add_inline_script()` to add our cookie script.

Using this method, the type attribute is managed by WordPress with `wp_get_inline_script_tag()`, see [here](https://github.com/WordPress/wordpress-develop/blob/6.7.2/src/wp-includes/script-loader.php#L2849).

We can also see that we have a filter `wp_inline_script_attributes` that allows attributes to be filtered in `current_theme_supports()`, which meets the customer's request.
