### PR TITLE
Run PHPUnit in wp-env containers.

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,5 @@
+{
+	"phpVersion": "8.3",
+	"core": null,
+	"plugins": [ "." ]
+}

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://polylang.pro",
 	"type": "wordpress-plugin",
+	"version": "3.8",
 	"require": {
 		"php": ">=7.2"
 	},
@@ -50,6 +51,7 @@
 		],
 		"test":"vendor/bin/phpunit",
 		"cs":"vendor/bin/phpcs",
+		"cs-fix": "vendor/bin/phpcbf",
 		"stan": "vendor/bin/phpstan analyze --memory-limit=1500M",
 		"rector-dry": "vendor/bin/rector process --dry-run",
 		"lint": [

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://polylang.pro",
 	"type": "wordpress-plugin",
-	"version": "3.8",
 	"require": {
 		"php": ">=7.2"
 	},

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:dev": "npm run clean && webpack --mode development",
     "dev": "npm run clean && webpack --mode development --watch",
     "clean": "rimraf js/build css/build",
-		"env:start": "wp-env start",
+    "env:start": "wp-env start",
     "env:stop": "wp-env stop",
     "env:clean": "wp-env clean",
     "env:composer": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang composer",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "build:dev": "npm run clean && webpack --mode development",
     "dev": "npm run clean && webpack --mode development --watch",
     "clean": "rimraf js/build css/build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+		"env:start": "wp-env start",
+    "env:stop": "wp-env stop",
+    "env:clean": "wp-env clean",
+    "env:composer": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang composer",
+    "wp-env": "wp-env",
+    "test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang vendor/bin/phpunit"
   },
   "repository": {
     "type": "git",
@@ -34,6 +39,7 @@
   },
   "homepage": "https://github.com/polylang/polylang#readme",
   "devDependencies": {
+    "@wordpress/env": "^10.21.0",
     "@wpsyntex/polylang-build-scripts": "^2.0.3",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^9.0.1",

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -3,6 +3,14 @@ use function WP_Syntex\Polylang_Phpunit\getCliColors;
 
 $_root_dir = dirname( __DIR__, 3 );
 $_tests_dir = ! empty( getenv( 'WP_TESTS_DIR' ) ) ? getenv( 'WP_TESTS_DIR' ) : $_root_dir . '/tmp/wordpress-tests-lib';
+
+/*
+ * Ensures GitHub actions is not running since it defines WP_TESTS_DIR like @wordpress/wp-env package does.
+ */
+if ( empty( getenv( 'GITHUB_ACTIONS' ) ) && ! empty( getenv( 'WP_TESTS_DIR' ) ) ) {
+	define( 'WP_TESTS_CONFIG_FILE_PATH', $_root_dir . '/tests/phpunit/includes/wp-tests-config-docker.php' );
+}
+
 require_once $_tests_dir . '/includes/functions.php';
 
 // load the plugin however *no* Polylang instance is created as no languages exist in DB

--- a/tests/phpunit/includes/links-trait.php
+++ b/tests/phpunit/includes/links-trait.php
@@ -35,6 +35,11 @@ trait PLL_Test_Links_Trait {
 					$url = str_replace( $orig_siteurl, $siteurl, $url );
 				}
 
+				if ( empty( getenv( 'GITHUB_ACTIONS' ) ) && ! empty( getenv( 'WP_TESTS_DIR' ) ) ) {
+					// Fix side effect of running PHPUnit in wp-env.
+					$url = str_replace( '/wordpress/wp-content/plugins', '', $url );
+				}
+
 				return $url;
 			},
 			-1

