### PR TITLE
Update `get_calendar()` hash

### DIFF
--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -8,7 +8,7 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_calendar() {
-		$this->check_method( 'a535a70ee39396528a16bcb4bffd47f3', '6.8', 'get_calendar' );
+		$this->check_method( '99d663e95afafddfda886b1b854d611c', '6.9', 'get_calendar' );
 	}
 
 	public function test_wp_admin_bar() {


### PR DESCRIPTION
due to a modification in a filter comment that we don't copy. See  https://core.trac.wordpress.org/ticket/63166#comment:7.