### PR TITLE
Enforce transient deletion and creation in options table when using external object cache.

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -735,6 +735,34 @@ class Languages {
 	}
 
 	/**
+	 * Deletes the transient from the options table since WordPress does not do it when using object cache.
+	 *
+	 * @since 3.8
+	 *
+	 * @return void
+	 */
+	public function delete_transient_from_options_table(): void {
+		if ( wp_using_ext_object_cache() || wp_installing() ) {
+			delete_option( '_transient_' . self::TRANSIENT_NAME );
+		}
+	}
+
+	/**
+	 * Sets the transient in the options table since WordPress does not do it when using object cache.
+	 *
+	 * @since 3.8
+	 *
+	 * @param mixed $value Value of the transient.
+	 * @return void
+	 */
+	public function set_transient_to_options_table( $value ): void {
+		if ( wp_using_ext_object_cache() || wp_installing() ) {
+			wp_prime_option_caches( array( '_transient_' . self::TRANSIENT_NAME ) );
+			add_option( '_transient_' . self::TRANSIENT_NAME, $value, '', true );
+		}
+	}
+
+	/**
 	 * Builds the language metas into an array and serializes it, to be stored in the term description.
 	 *
 	 * @since 3.4

--- a/include/model.php
+++ b/include/model.php
@@ -121,6 +121,9 @@ class PLL_Model {
 
 		// Just in case someone would like to display the language description ;).
 		add_filter( 'language_description', '__return_empty_string' );
+
+		add_action( 'delete_transient_pll_languages_list', array( $this->languages, 'delete_transient_from_options_table' ) );
+		add_action( 'set_transient_pll_languages_list', array( $this->languages, 'set_transient_to_options_table' ) );
 	}
 
 	/**

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -58,6 +58,7 @@ class PLL_Upgrade {
 		}
 
 		delete_transient( 'pll_languages_list' );
+		delete_option( '_transient_pll_languages_list' ); // Force deletion of the transient from the options table in case external object cache is used.
 		add_action( 'admin_init', array( $this, '_upgrade' ) );
 		return true;
 	}

--- a/tests/phpunit/data/object-cache-annihilator.php
+++ b/tests/phpunit/data/object-cache-annihilator.php
@@ -1,0 +1,633 @@
+<?php
+/**
+ * Object Cache Annihilator.
+ *
+ * @package WP_Syntex\Object_Cache_Annihilator
+ *
+ * A simple file-based object cache implementation for testing purposes.
+ * Stores cache data in the filesystem with support for groups and expiration.
+ */
+
+namespace WP_Syntex;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Check if WordPress is already loaded
+if ( function_exists( 'wp_cache_add' ) ) {
+	return;
+}
+
+use WP_Object_Cache;
+
+/**
+ * Cache object taking place of `WP_Object_Cache` and allows for easy testing of cache operations.
+ *
+ * @since 0.1.0
+ */
+class Object_Cache_Annihilator {
+	/**
+	 * Directory where cache files are stored.
+	 *
+	 * @var string
+	 */
+	private $cache_dir;
+
+	/**
+	 * Prefix for cache files.
+	 *
+	 * @var string
+	 */
+	private $cache_prefix;
+
+	/**
+	 * In-memory cache array.
+	 *
+	 * @var array
+	 */
+	private $cache = array();
+
+	/**
+	 * Number of successful cache retrievals.
+	 *
+	 * @var int
+	 */
+	private $cache_hits = 0;
+
+	/**
+	 * Number of failed cache retrievals.
+	 *
+	 * @var int
+	 */
+	private $cache_misses = 0;
+
+	/**
+	 * List of global cache groups.
+	 *
+	 * @var array
+	 */
+	private $global_groups = array();
+
+	/**
+	 * List of non-persistent cache groups.
+	 *
+	 * @var array
+	 */
+	private $non_persistent_groups = array();
+
+	/**
+	 * Whether the site is a multisite installation.
+	 *
+	 * @var bool
+	 */
+	private $multisite = false;
+
+	/**
+	 * Blog prefix for multisite installations.
+	 *
+	 * @var string
+	 */
+	private $blog_prefix = '';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->cache_dir = WP_CONTENT_DIR . '/object-cache/';
+		$this->cache_prefix = 'wp_cache_';
+		$this->multisite = is_multisite();
+		$this->blog_prefix = $this->multisite ? get_current_blog_id() . ':' : '';
+
+		if ( ! file_exists( $this->cache_dir ) ) {
+			wp_mkdir_p( $this->cache_dir );
+		}
+	}
+
+	/**
+	 * Adds data to the cache if it doesn't already exist.
+	 *
+	 * @param string $key    The cache key.
+	 * @param mixed  $data   The data to store.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @param int    $expire Optional. When to expire the cache contents. Default 0 (no expiration).
+	 * @return bool True if the data was added, false if it already exists.
+	 */
+	public function add( $key, $data, $group = 'default', $expire = 0 ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		if ( $this->get( $key, $group ) !== false ) {
+			return false;
+		}
+
+		return $this->set( $key, $data, $group, $expire );
+	}
+
+	/**
+	 * Sets data in the cache.
+	 *
+	 * @param string $key    The cache key.
+	 * @param mixed  $data   The data to store.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @param int    $expire Optional. When to expire the cache contents. Default 0 (no expiration).
+	 * @return bool True on success, false on failure.
+	 */
+	public function set( $key, $data, $group = 'default', $expire = 0 ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		$cache_file = $this->get_cache_file_path( $key, $group );
+		$cache_data = array(
+			'value' => $data,
+			'expires' => $expire ? time() + $expire : 0,
+		);
+
+		$this->cache[ $group ][ $key ] = $data;
+
+		// Ensure directory exists
+		$dir = dirname( $cache_file );
+		if ( ! file_exists( $dir ) ) {
+			wp_mkdir_p( $dir );
+		}
+
+		// Serialize with validation
+		$serialized = serialize( $cache_data ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		if ( false === $serialized ) {
+			return false;
+		}
+
+		return file_put_contents( $cache_file, $serialized );
+	}
+
+	/**
+	 * Retrieves data from the cache.
+	 *
+	 * @param string $key    The cache key.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @param bool   $force  Optional. Whether to force an update of the local cache. Default false.
+	 * @param bool   $found  Optional. Whether the key was found in the cache. Passed by reference.
+	 * @return mixed|false The cache contents on success, false on failure.
+	 */
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		// Check runtime cache first
+		if ( ! $force && isset( $this->cache[ $group ][ $key ] ) ) {
+			++$this->cache_hits;
+			$found = true;
+			return $this->cache[ $group ][ $key ];
+		}
+
+		$cache_file = $this->get_cache_file_path( $key, $group );
+
+		if ( ! file_exists( $cache_file ) ) {
+			++$this->cache_misses;
+			$found = false;
+			return false;
+		}
+
+		$file_contents = file_get_contents( $cache_file );
+		if ( false === $file_contents ) {
+			++$this->cache_misses;
+			$found = false;
+			return false;
+		}
+
+		$data = unserialize( $file_contents ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+
+		// Validate unserialized data structure
+		if ( ! is_array( $data ) || ! isset( $data['value'] ) ) {
+			if ( file_exists( $cache_file ) ) {
+				unlink( $cache_file );
+			}
+			++$this->cache_misses;
+			$found = false;
+			return false;
+		}
+
+		if ( $data['expires'] && time() > $data['expires'] ) {
+			unlink( $cache_file );
+			++$this->cache_misses;
+			$found = false;
+			return false;
+		}
+
+		$this->cache[ $group ][ $key ] = $data['value'];
+		++$this->cache_hits;
+		$found = true;
+		return $data['value'];
+	}
+
+	/**
+	 * Removes data from the cache.
+	 *
+	 * @param string $key   The cache key.
+	 * @param string $group Optional. The cache group. Default 'default'.
+	 * @return bool True on success, false on failure.
+	 */
+	public function delete( $key, $group = 'default' ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		$cache_file = $this->get_cache_file_path( $key, $group );
+
+		if ( isset( $this->cache[ $group ][ $key ] ) ) {
+			unset( $this->cache[ $group ][ $key ] );
+		}
+
+		if ( file_exists( $cache_file ) ) {
+			return unlink( $cache_file );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Replaces data in the cache if it already exists.
+	 *
+	 * @param string $key    The cache key.
+	 * @param mixed  $data   The data to store.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @param int    $expire Optional. When to expire the cache contents. Default 0 (no expiration).
+	 * @return bool True if the data was replaced, false if it doesn't exist.
+	 */
+	public function replace( $key, $data, $group = 'default', $expire = 0 ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		if ( false === $this->get( $key, $group ) ) {
+			return false;
+		}
+
+		return $this->set( $key, $data, $group, $expire );
+	}
+
+	/**
+	 * Clears all cached data.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function flush() {
+		$this->cache = array();
+		$this->cache_hits = 0;
+		$this->cache_misses = 0;
+
+		$this->cleanup_directory( $this->cache_dir );
+
+		return empty( glob( $this->cache_dir . '*' ) );
+	}
+
+	/**
+	 * Kills the object cache, disables external object cache, and replaces it with WordPress one.
+	 *
+	 * @global WP_Object_Cache $wp_object_cache
+	 */
+	public function die() {
+		global $wp_object_cache;
+
+		$this->flush();
+		$wp_object_cache = new WP_Object_Cache();
+		wp_using_ext_object_cache( false );
+	}
+
+	/**
+	 * Resurrects the object cache from the ashes and re-enables external object cache.
+	 *
+	 * @global WP_Object_Cache $wp_object_cache
+	 */
+	public function resurrect() {
+		global $wp_object_cache;
+
+		$wp_object_cache = $this;
+		wp_using_ext_object_cache( true );
+	}
+
+	/**
+	 * Recursively cleanup a directory by removing all its contents.
+	 *
+	 * @param string $dir Directory path to clean.
+	 */
+	private function cleanup_directory( $dir ) {
+		$files = glob( $dir . '*' );
+		if ( $files ) {
+			foreach ( $files as $file ) {
+				if ( is_file( $file ) ) {
+					unlink( $file );
+				} elseif ( is_dir( $file ) ) {
+					$this->cleanup_directory( $file . '/' );
+					rmdir( $file );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Adds groups to the list of global groups.
+	 *
+	 * @param string|array $groups A group or an array of groups to add.
+	 */
+	public function add_global_groups( $groups ) {
+		$groups = (array) $groups;
+		$this->global_groups = array_merge( $this->global_groups, $groups );
+		$this->global_groups = array_unique( $this->global_groups );
+	}
+
+	/**
+	 * Adds groups to the list of non-persistent groups.
+	 *
+	 * @param string|array $groups A group or an array of groups to add.
+	 */
+	public function add_non_persistent_groups( $groups ) {
+		$groups = (array) $groups;
+		$this->non_persistent_groups = array_merge( $this->non_persistent_groups, $groups );
+		$this->non_persistent_groups = array_unique( $this->non_persistent_groups );
+	}
+
+	/**
+	 * Increments numeric cache item's value.
+	 *
+	 * @param string $key    The cache key.
+	 * @param int    $offset Optional. The amount by which to increment the item's value. Default 1.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @return int|false The item's new value on success, false on failure.
+	 */
+	public function incr( $key, $offset = 1, $group = 'default' ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		$value = $this->get( $key, $group );
+		if ( false === $value ) {
+			return false;
+		}
+
+		if ( ! is_numeric( $value ) ) {
+			$value = 0;
+		}
+
+		$value += $offset;
+		if ( $value < 0 ) {
+			$value = 0;
+		}
+
+		$this->set( $key, $value, $group );
+		return $value;
+	}
+
+	/**
+	 * Decrements numeric cache item's value.
+	 *
+	 * @param string $key    The cache key.
+	 * @param int    $offset Optional. The amount by which to decrement the item's value. Default 1.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @return int|false The item's new value on success, false on failure.
+	 */
+	public function decr( $key, $offset = 1, $group = 'default' ) {
+		return $this->incr( $key, -$offset, $group );
+	}
+
+	/**
+	 * Switches the internal blog ID.
+	 *
+	 * @param int $blog_id Blog ID.
+	 */
+	public function switch_to_blog( $blog_id ) {
+		$this->blog_prefix = $this->multisite ? $blog_id . ':' : '';
+	}
+
+	/**
+	 * Retrieves multiple values from the cache in one call.
+	 *
+	 * @param array  $keys  Array of keys to retrieve.
+	 * @param string $group Optional. The cache group. Default 'default'.
+	 * @param bool   $force Optional. Whether to force an update of the local cache. Default false.
+	 * @return array Array of values.
+	 */
+	public function get_multiple( $keys, $group = 'default', $force = false ) {
+		$values = array();
+		foreach ( $keys as $key ) {
+			$values[ $key ] = $this->get( $key, $group, $force );
+		}
+		return $values;
+	}
+
+	/**
+	 * Sets multiple values to the cache in one call.
+	 *
+	 * @param array  $items  Array of key => value pairs to store.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @param int    $expire Optional. When to expire the cache contents. Default 0 (no expiration).
+	 * @return bool True on success, false on failure.
+	 */
+	public function set_multiple( $items, $group = 'default', $expire = 0 ) {
+		$success = true;
+		foreach ( $items as $key => $value ) {
+			if ( ! $this->set( $key, $value, $group, $expire ) ) {
+				$success = false;
+			}
+		}
+		return $success;
+	}
+
+	/**
+	 * Deletes multiple values from the cache in one call.
+	 *
+	 * @param array  $keys  Array of keys to delete.
+	 * @param string $group Optional. The cache group. Default 'default'.
+	 * @return bool True on success, false on failure.
+	 */
+	public function delete_multiple( $keys, $group = 'default' ) {
+		$success = true;
+		foreach ( $keys as $key ) {
+			if ( ! $this->delete( $key, $group ) ) {
+				$success = false;
+			}
+		}
+		return $success;
+	}
+
+	/**
+	 * Adds multiple values to the cache in one call.
+	 *
+	 * @param array  $items  Array of key => value pairs to store.
+	 * @param string $group  Optional. The cache group. Default 'default'.
+	 * @param int    $expire Optional. When to expire the cache contents. Default 0 (no expiration).
+	 * @return bool True on success, false on failure.
+	 */
+	public function add_multiple( $items, $group = 'default', $expire = 0 ) {
+		$success = true;
+		foreach ( $items as $key => $value ) {
+			if ( ! $this->add( $key, $value, $group, $expire ) ) {
+				$success = false;
+			}
+		}
+		return $success;
+	}
+
+	/**
+	 * Clears the in-memory runtime cache.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function flush_runtime() {
+		$this->cache = array();
+		$this->cache_hits = 0;
+		$this->cache_misses = 0;
+		return true;
+	}
+
+	/**
+	 * Clears the cache for a specific group.
+	 *
+	 * @param string $group Optional. The cache group. Default 'default'.
+	 * @return bool True on success, false on failure.
+	 */
+	public function flush_group( $group ) {
+		if ( empty( $group ) ) {
+			$group = 'default';
+		}
+
+		$group_dir = $this->cache_dir . $group . '/';
+		if ( ! file_exists( $group_dir ) ) {
+			return true;
+		}
+
+		$files = glob( $group_dir . $this->cache_prefix . '*' );
+		if ( $files ) {
+			foreach ( $files as $file ) {
+				if ( is_file( $file ) ) {
+					unlink( $file );
+				}
+			}
+		}
+
+		if ( isset( $this->cache[ $group ] ) ) {
+			unset( $this->cache[ $group ] );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the file path for a cache key.
+	 *
+	 * @param string $key   The cache key.
+	 * @param string $group The cache group.
+	 * @return string The cache file path.
+	 */
+	private function get_cache_file_path( $key, $group ) {
+		$group_dir = $this->cache_dir . $group . '/';
+		if ( ! file_exists( $group_dir ) ) {
+			wp_mkdir_p( $group_dir );
+		}
+		// Sanitize key more strictly
+		$safe_key = preg_replace( '/[^a-zA-Z0-9_-]/', '_', $key );
+		return $group_dir . $this->cache_prefix . $safe_key . '.cache';
+	}
+}
+
+/**
+ * Initializes the object cache.
+ *
+ * @global WP_Object_Cache $wp_object_cache WordPress Object Cache
+ */
+function wp_cache_init() { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+	global $wp_object_cache;
+
+	if ( ! ( $wp_object_cache instanceof Object_Cache_Annihilator ) ) {
+		$wp_object_cache = new Object_Cache_Annihilator();
+	}
+}
+
+/*
+ * phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+ * phpcs:disable Squiz.Commenting.FunctionComment.Missing
+ *
+ * Core cache functions implementation.
+ */
+
+function wp_cache_add( $key, $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->add( $key, $data, $group, $expire );
+}
+
+function wp_cache_add_global_groups( $groups ) {
+	global $wp_object_cache;
+	$wp_object_cache->add_global_groups( $groups );
+}
+
+function wp_cache_add_non_persistent_groups( $groups ) {
+	global $wp_object_cache;
+	$wp_object_cache->add_non_persistent_groups( $groups );
+}
+
+function wp_cache_incr( $key, $offset = 1, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->incr( $key, $offset, $group );
+}
+
+function wp_cache_decr( $key, $offset = 1, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->decr( $key, $offset, $group );
+}
+
+function wp_cache_switch_to_blog( $blog_id ) {
+	global $wp_object_cache;
+	$wp_object_cache->switch_to_blog( $blog_id );
+}
+
+function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+	global $wp_object_cache;
+	return $wp_object_cache->get( $key, $group, $force, $found );
+}
+
+function wp_cache_get_multiple( $keys, $group = '', $force = false ) {
+	global $wp_object_cache;
+	return $wp_object_cache->get_multiple( $keys, $group, $force );
+}
+
+function wp_cache_set( $key, $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->set( $key, $data, $group, $expire );
+}
+
+function wp_cache_set_multiple( $items, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->set_multiple( $items, $group, $expire );
+}
+
+function wp_cache_delete( $key, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->delete( $key, $group );
+}
+
+function wp_cache_delete_multiple( $keys, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->delete_multiple( $keys, $group );
+}
+
+function wp_cache_add_multiple( $items, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->add_multiple( $items, $group, $expire );
+}
+
+function wp_cache_flush_runtime() {
+	global $wp_object_cache;
+	return $wp_object_cache->flush_runtime();
+}
+
+function wp_cache_flush_group( $group ) {
+	global $wp_object_cache;
+	return $wp_object_cache->flush_group( $group );
+}
+
+function wp_cache_close() {
+	return true;
+}

--- a/tests/phpunit/tests/test-object-cache.php
+++ b/tests/phpunit/tests/test-object-cache.php
@@ -1,0 +1,96 @@
+<?php
+
+use WP_Syntex\Object_Cache_Annihilator;
+
+class Test_Object_Cache extends PLL_UnitTestCase {
+	private $cache_backup;
+
+	public function set_up() {
+		global $wp_object_cache;
+
+		parent::set_up();
+
+		$this->cache_backup = $wp_object_cache;
+
+		self::factory()->language->create_many( 2 );
+
+		// Drop in the annihilator.
+		copy( PLL_TEST_DATA_DIR . 'object-cache-annihilator.php', WP_CONTENT_DIR . '/object-cache.php' );
+		wp_using_ext_object_cache( true );
+		$wp_object_cache = new Object_Cache_Annihilator();
+
+		$options       = $this->create_options( array( 'default_lang' => 'en' ) );
+		$model         = new PLL_Model( $options );
+		$links         = $model->get_links_model();
+		$this->pll_env = new PLL_Frontend( $links, $model );
+		$this->pll_env->init();
+		$GLOBALS['polylang'] = $this->pll_env;
+	}
+
+	public function tear_down() {
+		global $wp_object_cache;
+
+		// Annihilate the annihilator.
+		$wp_object_cache->flush();
+		unlink( WP_CONTENT_DIR . '/object-cache.php' );
+		$wp_object_cache = $this->cache_backup;
+
+		parent::tear_down();
+	}
+
+	public function test_object_cache_unavailable() {
+		global $wp_object_cache;
+
+		$this->assertInstanceOf( Object_Cache_Annihilator::class, $wp_object_cache, 'The custom object cache should be enabled.' );
+
+		// Populate cache.
+		$this->assertTrue( $wp_object_cache->flush() );
+		$this->pll_env->model->languages->clean_cache();
+		$this->pll_env->model->languages->get_list();
+
+		$object_cache_languages = $wp_object_cache->get( 'pll_languages_list', 'transient' );
+
+		$this->assertNotFalse( $object_cache_languages, 'The transient should be available.' );
+		$this->assertIsArray( $object_cache_languages, 'The transient should be an array.' );
+		$this->assertSame( 'en', $object_cache_languages[0]['slug'], 'The first language should be en.' );
+		$this->assertSame( 'fr', $object_cache_languages[1]['slug'], 'The second language should be fr.' );
+
+		// Let's mess around and create a new language.
+		$this->assertGreaterThan( 0, self::factory()->language->create( array( 'locale' => 'de_DE' ) ) );
+
+		$this->pll_env->model->languages->clean_cache();
+		$this->assertCount( 3, $this->pll_env->model->languages->get_list(), 'All 3 languages should be available.' );
+
+		$object_cache_languages = $wp_object_cache->get( 'pll_languages_list', 'transient' );
+
+		$this->assertNotFalse( $object_cache_languages );
+		$this->assertIsArray( $object_cache_languages );
+		$this->assertSame( 'en', $object_cache_languages[0]['slug'], 'The first language should be en.' );
+		$this->assertSame( 'fr', $object_cache_languages[1]['slug'], 'The second language should be fr.' );
+		$this->assertSame( 'de', $object_cache_languages[2]['slug'], 'The third language should be de.' );
+
+		// Another request, another day, another cache.
+		$this->pll_env->model->languages->clean_cache();
+		$cache_backup = $wp_object_cache;
+		$wp_object_cache->die();
+
+		$this->assertEmpty( get_option( '_transient_pll_languages_list' ), 'The transient should be deleted from the options table.' );
+
+		$this->assertCount( 3, $this->pll_env->model->languages->get_list(), 'All 3 languages should be available.' );
+
+		// Suprise, surprise, the annihilator is back.
+		$cache_backup->resurrect();
+		$this->pll_env->model->languages->clean_cache();
+
+		$this->assertInstanceOf( Object_Cache_Annihilator::class, $wp_object_cache, 'The custom object cache should be enabled.' );
+
+		$this->assertCount( 3, $this->pll_env->model->languages->get_list(), 'All 3 languages should be available.' );
+
+		$object_cache_languages = $wp_object_cache->get( 'pll_languages_list', 'transient' );
+
+		$this->assertNotFalse( $object_cache_languages, 'The transient should be available from the cache.' );
+		$this->assertIsArray( $object_cache_languages, 'The transient should be an array.' );
+		$this->assertSame( 'en', $object_cache_languages[0]['slug'], 'The first language should be en.' );
+		$this->assertSame( 'fr', $object_cache_languages[1]['slug'], 'The second language should be fr.' );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -186,6 +186,7 @@ class PLL_Uninstall {
 
 		// Delete transients.
 		delete_transient( 'pll_languages_list' );
+		delete_option( '_transient_pll_languages_list' ); // Force deletion of the transient from the options table in case external object cache is used.
 	}
 }
 


### PR DESCRIPTION
## What?
Partially fixes #2125.

## How?
- Ensure `pll_languages_list` transient is deleted from/created in options table even if external object cache is used.
    - In usual process thanks to `set_transient_pll_languages_list` and `delete_transient_pll_languages_list` hooks with new methods in `Languages` model.
    - In upgrade or uninstallation by calling related core functions.
- Add a PHPUnit test to cover the issue, introducing a new drop in for external object cache in tests (`Object_Cache_Annihilator`).
