### PR TITLE
Fix widget block wrongly added to string translation

### DIFF
--- a/admin/admin-strings.php
+++ b/admin/admin-strings.php
@@ -79,12 +79,13 @@ class PLL_Admin_Strings {
 
 			foreach ( $widgets as $widget ) {
 				// Nothing can be done if the widget is created using pre WP2.8 API. There is no object, so we can't access it to get the widget options.
-				if ( ! isset( $wp_registered_widgets[ $widget ]['callback'][0] ) || ! is_object( $wp_registered_widgets[ $widget ]['callback'][0] ) || ! method_exists( $wp_registered_widgets[ $widget ]['callback'][0], 'get_settings' ) ) {
+				if ( ! isset( $wp_registered_widgets[ $widget ]['callback'][0] ) || ! $wp_registered_widgets[ $widget ]['callback'][0] instanceof WP_Widget ) {
 					continue;
 				}
 
-				$widget_settings = $wp_registered_widgets[ $widget ]['callback'][0]->get_settings();
-				$number = $wp_registered_widgets[ $widget ]['params'][0]['number'];
+				$widget_instance = $wp_registered_widgets[ $widget ]['callback'][0];
+				$widget_settings = $widget_instance->get_settings();
+				$number          = $wp_registered_widgets[ $widget ]['params'][0]['number'];
 
 				// Don't enable widget translation if the widget is visible in only one language or if there is no title.
 				if ( ! empty( $widget_settings[ $number ]['pll_lang'] ) ) {
@@ -92,7 +93,7 @@ class PLL_Admin_Strings {
 				}
 
 				// Widget title.
-				if ( ! empty( $widget_settings[ $number ]['title'] ) ) { 
+				if ( ! empty( $widget_settings[ $number ]['title'] ) ) {
 					self::register_string( self::$default_strings['widget_title'], $widget_settings[ $number ]['title'], 'Widget' );
 				}
 
@@ -102,7 +103,7 @@ class PLL_Admin_Strings {
 				}
 
 				// Content of the widget custom html.
-				if ( ! empty( $widget_settings[ $number ]['content'] ) ) {
+				if ( $widget_instance instanceof WP_Widget_Custom_HTML && ! empty( $widget_settings[ $number ]['content'] ) ) {
 					self::register_string( self::$default_strings['widget_text'], $widget_settings[ $number ]['content'], 'Widget', true );
 				}
 			}


### PR DESCRIPTION
See https://github.com/polylang/polylang-pro/issues/2552

In #1423, we introduced the possibility to translate the widget custom html which can be translated the same way as the widget text but stores the text with a different key.

This however introduces an undesired side effect that widget blocks are now registered in the strings translations because the content is stored exactly the same ways as the widget custom html text. These blocks are however not translated as they don't honor the filter `widget_text`. These are also much more complex to handle as we need to parse block to export them properly.

This PR checks the widget instance to avoid to mix the widget custom html and the widget block. 
