### PR TITLE
Deactivate `PLL_OLT_Manager` for REST requests

### DIFF
--- a/include/olt-manager.php
+++ b/include/olt-manager.php
@@ -31,7 +31,7 @@ class PLL_OLT_Manager {
 		add_filter( 'pre_update_option_active_sitewide_plugins', array( $this, 'make_polylang_first' ) );
 
 		// Overriding load text domain only on front since WP 4.7.
-		if ( is_admin() && ! Polylang::is_ajax_on_front() ) {
+		if ( ( is_admin() && ! Polylang::is_ajax_on_front() ) || Polylang::is_rest_request() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2600
Follow-up of #1395 

The PR simply deactivates `PLL_OLT_Manager` for REST requests.
- This quick fixes https://github.com/polylang/polylang-pro/issues/2600
- The feature is supposed to used only on front (especially when the language is set from the content)
- This doesn't work around the WordPress issue which erases object types registered with `register_taxonomy_for_object_type()` when the action `change_locale` is fired.