### PR TITLE
Avoids syncing term parent on term creation if parent term isn't translated.

### DIFF
--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -201,7 +201,6 @@ class PLL_Sync {
 	public function sync_term_parent( $term_id, $tt_id, $taxonomy ) {
 		global $wpdb;
 
-		$action = explode( '_', current_filter() )[0]; // Either "created" or "edited".
 		if ( ! is_taxonomy_hierarchical( $taxonomy ) || ! $this->model->is_translated_taxonomy( $taxonomy ) ) {
 			return;
 		}
@@ -218,8 +217,8 @@ class PLL_Sync {
 				$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
 				$tr_term   = get_term( (int) $tr_id, $taxonomy );
 
-				if ( str_starts_with(current_filter(), 'created_') && 0 === $tr_parent ) {
-					// Do not remove existing hierarchy of translations when creating new term without parent.
+				if ( str_starts_with( current_filter(), 'created_' ) && 0 === $tr_parent ) {
+					// Do not remove the existing hierarchy of translations when creating new term without parent.
 					continue;
 				}
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -218,7 +218,7 @@ class PLL_Sync {
 				$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
 				$tr_term   = get_term( (int) $tr_id, $taxonomy );
 
-				if ( 'created' === $action && 0 === $tr_parent ) {
+				if ( str_starts_with(current_filter(), 'created_') && 0 === $tr_parent ) {
 					// We're on a term creation and the parent of the current term is not translated, so nothing to sync.
 					continue;
 				}

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -188,7 +188,7 @@ class PLL_Sync {
 	}
 
 	/**
-	 * Synchronize term parent in translations
+	 * Synchronize term parent in translations.
 	 * Calling clean_term_cache *after* this is mandatory otherwise the $taxonomy_children option is not correctly updated
 	 *
 	 * @since 2.3
@@ -201,6 +201,8 @@ class PLL_Sync {
 	public function sync_term_parent( $term_id, $tt_id, $taxonomy ) {
 		global $wpdb;
 
+		$action = explode( '_' , current_filter() ); // `created` or `edited`.
+
 		if ( is_taxonomy_hierarchical( $taxonomy ) && $this->model->is_translated_taxonomy( $taxonomy ) ) {
 			$term = get_term( $term_id );
 
@@ -211,6 +213,11 @@ class PLL_Sync {
 					if ( $tr_id !== $term_id ) {
 						$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
 						$tr_term   = get_term( (int) $tr_id, $taxonomy );
+
+						if ( 'created' === $action &&  0 === $tr_parent ) {
+							// We're on a term creation and the parent of the current term is not translated, so nothing to sync.
+							continue;
+						}
 
 						if ( $tr_term instanceof WP_Term && ! ( $term->parent && empty( $tr_parent ) ) ) {
 							$wpdb->update(

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -219,7 +219,7 @@ class PLL_Sync {
 				$tr_term   = get_term( (int) $tr_id, $taxonomy );
 
 				if ( str_starts_with(current_filter(), 'created_') && 0 === $tr_parent ) {
-					// We're on a term creation and the parent of the current term is not translated, so nothing to sync.
+					// Do not remove existing hierarchy of translations when creating new term without parent.
 					continue;
 				}
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -213,24 +213,26 @@ class PLL_Sync {
 		$translations = $this->model->term->get_translations( $term_id );
 
 		foreach ( $translations as $lang => $tr_id ) {
-			if ( $tr_id !== $term_id ) {
-				$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
-				$tr_term   = get_term( (int) $tr_id, $taxonomy );
+			if ( $tr_id === $term_id ) {
+				continue;
+			}
+			
+			$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
+			$tr_term   = get_term( (int) $tr_id, $taxonomy );
 
-				if ( str_starts_with( current_filter(), 'created_' ) && 0 === $tr_parent ) {
-					// Do not remove the existing hierarchy of translations when creating new term without parent.
-					continue;
-				}
+			if ( str_starts_with( current_filter(), 'created_' ) && 0 === $tr_parent ) {
+				// Do not remove the existing hierarchy of translations when creating new term without parent.
+				continue;
+			}
 
-				if ( $tr_term instanceof WP_Term && ! ( $term->parent && empty( $tr_parent ) ) ) {
-					$wpdb->update(
-						$wpdb->term_taxonomy,
-						array( 'parent' => $tr_parent ?: 0 ),
-						array( 'term_taxonomy_id' => $tr_term->term_taxonomy_id )
-					);
+			if ( $tr_term instanceof WP_Term && ! ( $term->parent && empty( $tr_parent ) ) ) {
+				$wpdb->update(
+					$wpdb->term_taxonomy,
+					array( 'parent' => $tr_parent ?: 0 ),
+					array( 'term_taxonomy_id' => $tr_term->term_taxonomy_id )
+				);
 
-					clean_term_cache( $tr_id, $taxonomy ); // OK since WP 3.9.
-				}
+				clean_term_cache( $tr_id, $taxonomy ); // OK since WP 3.9.
 			}
 		}
 	}

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -497,12 +497,14 @@ class Sync_Test extends PLL_UnitTestCase {
 		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
 		$this->pll_admin->sync = new PLL_Admin_Sync( $this->pll_admin );
 		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests.
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'term_tr_lang'     => array( 'en' => $child_en ),
 		);
+		
+		$_REQUEST = $_POST;
 
 		$this->pll_admin->curlang = self::$model->get_language( 'fr' );
 		$to = self::factory()->term->create( array( 'taxonomy' => 'category' ) );

--- a/tests/phpunit/tests/test-sync.php
+++ b/tests/phpunit/tests/test-sync.php
@@ -489,7 +489,8 @@ class Sync_Test extends PLL_UnitTestCase {
 		self::$model->term->set_language( $parent_en, 'en' );
 
 		// Children EN.
-		$child_en = $this->factory()->term->create( array( 'taxonomy' => 'category', 'parent' => $parent_en ) );;
+		$child_en = $this->factory()->term->create( array( 'taxonomy' => 'category', 'parent' => $parent_en ) );
+
 		self::$model->term->set_language( $child_en, 'en' );
 
 		$this->pll_admin->filters_term = new PLL_Admin_Filters_Term( $this->pll_admin );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2624.

Do not synchronize a parent term when creating a new term that has no translated parent.

Adds a test.
Also took the opportunity to simplify the method by avoiding code nesting.