### PR TITLE
Remove multiple assignments

### DIFF
--- a/admin/admin-classic-editor.php
+++ b/admin/admin-classic-editor.php
@@ -97,12 +97,18 @@ class PLL_Admin_Classic_Editor {
 		global $post_ID;
 		$post_type = get_post_type( $post_ID );
 
-		// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$from_post_id = isset( $_GET['from_post'] ) ? (int) $_GET['from_post'] : 0;
+		$from_post_id  = 0;
+		$lang          = $this->model->post->get_language( $post_ID );
+		$new_post_data = $this->links->get_data_from_new_post_translation_request();
 
-		$lang = ( $lg = $this->model->post->get_language( $post_ID ) ) ? $lg :
-			( isset( $_GET['new_lang'] ) ? $this->model->get_language( sanitize_key( $_GET['new_lang'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification
-			$this->pref_lang );
+		if ( ! empty( $new_post_data ) ) {
+			$from_post_id = $new_post_data['from_post']->ID;
+			$lang         = $new_post_data['new_lang'];
+		}
+
+		if ( empty( $lang ) ) {
+			$lang = $this->pref_lang;
+		}
 
 		$dropdown = new PLL_Walker_Dropdown();
 

--- a/frontend/choose-lang-url.php
+++ b/frontend/choose-lang-url.php
@@ -38,35 +38,37 @@ class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
 	}
 
 	/**
-	 * Finds the language according to information found in the url
+	 * Finds the language according to information found in the url.
 	 *
 	 * @since 1.2
 	 *
 	 * @return void
 	 */
 	public function set_language_from_url() {
-		$host      = str_replace( 'www.', '', (string) wp_parse_url( $this->links_model->home, PHP_URL_HOST ) ); // Remove www. for the comparison
+		$host      = str_replace( 'www.', '', (string) wp_parse_url( $this->links_model->home, PHP_URL_HOST ) ); // Remove www. for the comparison.
 		$home_path = (string) wp_parse_url( $this->links_model->home, PHP_URL_PATH );
 
 		$requested_url   = pll_get_requested_url();
-		$requested_host  = str_replace( 'www.', '', (string) wp_parse_url( $requested_url, PHP_URL_HOST ) ); // Remove www. for the comparison
-		$requested_path  = rtrim( str_replace( $this->index, '', (string) wp_parse_url( $requested_url, PHP_URL_PATH ) ), '/' ); // Some PHP setups turn requests for / into /index.php in REQUEST_URI
+		$requested_host  = str_replace( 'www.', '', (string) wp_parse_url( $requested_url, PHP_URL_HOST ) ); // Remove www. for the comparison.
+		$requested_path  = rtrim( str_replace( $this->index, '', (string) wp_parse_url( $requested_url, PHP_URL_PATH ) ), '/' ); // Some PHP setups turn requests for / into /index.php in REQUEST_URI.
 		$requested_query = wp_parse_url( $requested_url, PHP_URL_QUERY );
 
-		// Home is requested
+		// Home is requested.
 		if ( $requested_host === $host && $requested_path === $home_path && empty( $requested_query ) ) {
 			$this->home_language();
 			add_action( 'setup_theme', array( $this, 'home_requested' ) );
 		}
 
-		// Take care to post & page preview http://wordpress.org/support/topic/static-frontpage-url-parameter-url-language-information
+		// Take care to post & page preview http://wordpress.org/support/topic/static-frontpage-url-parameter-url-language-information.
 		elseif ( isset( $_GET['preview'] ) && ( ( isset( $_GET['p'] ) && $id = (int) $_GET['p'] ) || ( isset( $_GET['page_id'] ) && $id = (int) $_GET['page_id'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$curlang = ( $lg = $this->model->post->get_language( $id ) ) ? $lg : $this->model->get_default_language();
+			$lang    = $this->model->post->get_language( $id );
+			$curlang = $lang ?: $this->model->get_default_language();
 		}
 
-		// Take care to ( unattached ) attachments
+		// Take care to ( unattached ) attachments.
 		elseif ( isset( $_GET['attachment_id'] ) && $id = (int) $_GET['attachment_id'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$curlang = ( $lg = $this->model->post->get_language( $id ) ) ? $lg : $this->get_preferred_language();
+			$lang    = $this->model->post->get_language( $id );
+			$curlang = $lang ?: $this->get_preferred_language();
 		}
 
 		elseif ( $slug = $this->links_model->get_language_from_url() ) {
@@ -77,8 +79,10 @@ class PLL_Choose_Lang_Url extends PLL_Choose_Lang {
 			$curlang = $this->model->get_default_language();
 		}
 
-		// If no language found, check_language_code_in_url() will attempt to find one and redirect to the correct url
-		// Otherwise a 404 will be fired in the preferred language
+		/*
+		 * If no language is found, check_canonical_url() will attempt to find one and redirect to the correct url.
+		 * Otherwise a 404 will be fired in the preferred language.
+		 */
 		$this->set_language( empty( $curlang ) ? $this->get_preferred_language() : $curlang );
 	}
 

--- a/frontend/frontend-nav-menu.php
+++ b/frontend/frontend-nav-menu.php
@@ -182,16 +182,17 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	 * @return stdClass[]
 	 */
 	public function wp_nav_menu_objects( $items ) {
-		$r_ids = $k_ids = array();
+		$k_ids = array();
+		$r_ids = array();
 
 		foreach ( $items as $item ) {
 			if ( ! empty( $item->classes ) && is_array( $item->classes ) ) {
 				if ( in_array( 'current-lang', $item->classes ) ) {
 					$item->current = false;
 					$item->classes = array_diff( $item->classes, array( 'current-menu-item' ) );
-					$r_ids = array_merge( $r_ids, $this->get_ancestors( $item ) ); // Remove the classes for these ancestors
+					$r_ids = array_merge( $r_ids, $this->get_ancestors( $item ) ); // Remove the classes for these ancestors.
 				} elseif ( in_array( 'current-menu-item', $item->classes ) ) {
-					$k_ids = array_merge( $k_ids, $this->get_ancestors( $item ) ); // Keep the classes for these ancestors
+					$k_ids = array_merge( $k_ids, $this->get_ancestors( $item ) ); // Keep the classes for these ancestors.
 				}
 			}
 		}
@@ -219,7 +220,8 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	 */
 	public function nav_menu_link_attributes( $atts, $item ) {
 		if ( isset( $item->lang ) ) {
-			$atts['lang'] = $atts['hreflang'] = esc_attr( $item->lang );
+			$atts['lang']     = esc_attr( $item->lang );
+			$atts['hreflang'] = $atts['lang'];
 		}
 		return $atts;
 	}

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -171,10 +171,12 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 
 		// Redirect the language page to the homepage when using a static front page
 		if ( ( $this->options['redirect_lang'] || $this->options['hide_default'] ) && $this->is_front_page( $query ) && $lang = $this->model->get_language( get_query_var( 'lang' ) ) ) {
-			$query->is_archive = $query->is_tax = false;
+			$query->is_archive = false;
+			$query->is_tax     = false;
 			if ( 'page' === get_option( 'show_on_front' ) && ! empty( $lang->page_on_front ) ) {
 				$query->set( 'page_id', $lang->page_on_front );
-				$query->is_singular = $query->is_page = true;
+				$query->is_singular = true;
+				$query->is_page     = true;
 				unset( $query->query_vars['lang'], $query->queried_object ); // Reset queried object
 			} else {
 				// Handle case where the static front page hasn't be translated to avoid a possible infinite redirect loop.
@@ -189,8 +191,10 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 				return $lang;
 			}
 			$query->set( 'page_id', $lang->page_on_front );
-			$query->is_singular = $query->is_page = true;
-			$query->is_archive = $query->is_tax = false;
+			$query->is_singular = true;
+			$query->is_page     = true;
+			$query->is_archive  = false;
+			$query->is_tax      = false;
 			unset( $query->query_vars['lang'], $query->queried_object ); // Reset queried object
 		}
 
@@ -243,8 +247,10 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 			_prime_post_caches( $pages ); // Fill the cache with all pages for posts to avoid one query per page later.
 
 			$lang = $this->model->post->get_language( $page_id );
-			$query->is_singular = $query->is_page = false;
-			$query->is_home = $query->is_posts_page = true;
+			$query->is_singular   = false;
+			$query->is_page       = false;
+			$query->is_home       = true;
+			$query->is_posts_page = true;
 		}
 
 		return $lang;

--- a/include/license.php
+++ b/include/license.php
@@ -230,7 +230,8 @@ class PLL_License {
 			$data = (object) json_decode( wp_remote_retrieve_body( $response ) );
 
 			if ( isset( $data->license ) && 'deactivated' !== $data->license ) {
-				$licenses[ $this->id ]['data'] = $this->license_data = $data;
+				$licenses[ $this->id ]['data'] = $data;
+				$this->license_data            = $data;
 			}
 		}
 

--- a/include/walker.php
+++ b/include/walker.php
@@ -43,7 +43,9 @@ class PLL_Walker extends Walker {
 			$element->locale = $element->w3c ?? $element->locale;
 		}
 
-		$element->parent = $element->id = 0; // Don't care about this.
+		// Don't care about this.
+		$element->id     = 0;
+		$element->parent = 0;
 
 		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,7 +25,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
 		<exclude name="Universal.Operators.StrictComparisons" />

--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -61,16 +61,17 @@ class WP_Importer_Test extends PLL_UnitTestCase {
 	 * @param bool   $fetch_files Whether or not do download remote attachments.
 	 */
 	protected function _import_wp( $filename, $users = array(), $fetch_files = true ) {
-		$importer = new PLL_WP_Import(); // Change to our importer
+		$importer = new PLL_WP_Import(); // Change to our importer.
 		$file = realpath( $filename );
 		$this->assertTrue( ! empty( $file ), 'Path to import file is empty.' );
 		$this->assertTrue( is_file( $file ), 'Import file is not a file.' );
 
-		$authors = $mapping = $new = array();
-		$i = 0;
+		$authors = array();
+		$mapping = array();
+		$new     = array();
+		$i       = 0;
 
-		// each user is either mapped to a given ID, mapped to a new user
-		// with given login or imported using details in WXR file
+		// Each user is either mapped to a given ID, mapped to a new user with given login or imported using details in WXR file.
 		foreach ( $users as $user => $map ) {
 			$authors[ $i ] = $user;
 			if ( is_int( $map ) ) {

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -58,23 +58,25 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public function test_save_post_from_metabox() {
 		$GLOBALS['post_type'] = 'post';
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'post_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'post_ID'          => $en = self::factory()->post->create(),
 		);
+		$_REQUEST = $_POST;
 		do_action( 'load-post.php' );
 		edit_post();
 
 		$this->assertEquals( 'en', self::$model->post->get_language( $en )->slug );
 
-		// Set the language and translations
-		$_REQUEST = $_POST = array(
+		// Set the language and translations.
+		$_POST = array(
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'post_tr_lang'     => array( 'en' => $en ),
 			'post_ID'          => $fr = self::factory()->post->create(),
 		);
+		$_REQUEST = $_POST;
 		do_action( 'load-post.php' );
 		edit_post();
 
@@ -87,22 +89,24 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $posts[0], 'en' );
 		self::$model->post->set_language( $posts[1], 'fr' );
 
-		// First do not modify any language
-		$_REQUEST = $_GET = array(
+		// First do not modify any language.
+		$_GET = array(
 			'inline_lang_choice' => -1,
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
 			'bulk_edit'          => 'Update',
 			'post'               => $posts,
 			'_status'            => 'publish',
 		);
+		$_REQUEST = $_GET;
 
 		do_action( 'load-edit.php' );
 		bulk_edit_posts( $_REQUEST );
 		$this->assertEquals( 'en', self::$model->post->get_language( $posts[0] )->slug );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $posts[1] )->slug );
 
-		// Second modify all languages
-		$_REQUEST['inline_lang_choice'] = $_GET['inline_lang_choice'] = 'fr';
+		// Second modify all languages.
+		$_GET['inline_lang_choice']     = 'fr';
+		$_REQUEST['inline_lang_choice'] = 'fr';
 		do_action( 'load-edit.php' );
 		bulk_edit_posts( $_REQUEST );
 		$this->assertEquals( 'fr', self::$model->post->get_language( $posts[0] )->slug );
@@ -135,12 +139,13 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$fr2 = self::factory()->category->create();
 		self::$model->term->set_language( $fr2, 'fr' );
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'post_category'    => array( $en, $en2, $fr2 ),
 			'post_ID'          => $post_id = self::factory()->post->create(),
 		);
+		$_REQUEST = $_POST;
 		do_action( 'load-post.php' );
 		edit_post();
 
@@ -159,12 +164,13 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$fr = self::factory()->tag->create( array( 'name' => 'test', 'slug' => 'test-fr' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'tax_input'        => array( 'post_tag' => array( 'test', 'new' ) ),
 			'post_ID'          => $post_id = self::factory()->post->create(),
 		);
+		$_REQUEST = $_POST;
 		do_action( 'load-post.php' );
 		edit_post();
 
@@ -230,7 +236,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public function test_languages_meta_box_for_new_post() {
 		global $post_ID;
 
-		$lang = $this->pll_admin->pref_lang = self::$model->get_language( 'en' );
+		$lang = self::$model->get_language( 'en' );
+		$this->pll_admin->pref_lang = $lang;
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 		$post_ID = self::factory()->post->create();
 		wp_set_object_terms( $post_ID, array(), 'language' ); // Intentionally remove the language
@@ -277,17 +284,17 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_languages_meta_box_for_existing_post_with_translations() {
-		global $post_ID;
-
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
 		$en = self::factory()->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 
-		$post_ID = $fr = self::factory()->post->create( array( 'post_title' => 'essai' ) );
+		$fr = self::factory()->post->create( array( 'post_title' => 'essai' ) );
 		self::$model->post->set_language( $fr, 'fr' );
 
 		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
+
+		$GLOBALS['post_ID'] = $fr;
 
 		$lang = self::$model->get_language( 'fr' );
 
@@ -298,22 +305,22 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$doc->loadHTML( '<?xml encoding="UTF-8">' . $form );
 		$xpath = new DOMXpath( $doc );
 
-		// language is French
+		// Language is French.
 		$option = $xpath->query( '//div/select/option[.="' . $lang->name . '"]' );
 		$this->assertEquals( 'selected', $option->item( 0 )->getAttribute( 'selected' ) );
 
-		// Link to English post
+		// Link to the English post.
 		$input = $xpath->query( '//input[@name="post_tr_lang[en]"]' );
 		$this->assertEquals( $en, $input->item( 0 )->getAttribute( 'value' ) );
 
 		$input = $xpath->query( '//input[@id="tr_lang_en"]' );
 		$this->assertEquals( 'test', $input->item( 0 )->getAttribute( 'value' ) );
 
-		// No self link
+		// No self link.
 		$this->assertEmpty( $xpath->query( '//input[@name="post_tr_lang[fr]"]' )->length );
 		$this->assertEmpty( $xpath->query( '//input[@id="tr_lang_fr"]' )->length );
 
-		// Link to empty German post
+		// Link to empty German post.
 		$input = $xpath->query( '//input[@name="post_tr_lang[de]"]' );
 		$this->assertEquals( 0, (int) $input->item( 0 )->getAttribute( 'value' ) );
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -263,8 +263,19 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$en = self::factory()->post->create( array( 'post_title' => 'test' ) );
 		self::$model->post->set_language( $en, 'en' );
 		$lang = self::$model->get_language( 'fr' );
-		$_GET['from_post'] = $en;
-		$_GET['new_lang'] = 'fr';
+
+		$_GET = array(
+			'post_type' => 'post',
+			'from_post' => $en,
+			'new_lang'  => 'fr',
+			'_wpnonce'  => wp_create_nonce( 'new-post-translation' ),
+		);
+
+		$_REQUEST = $_GET;
+
+		$GLOBALS['pagenow']   = 'post-new.php';
+		$GLOBALS['post_type'] = 'post';
+		$GLOBALS['post']      = get_post( $en );
 
 		ob_start();
 		$this->pll_admin->classic_editor->post_language();

--- a/tests/phpunit/tests/test-admin-filters-term.php
+++ b/tests/phpunit/tests/test-admin-filters-term.php
@@ -51,21 +51,24 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_save_term_from_edit_tags() {
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
+		$_REQUEST = $_POST;
+
 		$en = self::factory()->category->create();
 		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
 
-		// Set the language and translations
-		$_REQUEST = $_POST = array(
+		// Set the language and translations.
+		$_POST = array(
 			'action'           => 'add-tag',
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'term_tr_lang'     => array( 'en' => $en ),
 		);
+		$_REQUEST = $_POST;
 
 		$fr = self::factory()->category->create();
 		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
@@ -73,18 +76,19 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_term_from_categories_metabox() {
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'action'                   => 'add-category',
 			'term_lang_choice'         => 'fr',
 			'_ajax_nonce-add-category' => wp_create_nonce( 'add-category' ),
 		);
+		$_REQUEST = $_POST;
 
 		$fr = self::factory()->category->create();
 		$this->assertEquals( 'fr', self::$model->term->get_language( $fr )->slug );
 	}
 
 	public function test_save_term_from_quick_edit() {
-		$term_id = $en = self::factory()->category->create();
+		$en = self::factory()->category->create();
 		self::$model->term->set_language( $en, 'en' );
 
 		$de = self::factory()->category->create();
@@ -95,25 +99,28 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		self::$model->term->save_translations( $en, compact( 'en', 'de', 'es' ) );
 
-		// Post quick edit
-		// + the language is free in the translation group
-		$_REQUEST = $_POST = array(
+		$term_id = $en;
+
+		// Post quick edit + the language is free in the translation group.
+		$_POST = array(
 			'action'             => 'inline-save',
 			'inline_lang_choice' => 'fr',
 			'_inline_edit'       => wp_create_nonce( 'inlineeditnonce' ),
 		);
+		$_REQUEST = $_POST;
 
-		wp_update_term( $fr = $term_id, 'category' );
+		$fr = $term_id;
+		wp_update_term( $term_id, 'category' );
 		$this->assertEquals( 'fr', self::$model->term->get_language( $term_id )->slug );
 		$this->assertEqualSetsWithIndex( compact( 'fr', 'de', 'es' ), self::$model->term->get_translations( $es ) );
 
-		// edit-tags quick edit
-		// + the language is *not* free in the translation group
-		$_REQUEST = $_POST = array(
+		// The edit-tags quick edit + the language is *not* free in the translation group.
+		$_POST = array(
 			'action'             => 'inline-save-tax',
 			'inline_lang_choice' => 'de',
 			'_inline_edit'       => wp_create_nonce( 'taxinlineeditnonce' ),
 		);
+		$_REQUEST = $_POST;
 
 		wp_update_term( $term_id, 'category' );
 		$this->assertEquals( 'de', self::$model->term->get_language( $term_id )->slug );
@@ -132,8 +139,8 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$test_tag = self::factory()->tag->create( array( 'name' => 'test_tag' ) );
 		self::$model->term->set_language( $test_tag, 'fr' );
 
-		// First do not modify any language
-		$_REQUEST = $_GET = array(
+		// First do not modify any language.
+		$_GET = array(
 			'inline_lang_choice' => -1,
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
 			'bulk_edit'          => 'Update',
@@ -141,6 +148,7 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 			'_status'            => 'publish',
 			'tax_input'          => array( 'post_tag' => 'new_tag,test_tag' ),
 		);
+		$_REQUEST = $_GET;
 		do_action( 'load-edit.php' );
 		bulk_edit_posts( $_REQUEST );
 
@@ -164,9 +172,10 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertEqualSetsWithIndex( array( 'en' => $new_en, 'fr' => $new_fr ), self::$model->term->get_translations( $new_en ) );
 		$this->assertEqualSetsWithIndex( array( 'en' => $test_en, 'fr' => $test_fr ), self::$model->term->get_translations( $test_en ) );
 
-		// Second modify all languages
-		$_GET['inline_lang_choice'] = $_REQUEST['inline_lang_choice'] = 'fr';
-		$_GET['tax_input']  = $_REQUEST['tax_input'] = array( 'post_tag' => 'third_tag' );
+		// Second modify all languages.
+		$_GET['inline_lang_choice'] = 'fr';
+		$_GET['tax_input']          = array( 'post_tag' => 'third_tag' );
+		$_REQUEST = $_GET;
 		do_action( 'load-edit.php' );
 		bulk_edit_posts( $_REQUEST );
 
@@ -205,11 +214,12 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	protected function get_edit_term_form( $tag_ID, $taxonomy ) {
-		// Prepare all needed info before loading the entire form
+		// Prepare all needed info before loading the entire form.
 		$GLOBALS['post_type'] = 'post';
 		$tax = get_taxonomy( $taxonomy );
-		$_GET['taxonomy'] = $taxonomy;
-		$_REQUEST['tag_ID'] = $_GET['tag_ID'] = $tag_ID;
+		$_GET['taxonomy']   = $taxonomy;
+		$_GET['tag_ID']     = $tag_ID;
+		$_REQUEST['tag_ID'] = $tag_ID;
 		$tag = get_term( $tag_ID, $taxonomy, OBJECT, 'edit' );
 		$wp_http_referer = home_url( '/wp-admin/edit-tags.php?taxonomy=category' );
 		$message = '';
@@ -240,15 +250,17 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
 
-		// The admin language filter must have no impact
-		$this->pll_admin->pref_lang = $this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		// The admin language filter must have no impact.
+		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		$this->pll_admin->pref_lang   = $this->pll_admin->filter_lang;
 		$form = $this->get_edit_term_form( $tag_ID, 'category' );
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
 		$this->pll_admin->filter_lang = false;
 
 		// Even when we just activated the admin language filter
-		$_REQUEST['lang'] = $_GET['lang'] = 'en';
+		$_GET['lang']     = 'en';
+		$_REQUEST['lang'] = 'en';
 		$form = $this->get_edit_term_form( $tag_ID, 'category' );
 		$this->assertFalse( strpos( $form, 'test' ) );
 		$this->assertNotFalse( strpos( $form, 'essai' ) );
@@ -351,9 +363,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );
 
-		$_GET['taxonomy'] = 'category';
+		$_GET['taxonomy']     = 'category';
 		$GLOBALS['post_type'] = 'post';
-		$lang = $this->pll_admin->pref_lang = self::$model->get_language( 'en' );
+
+		$lang = self::$model->get_language( 'en' );
+		$this->pll_admin->pref_lang = $lang;
 		$this->pll_admin->set_current_language();
 
 		ob_start();
@@ -436,8 +450,9 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $out, 'test' ) );
 		$this->assertNotFalse( strpos( $out, 'essai' ) );
 
-		// The admin language filter is active
-		$this->pll_admin->pref_lang = $this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		// The admin language filter is active.
+		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		$this->pll_admin->pref_lang   = $this->pll_admin->filter_lang;
 		$this->pll_admin->set_current_language();
 
 		ob_start();
@@ -472,11 +487,12 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_create_terms_with_same_name() {
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
+		$_REQUEST = $_POST;
 
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test' ) );
 		$this->assertEquals( 'en', self::$model->term->get_language( $en )->slug );
@@ -579,13 +595,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		);
 
 		// Set globals like a language change in bluk edit and update a category.
-		$_REQUEST = $_GET = array(
+		$_GET = array(
 			'inline_lang_choice' => 'fr',
 			'_wpnonce'           => wp_create_nonce( 'bulk-posts' ),
 			'bulk_edit'          => 'Update',
 			'post'               => $en_post,
 			'_status'            => 'publish',
 		);
+		$_REQUEST = $_GET;
 
 		do_action( 'load-edit.php' );
 		bulk_edit_posts( $_REQUEST );
@@ -627,12 +644,14 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$en_child = self::factory()->category->create( array( 'name' => 'child', 'slug' => 'child', 'parent' => $en_parent ) );
 		self::$model->term->set_language( $en_child, 'en' );
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'parent'           => $de_parent,
 			'term_lang_choice' => 'de',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'term_tr_lang'     => array( 'en' => $en_child ),
 		);
+		$_REQUEST = $_POST;
+
 		$de_child     = wp_insert_term( 'child', 'category', array( 'parent' => $de_parent ) );
 		$de_child_obj = get_term( $de_child['term_id'], 'category' );
 
@@ -700,10 +719,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertSame( sanitize_title( $original_name ), $cat_en->slug, 'The category slug is well created.' );
 
 		// Add globals like an admin request.
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'term_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
+		$_REQUEST = $_POST;
 
 		// Now update the category with a new name.
 		$updated_cat = wp_update_term(
@@ -735,10 +755,11 @@ class Admin_Filters_Term_Test extends PLL_UnitTestCase {
 		$this->assertSame( sanitize_title( $original_name ), $cat_en->slug, 'The category slug is not well created.' );
 
 		// Add globals like an admin request.
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'term_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
+		$_REQUEST = $_POST;
 
 		// Now update the category with a new slug.
 		$updated_cat = wp_update_term(

--- a/tests/phpunit/tests/test-admin-notices.php
+++ b/tests/phpunit/tests/test-admin-notices.php
@@ -13,10 +13,11 @@ class Admin_Notices_Test extends PLL_UnitTestCase {
 	public function test_hide_notice() {
 		wp_set_current_user( 1 );
 
-		$_GET = $_REQUEST = array(
+		$_GET = array(
 			'pll-hide-notice'   => 'review',
 			'_pll_notice_nonce' => wp_create_nonce( 'review' ),
 		);
+		$_REQUEST = $_GET;
 
 		$this->pll_admin->admin_notices = new PLL_Admin_Notices( $this->pll_admin );
 

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -30,16 +30,16 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	}
 
 	public function test_post_lang_choice() {
-		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin ); // We need this for categories and tags
+		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin ); // We need this for categories and tags.
 
-		// categories
+		// Categories.
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'test cat' ) );
 		self::$model->term->set_language( $en, 'en' );
 
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'essai cat' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
-		// the post
+		// The post.
 		$post_id = self::factory()->post->create();
 		self::$model->post->set_language( $post_id, 'en' );
 
@@ -63,7 +63,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		}
 		$xml = simplexml_load_string( $this->_last_response, 'SimpleXMLElement', LIBXML_NOCDATA );
 
-		// translations
+		// Translations.
 		$form = $xml->response[0]->translations->response_data;
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
@@ -74,26 +74,26 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		$this->assertEmpty( $xpath->query( '//input[@id="tr_lang_fr"]' )->length );
 
-		// categories dropdown
+		// Categories dropdown.
 		$dropdown = $xml->response[1]->taxonomy->supplemental->dropdown;
-		$this->assertNotFalse( strpos( $dropdown, 'essai cat' ) );
-		$this->assertFalse( strpos( $dropdown, 'test cat' ) );
+		$this->assertStringContainsString( 'essai cat', $dropdown );
+		$this->assertStringNotContainsString( 'test cat', $dropdown );
 
-		// flag
-		$this->assertNotFalse( strpos( $flag = $xml->response[3]->flag->response_data, 'Français' ) );
+		// Flag.
+		$this->assertStringContainsString( 'Français', $xml->response[3]->flag->response_data );
 	}
 
 	public function test_page_lang_choice() {
-		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // we need this for the pages dropdown
+		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // We need this for the pages dropdown.
 
-		// possible parents
+		// Possible parents.
 		$en = self::factory()->post->create( array( 'post_title' => 'test', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
 		$fr = self::factory()->post->create( array( 'post_title' => 'essai', 'post_type' => 'page' ) );
 		self::$model->post->set_language( $fr, 'fr' );
 
-		// the post
+		// The post.
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $post_id, 'en' );
 
@@ -116,7 +116,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		}
 		$xml = simplexml_load_string( $this->_last_response, 'SimpleXMLElement', LIBXML_NOCDATA );
 
-		// translations
+		// Translations.
 		$form = $xml->response[0]->translations->response_data;
 		$doc = new DomDocument();
 		$doc->loadHTML( $form );
@@ -127,13 +127,13 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 
 		$this->assertEmpty( $xpath->query( '//input[@id="tr_lang_fr"]' )->length );
 
-		// parents
+		// Parents.
 		$dropdown = $xml->response[1]->pages->response_data;
-		$this->assertNotFalse( strpos( $dropdown, 'essai' ) );
-		$this->assertFalse( strpos( $dropdown, 'test' ) );
+		$this->assertStringContainsString( 'essai', $dropdown );
+		$this->assertStringNotContainsString( 'test', $dropdown );
 
-		// flag
-		$this->assertNotFalse( strpos( $flag = $xml->response[2]->flag->response_data, 'Français' ) );
+		// Flag.
+		$this->assertStringContainsString( 'Français', $xml->response[2]->flag->response_data );
 	}
 
 	public function test_posts_not_translated() {
@@ -254,21 +254,24 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 	}
 
 	public function test_save_post_from_quick_edit() {
-		$post_id = $en = self::factory()->post->create();
-		self::$model->post->set_language( $post_id, 'en' );
+		$en = self::factory()->post->create();
+		self::$model->post->set_language( $en, 'en' );
 
 		$es = self::factory()->post->create();
 		self::$model->post->set_language( $es, 'es' );
 
 		self::$model->post->save_translations( $en, compact( 'en', 'es' ) );
 
-		// Switch to a free language in the translation group
-		$_REQUEST = $_POST = array(
+		$post_id = $en;
+
+		// Switch to a free language in the translation group.
+		$_POST = array(
 			'action'             => 'inline-save',
 			'post_ID'            => $post_id,
 			'inline_lang_choice' => 'fr',
 			'_inline_edit'       => wp_create_nonce( 'inlineeditnonce' ),
 		);
+		$_REQUEST = $_POST;
 
 		try {
 			$this->_handleAjax( 'inline-save' );
@@ -281,8 +284,9 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$model->post->get_translations( $post_id ) );
 		$this->assertEqualSets( array( 'fr' => $post_id, 'es' => $es ), self::$model->post->get_translations( $es ) );
 
-		// Switch to a *non* free language in the translation group
-		$_REQUEST['inline_lang_choice'] = $_POST['inline_lang_choice'] = 'es';
+		// Switch to a *non* free language in the translation group.
+		$_POST['inline_lang_choice']    = 'es';
+		$_REQUEST['inline_lang_choice'] = 'es';
 
 		try {
 			$this->_handleAjax( 'inline-save' );

--- a/tests/phpunit/tests/test-ajax-filters-term.php
+++ b/tests/phpunit/tests/test-ajax-filters-term.php
@@ -69,11 +69,11 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 
 		// Parent dropdown.
 		$dropdown = $xml->response[1]->parent->response_data;
-		$this->assertNotFalse( strpos( $dropdown, 'essai cat' ) );
-		$this->assertFalse( strpos( $dropdown, 'test cat' ) );
+		$this->assertStringContainsString( 'essai cat', $dropdown );
+		$this->assertStringNotContainsString( 'test cat', $dropdown );
 
 		// Flag.
-		$this->assertNotFalse( strpos( $flag = $xml->response[2]->flag->response_data, 'Français' ) );
+		$this->assertStringContainsString( 'Français', $xml->response[2]->flag->response_data );
 	}
 
 	public function test_term_lang_choice_in_new_tag() {
@@ -118,11 +118,11 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		// Tag cloud.
 		$cloud = $xml->response[1]->tag_cloud->response_data;
 
-		$this->assertNotFalse( strpos( $cloud, 'essai' ) );
-		$this->assertFalse( strpos( $cloud, 'test' ) );
+		$this->assertStringContainsString( 'essai', $cloud );
+		$this->assertStringNotContainsString( 'test', $cloud );
 
 		// Flag.
-		$this->assertNotFalse( strpos( $flag = $xml->response[2]->flag->response_data, 'Français' ) );
+		$this->assertStringContainsString( 'Français', $xml->response[2]->flag->response_data );
 	}
 
 	public function test_terms_not_translated() {
@@ -237,11 +237,13 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		self::$model->term->set_language( $en, 'en' );
 
 		// Create a category translation with the same name (i.e. the same slug).
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
+		$_REQUEST = $_POST;
+
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'Test' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -252,7 +254,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertSame( 'fr', self::$model->term->get_language( $fr )->slug, 'The langue is not set correctly for the category.' );
 
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'name'               => 'More test',
 			'slug'               => 'test-fr',
 			'inline_lang_choice' => 'fr',
@@ -265,6 +267,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 			'pll_ajax_backend'   => '1',
 			'description'        => '',
 		);
+		$_REQUEST = $_POST;
 
 		try {
 			$this->_handleAjax( 'inline-save-tax' );
@@ -289,11 +292,13 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		self::$model->term->set_language( $en, 'en' );
 
 		// Create a category translation with the same name (i.e. the same slug).
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'action'           => 'add-tag',
 			'term_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 		);
+		$_REQUEST = $_POST;
+
 		$fr = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'Test' ) );
 		self::$model->term->set_language( $fr, 'fr' );
 
@@ -304,7 +309,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 		$this->assertSame( 'fr', self::$model->term->get_language( $fr )->slug, 'The langue is not set correctly for the category.' );
 
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'name'               => 'Test',
 			'slug'               => 'test-new-fr',
 			'inline_lang_choice' => 'fr',
@@ -317,6 +322,7 @@ class Ajax_Filters_Term_Test extends PLL_Ajax_UnitTestCase {
 			'pll_ajax_backend'   => '1',
 			'description'        => '',
 		);
+		$_REQUEST = $_POST;
 
 		try {
 			$this->_handleAjax( 'inline-save-tax' );

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -72,13 +72,13 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$custom_term_en = self::factory()->term->create( array( 'taxonomy' => 'custom_tax', 'name' => 'custom-term' ) );
 		self::$model->term->set_language( self::$custom_term_en, 'en' );
 
-		$en = self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
+		self::$page_for_posts_en = $factory->post->create( array( 'post_title' => 'posts', 'post_type' => 'page' ) );
 		self::$model->post->set_language( self::$page_for_posts_en, 'en' );
 
-		$fr = self::$page_for_posts_fr = $factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
+		self::$page_for_posts_fr = $factory->post->create( array( 'post_title' => 'articles', 'post_type' => 'page' ) );
 		self::$model->post->set_language( self::$page_for_posts_fr, 'fr' );
 
-		self::$model->post->save_translations( self::$page_for_posts_en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( self::$page_for_posts_en, array( 'en' => self::$page_for_posts_en, 'fr' => self::$page_for_posts_fr ) );
 	}
 
 	public function init_for_sitemaps() {

--- a/tests/phpunit/tests/test-choose-lang-content.php
+++ b/tests/phpunit/tests/test-choose-lang-content.php
@@ -52,8 +52,9 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 	 * @param string $url The URL for the request.
 	 */
 	public function go_to( $url ) {
-		// copy paste of WP_UnitTestCase::go_to
-		$_GET = $_POST = array();
+		// Copy paste of WP_UnitTestCase::go_to().
+		$_GET  = array();
+		$_POST = array();
 		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
 			if ( isset( $GLOBALS[ $v ] ) ) {
 				unset( $GLOBALS[ $v ] );
@@ -64,7 +65,7 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 			$req = $parts['path'] ?? '';
 			if ( isset( $parts['query'] ) ) {
 				$req .= '?' . $parts['query'];
-				// parse the url query vars into $_GET
+				// Parse the url query vars into $_GET.
 				parse_str( $parts['query'], $_GET );
 			}
 		} else {
@@ -80,12 +81,12 @@ class Choose_Lang_Content_Test extends PLL_UnitTestCase {
 		$this->flush_cache();
 		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
 
-		// insert Polylang specificity
+		// Insert Polylang specificity.
 		unset( $GLOBALS['wp_actions']['pll_language_defined'] );
 		unset( $this->frontend->curlang );
 		$this->frontend->init();
 
-		// restart copy paste of WP_UnitTestCase::go_to
+		// Restart copy paste of WP_UnitTestCase::go_to().
 		$GLOBALS['wp_the_query'] = new WP_Query();
 		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
 		$GLOBALS['wp'] = new WP();

--- a/tests/phpunit/tests/test-choose-lang-domain.php
+++ b/tests/phpunit/tests/test-choose-lang-domain.php
@@ -64,8 +64,10 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 	 * @param string $url The URL for the request.
 	 */
 	public function go_to( $url ) {
-		// copy paste of WP_UnitTestCase::go_to
-		$_GET = $_POST = array();
+		// Copy paste of WP_UnitTestCase::go_to().
+		$_GET  = array();
+		$_POST = array();
+
 		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
 			if ( isset( $GLOBALS[ $v ] ) ) {
 				unset( $GLOBALS[ $v ] );
@@ -76,7 +78,7 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 			$req = $parts['path'] ?? '';
 			if ( isset( $parts['query'] ) ) {
 				$req .= '?' . $parts['query'];
-				// parse the url query vars into $_GET
+				// Parse the url query vars into $_GET.
 				parse_str( $parts['query'], $_GET );
 			}
 		} else {
@@ -92,13 +94,13 @@ class Choose_Lang_Domain_Test extends PLL_UnitTestCase {
 		$this->flush_cache();
 		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
 
-		// insert Polylang specificity
+		// Insert Polylang specificity.
 		unset( $GLOBALS['wp_actions']['pll_language_defined'] );
 		unset( $this->frontend->curlang );
 		$_SERVER['HTTP_HOST'] = wp_parse_url( $url, PHP_URL_HOST );
 		$this->frontend->init();
 
-		// restart copy paste of WP_UnitTestCase::go_to
+		// Restart copy paste of WP_UnitTestCase::go_to().
 		$GLOBALS['wp_the_query'] = new WP_Query();
 		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
 		$GLOBALS['wp'] = new WP();

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -179,7 +179,8 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 				);
 			}
 
-			$_REQUEST = $_POST = $data;
+			$_POST    = $data;
+			$_REQUEST = $data;
 			do_action( 'load-post.php' );
 			edit_post();
 
@@ -266,11 +267,12 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 
 		// Simulate the request that create the post and assigns language.
 		$post = get_default_post_to_edit( 'post', true );
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'post_lang_choice' => 'en',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'post_ID'          => $post->ID,
 		);
+		$_REQUEST = $_POST;
 		edit_post();
 
 		$this->assertEmpty( wp_get_post_categories( $post->ID ) );

--- a/tests/phpunit/tests/test-default-term.php
+++ b/tests/phpunit/tests/test-default-term.php
@@ -43,7 +43,8 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$GLOBALS['post_type'] = 'post';
 		$tax                  = get_taxonomy( $taxonomy );
 		$_GET['taxonomy']     = $taxonomy;
-		$_REQUEST['tag_ID']   = $_GET['tag_ID'] = $tag_ID;
+		$_GET['tag_ID']       = $tag_ID;
+		$_REQUEST['tag_ID']   = $tag_ID;
 		$tag                  = get_term( $tag_ID, $taxonomy, OBJECT, 'edit' );
 		$wp_http_referer      = home_url( '/wp-admin/edit-tags.php?taxonomy=category' );
 		$message              = '';
@@ -127,7 +128,10 @@ class Default_Term_Test extends PLL_UnitTestCase {
 		$en = self::$model->term->get( $default, 'en' );
 		$fr = self::$model->term->get( $default, 'fr' );
 
-		$GLOBALS['taxnow'] = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
+		// WP_Screen tests $_REQUEST, Polylang tests $_GET.
+		$_GET['taxonomy']       = 'category';
+		$_REQUEST['taxonomy']   = 'category';
+		$GLOBALS['taxnow']      = 'category';
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen();
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );

--- a/tests/phpunit/tests/test-filters.php
+++ b/tests/phpunit/tests/test-filters.php
@@ -43,9 +43,9 @@ class Filters_Test extends PLL_UnitTestCase {
 
 		// request all pages
 		$pages = get_pages();
-		$fr_page_ids = $pages = wp_list_pluck( $pages, 'ID' );
-		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $pages ), 'slug' );
-		$this->assertCount( 3, $pages );
+		$fr_page_ids = wp_list_pluck( $pages, 'ID' );
+		$languages = wp_list_pluck( array_map( array( self::$model->post, 'get_language' ), $fr_page_ids ), 'slug' );
+		$this->assertCount( 3, $fr_page_ids );
 		$this->assertEquals( array( 'fr' ), array_values( array_unique( $languages ) ) );
 
 		// request less pages than exist

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -385,13 +385,14 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 		$menu_en = wp_create_nav_menu( 'menu_en' );
 		$item_id = wp_update_nav_menu_item( $menu_en, 0, $args );
 
-		$_REQUEST = $_POST = array(
+		$_POST = array(
 			'menu-item-url'         => array( $item_id => '#pll_switcher' ),
 			'menu-item-show_names'  => array( $item_id => 1 ),
 			'menu-item-show_flags'  => array( $item_id => 1 ),
 			'menu-item-pll-detect'  => array( $item_id => 1 ),
 			'update-nav-menu-nonce' => wp_create_nonce( 'update-nav_menu' ),
 		);
+		$_REQUEST = $_POST;
 
 		wp_update_nav_menu_item( $menu_en, $item_id, $args );
 
@@ -438,11 +439,12 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 			$locations[1] => 3,
 		);
 
-		$_POST = $_REQUEST = array(
+		$_POST = array(
 			'menu-locations'        => $nav_menu_locations,
 			'action'                => 'update',
 			'update-nav-menu-nonce' => wp_create_nonce( 'update-nav_menu' ),
 		);
+		$_REQUEST = $_POST;
 
 		set_theme_mod( 'nav_menu_locations', $nav_menu_locations );
 		$this->assertEqualSets( array( 'en' => 2, 'fr' => 3 ), $pll_admin->options['nav_menus'][ get_stylesheet() ][ $primary_location ] );

--- a/tests/phpunit/tests/test-parent-page.php
+++ b/tests/phpunit/tests/test-parent-page.php
@@ -40,11 +40,14 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $child_page_id, 'fr' );
 		// Before the post is updated.
 		$GLOBALS['post_type'] = 'page';
-		$_REQUEST = $_POST = array(
+
+		$_POST = array(
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'post_ID'          => $child_page_id,
 		);
+		$_REQUEST = $_POST;
+
 		do_action( 'load-post.php' );
 		edit_post();
 
@@ -65,11 +68,14 @@ class Parent_Page_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $child_page_id, 'fr' );
 		// Before the post is updated.
 		$GLOBALS['post_type'] = 'page';
-		$_REQUEST = $_POST = array(
+
+		$_POST = array(
 			'post_lang_choice' => 'fr',
 			'_pll_nonce'       => wp_create_nonce( 'pll_language' ),
 			'post_ID'          => $child_page_id,
 		);
+		$_REQUEST = $_POST;
+
 		do_action( 'load-post.php' );
 		edit_post();
 

--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -15,7 +15,8 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 	public function init( $pagename ) {
 		wp_set_current_user( 1 );
 
-		$GLOBALS['plugin_page'] = $_GET['page'] = $pagename;
+		$GLOBALS['plugin_page'] = $pagename;
+		$_GET['page']           = $pagename;
 
 		$links_model = self::$model->get_links_model();
 		return new PLL_Settings( $links_model );

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -30,10 +30,11 @@ class Settings_Test extends PLL_UnitTestCase {
 	public function test_edit_language() {
 		$lang = self::$model->get_language( 'fr' );
 
-		// setup globals
-		$_GET['page'] = 'mlang';
-		$_GET['pll_action'] = $_REQUEST['pll_action'] = 'edit'; // languages_page() tests $_REQUEST
-		$_GET['lang'] = $lang->term_id;
+		// Setup globals.
+		$_GET['lang']           = $lang->term_id;
+		$_GET['page']           = 'mlang';
+		$_GET['pll_action']     = 'edit';
+		$_REQUEST['pll_action'] = 'edit'; // languages_page() tests $_REQUEST.
 		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
 		$GLOBALS['plugin_page'] = 'mlang';
 		get_admin_page_title();
@@ -49,7 +50,7 @@ class Settings_Test extends PLL_UnitTestCase {
 		$xpath = new DOMXpath( $doc );
 
 		$input = $xpath->query( '//input[@name="lang_id"]' );
-		$this->assertEquals( $lang->term_id, $input->item( 0 )->getAttribute( 'value' ) ); // hidden field
+		$this->assertEquals( $lang->term_id, $input->item( 0 )->getAttribute( 'value' ) ); // Hidden field.
 
 		$input = $xpath->query( '//input[@name="name"]' );
 		$this->assertEquals( 'Français', $input->item( 0 )->getAttribute( 'value' ) );

--- a/tests/phpunit/tests/test-terms-list.php
+++ b/tests/phpunit/tests/test-terms-list.php
@@ -18,11 +18,11 @@ class Terms_List_Test extends PLL_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		wp_set_current_user( self::$editor ); // set a user to pass current_user_can tests
+		wp_set_current_user( self::$editor ); // Set a user to pass current_user_can() tests.
 
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
-		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // To activate the fix_delete_default_category() filter
+		$this->pll_admin->filters = new PLL_Admin_Filters( $this->pll_admin ); // To activate the fix_delete_default_category() filter.
 		$this->pll_admin->terms = new PLL_CRUD_Terms( $this->pll_admin );
 	}
 
@@ -39,13 +39,16 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		$en = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'child', 'parent' => $en ) );
 		self::$model->term->set_language( $en, 'en' );
 
-		$GLOBALS['taxnow'] = $_REQUEST['taxonomy'] = $_GET['taxonomy'] = 'category'; // WP_Screen tests $_REQUEST, Polylang tests $_GET
+		// WP_Screen tests $_REQUEST, Polylang tests $_GET.
+		$_GET['taxonomy']       = 'category';
+		$_REQUEST['taxonomy']   = 'category';
+		$GLOBALS['taxnow']      = 'category';
 		$GLOBALS['hook_suffix'] = 'edit-tags.php';
 		set_current_screen();
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );
 		$this->pll_admin->set_current_language();
 
-		// without filter
+		// Without filter.
 		ob_start();
 		$wp_list_table->prepare_items();
 		$wp_list_table->display();
@@ -56,8 +59,9 @@ class Terms_List_Test extends PLL_UnitTestCase {
 		$this->assertNotFalse( strpos( $list, 'child' ) );
 		$this->assertNotFalse( strpos( $list, 'enfant' ) );
 
-		// the filter is active
-		$this->pll_admin->pref_lang = $this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		// The filter is active.
+		$this->pll_admin->filter_lang = self::$model->get_language( 'en' );
+		$this->pll_admin->pref_lang   = $this->pll_admin->filter_lang;
 		$this->pll_admin->set_current_language();
 
 		ob_start();

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -115,7 +115,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
-		$en = $from = self::factory()->post->create();
+		$from = self::factory()->post->create();
 		self::$model->post->set_language( $from, 'en' );
 		add_post_meta( $from, 'quantity', 1 ); // `copy`
 		add_post_meta( $from, 'custom-title', 'title' ); // `translate`
@@ -123,9 +123,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		add_post_meta( $from, 'date-added', 2007 ); // `ignore`
 		add_post_meta( $from, 'a_json_meta', $json ); // `translate` + encoding.
 
-		$fr = $to = self::factory()->post->create();
+		$to = self::factory()->post->create();
 		self::$model->post->set_language( $to, 'fr' );
-		self::$model->post->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->post->save_translations( $from, array( 'en' => $from, 'fr' => $to ) );
 
 		// Test encodings.
 		$encodings = apply_filters( 'pll_post_meta_encodings', array(), $from, $to );
@@ -174,16 +174,16 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$pll_admin = new PLL_Admin( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
-		$en = $from = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
+		$from = self::factory()->category->create();
 		self::$model->term->set_language( $from, 'en' );
 		add_term_meta( $from, 'term_meta_A', 'A' ); // copy
 		add_term_meta( $from, 'term_meta_B', 'B' ); // translate
 		add_term_meta( $from, 'term_meta_C', 'C' ); // ignore
 		add_term_meta( $from, 'term_meta_D', 'D' ); // copy-once
 
-		$fr = $to = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
+		$to = self::factory()->category->create();
 		self::$model->term->set_language( $to, 'fr' );
-		self::$model->term->save_translations( $en, compact( 'en', 'fr' ) );
+		self::$model->term->save_translations( $from, array( 'en' => $from, 'fr' => $to ) );
 
 		// Copy
 		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
@@ -302,10 +302,10 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->prepare_options( 'ARRAY' ); // Before reading the wpml-config.xml file.
 		$this->translate_options( 'fr' );
 
-		$GLOBALS['polylang'] = $frontend = new PLL_Frontend( $this->links_model );
+		$GLOBALS['polylang'] = new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
-		$frontend->curlang = self::$model->get_language( 'fr' );
+		$GLOBALS['polylang']->curlang = self::$model->get_language( 'fr' );
 		do_action( 'pll_language_defined' );
 
 		$options = get_option( 'my_plugins_options' );
@@ -333,10 +333,10 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->prepare_options( 'OBJECT' ); // Before reading the wpml-config.xml file.
 		$this->translate_options( 'fr' );
 
-		$GLOBALS['polylang'] = $frontend = new PLL_Frontend( $this->links_model );
+		$GLOBALS['polylang'] = new PLL_Frontend( $this->links_model );
 		PLL_WPML_Config::instance()->init();
 
-		$frontend->curlang = self::$model->get_language( 'fr' );
+		$GLOBALS['polylang']->curlang = self::$model->get_language( 'fr' );
 		do_action( 'pll_language_defined' );
 
 		$options = get_option( 'my_plugins_options' );


### PR DESCRIPTION
This PR removes all multiple assignments including in tests.

It also uses `get_data_from_new_post_translation_request()` to avoid a direct access to super globals in `PLL_Admin_Classic_Editor::post_language()`.