### PR TITLE
Fix a conflict with WooCommerce Price Based on Country

### DIFF
--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -312,13 +312,17 @@ class PLL_Frontend_Auto_Translate {
 		$slugs = array();
 
 		if ( is_array( $query_var ) ) {
-			$slugs = &$query_var;
+			$slugs = $query_var;
 		} elseif ( is_string( $query_var ) ) {
 			$sep   = strpos( $query_var, ',' ) !== false ? ',' : '+'; // Two possible separators.
 			$slugs = explode( $sep, $query_var );
 		}
 
 		foreach ( $slugs as &$slug ) {
+			if ( ! is_string( $slug ) ) {
+				// We got an unexpected query var, let return it unchanged.
+				return $query_var;
+			}
 			$slug = $this->get_translated_term_by( 'slug', $slug, $taxonomy );
 		}
 

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -327,9 +327,9 @@ class PLL_Frontend_Auto_Translate {
 		}
 
 		if ( ! empty( $sep ) ) {
-			$query_var = implode( $sep, $slugs );
+			return implode( $sep, $slugs );
 		}
 
-		return $query_var;
+		return $slugs;
 	}
 }

--- a/frontend/frontend-auto-translate.php
+++ b/frontend/frontend-auto-translate.php
@@ -141,7 +141,7 @@ class PLL_Frontend_Auto_Translate {
 		// According to the codex, this type of query is deprecated as of WP 3.1 but it does not appear in WP 3.5 source code
 		foreach ( array_intersect( $this->model->get_translated_taxonomies(), get_taxonomies( array( '_builtin' => false ) ) ) as $taxonomy ) {
 			$tax = get_taxonomy( $taxonomy );
-			if ( ! empty( $tax ) && ! empty( $qv[ $tax->query_var ] ) ) {
+			if ( ! empty( $tax ) && ! empty( $tax->query_var ) && ! empty( $qv[ $tax->query_var ] ) ) {
 				$qv[ $tax->query_var ] = $this->translate_terms_list( $qv[ $tax->query_var ], $taxonomy );
 			}
 		}

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -17,16 +17,24 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 		register_post_type( 'trcpt', array( 'public' => true, 'has_archive' => true ) ); // Translated custom post type with archives.
 		register_taxonomy( 'trtax', 'trcpt' ); // Translated custom tax.
-		register_taxonomy( 'without_qv', 'trcpt', array( 'query_var' => false ) );
+		register_taxonomy( 'tax_without_qv', 'trcpt', array( 'query_var' => false ) );
 
 		$options = array(
 			'post_types' => array( 'trcpt' ),
-			'taxonomies' => array( 'trtax', 'without_qv' ),
+			'taxonomies' => array( 'trtax', 'tax_without_qv' ),
 		);
 
 		$frontend = ( new PLL_Context_Frontend( array( 'options' => $options ) ) )->get();
 
 		$frontend->curlang = $frontend->model->get_language( 'fr' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		_unregister_post_type( 'trcpt' );
+		_unregister_taxonomy( 'trtax' );
+		_unregister_taxonomy( 'tax_without_qv' );
 	}
 
 	public function test_category() {
@@ -232,6 +240,8 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 
 	/**
 	 * Conflict with WooCommerce Price Based on Country #1638.
+	 *
+	 * This test implicitly depends on the taxonomy without query var `tax_without_qv`.
 	 */
 	public function test_query_with_unexpected_extra_data() {
 		$posts = self::factory()->post->create_translated(


### PR DESCRIPTION
## What?
Polylang + WooCommerce + WooCommerce Price Based on Country causes a fatal error:
```
PHP Fatal error:  Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in /app/wp-includes/formatting.php:1596
Stack trace:
#0 /app/wp-includes/formatting.php(1596): preg_match('/[\\x80-\\xff]/', Array)
#1 /app/wp-includes/formatting.php(2211): remove_accents(Array)
#2 [internal function]: sanitize_title(Array)
#3 /app/wp-includes/class-wp-term-query.php(561): array_map('sanitize_title', Array)
#4 /app/wp-includes/class-wp-term-query.php(308): WP_Term_Query->get_terms()
#5 /app/wp-includes/taxonomy.php(1357): WP_Term_Query->query(Array)
#6 /app/wp-content/plugins/polylang-pro/vendor/wpsyntex/polylang/frontend/frontend-auto-translate.php(289): get_terms(Array)
#7 /app/wp-content/plugins/polylang-pro/vendor/wpsyntex/polylang/frontend/frontend-auto-translate.php(327): PLL_Frontend_Auto_Translate->get_translated_term_by('slug', Array, 'pa_side')
#8 /app/wp-content/plugins/polylang-pro/vendor/wpsyntex/polylang/frontend/frontend-auto-translate.php(150): PLL_Frontend_Auto_Translate->translate_terms_list(Array, 'pa_side')
#9 /app/wp-includes/class-wp-hook.php(324): PLL_Frontend_Auto_Translate->translate_included_ids_in_query(Object(WP_Query))
#10 /app/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#11 /app/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#12 /app/wp-includes/class-wp-query.php(1140): do_action_ref_array('parse_query', Array)
#13 /app/wp-includes/class-wp-query.php(1868): WP_Query->parse_query()
#14 /app/wp-includes/class-wp-query.php(3852): WP_Query->get_posts()
#15 /app/wp-includes/class-wp-query.php(3984): WP_Query->query(Array)
#16 /app/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php(572): WP_Query->__construct(Array)
#17 /app/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php(615): WC_Shortcode_Products->get_query_results()
#18 /app/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php(100): WC_Shortcode_Products->product_loop()
#19 /app/wp-content/plugins/woocommerce/includes/class-wc-shortcodes.php(286): WC_Shortcode_Products->get_content()
#20 /app/wp-includes/shortcodes.php(434): WC_Shortcodes::products(Array, '', 'products')
#21 [internal function]: do_shortcode_tag(Array)
#22 /app/wp-includes/shortcodes.php(273): preg_replace_callback('/\\[(\\[?)(produc...', 'do_shortcode_ta...', '<div class="wp-...')
#23 /app/wp-includes/class-wp-hook.php(324): do_shortcode('<div class="wp-...')
#24 /app/wp-includes/plugin.php(205): WP_Hook->apply_filters('<div class="wp-...', Array)
#25 /app/wp-content/themes/kadence/inc/components/woocommerce/component.php(280): apply_filters('kadence_theme_s...', '<!-- wp:kadence...')
#26 /app/wp-includes/class-wp-hook.php(324): Kadence\Woocommerce\Component->add_product_archive_description('')
#27 /app/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#28 /app/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#29 /app/wp-content/plugins/woocommerce/templates/loop/header.php(45): do_action('woocommerce_arc...')
#30 /app/wp-content/plugins/woocommerce/includes/wc-core-functions.php(346): include('/app/wp-content...')
#31 /app/wp-content/plugins/woocommerce/includes/wc-template-functions.php(1270): wc_get_template('loop/header.php')
#32 /app/wp-includes/class-wp-hook.php(324): woocommerce_product_taxonomy_archive_header('')
#33 /app/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#34 /app/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#35 /app/wp-content/plugins/woocommerce/templates/archive-product.php(38): do_action('woocommerce_sho...')
#36 /app/wp-includes/template-loader.php(106): include('/app/wp-content...')
#37 /app/wp-blog-header.php(19): require_once('/app/wp-include...')
#38 /app/index.php(17): require('/app/wp-blog-he...')
#39 {main}
  thrown in /app/wp-includes/formatting.php on line 1596
```

## Why?
1. A taxonomy is defined with `tax->query_var === false` (typically a Woo product attribute without archive)
2. The plugin WooCommerce Price Based on Country unexpectedly adds a query var with a numerical index 0 (when all query vars keys are expected to be a string)
```
            [0] => Array
                (
                    [zone_id] => denmark
                    [enabled] => yes
                    [name] => Denmark
                    [countries] => Array
                        (
                            [60] => DK
                            [73] => FO
                            [87] => GL
                        )
                    [currency] => DKK
                    [exchange_rate] => 10.31034483
                    [auto_exchange_rate] => no
                    [disable_tax_adjustment] => yes
                    [order] => 22
                    [_cache] => Array
                        (
                            [11113] => Array
                                (
                                    [is_exchange_rate_price] => true
                                    [_price] => 299
                                    [_regular_price] => 299
                                    [_sale_price] => 
                                )
                        )
                )
```
3. In Polylang, we check that a query var is filled for all registered taxonomies. Generally nothing's found for taxonomies not defining a query_var, ie `$qv[ $tax->query_var ]` ( `$qv[ false ]` ) is empty. But with plugin, `$qv[ false ]` finds the unexpected `$qv[0]` which is an array (instead of a string).

At some point, the array (instead of a string) passed to the WP code causes the fatal error. 

## How?
Check that `$qv[ $tax->query_var ]` is not empty.