### PR TITLE
Fix `wp_kses()` tag attributes

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -225,7 +225,7 @@ function pll_add_notice( WP_Error $error ) {
 		$message = wp_kses(
 			implode( '<br>', $error->get_error_messages( $error_code ) ),
 			array(
-				'a'    => array( 'href' ),
+				'a'    => array( 'href' => true ),
 				'br'   => array(),
 				'code' => array(),
 				'em'   => array(),


### PR DESCRIPTION
Attributes must be in the form of `array( 'att-name' => true )` or `array( 'att-name' => array( 'list', 'of', 'accepted', 'values' ) )`.
See the global vars `$allowedposttags` and `$allowedtags` in [`/wp-includes/kses.php`](https://github.com/WordPress/WordPress/blob/2eb7a359e3cc11c6eae698072f7d0568f8ba9574/wp-includes/kses.php#L71).