### PR TITLE
Allow `null` in the `nav_menus` option 

### DIFF
--- a/include/Options/Business/Nav_Menus.php
+++ b/include/Options/Business/Nav_Menus.php
@@ -84,6 +84,57 @@ class Nav_Menus extends Abstract_Option {
 	}
 
 	/**
+	 * Prepares a value before validation.
+	 *
+	 * @since 3.7.2
+	 *
+	 * @param mixed $value Value to format.
+	 * @return mixed
+	 */
+	protected function prepare( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$cur_theme = get_option( 'stylesheet' );
+
+		foreach ( $value as $theme => &$menus_by_loc ) {
+			if ( ! is_array( $menus_by_loc ) ) {
+				if ( $theme !== $cur_theme ) {
+					// Not the current theme: prevent a validation error.
+					unset( $value[ $theme ] );
+				}
+				// Current theme: let the validation process trigger an error.
+				continue;
+			}
+			foreach ( $menus_by_loc as $location => &$menus_by_lang ) {
+				if ( ! is_array( $menus_by_lang ) ) {
+					if ( $theme !== $cur_theme ) {
+						// Not the current theme: prevent a validation error.
+						unset( $menus_by_loc[ $location ] );
+					}
+					// Current theme: let the validation process trigger an error.
+					continue;
+				}
+				foreach ( $menus_by_lang as &$menu_id ) {
+					if ( null === $menu_id ) {
+						// Prevent a useless validation error.
+						$menu_id = 0;
+					} elseif ( ! is_numeric( $menu_id ) || $menu_id < 0 ) {
+						if ( $theme !== $cur_theme ) {
+							// Not the current theme: prevent a validation error.
+							$menu_id = 0;
+						}
+						// Current theme: let the validation process trigger an error.
+					}
+				}
+			}
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Sanitizes option's value.
 	 * Can populate the `$errors` property with blocking and non-blocking errors: in case of non-blocking errors,
 	 * the value is sanitized and can be stored.


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2615.

In the `nav_menus` option, if a menu ID is `null` instead of an integer, it is now casted to `0` instead of invalidating the whole option.

Example:
```
'twentytwentyone' => array(
	'primary' => array(
		'en' => 22,
		'fr' => null, // This will become `0`.
	),
	'footer' => array(
		'en' => 24,
		'fr' => 0,
	),
),
```

This is done by implementing `Abstract_Option::prepare()` in the class `Nav_Menus`. It is called before `rest_sanitize_value_from_schema()` (in constructor) and before `rest_validate_value_from_schema()` in the `set()` method.

This new implementation replaces all `null` menu IDs by `0`. 

Also, it removes all non-array values that are not in the current theme "branch". For non-array values that are in the current theme "branch", we let the validation process trigger its error. Note: I don't expect this to be triggered often, even less in the contructor (since the data comes from the DB).