### PR TITLE
Avoid fetching  `active_sitewide_plugins` on single site installation.

### DIFF
--- a/include/Options/Options.php
+++ b/include/Options/Options.php
@@ -78,7 +78,7 @@ class Options implements ArrayAccess, IteratorAggregate {
 		$this->current_blog_id = $this->blog_id;
 
 		// Handle options.
-		$this->init_options_for_blog( $this->blog_id );
+		$this->init_options_for_current_blog();
 
 		add_filter( 'pre_update_option_polylang', array( $this, 'protect_wp_option_storage' ), 1 );
 		add_action( 'switch_blog', array( $this, 'on_blog_switch' ), PHP_INT_MIN ); // Options must be ready early.
@@ -135,39 +135,6 @@ class Options implements ArrayAccess, IteratorAggregate {
 	}
 
 	/**
-	 * Initializes options for the given blog:
-	 * - stores the blog ID,
-	 * - stores the options.
-	 * Hooked to `switch_blog`.
-	 *
-	 * @since 3.7
-	 *
-	 * @param int $blog_id The blog ID.
-	 * @return void
-	 */
-	public function init_options_for_blog( $blog_id ): void {
-		$options = get_option( self::OPTION_NAME );
-
-		if ( empty( $options ) || ! is_array( $options ) ) {
-			$this->options[ $blog_id ]  = array();
-			$this->modified[ $blog_id ] = true;
-		} else {
-			$this->options[ $blog_id ] = $options;
-		}
-
-		/**
-		 * Fires after the options have been init for the current blog.
-		 * This is the best place to register options.
-		 *
-		 * @since 3.7
-		 *
-		 * @param Options $options         Instance of the options.
-		 * @param int     $current_blog_id Current blog ID.
-		 */
-		do_action( 'pll_init_options_for_blog', $this, $this->current_blog_id );
-	}
-
-	/**
 	 * Initializes options for the newly switched blog if applicable.
 	 *
 	 * @since 3.7
@@ -186,7 +153,7 @@ class Options implements ArrayAccess, IteratorAggregate {
 			return;
 		}
 
-		$this->init_options_for_blog( $this->current_blog_id );
+		$this->init_options_for_current_blog();
 	}
 
 	/**
@@ -569,5 +536,34 @@ class Options implements ArrayAccess, IteratorAggregate {
 		}
 
 		return $this->modified;
+	}
+
+	/**
+	 * Initializes options for the current blog.
+	 *
+	 * @since 3.7
+	 *
+	 * @return void
+	 */
+	private function init_options_for_current_blog(): void {
+		$options = get_option( self::OPTION_NAME );
+
+		if ( empty( $options ) || ! is_array( $options ) ) {
+			$this->options[ $this->current_blog_id ]  = array();
+			$this->modified[ $this->current_blog_id ] = true;
+		} else {
+			$this->options[ $this->current_blog_id ] = $options;
+		}
+
+		/**
+		 * Fires after the options have been init for the current blog.
+		 * This is the best place to register options.
+		 *
+		 * @since 3.7
+		 *
+		 * @param Options $options         Instance of the options.
+		 * @param int     $current_blog_id Current blog ID.
+		 */
+		do_action( 'pll_init_options_for_blog', $this, $this->current_blog_id );
 	}
 }

--- a/include/Options/Options.php
+++ b/include/Options/Options.php
@@ -81,7 +81,7 @@ class Options implements ArrayAccess, IteratorAggregate {
 		$this->init_options_for_current_blog();
 
 		add_filter( 'pre_update_option_polylang', array( $this, 'protect_wp_option_storage' ), 1 );
-		add_action( 'switch_blog', array( $this, 'on_blog_switch' ), PHP_INT_MIN ); // Options must be ready early.
+		add_action( 'switch_blog', array( $this, 'on_blog_switch' ), -1000 ); // Options must be ready early.
 		add_action( 'shutdown', array( $this, 'save_all' ), 1000 ); // Make sure to save options after everything.
 	}
 
@@ -173,7 +173,7 @@ class Options implements ArrayAccess, IteratorAggregate {
 			return;
 		}
 
-		remove_action( 'switch_blog', array( $this, 'on_blog_switch' ), PHP_INT_MIN );
+		remove_action( 'switch_blog', array( $this, 'on_blog_switch' ), -1000 );
 
 		// Handle the original blog first, maybe this will prevent the use of `switch_to_blog()`.
 		if ( isset( $modified[ $this->blog_id ] ) && $this->current_blog_id === $this->blog_id ) {

--- a/tests/phpunit/tests/Performances/test-Single_Site.php
+++ b/tests/phpunit/tests/Performances/test-Single_Site.php
@@ -12,6 +12,10 @@ class Single_Site_Test extends PLL_UnitTestCase {
 	 * @see https://github.com/polylang/polylang/issues/2557
 	 */
 	public function test_active_sitewide_plugins_is_not_called() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'This test is not relevant on multisite.' );
+		}
+
 		add_action( 'pll_init_options_for_blog', array( Registry::class, 'register' ) );
 		new Options();
 

--- a/tests/phpunit/tests/Performances/test-Single_Site.php
+++ b/tests/phpunit/tests/Performances/test-Single_Site.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Integration\Performances;
+
+use PLL_UnitTestCase;
+use WP_Syntex\Polylang\Options\Options;
+use WP_Syntex\Polylang\Options\Registry;
+
+class Single_Site_Test extends PLL_UnitTestCase {
+	/**
+	 * @ticket #2557
+	 * @see https://github.com/polylang/polylang/issues/2557
+	 */
+	public function test_active_sitewide_plugins_is_not_called() {
+		add_action( 'pll_init_options_for_blog', array( Registry::class, 'register' ) );
+		new Options();
+
+		$this->assertSame( 0, did_filter( 'site_option_active_sitewide_plugins' ) );
+	}
+}


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2557

## How?
- Split `Options::init_options_for_blog()` and create a new method `Options::on_blog_switch()` to manage multisite logic.
- Ensure `Options::__construct()` populates `Options::$current_blog_id` property correctly.
- Add a test to cover the regression.