### PR TITLE
Makes jQuery.ajaxPrefilter() work

### DIFF
--- a/js/src/lib/ajax-filter/index.js
+++ b/js/src/lib/ajax-filter/index.js
@@ -15,35 +15,31 @@ export function ajaxFilter( data ) {
 		return;
 	}
 
-	jQuery(
-		function ( $ ) {
-			const dataStr = $.param( data );
+	const dataStr = jQuery.param( data );
 
-			$.ajaxPrefilter( function ( options ) {
-				if ( -1 === options.url.indexOf( ajaxurl ) && -1 === ajaxurl.indexOf( options.url ) ) {
-					return;
-				}
-
-				if (
-					'undefined' === typeof options.data ||
-					null === options.data ||
-					'string' === typeof options.data && '' === options.data.trim()
-				) {
-					// An empty string or null/undefined.
-					options.data = dataStr;
-				} else if ( 'string' === typeof options.data ) {
-					// A non-empty string: can be a JSON string or a query string.
-					try {
-						options.data = JSON.stringify( Object.assign( JSON.parse( options.data ), data ) );
-					} catch ( exception ) {
-						// A non-empty non-JSON string is considered a query string.
-						options.data = `${ options.data }&${ dataStr }`;
-					}
-				} else if ( $.isPlainObject( options.data ) ) {
-					// An object.
-					options.data = Object.assign( options.data, data );
-				}
-			} );
+	jQuery.ajaxPrefilter( function ( options ) {
+		if ( -1 === options.url.indexOf( ajaxurl ) && -1 === ajaxurl.indexOf( options.url ) ) {
+			return;
 		}
-	);
+
+		if (
+			'undefined' === typeof options.data ||
+			null === options.data ||
+			'string' === typeof options.data && '' === options.data.trim()
+		) {
+			// An empty string or null/undefined.
+			options.data = dataStr;
+		} else if ( 'string' === typeof options.data ) {
+			// A non-empty string: can be a JSON string or a query string.
+			try {
+				options.data = JSON.stringify( Object.assign( JSON.parse( options.data ), data ) );
+			} catch ( exception ) {
+				// A non-empty non-JSON string is considered a query string.
+				options.data = `${ options.data }&${ dataStr }`;
+			}
+		} else if ( jQuery.isPlainObject( options.data ) ) {
+			// An object.
+			options.data = Object.assign( options.data, data );
+		}
+	} );
 }


### PR DESCRIPTION
Fixes #2634

## What?

see this [issue comment](https://github.com/polylang/polylang-pro/issues/2634#issuecomment-2911421136)

## How?
- Removes `jQuery( callback )` call which binds the callback when the DOM is ready to be used
See https://api.jquery.com/jQuery/#jQuery-callback. It's useless in ajax calls context.

> [!Note]
> Also tested with jQuery 4 thanks to [Test jQuery Updates](https://wordpress.org/plugins/wp-jquery-update-test/) plugin. 
> Parameters are still added as string with jQuery 3 and will be added as object with jQuery 4