### PR TITLE
Prevent DB queries to fetch the language terms

### DIFF
--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -88,10 +88,8 @@ class PLL_Frontend extends PLL_Base {
 		// Avoids the language being the queried object when querying multiple taxonomies
 		add_action( 'parse_tax_query', array( $this, 'parse_tax_query' ), 1 );
 
-		if ( $this->model->has_languages() ) {
-			// Prevent unnecessary queries to the DB.
-			add_action( 'parse_tax_query', array( $this, 'transform_query' ) );
-		}
+		// Prevent unnecessary queries to the DB.
+		add_action( 'parse_tax_query', array( $this, 'transform_query' ) );
 
 		// Filters posts by language
 		add_action( 'parse_query', array( $this, 'parse_query' ), 6 );

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -189,51 +189,13 @@ class PLL_Frontend extends PLL_Base {
 	 * These extra queries occur when the language slug is displayed in the current's page URL, because WP wants a list
 	 * of `term_taxonomy_id`.
 	 *
-	 * Example:
-	 * From: array(
-	 *     'taxonomy'         => 'language',
-	 *     'terms'            => array( 'en' ),
-	 *     'field'            => 'slug',
-	 *     'operator'         => 'IN',
-	 *     'include_children' => 1,
-	 * )
-	 * To: array(
-	 *     'taxonomy'         => 'language',
-	 *     'terms'            => array( 238 ),
-	 *     'field'            => 'term_taxonomy_id',
-	 *     'operator'         => 'IN',
-	 *     'include_children' => 1,
-	 * )
-	 *
 	 * @since 3.8
 	 *
 	 * @param WP_Query $query WP_Query object.
 	 * @return void
 	 */
 	public function transform_query( $query ): void {
-		if ( empty( $query->tax_query ) ) {
-			// Null.
-			return;
-		}
-
-		foreach ( $query->tax_query->queries as &$tax_query ) {
-			if ( ! is_array( $tax_query ) || ! isset( $tax_query['taxonomy'], $tax_query['field'], $tax_query['terms'] ) ) {
-				// Can be a `relation` entry (string), or a sub-query.
-				continue;
-			}
-
-			if ( 'language' !== $tax_query['taxonomy'] || 'slug' !== $tax_query['field'] ) {
-				// Not what we're looking for.
-				continue;
-			}
-
-			$tax_query['field'] = 'term_taxonomy_id';
-
-			foreach ( $tax_query['terms'] as &$term ) {
-				$language = $this->model->get_language( $term );
-				$term     = ! empty( $language ) ? $language->get_tax_prop( 'language', 'term_taxonomy_id' ) : 0;
-			}
-		}
+		( new PLL_Query( $query, $this->model ) )->transform_query();
 	}
 
 	/**

--- a/tests/phpunit/tests/test-frontend.php
+++ b/tests/phpunit/tests/test-frontend.php
@@ -49,4 +49,45 @@ class Frontend_Test extends PLL_UnitTestCase {
 
 		$this->assertInstanceOf( stdClass::class, $wp_admin_bar->get_node( 'customize' ) );
 	}
+
+	/**
+	 * Tests that the main query doesn't do extra queries to fetch the language's `term_taxonomy_id`.
+	 *
+	 * @see https://github.com/polylang/polylang-pro/issues/2562
+	 *
+	 * @return void
+	 */
+	public function test_optimize_query(): void {
+		self::create_language( 'en_US' );
+
+		$options = self::create_options(
+			array(
+				'hide_default' => false,
+				'default_lang' => 'en',
+			)
+		);
+
+		$model = new PLL_Model( $options );
+		$links_model = $model->get_links_model();
+		$links_model->init();
+
+		new PLL_Frontend( $links_model );
+
+		$model->get_language( 'en' ); // Put the query in cache before the following filter.
+		$queries = array();
+
+		add_filter(
+			'query',
+			function ( $query ) use ( &$queries ) {
+				$queries[] = $query;
+				return $query;
+			}
+		);
+
+		$GLOBALS['wp_object_cache']->flush_group( 'term-queries' );
+		$GLOBALS['wp_object_cache']->flush_group( 'terms' );
+		new WP_Query( array( 'lang' => 'en' ) );
+
+		$this->assertCount( 1, $queries );
+	}
 }


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/2562.

When the language slug is present in the URL, and then passed to the query, WP changes the "tax query by `slug`" by a "tax query by `term_taxonomy_id`. This creates 2 extra queries to fetch this ID.

These 2 extra queries are useless because the `term_taxonomy_id` of the language can be fetch from our `PLL_Language` object.