### PR TITLE
Remove useless `$post_type` param

### DIFF
--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -242,7 +242,7 @@ class PLL_Admin_Links extends PLL_Links {
 			return $this->get_data_from_new_media_translation_request();
 		}
 
-		if ( ! isset( $GLOBALS['pagenow'], $_GET['_wpnonce'], $_GET['from_post'], $_GET['new_lang'], $_GET['post_type'] ) ) {
+		if ( ! isset( $GLOBALS['pagenow'], $GLOBALS['post_type'], $_GET['_wpnonce'], $_GET['from_post'], $_GET['new_lang'], $_GET['post_type'] ) ) {
 			return array();
 		}
 

--- a/admin/admin-links.php
+++ b/admin/admin-links.php
@@ -228,8 +228,8 @@ class PLL_Admin_Links extends PLL_Links {
 	 * Returns some data (`from_post` and `new_lang`) from the current request.
 	 *
 	 * @since 3.7
+	 * @since 3.8 Removed parameter.
 	 *
-	 * @param string $post_type A post type.
 	 * @return array {
 	 *     @type WP_Post      $from_post The source post.
 	 *     @type PLL_Language $new_lang  The target language.
@@ -237,8 +237,8 @@ class PLL_Admin_Links extends PLL_Links {
 	 *
 	 * @phpstan-return array{}|array{from_post: WP_Post, new_lang: PLL_Language}|never
 	 */
-	public function get_data_from_new_post_translation_request( string $post_type ): array {
-		if ( 'attachment' === $post_type ) {
+	public function get_data_from_new_post_translation_request(): array {
+		if ( isset( $_GET['from_media'] ) ) {
 			return $this->get_data_from_new_media_translation_request();
 		}
 
@@ -246,11 +246,7 @@ class PLL_Admin_Links extends PLL_Links {
 			return array();
 		}
 
-		if ( 'post-new.php' !== $GLOBALS['pagenow'] ) {
-			return array();
-		}
-
-		if ( empty( $post_type ) || $post_type !== $_GET['post_type'] || ! $this->model->is_translated_post_type( $post_type ) ) {
+		if ( 'post-new.php' !== $GLOBALS['pagenow'] || ! $this->model->is_translated_post_type( $GLOBALS['post_type'] ) ) {
 			return array();
 		}
 

--- a/modules/sync/admin-sync.php
+++ b/modules/sync/admin-sync.php
@@ -26,7 +26,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 
 		$this->links = &$polylang->links;
 
-		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ), 10, 3 );
+		add_filter( 'wp_insert_post_parent', array( $this, 'wp_insert_post_parent' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'wp_insert_post_data' ) );
 		add_filter( 'use_block_editor_for_post', array( $this, 'new_post_translation' ), 5000 ); // After content duplication.
 	}
@@ -35,14 +35,13 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * Translates the post parent if it exists when using "Add new" (translation).
 	 *
 	 * @since 0.6
+	 * @since 3.8 Removed second and third parameters.
 	 *
-	 * @param int   $post_parent Post parent ID.
-	 * @param int   $post_id     Post ID, unused.
-	 * @param array $postarr     Array of parsed post data.
+	 * @param int $post_parent Post parent ID.
 	 * @return int
 	 */
-	public function wp_insert_post_parent( $post_parent, $post_id, $postarr ) {
-		$context_data = $this->links->get_data_from_new_post_translation_request( $postarr['post_type'] ?? '' );
+	public function wp_insert_post_parent( $post_parent ) {
+		$context_data = $this->links->get_data_from_new_post_translation_request();
 
 		if ( empty( $context_data ) ) {
 			return $post_parent;
@@ -73,7 +72,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 	 * @return array
 	 */
 	public function wp_insert_post_data( $data ) {
-		$context_data = $this->links->get_data_from_new_post_translation_request( $data['post_type'] ?? '' );
+		$context_data = $this->links->get_data_from_new_post_translation_request();
 
 		if ( empty( $context_data ) ) {
 			return $data;
@@ -109,7 +108,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 			return $is_block_editor;
 		}
 
-		$context_data = $this->links->get_data_from_new_post_translation_request( $post->post_type );
+		$context_data = $this->links->get_data_from_new_post_translation_request();
 
 		if ( empty( $context_data ) || ! empty( $done[ $context_data['from_post']->ID ] ) ) {
 			return $is_block_editor;
@@ -145,7 +144,7 @@ class PLL_Admin_Sync extends PLL_Sync {
 		global $wpdb;
 
 		$postarr      = parent::get_fields_to_sync( $post );
-		$context_data = $this->links->get_data_from_new_post_translation_request( $post->post_type );
+		$context_data = $this->links->get_data_from_new_post_translation_request();
 
 		// For new drafts, save the date now otherwise it is overridden by WP. Thanks to JoryHogeveen. See #32.
 		if ( ! empty( $context_data ) && in_array( 'post_date', $this->options['sync'], true ) ) {

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -162,7 +162,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_post_translation() {
-		// categories
+		// Categories.
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
 		self::$model->term->set_language( $en, 'en' );
 
@@ -171,7 +171,7 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		self::$model->term->save_translations( $en, compact( 'fr' ) );
 
-		// source post
+		// Source post.
 		$from = self::factory()->post->create( array( 'post_category' => array( $en ) ) );
 		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, 'key', 'value' );
@@ -179,23 +179,24 @@ class Sync_Test extends PLL_UnitTestCase {
 		set_post_format( $from, 'aside' );
 		stick_post( $from );
 
-		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin );
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
-		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
+		$this->pll_admin->sync  = new PLL_Admin_Sync( $this->pll_admin );
 
-		$_REQUEST = $_GET = array(
+		$GLOBALS['pagenow']   = 'post-new.php';
+		$GLOBALS['post_type'] = 'post';
+
+		$_GET = array(
 			'post_type' => 'post',
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
 		);
+		$_REQUEST = $_GET;
 
-		$to = self::factory()->post->create();
-
-		$GLOBALS['pagenow'] = 'post-new.php';
+		$to              = self::factory()->post->create();
 		$GLOBALS['post'] = get_post( $to );
 
-		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // Fires the copy.
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( array( get_category( $fr ) ), get_the_category( $to ) );
@@ -206,7 +207,7 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_page_translation() {
-		// parent pages
+		// Parent pages.
 		$en = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -215,28 +216,29 @@ class Sync_Test extends PLL_UnitTestCase {
 
 		self::$model->post->save_translations( $en, compact( 'fr' ) );
 
-		// source page
-		$GLOBALS['pagenow'] = 'post-new.php';
-
+		// Source page.
 		$from = self::factory()->post->create( array( 'post_type' => 'page', 'menu_order' => 12, 'post_parent' => $en ) );
 		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, '_wp_page_template', 'full-width.php' );
 
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
-		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
+		$this->pll_admin->sync  = new PLL_Admin_Sync( $this->pll_admin );
 
-		$_REQUEST = $_GET = array(
+		$GLOBALS['pagenow']   = 'post-new.php';
+		$GLOBALS['post_type'] = 'page';
+
+		$_GET = array(
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'post_type' => 'page',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
 		);
+		$_REQUEST = $_GET;
 
-		$to = self::factory()->post->create( array( 'post_type' => 'page' ) );
-
+		$to              = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$GLOBALS['post'] = get_post( $to );
 
-		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // fires the copy
+		apply_filters( 'use_block_editor_for_post', false, $GLOBALS['post'] ); // Fires the copy.
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( $fr, wp_get_post_parent_id( $to ) );
@@ -481,25 +483,29 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_post_translation_with_sync_post_date() {
-		// source post
+		// Source post.
 		$from = self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		self::$model->post->set_language( $from, 'en' );
 
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
-		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
-		self::$model->options['sync'] = array( 'post_date' ); // Sync publish date
+		$this->pll_admin->sync  = new PLL_Admin_Sync( $this->pll_admin );
+		self::$model->options['sync'] = array( 'post_date' ); // Sync publish date.
 
-		$GLOBALS['pagenow'] = 'post-new.php';
+		$GLOBALS['pagenow']   = 'post-new.php';
+		$GLOBALS['post_type'] = 'post';
 
-		$_REQUEST = $_GET = array(
+		$_GET = array(
 			'post_type' => 'post',
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
 		);
+		$_REQUEST = $_GET;
 
-		$to = self::factory()->post->create();
-		clean_post_cache( $to ); // Necessary before calling get_post() below otherwise we don't get the synchronized date
+		$to              = self::factory()->post->create();
+		$GLOBALS['post'] = get_post( $to );
+
+		clean_post_cache( $to ); // Necessary before calling get_post() below otherwise we don't get the synchronized date.
 
 		$this->assertEquals( get_post( $from )->post_date, get_post( $to )->post_date );
 		$this->assertEquals( get_post( $from )->post_date_gmt, get_post( $to )->post_date_gmt );
@@ -541,30 +547,30 @@ class Sync_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_post_translation_with_sync_date() {
-		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // sync everything
+		self::$model->options['sync'] = array_keys( PLL_Settings_Sync::list_metas_to_sync() ); // Sync everything.
 
-		// source post
+		// Source post.
 		$from = self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		self::$model->post->set_language( $from, 'en' );
 
 		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
-		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
+		$this->pll_admin->sync  = new PLL_Admin_Sync( $this->pll_admin );
 
-		$_REQUEST = $_GET = array(
+		$GLOBALS['pagenow']   = 'post-new.php';
+		$GLOBALS['post_type'] = 'post';
+
+		$_GET = array(
 			'post_type' => 'post',
 			'from_post' => $from,
 			'new_lang'  => 'fr',
 			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
 		);
+		$_REQUEST = $_GET;
 
-		$GLOBALS['pagenow'] = 'post-new.php';
-
-		$to = self::factory()->post->create();
-
+		$to              = self::factory()->post->create();
 		$GLOBALS['post'] = get_post( $to );
 
-		do_action( 'add_meta_boxes', 'post', $GLOBALS['post'] ); // fires the copy
-		clean_post_cache( $to ); // Usually WordPress will do it for us when the post will be saved
+		clean_post_cache( $to ); // Usually WordPress will do it for us when the post will be saved.
 
 		$this->assertEquals( 'fr', self::$model->post->get_language( $to )->slug );
 		$this->assertEquals( '2007-09-04 00:00:00', get_post( $to )->post_date );


### PR DESCRIPTION
We introduced the method `get_data_from_new_post_translation_request()` in v3.7 with a `$post_type` but this param is useless. Indeed the method doesn't return anything if `$post_type !== $_GET['post_type']` so we can access the post type directly from `$_GET['post_type']`. However instead of using `$_GET['post_type']`, I chose to use `$GLOBALS['post_type']` which is more convenient as we don't need to redo the validation done by WP (See https://github.com/WordPress/WordPress/blob/6.8.1/wp-admin/post-new.php#L17-L25). This required to adapt some tests where `$GLOBALS['post_type']` was not defined.