### PR TITLE
Fix integrations' singleton

### DIFF
--- a/integrations/integrations.php
+++ b/integrations/integrations.php
@@ -17,33 +17,43 @@ class PLL_Integrations {
 	 *
 	 * @var PLL_Integrations|null
 	 */
-	protected static $instance;
+	protected static $instance = null;
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 1.0
 	 */
-	protected function __construct() {
+	protected function __construct() {}
+
+	/**
+	 * Returns the single instance of the class.
+	 *
+	 * @since 1.7
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+			self::$instance->init();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Requires integrations.
+	 *
+	 * @since 3.7
+	 *
+	 * @return void
+	 */
+	protected function init(): void {
 		// Loads external integrations.
 		foreach ( glob( __DIR__ . '/*/load.php', GLOB_NOSORT ) as $load_script ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 			require_once $load_script; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		}
-	}
-
-	/**
-	 * Access to the single instance of the class.
-	 *
-	 * @since 1.7
-	 *
-	 * @return PLL_Integrations
-	 */
-	public static function instance() {
-		if ( empty( self::$instance ) ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2560

## "Saved" by `require_once`

This is what was happening before this PR and it is very funny. Everything has to do with the order in which things are done.

1. Call to `PLL_Integrations::instance()` for the first time.
2. This was the method `instance()`:
    ```php
	public static function instance() {
		if ( empty( self::$instance ) ) {
			self::$instance = new self();
		}

		return self::$instance;
	}
    ```
    Since `self::$instance` is still emty, the line we're interested in is `self::$instance = new self();`. Then the first operation executed is `new self()`: the instance must be created before being assigned to the property.
3. `__construct()` is called, which will require the `load.php` files.
4. The first `load.php` file will call `PLL_Integrations::instance()`. This point is the same as the first point. I mean it is the exact same situation than when we called it the first time in the first point: if you take another look at the 2nd point you will realize that `self::$instance` is still empty because we're not done with the first `new self()` yet, so the instance is still not assigned to `self::$instance`. This means we do `new self()` again, which will require files again. The slight difference is that the first `require_once` has been done, so it will be skipped (that's why we don't end in an infinite loop). And so on until we require all files.

## Solution

In the suggested solution, the files are not required in the constructor: this allows to create the instance first, and then require the files.