### PR TITLE
Require API file in tests

### DIFF
--- a/tests/phpunit/includes/testcase-assets.php
+++ b/tests/phpunit/includes/testcase-assets.php
@@ -1,6 +1,4 @@
 <?php
-require POLYLANG_DIR . '/include/api.php';
-
 abstract class PLL_Assets_UnitTestCase extends PLL_UnitTestCase {
 	/**
 	 * The Polylang assets identifiers (those rendered by WordPress in HTML tags).

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -239,6 +239,15 @@ trait PLL_UnitTestCase_Trait {
 	}
 
 	/**
+	 * Requires the API functions.
+	 *
+	 * @return void
+	 */
+	protected static function require_api(): void {
+		require_once POLYLANG_DIR . '/include/api.php';
+	}
+
+	/**
 	 * Creates the static model used to add languages before tests.
 	 *
 	 * @deprecated Use `PLL_UnitTest_Factory_For_Language` instead.

--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -24,7 +24,7 @@ class Jetpack_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
+		self::require_api(); // usually loaded only if an instance of Polylang exists
 		$this->load_jetpack();
 
 		$links_model = self::$model->get_links_model();

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -26,7 +26,7 @@ class WP_Importer_Test extends PLL_UnitTestCase {
 
 		parent::set_up();
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 
 		self::$model->options['hide_default'] = 0;
 

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -23,7 +23,7 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 
 		self::generate_shared_fixtures( $factory );
 		self::$model->clean_languages_cache();

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -12,7 +12,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -15,7 +15,7 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-email-strings.php
+++ b/tests/phpunit/tests/test-email-strings.php
@@ -12,7 +12,7 @@ class Email_Strings_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'es_ES' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -14,7 +14,7 @@ class Filters_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'es_ES' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-model.php
+++ b/tests/phpunit/tests/test-model.php
@@ -11,7 +11,7 @@ class Model_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function test_languages_list() {

--- a/tests/phpunit/tests/test-multisite-option.php
+++ b/tests/phpunit/tests/test-multisite-option.php
@@ -9,7 +9,7 @@ if ( is_multisite() ) :
 
 			self::create_language( 'en_US' );
 
-			require_once POLYLANG_DIR . '/include/api.php';
+			self::require_api();
 		}
 
 		public function set_up() {

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -279,7 +279,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$frontend->links = new PLL_Frontend_Links( $frontend );
 		$frontend->nav_menu = new PLL_Frontend_Nav_Menu( $frontend );
 
-		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
+		self::require_api(); // usually loaded only if an instance of Polylang exists
 		$GLOBALS['polylang'] = $frontend; // FIXME we still use PLL() in PLL_Frontend_Nav_Menu
 
 		$args = array( 'theme_location' => $primary_location, 'echo' => false );
@@ -299,7 +299,7 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$frontend->links = new PLL_Frontend_Links( $frontend );
 		$frontend->nav_menu = new PLL_Frontend_Nav_Menu( $frontend );
 
-		require_once POLYLANG_DIR . '/include/api.php'; // Usually loaded only if an instance of Polylang exists.
+		self::require_api(); // Usually loaded only if an instance of Polylang exists.
 		$GLOBALS['polylang'] = $frontend; // FIXME we still use PLL() in PLL_Frontend_Nav_Menu
 
 		$args = array( 'theme_location' => $primary_location, 'echo' => false );

--- a/tests/phpunit/tests/test-no-languages.php
+++ b/tests/phpunit/tests/test-no-languages.php
@@ -6,7 +6,7 @@ class No_Languages_Test extends PLL_UnitTestCase {
 	 * Bug fixed in 1.8.2.
 	 */
 	public function test_api_on_admin() {
-		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
+		self::require_api(); // usually loaded only if an instance of Polylang exists
 
 		$links_model = self::$model->get_links_model();
 		$GLOBALS['polylang'] = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-strings.php
+++ b/tests/phpunit/tests/test-strings.php
@@ -12,7 +12,7 @@ class Strings_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -15,7 +15,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE_formal' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -12,7 +12,7 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/test-widgets-calendar.php
+++ b/tests/phpunit/tests/test-widgets-calendar.php
@@ -15,7 +15,7 @@ class Widget_Calendar_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		require_once POLYLANG_DIR . '/include/api.php'; // usually loaded only if an instance of Polylang exists
+		self::require_api(); // usually loaded only if an instance of Polylang exists
 
 		self::$model->options['hide_default'] = 0;
 

--- a/tests/phpunit/tests/test-widgets-filter.php
+++ b/tests/phpunit/tests/test-widgets-filter.php
@@ -17,7 +17,7 @@ class Widgets_Filter_Test extends PLL_UnitTestCase {
 
 		$this->links_model = self::$model->get_links_model();
 
-		require_once POLYLANG_DIR . '/include/api.php'; // Usually loaded only if an instance of Polylang exists
+		self::require_api(); // Usually loaded only if an instance of Polylang exists
 
 		update_option(
 			'widget_search',

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -13,7 +13,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		@mkdir( WP_CONTENT_DIR . '/polylang' );
 		copy( __DIR__ . '/../data/wpml-config.xml', WP_CONTENT_DIR . '/polylang/wpml-config.xml' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public static function wpTearDownAfterClass() {

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -13,7 +13,7 @@ class WPML_Test extends PLL_UnitTestCase {
 		self::create_language( 'fr_FR' );
 		self::create_language( 'de_DE_formal' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/themes/test-twenty-fourteen.php
+++ b/tests/phpunit/tests/themes/test-twenty-fourteen.php
@@ -16,7 +16,7 @@ class Twenty_Fourteen_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 
 		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
 		switch_theme( 'twentyfourteen' );

--- a/tests/phpunit/tests/themes/test-twenty-seventeen.php
+++ b/tests/phpunit/tests/themes/test-twenty-seventeen.php
@@ -14,7 +14,7 @@ class Twenty_Seventeen_Test extends PLL_UnitTestCase {
 		self::create_language( 'en_US' );
 		self::create_language( 'fr_FR' );
 
-		require_once POLYLANG_DIR . '/include/api.php';
+		self::require_api();
 
 		self::$stylesheet = get_option( 'stylesheet' ); // save default theme
 		switch_theme( 'twentyseventeen' );


### PR DESCRIPTION
This PR introduces the static method `PLL_UnitTestCase_Trait::require_api()` that requires the `api.php` file.
The aim is to ease future changes in files structure, in this plugin but also PLL Pro and PLLWC.

Extracted from #1642.