### PR TITLE
Document options type in class properties

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -10,6 +10,11 @@
  */
 abstract class PLL_Admin_Base extends PLL_Base {
 	/**
+	 * @var PLL_Admin_Model
+	 */
+	public $model;
+
+	/**
 	 * Current language (used to filter the content).
 	 *
 	 * @var PLL_Language|null

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -10,11 +10,6 @@
  */
 abstract class PLL_Admin_Base extends PLL_Base {
 	/**
-	 * @var PLL_Admin_Model
-	 */
-	public $model;
-
-	/**
 	 * Current language (used to filter the content).
 	 *
 	 * @var PLL_Language|null

--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * A class to manage admin notices
  * displayed only to admin, based on 'manage_options' capability
@@ -15,7 +17,7 @@ class PLL_Admin_Notices {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -34,10 +34,10 @@ class PLL_Admin_Notices {
 	 *
 	 * @since 2.3.9
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Admin_Base $polylang The Polylang object.
 	 */
-	public function __construct( $polylang ) {
-		$this->options = &$polylang->options;
+	public function __construct( PLL_Admin_Base $polylang ) {
+		$this->options = $polylang->options;
 
 		add_action( 'admin_init', array( $this, 'hide_notice' ) );
 		add_action( 'admin_notices', array( $this, 'display_notices' ) );

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -33,7 +33,7 @@ class PLL_Canonical {
 	/**
 	 * Current language.
 	 *
-	 * @var PLL_Language
+	 * @var PLL_Language|null
 	 */
 	protected $curlang;
 
@@ -42,12 +42,12 @@ class PLL_Canonical {
 	 *
 	 * @since 3.3
 	 *
-	 * @param object $polylang Main Polylang object.
+	 * @param PLL_Frontend $polylang Main Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Frontend &$polylang ) {
 		$this->links_model = &$polylang->links_model;
 		$this->model       = &$polylang->model;
-		$this->options     = &$polylang->options;
+		$this->options     = $polylang->options;
 		$this->curlang     = &$polylang->curlang;
 	}
 
@@ -126,6 +126,9 @@ class PLL_Canonical {
 		}
 
 		if ( empty( $language ) ) {
+			if ( empty( $this->curlang ) ) {
+				return $requested_url;
+			}
 			$language = $this->curlang;
 			$redirect_url = $requested_url;
 		} else {

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -126,10 +126,8 @@ class PLL_Canonical {
 		}
 
 		if ( empty( $language ) ) {
-			if ( empty( $this->curlang ) ) {
-				return $requested_url;
-			}
-			$language = $this->curlang;
+			/** @var PLL_Language $language */
+			$language     = $this->curlang;
 			$redirect_url = $requested_url;
 		} else {
 			$redirect_url = $this->redirect_canonical( $requested_url, $language );

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Manages canonical redirect on frontend.
  *
@@ -12,7 +14,7 @@ class PLL_Canonical {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -42,12 +42,12 @@ abstract class PLL_Choose_Lang {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Frontend $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Frontend &$polylang ) {
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->model       = &$polylang->model;
+		$this->options     = $polylang->options;
 
 		$this->curlang = &$polylang->curlang;
 	}

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Base class to choose the language
  *
@@ -12,7 +14,7 @@ abstract class PLL_Choose_Lang {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -35,14 +35,14 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Frontend $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Frontend &$polylang ) {
 		parent::__construct( $polylang );
 
 		$this->links_model = &$polylang->links_model;
 		$this->links       = &$polylang->links;
-		$this->options     = &$polylang->options;
+		$this->options     = $polylang->options;
 
 		add_action( 'pll_home_requested', array( $this, 'pll_home_requested' ) );
 

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Manages the static front page and the page for posts on frontend
  *
@@ -24,7 +26,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	/**
 	 * Stores plugin's options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/include/base.php
+++ b/include/base.php
@@ -52,10 +52,10 @@ abstract class PLL_Base {
 	 *
 	 * @param PLL_Links_Model $links_model Links Model.
 	 */
-	public function __construct( &$links_model ) {
+	public function __construct( PLL_Links_Model &$links_model ) {
 		$this->links_model = &$links_model;
-		$this->model = &$links_model->model;
-		$this->options = &$this->model->options;
+		$this->model       = &$links_model->model;
+		$this->options     = $this->model->options;
 
 		$GLOBALS['l10n_unloaded']['pll_string'] = true; // Short-circuit _load_textdomain_just_in_time() for 'pll_string' domain in WP 4.6+
 

--- a/include/base.php
+++ b/include/base.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Base class for both admin and frontend
  *
@@ -13,7 +15,7 @@ abstract class PLL_Base {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Adds actions and filters related to languages when creating, updating or deleting posts.
  * Actions and filters triggered when reading posts are handled separately.
@@ -32,7 +34,7 @@ class PLL_CRUD_Posts {
 	/**
 	 * Reference to the Polylang options array.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -43,10 +43,10 @@ class PLL_CRUD_Posts {
 	 *
 	 * @since 2.4
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
-		$this->options   = &$polylang->options;
+	public function __construct( PLL_Base &$polylang ) {
+		$this->options   = $polylang->options;
 		$this->model     = &$polylang->model;
 		$this->pref_lang = &$polylang->pref_lang;
 		$this->curlang   = &$polylang->curlang;

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Adds actions and filters related to languages when creating, reading, updating or deleting posts
  * Acts both on frontend and backend
@@ -53,7 +55,7 @@ class PLL_CRUD_Terms {
 	/**
 	 * Reference to the Polylang options array.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -64,10 +64,10 @@ class PLL_CRUD_Terms {
 	 *
 	 * @since 2.4
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
-		$this->options     = &$polylang->options;
+	public function __construct( PLL_Base &$polylang ) {
+		$this->options     = $polylang->options;
 		$this->model       = &$polylang->model;
 		$this->curlang     = &$polylang->curlang;
 		$this->filter_lang = &$polylang->filter_lang;

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Manages links filters needed on both frontend and admin
  *
@@ -12,7 +14,7 @@ class PLL_Filters_Links {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -47,14 +47,14 @@ class PLL_Filters_Links {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
-		$this->links = &$polylang->links;
+	public function __construct( PLL_Base &$polylang ) {
+		$this->links       = &$polylang->links;
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
-		$this->curlang = &$polylang->curlang;
+		$this->model       = &$polylang->model;
+		$this->options     = $polylang->options;
+		$this->curlang     = &$polylang->curlang;
 
 		// Low priority on links filters to come after any other modifications.
 		if ( $this->options['force_lang'] ) {

--- a/include/filters.php
+++ b/include/filters.php
@@ -42,15 +42,15 @@ class PLL_Filters {
 	 *
 	 * @since 1.4
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Base &$polylang ) {
 		global $wp_version;
 
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
-		$this->curlang = &$polylang->curlang;
+		$this->model       = &$polylang->model;
+		$this->options     = $polylang->options;
+		$this->curlang     = &$polylang->curlang;
 
 		// Deletes our cache for sticky posts when the list is updated.
 		add_action( 'update_option_sticky_posts', array( $this, 'delete_sticky_posts_cache' ) );

--- a/include/filters.php
+++ b/include/filters.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Setup filters common to admin and frontend
  *
@@ -12,7 +14,7 @@ class PLL_Filters {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * PLL_Language factory.
  *
@@ -23,7 +25,7 @@ class PLL_Language_Factory {
 	/**
 	 * Polylang's options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	private $options;
 
@@ -31,8 +33,9 @@ class PLL_Language_Factory {
 	 * Constructor.
 	 *
 	 * @since 3.4
+	 * @since 3.7 The `$options` parameter is an instance of `Options`.
 	 *
-	 * @param array $options Array of Poylang's options passed by reference.
+	 * @param Options $options Poylang's options passed by reference.
 	 * @return void
 	 */
 	public function __construct( &$options ) {

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -35,11 +35,11 @@ class PLL_Language_Factory {
 	 * @since 3.4
 	 * @since 3.7 The `$options` parameter is an instance of `Options`.
 	 *
-	 * @param Options $options Poylang's options passed by reference.
+	 * @param Options $options Poylang's options.
 	 * @return void
 	 */
-	public function __construct( Options &$options ) {
-		$this->options = &$options;
+	public function __construct( Options $options ) {
+		$this->options = $options;
 	}
 
 	/**

--- a/include/language-factory.php
+++ b/include/language-factory.php
@@ -38,7 +38,7 @@ class PLL_Language_Factory {
 	 * @param Options $options Poylang's options passed by reference.
 	 * @return void
 	 */
-	public function __construct( &$options ) {
+	public function __construct( Options &$options ) {
 		$this->options = &$options;
 	}
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -51,9 +51,9 @@ abstract class PLL_Links_Model {
 	 *
 	 * @param PLL_Model $model PLL_Model instance.
 	 */
-	public function __construct( &$model ) {
+	public function __construct( PLL_Model &$model ) {
 		$this->model   = &$model;
-		$this->options = &$model->options;
+		$this->options = $model->options;
 
 		$this->home = home_url();
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Links model abstract class.
  *
@@ -19,7 +21,7 @@ abstract class PLL_Links_Model {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/include/links.php
+++ b/include/links.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Manages links related functions
  *
@@ -12,7 +14,7 @@ class PLL_Links {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/include/links.php
+++ b/include/links.php
@@ -42,12 +42,12 @@ class PLL_Links {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Base &$polylang ) {
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->model       = &$polylang->model;
+		$this->options     = $polylang->options;
 	}
 
 	/**

--- a/include/model.php
+++ b/include/model.php
@@ -99,8 +99,8 @@ class PLL_Model {
 	 *
 	 * @param Options $options Polylang options.
 	 */
-	public function __construct( Options &$options ) {
-		$this->options              = &$options;
+	public function __construct( Options $options ) {
+		$this->options              = $options;
 		$this->cache                = new PLL_Cache();
 		$this->translatable_objects = new PLL_Translatable_Objects();
 		$this->languages            = new Model\Languages( $this->options, $this->translatable_objects, $this->cache );

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -43,11 +43,11 @@ class PLL_Nav_Menu {
 	 *
 	 * @since 1.7.7
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
+	public function __construct( PLL_Base &$polylang ) {
+		$this->model   = &$polylang->model;
+		$this->options = $polylang->options;
 
 		$this->theme = get_option( 'stylesheet' );
 

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -14,7 +14,7 @@ class PLL_Upgrade {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 
@@ -22,8 +22,9 @@ class PLL_Upgrade {
 	 * Constructor
 	 *
 	 * @since 1.2
+	 * @since 3.7 The `$options` parameter is an instance of `Options`.
 	 *
-	 * @param array $options Polylang options
+	 * @param Options $options Polylang options.
 	 */
 	public function __construct( &$options ) {
 		$this->options = &$options;

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -26,7 +26,7 @@ class PLL_Upgrade {
 	 *
 	 * @param Options $options Polylang options.
 	 */
-	public function __construct( &$options ) {
+	public function __construct( Options &$options ) {
 		$this->options = &$options;
 	}
 

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -26,8 +26,8 @@ class PLL_Upgrade {
 	 *
 	 * @param Options $options Polylang options.
 	 */
-	public function __construct( Options &$options ) {
-		$this->options = &$options;
+	public function __construct( Options $options ) {
+		$this->options = $options;
 	}
 
 	/**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Handles the core sitemaps for sites using a single domain.
  *
@@ -22,7 +24,7 @@ class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -33,12 +33,12 @@ class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	 *
 	 * @since 2.8
 	 *
-	 * @param object $polylang Main Polylang object.
+	 * @param PLL_Base $polylang Main Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Base &$polylang ) {
 		$this->links_model = &$polylang->links_model;
-		$this->model = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->model       = &$polylang->model;
+		$this->options     = $polylang->options;
 	}
 
 	/**

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -23,14 +23,14 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 	 *
 	 * @since 2.3
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Base &$polylang ) {
 		$this->meta_type = 'post';
 
 		parent::__construct( $polylang );
 
-		$this->options = &$polylang->options;
+		$this->options = $polylang->options;
 
 		add_filter( 'pll_translate_post_meta', array( $this, 'translate_thumbnail_id' ), 10, 3 );
 	}

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * A class to manage copy and synchronization of post metas.
  *
@@ -12,7 +14,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -29,11 +29,11 @@ class PLL_Sync_Tax {
 	 *
 	 * @since 2.3
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Base &$polylang ) {
 		$this->model   = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->options = $polylang->options;
 
 		add_action( 'set_object_terms', array( $this, 'set_object_terms' ), 10, 5 );
 		add_action( 'pll_save_term', array( $this, 'create_term' ), 10, 3 );

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * A class to manage the synchronization of taxonomy terms across posts translations
  *
@@ -13,7 +15,7 @@ class PLL_Sync_Tax {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Manages copy and synchronization of terms and post metas on front
  *
@@ -27,7 +29,7 @@ class PLL_Sync {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 
@@ -216,7 +218,7 @@ class PLL_Sync {
 			if ( $tr_id === $term_id ) {
 				continue;
 			}
-			
+
 			$tr_parent = $this->model->term->get_translation( $term->parent, $lang );
 			$tr_term   = get_term( (int) $tr_id, $taxonomy );
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -43,11 +43,11 @@ class PLL_Sync {
 	 *
 	 * @since 1.2
 	 *
-	 * @param object $polylang The Polylang object.
+	 * @param PLL_Base $polylang The Polylang object.
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Base &$polylang ) {
 		$this->model   = &$polylang->model;
-		$this->options = &$polylang->options;
+		$this->options = $polylang->options;
 
 		$this->taxonomies = new PLL_Sync_Tax( $polylang );
 		$this->post_metas = new PLL_Sync_Post_Metas( $polylang );

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -16,7 +16,7 @@ class PLL_Wizard {
 	/**
 	 * Reference to the model object
 	 *
-	 * @var PLL_Admin_Model
+	 * @var PLL_Model
 	 */
 	protected $model;
 

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -23,7 +23,7 @@ class PLL_Wizard {
 	/**
 	 * Reference to the Polylang options array.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	protected $options;
 

--- a/modules/wizard/wizard.php
+++ b/modules/wizard/wizard.php
@@ -61,11 +61,11 @@ class PLL_Wizard {
 	/**
 	 * Constructor
 	 *
-	 * @param object $polylang Reference to Polylang global object.
+	 * @param PLL_Admin_Base $polylang Reference to Polylang global object.
 	 * @since 2.7
 	 */
-	public function __construct( &$polylang ) {
-		$this->options = &$polylang->options;
+	public function __construct( PLL_Admin_Base &$polylang ) {
+		$this->options = $polylang->options;
 		$this->model   = &$polylang->model;
 
 		// Display Wizard page before any other action to ensure displaying it outside the WordPress admin context.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -366,11 +366,6 @@ parameters:
 			path: frontend/frontend.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$options\\.$#"
-			count: 1
-			path: include/crud-posts.php
-
-		-
 			message: "#^Cannot access offset 'term_id' on array\\{term_id\\: int, term_taxonomy_id\\: int\\|string\\}\\|WP_Error\\.$#"
 			count: 1
 			path: include/default-term.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,16 +35,6 @@ parameters:
 			count: 1
 			path: frontend/frontend.php
 
-		# Ignored temporarily to prevent changing the type of the options everywhere in the plugin.
-		-
-			message: "#^Cannot call method merge\\(\\) on array\\.$#"
-			count: 1
-			path: settings/settings-module.php
-
-		# Ignored temporarily to prevent changing the type of the options everywhere in the plugin.
-		-
-			message: "#^Property .+\\:\\:\\$options \\(array\\) does not accept WP_Syntex\\\\Polylang\\\\Options\\\\Options\\.$#"
-
 		# Ignored because PHPStan is confused about the objects and method names (classes with same method names).
 		-
 			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\): mixed, array\\{.+\\} given\\.$#"

--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -21,9 +21,9 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Admin_Base $polylang polylang object
+	 * @param PLL_Settings $polylang polylang object
 	 */
-	public function __construct( PLL_Admin_Base &$polylang ) {
+	public function __construct( PLL_Settings &$polylang ) {
 		// Needed for `$this->is_available()`, which is used before calling the parent's constructor.
 		$this->options = $polylang->options;
 

--- a/settings/settings-browser.php
+++ b/settings/settings-browser.php
@@ -21,11 +21,11 @@ class PLL_Settings_Browser extends PLL_Settings_Module {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $polylang polylang object
+	 * @param PLL_Admin_Base $polylang polylang object
 	 */
-	public function __construct( &$polylang ) {
+	public function __construct( PLL_Admin_Base &$polylang ) {
 		// Needed for `$this->is_available()`, which is used before calling the parent's constructor.
-		$this->options = &$polylang->options;
+		$this->options = $polylang->options;
 
 		parent::__construct(
 			$polylang,

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -100,8 +100,8 @@ class PLL_Settings_Module {
 	 *
 	 * @since 1.8
 	 *
-	 * @param object $polylang The Polylang object.
-	 * @param array  $args {
+	 * @param PLL_Admin_Base $polylang The Polylang object.
+	 * @param array          $args {
 	 *   @type string $module        Unique module name.
 	 *   @type string $title         The title of the settings module.
 	 *   @type string $description   The description of the settings module.
@@ -120,8 +120,8 @@ class PLL_Settings_Module {
 	 *   active_option?: non-falsy-string
 	 * } $args
 	 */
-	public function __construct( &$polylang, $args ) {
-		$this->options     = &$polylang->options;
+	public function __construct( PLL_Admin_Base &$polylang, $args ) {
+		$this->options     = $polylang->options;
 		$this->model       = &$polylang->model;
 		$this->links_model = &$polylang->links_model;
 

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Options\Options;
+
 /**
  * Base class for all settings
  *
@@ -12,7 +14,7 @@ class PLL_Settings_Module {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var array
+	 * @var Options
 	 */
 	public $options;
 

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -100,8 +100,8 @@ class PLL_Settings_Module {
 	 *
 	 * @since 1.8
 	 *
-	 * @param PLL_Admin_Base $polylang The Polylang object.
-	 * @param array          $args {
+	 * @param PLL_Settings $polylang The Polylang object.
+	 * @param array        $args {
 	 *   @type string $module        Unique module name.
 	 *   @type string $title         The title of the settings module.
 	 *   @type string $description   The description of the settings module.
@@ -120,7 +120,7 @@ class PLL_Settings_Module {
 	 *   active_option?: non-falsy-string
 	 * } $args
 	 */
-	public function __construct( PLL_Admin_Base &$polylang, $args ) {
+	public function __construct( PLL_Settings &$polylang, $args ) {
 		$this->options     = $polylang->options;
 		$this->model       = &$polylang->model;
 		$this->links_model = &$polylang->links_model;

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -11,12 +11,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.2
  */
 class PLL_Settings extends PLL_Admin_Base {
-
-	/**
-	 * @var PLL_Admin_Model
-	 */
-	public $model;
-
 	/**
 	 * Name of the active module.
 	 *

--- a/tests/features/bootstrap/BrowserPreferredLanguageContext.php
+++ b/tests/features/bootstrap/BrowserPreferredLanguageContext.php
@@ -87,7 +87,7 @@ class BrowserPreferredLanguageContext extends PLL_UnitTestCase implements Contex
 	public function polylang_will_remember( $language_code ) {
 		self::$model->clean_languages_cache();
 
-		$links_model = new PLL_Links_Model( self::$model );
+		$links_model = new PLL_Links_Default( self::$model );
 		$polylang    = new PLL_Frontend( $links_model );
 		$choose_lang = new PLL_Choose_Lang_Url( $polylang );
 

--- a/tests/features/bootstrap/BrowserPreferredLanguageContext.php
+++ b/tests/features/bootstrap/BrowserPreferredLanguageContext.php
@@ -87,8 +87,8 @@ class BrowserPreferredLanguageContext extends PLL_UnitTestCase implements Contex
 	public function polylang_will_remember( $language_code ) {
 		self::$model->clean_languages_cache();
 
-		$polylang = new stdClass();
-		$polylang->model = self::$model;
+		$links_model = new PLL_Links_Model( self::$model );
+		$polylang    = new PLL_Frontend( $links_model );
 		$choose_lang = new PLL_Choose_Lang_Url( $polylang );
 
 		$preferred_browser_language = $choose_lang->get_preferred_browser_language();


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2648.

This PR properly documents all the `$options` class properties as an instance of `Options` instead of an array.

This PR also removes all references like `$this->options = &$options;` and adds a lot of type-hints.