### PR TITLE
Avoid double escape

### DIFF
--- a/modules/site-health/admin-site-health.php
+++ b/modules/site-health/admin-site-health.php
@@ -119,68 +119,68 @@ class PLL_Admin_Site_Health {
 		switch ( $key ) {
 			case 'browser':
 				if ( ! $value ) {
-					$value = '0: ' . esc_html__( 'Detect browser language deactivated', 'polylang' );
+					$value = '0: ' . __( 'Detect browser language deactivated', 'polylang' );
 					break;
 				}
-				$value = '1: ' . esc_html__( 'Detect browser language activated', 'polylang' );
+				$value = '1: ' . __( 'Detect browser language activated', 'polylang' );
 				break;
 			case 'rewrite':
 				if ( $value ) {
 					$value = '1: ' . sprintf(
 						/* translators: %s is a URL slug: `/language/`. */
-						esc_html__( 'Remove %s in pretty permalinks', 'polylang' ),
+						__( 'Remove %s in pretty permalinks', 'polylang' ),
 						'`/language/`'
 					);
 					break;
 				}
 				$value = '0: ' . sprintf(
 					/* translators: %s is a URL slug: `/language/`. */
-					esc_html__( 'Keep %s in pretty permalinks', 'polylang' ),
+					__( 'Keep %s in pretty permalinks', 'polylang' ),
 					'`/language/`'
 				);
 				break;
 			case 'hide_default':
 				if ( $value ) {
-					$value = '1: ' . esc_html__( 'Hide URL language information for default language', 'polylang' );
+					$value = '1: ' . __( 'Hide URL language information for default language', 'polylang' );
 					break;
 				}
-				$value = '0: ' . esc_html__( 'Display URL language information for default language', 'polylang' );
+				$value = '0: ' . __( 'Display URL language information for default language', 'polylang' );
 				break;
 			case 'force_lang':
 				switch ( $value ) {
 					case '0':
-						$value = '0: ' . esc_html__( 'The language is set from content', 'polylang' );
+						$value = '0: ' . __( 'The language is set from content', 'polylang' );
 						break;
 					case '1':
-						$value = '1: ' . esc_html__( 'The language is set from the directory name in pretty permalinks', 'polylang' );
+						$value = '1: ' . __( 'The language is set from the directory name in pretty permalinks', 'polylang' );
 						break;
 					case '2':
-						$value = '2: ' . esc_html__( 'The language is set from the subdomain name in pretty permalinks', 'polylang' );
+						$value = '2: ' . __( 'The language is set from the subdomain name in pretty permalinks', 'polylang' );
 						break;
 					case '3':
-						$value = '3: ' . esc_html__( 'The language is set from different domains', 'polylang' );
+						$value = '3: ' . __( 'The language is set from different domains', 'polylang' );
 						break;
 				}
 				break;
 			case 'redirect_lang':
 				if ( $value ) {
-					$value = '1: ' . esc_html__( 'The front page URL contains the language code instead of the page name or page id', 'polylang' );
+					$value = '1: ' . __( 'The front page URL contains the language code instead of the page name or page id', 'polylang' );
 					break;
 				}
-				$value = '0: ' . esc_html__( 'The front page URL contains the page name or page id instead of the language code', 'polylang' );
+				$value = '0: ' . __( 'The front page URL contains the page name or page id instead of the language code', 'polylang' );
 
 				break;
 			case 'media_support':
 				if ( ! $value ) {
-					$value = '0: ' . esc_html__( 'The media are not translated', 'polylang' );
+					$value = '0: ' . __( 'The media are not translated', 'polylang' );
 					break;
 				}
-				$value = '1: ' . esc_html__( 'The media are translated', 'polylang' );
+				$value = '1: ' . __( 'The media are translated', 'polylang' );
 				break;
 
 			case 'sync':
 				if ( empty( $value ) ) {
-					$value = '0: ' . esc_html__( 'Synchronization disabled', 'polylang' );
+					$value = '0: ' . __( 'Synchronization disabled', 'polylang' );
 				}
 				break;
 		}
@@ -380,7 +380,7 @@ class PLL_Admin_Site_Health {
 	 */
 	public function homepage_test() {
 		$result = array(
-			'label'       => esc_html__( 'All languages have a translated homepage', 'polylang' ),
+			'label'       => __( 'All languages have a translated homepage', 'polylang' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => POLYLANG,
@@ -398,7 +398,7 @@ class PLL_Admin_Site_Health {
 
 		if ( ! empty( $message ) ) {
 			$result['status']      = 'critical';
-			$result['label']       = esc_html__( 'The homepage is not translated in all languages', 'polylang' );
+			$result['label']       = __( 'The homepage is not translated in all languages', 'polylang' );
 			$result['description'] = sprintf( '<p>%s</p>', $message );
 		}
 		return $result;


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2510

For site health info, [WP already escapes labels and values](https://github.com/WordPress/WordPress/blob/6.7.1/wp-admin/site-health-info.php#L115-L133). [The description is not escaped](https://github.com/WordPress/WordPress/blob/6.7.1/wp-admin/site-health-info.php#L107).
For the site health tests, [WP already escapes the test result label](https://github.com/WordPress/WordPress/blob/6.7.1/wp-admin/site-health.php#L305). [The description is not escaped](https://github.com/WordPress/WordPress/blob/6.7.1/wp-admin/site-health.php#L313). See https://codex.wordpress.org/Javascript_Reference/wp.template#Template_Interpolation for template usage.
The test label itself doesn't seem to be used. I kept it escaped to be on the safe side. 