### PR TITLE
Fix warning when querying a non-existing language

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -214,9 +214,9 @@ class PLL_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string[]           $clauses The list of sql clauses in terms query.
-	 * @param PLL_Language|false $lang    PLL_Language object.
-	 * @return string[]                   Modified list of clauses.
+	 * @param string[]                          $clauses The list of sql clauses in terms query.
+	 * @param PLL_Language|string|string[]|null $lang    PLL_Language object.
+	 * @return string[] Modified list of clauses.
 	 */
 	public function terms_clauses( $clauses, $lang ) {
 		if ( ! empty( $lang ) && false === strpos( $clauses['join'], 'pll_tr' ) ) {

--- a/include/model.php
+++ b/include/model.php
@@ -214,8 +214,8 @@ class PLL_Model {
 	 *
 	 * @since 1.2
 	 *
-	 * @param string[]                          $clauses The list of sql clauses in terms query.
-	 * @param PLL_Language|string|string[]|null $lang    PLL_Language object.
+	 * @param string[]                                         $clauses The list of sql clauses in terms query.
+	 * @param PLL_Language|PLL_Language[]|string|string[]|null $lang    PLL_Language object.
 	 * @return string[] Modified list of clauses.
 	 */
 	public function terms_clauses( $clauses, $lang ) {

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -324,8 +324,6 @@ abstract class PLL_Translatable_Object {
 	 *
 	 * @param PLL_Language|PLL_Language[]|string|string[] $lang A `PLL_Language` object, or a comma separated list of language slugs, or an array of language slugs or objects.
 	 * @return string The WHERE clause.
-	 *
-	 * @phpstan-param PLL_Language|PLL_Language[]|non-empty-string|non-empty-string[] $lang
 	 */
 	public function where_clause( $lang ) {
 		/*

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -371,21 +371,6 @@ parameters:
 			path: include/crud-posts.php
 
 		-
-			message: "#^Cannot access property \\$slug on PLL_Language\\|false\\.$#"
-			count: 1
-			path: include/crud-terms.php
-
-		-
-			message: "#^Method PLL_CRUD_Terms\\:\\:get_queried_language\\(\\) should return PLL_Language\\|string\\|false but returns PLL_Language\\|null\\.$#"
-			count: 2
-			path: include/crud-terms.php
-
-		-
-			message: "#^Parameter \\#2 \\$lang of method PLL_Model\\:\\:terms_clauses\\(\\) expects PLL_Language\\|false, PLL_Language\\|string\\|false given\\.$#"
-			count: 1
-			path: include/crud-terms.php
-
-		-
 			message: "#^Cannot access offset 'term_id' on array\\{term_id\\: int, term_taxonomy_id\\: int\\|string\\}\\|WP_Error\\.$#"
 			count: 1
 			path: include/default-term.php


### PR DESCRIPTION
Fix #1661 Although I did not reproduce the issue, it's a valid bug.

The main purpose of the PR is to ensure that we don't attempt to get the slug of an invalid language.
Then, the code is simplified by changing the behavior of `get_queried_language()` - renamed to `get_queried_languages()` - always return an array of `PLL_Language` objects (possibly empty or with a unique item.
Positive side effect: 3 PHPStan errors are fixed.