### PR TITLE
Fix properties not set in updater

### DIFF
--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -7,10 +7,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Allows plugins to use their own update API.
- * Modified version with 'polylang' text domain and missing comments for translators.
+ * Modified version with 'polylang' text domain, missing comments for translators, and a bug fix.
  *
  * @author Easy Digital Downloads
  * @version 1.9.4
+ *
+ * @see https://github.com/polylang/polylang-pro/pull/2516
  */
 class PLL_Plugin_Updater {
 
@@ -150,6 +152,20 @@ class PLL_Plugin_Updater {
 
 			$this->set_version_info_cache( $version_info );
 		}
+
+		// Added by Polylang.
+		foreach ( array( 'url', 'package', 'new_version', 'tested', 'requires', 'requires_php' ) as $prop ) {
+			if ( ! isset( $version_info->$prop ) ) {
+				$version_info->$prop = '';
+			}
+		}
+
+		foreach ( array( 'icons', 'banners' ) as $prop ) {
+			if ( ! isset( $version_info->$prop ) ) {
+				$version_info->$prop = new stdClass();
+			}
+		}
+		// End of added by Polylang.
 
 		return $version_info;
 	}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2513.

This PR fixes php warnings due to missing object properties.
These warnings are caused by the upgrade of `EDD_SL_Plugin_Updater` from 1.9.1 to 1.9.4: backward compatibility is incomplete. This happens if the data in cache is still in 1.9.1 format, without the new properties.
See https://github.com/polylang/polylang/commit/1fc74e2967d969c18b31ea30ba4532e3c7f0f53a.