### PR TITLE
return if PLL does not exists

### DIFF
--- a/integrations/domain-mapping/domain-mapping.php
+++ b/integrations/domain-mapping/domain-mapping.php
@@ -41,6 +41,7 @@ class PLL_Domain_Mapping {
 		if ( ! function_exists( 'PLL' ) ) {
 			// Rely on MU Domain Mapping.
 			redirect_to_mapped_domain();
+			return;
 		}
 
 		// The language is set from the subdomain or domain name


### PR DESCRIPTION
please verify the change because it would seem that redirect_to_mapping_domain stops execution only if it performs a true redirect so if PLL does not exists the function execution must stop