### PR TITLE
Improve performances of textdomain unloading, the return

### DIFF
--- a/include/Options/Business/Sync.php
+++ b/include/Options/Business/Sync.php
@@ -5,6 +5,8 @@
 
 namespace WP_Syntex\Polylang\Options\Business;
 
+use NOOP_Translations;
+use PLL_Settings_Sync;
 use WP_Syntex\Polylang\Options\Primitive\Abstract_List;
 
 defined( 'ABSPATH' ) || exit;
@@ -40,10 +42,10 @@ class Sync extends Abstract_List {
 	 * @phpstan-return array{type: 'array', items: array{type: SchemaType, enum: non-empty-list<non-falsy-string>}}
 	 */
 	protected function get_data_structure(): array {
-		add_filter( 'lang_dir_for_domain', '__return_false' ); // Prevents loading the translations too early.
-		$enum = array_keys( \PLL_Settings_Sync::list_metas_to_sync() );
-		remove_filter( 'lang_dir_for_domain', '__return_false' );
-		unload_textdomain( 'polylang', true ); // Required to allow `_load_textdomain_just_in_time()` to load the translations.
+		$GLOBALS['l10n']['polylang'] = new NOOP_Translations(); // Prevents loading the translations too early.
+		$enum = array_keys( PLL_Settings_Sync::list_metas_to_sync() );
+		unset( $GLOBALS['l10n']['polylang'] );
+
 		return array(
 			'type'  => 'array',
 			'items' => array(


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2563.
Replaces #1648.

In `Options\Primitive\Abstract_List\sync::get_data_structure()` we had a way to prevent WP to load the plugin's textdomain.
While it works, it doesn't prevent WP from fetching the `.mo` files, resulting in an unnecessary loss of performances.

## Numbers

By using the code provided in the issue to measure timings, here are the results, with 3 measurements for each case. The important value is the 1st timer.

Without the solution of this PR, without the "trick" added to `Options\Primitive\Abstract_List\sync::get_data_structure()`:

| | 1st timer | 2nd timer |
|---|---|---|
| Measure 1 | 8.8849067687988 | 0.072002410888672 |
| Measure 2 | 7.2968006134033 | 0.075101852416992 |
| Measure 3 | 6.9570541381836 | 0.077962875366211 |


Without the solution of this PR, but with the "trick" added to `Options\Primitive\Abstract_List\sync::get_data_structure()`:

| | 1st timer | 2nd timer |
|---|---|---|
| Measure 1 | 4.2450428009033 | 0.041961669921875 |
| Measure 2 | 2.2268295288086 | 0.040054321289062 |
| Measure 3 | 3.0200481414795 | 0.036954879760742 |


With the solution of this PR:

| | 1st timer | 2nd timer |
|---|---|---|
| Measure 1 | 0.0071525573730469 | 0.038862228393555 |
| Measure 2 | 0.0069141387939453 | 0.036001205444336 |
| Measure 3 | 0.0069141387939453 | 0.036954879760742 |

