### PR TITLE
Create a `PLL_MO_Trait` for PHPUnit.

### DIFF
--- a/tests/phpunit/includes/pll-mo-trait.php
+++ b/tests/phpunit/includes/pll-mo-trait.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Trait to handle PLL_MO objects.
+ */
+trait PLL_MO_Trait {
+	/**
+	 * Flushes the PLL_MO cache for the given languages.
+	 *
+	 * @param PLL_Language[] $languages The languages to flush the cache for.
+	 */
+	public function flush_pll_mo_cache( array $languages ): void {
+		if ( empty( $languages ) ) {
+			return;
+		}
+
+		$mo = new PLL_MO();
+		foreach ( $languages as $lang ) {
+			// Flush the cache.
+			$mo->export_to_db( $lang );
+		}
+	}
+}

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -1,6 +1,8 @@
 <?php
 
 class Test_PLL_MO extends PLL_UnitTestCase {
+	use PLL_MO_Trait;
+
 	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
 		parent::pllSetUpBeforeClass( $factory );
 
@@ -17,11 +19,7 @@ class Test_PLL_MO extends PLL_UnitTestCase {
 	}
 
 	public function tear_down() {
-		$mo = new PLL_MO();
-		foreach ( $this->pll_admin->model->languages->get_list() as $lang ) {
-			// Flush the cache.
-			$mo->export_to_db( $lang );
-		}
+		$this->flush_pll_mo_cache( $this->pll_admin->model->languages->get_list() );
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/test-translate-option.php
+++ b/tests/phpunit/tests/test-translate-option.php
@@ -5,6 +5,7 @@
  * Registering and translating options is already tested in WPML_Config_Test
  */
 class Translate_Option_Test extends PLL_UnitTestCase {
+	use PLL_MO_Trait;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
@@ -24,15 +25,11 @@ class Translate_Option_Test extends PLL_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
-		$mo = new PLL_MO();
-		foreach ( $this->pll_admin->model->languages->get_list() as $lang ) {
-			// Flush the cache.
-			$mo->export_to_db( $lang );
-		}
+		$this->flush_pll_mo_cache( $this->pll_admin->model->languages->get_list() );
 
 		unset( $GLOBALS['polylang'] );
+
+		parent::tear_down();
 	}
 
 	protected function add_string_translations( $lang, $translations ) {


### PR DESCRIPTION
## What?
All in the title, suggested in https://github.com/polylang/polylang-pro/pull/2598/files#r2063806053.

## Why?
Keep it DRY.

## How?
- Create a dedicated trait, no need to pollute the main trait, also some tests might only need that (and not the whole features from `PLL_UnitTestCase_Trait`)
- We must pass the languages, because some tests use different models to get them (static vs non static...)