--- a/tests/phpunit/includes/wp-tests-config-docker.php
+++ b/tests/phpunit/includes/wp-tests-config-docker.php
@@ -1,0 +1,95 @@
+<?php
+
+if ( ! function_exists( 'getenv_docker' ) ) {
+	/**
+	 * Gets environment variable from docker.
+	 * Partially copied from @wordpress/wp-env package.
+	 *
+	 * @param string $env     The environment variable to get.
+	 * @param string $default The default value to return if the environment variable is not set.
+	 * @return string The environment variable value.
+	 */
+	function getenv_docker( $env, $default ) {
+		if ( $file_env = getenv( $env . '_FILE' ) ) {
+			return rtrim( file_get_contents( $file_env ), "\r\n" );
+		} elseif ( ( $val = getenv( $env ) ) !== false ) {
+			return $val;
+		} else {
+			return $default;
+		}
+	}
+}
+
+/*
+ * Following code is greatly inspired by @see{wordpress-tests-lib/wp-tests-config-sample.php}.
+ */
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+define( 'ABSPATH', '/var/www/html/' );
+
+/*
+ * Path to the theme to test with.
+ *
+ * The 'default' theme is symlinked from test/phpunit/data/themedir1/default into
+ * the themes directory of the WordPress installation defined above.
+ */
+define( 'WP_DEFAULT_THEME', 'default' );
+
+/*
+ * Test with multisite enabled.
+ * Alternatively, use the tests/phpunit/multisite.xml configuration file.
+ */
+// define( 'WP_TESTS_MULTISITE', true );
+
+/*
+ * Force known bugs to be run.
+ * Tests with an associated Trac ticket that is still open are normally skipped.
+ */
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** Database settings ** //
+
+/*
+ * This configuration file will be used by the copy of WordPress being tested.
+ * wordpress/wp-config.php will be ignored.
+ *
+ * WARNING WARNING WARNING!
+ * These tests will DROP ALL TABLES in the database with the prefix named below.
+ * DO NOT use a production database or one that is shared with something else.
+ */
+
+define( 'DB_NAME', getenv_docker( 'WORDPRESS_DB_NAME', 'wordpress' ) );
+define( 'DB_USER', getenv_docker( 'WORDPRESS_DB_USER', 'example username' ) );
+define( 'DB_PASSWORD', getenv_docker( 'WORDPRESS_DB_PASSWORD', 'example password' ) );
+define( 'DB_HOST', getenv_docker( 'WORDPRESS_DB_HOST', 'mysql' ) );
+define( 'DB_CHARSET', getenv_docker( 'WORDPRESS_DB_CHARSET', 'utf8' ) );
+define( 'DB_COLLATE', getenv_docker( 'WORDPRESS_DB_COLLATE', '' ) );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ */
+define( 'AUTH_KEY', 'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY', 'put your unique phrase here' );
+define( 'LOGGED_IN_KEY', 'put your unique phrase here' );
+define( 'NONCE_KEY', 'put your unique phrase here' );
+define( 'AUTH_SALT', 'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT', 'put your unique phrase here' );
+define( 'NONCE_SALT', 'put your unique phrase here' );
+
+// Only numbers, letters, and underscores please!
+$table_prefix = 'wptests_'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );


### PR DESCRIPTION
## What?
Improve DX by allowing PHPUnit to run in wp-env Docker containers.

## Why?
Benefit from wp-env installation that provides a clean WordPress installation, a DB server and `wordpress-test-utils` library out of the box.
No need to install manually all of this in `tmp/` anymore.

## How?
- Add `wordpress/wp-env` to NPM dependencies.
- Add `.wp-env.json` config file.
- Create a custom `wp-tests-config-docker.php` file for this purpose. It differs in two things from the usual `wordpress-tests-lib/wp-tests-config.php`:
    - It defines `ABSPATH` according to wp-env Docker mapping for the root of the web server (where WordPress is installed, no matter which container you want to use).
    - It dynamically use Docker defined database constant, so connexion to MySQL is seamless.
- Adapt bootstrap files for both integration and unit tests, need `WP_TESTS_CONFIG_FILE_PATH` to point to `wp-tests-config-docker.php`.
- Minor changes in `links-trait.php` to avoid a side effect when generating path with `plugins_url()` in specific links configuration.
- Add some NPM script for ease of use (forwarding PHPUnit commands to desired Docker container is a bit verbose).