### PR TITLE
Use the `SensitiveParameter` attribute

### DIFF
--- a/include/license.php
+++ b/include/license.php
@@ -146,7 +146,10 @@ class PLL_License {
 	 * @param string $license_key Activation key.
 	 * @return PLL_License Updated PLL_License object.
 	 */
-	public function activate_license( $license_key ) {
+	public function activate_license(
+		#[\SensitiveParameter]
+		string $license_key
+	): self {
 		$this->license_key = $license_key;
 		$this->api_request( 'activate_license' );
 


### PR DESCRIPTION
Duplicates https://github.com/polylang/updater/pull/17.

Prevent disclosing the license key if a fatal error occurs in `License::activate_license()` with php 8.2.

Note: no need to add this attribute if the parameter in an array or an object, since their internal values are not printed anyway.

[Doc](https://www.php.net/manual/en/class.sensitiveparameter.php).