### PR TITLE
Don't use translated labels in the sync option

### DIFF
--- a/include/Options/Business/Sync.php
+++ b/include/Options/Business/Sync.php
@@ -40,14 +40,11 @@ class Sync extends Abstract_List {
 	 * @phpstan-return array{type: 'array', items: array{type: SchemaType, enum: non-empty-list<non-falsy-string>}}
 	 */
 	protected function get_data_structure(): array {
-		add_filter( 'lang_dir_for_domain', '__return_false' ); // Prevents loading the translations too early.
-		$enum = array_keys( \PLL_Settings_Sync::list_metas_to_sync() );
-		remove_filter( 'lang_dir_for_domain', '__return_false' );
 		return array(
 			'type'  => 'array',
 			'items' => array(
 				'type' => $this->get_type(),
-				'enum' => $enum,
+				'enum' => \PLL_Settings_Sync::get_synchronizable_elements(),
 			),
 		);
 	}

--- a/modules/sync/settings-sync.php
+++ b/modules/sync/settings-sync.php
@@ -113,4 +113,29 @@ class PLL_Settings_Sync extends PLL_Settings_Module {
 			'_thumbnail_id'     => __( 'Featured image', 'polylang' ),
 		);
 	}
+
+	/**
+	 * Returns the list of elements that can be synced at the post level.
+	 *
+	 * @since 3.7
+	 *
+	 * @return string[]
+	 *
+	 * @phpstan-return non-empty-list<non-falsy-string>
+	 */
+	public static function get_synchronizable_elements() {
+		return array(
+			'taxonomies',
+			'post_meta',
+			'comment_status',
+			'ping_status',
+			'sticky_posts',
+			'post_date',
+			'post_format',
+			'post_parent',
+			'_wp_page_template',
+			'menu_order',
+			'_thumbnail_id',
+		);
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2470

## What?

## How?
- Cherry pick the initial [commit](https://github.com/polylang/polylang/pull/1550/commits/b1ca2acf6ae20bf1d7031359ad20415c9875edb8) as proposed in https://github.com/polylang/polylang/pull/1550