### PR TITLE
Allow multiple encodings for metas in `wpml-config.xml`

### DIFF
--- a/modules/wpml/wpml-config.php
+++ b/modules/wpml/wpml-config.php
@@ -1029,14 +1029,10 @@ class PLL_WPML_Config {
 					continue;
 				}
 
-				$data = array(
+				$this->parsed_metas[ $xpath ][ $name ] = array(
 					'action'   => $this->get_field_attribute( $custom_field, 'action' ),
 					'encoding' => $this->get_field_attribute( $custom_field, 'encoding' ),
 				);
-
-				$data['encoding'] = 'json' === $data['encoding'] ? 'json' : ''; // Only JSON is supported for now.
-
-				$this->parsed_metas[ $xpath ][ $name ] = $data;
 			}
 		}
 

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -8,6 +8,7 @@
 				<custom-field action="translate">custom-description</custom-field>
 				<custom-field action="ignore">date-added</custom-field>
 				<custom-field action="translate" encoding="json">a_json_meta</custom-field>
+				<custom-field action="translate" encoding="json, urlencode, base64">an_encoded_meta</custom-field>
 		</custom-fields>
 		<custom-fields-texts>
 			<key name="custom|nested">
@@ -22,6 +23,9 @@
 				</key>
 			</key>
 			<key name="a_json_meta">
+				<key name="to_translate" />
+			</key>
+			<key name="an_encoded_meta">
 				<key name="to_translate" />
 			</key>
 			<key name="custom-nested-2">

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -110,7 +110,8 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 
 	public function test_cf() {
 		wp_set_current_user( 1 ); // To pass current_user_can_synchronize() test.
-		$json = '{"to_translate":"Value 1","not_to_translate":"Value other"}';
+		$json    = '{"to_translate":"Value 1","not_to_translate":"Value other"}';
+		$encoded = base64_encode( rawurlencode( wp_json_encode( array( 'to_translate' => 'Encoded value to translate', 'not_to_translate' => 'Encoded value NOT to translate.' ) ) ) );
 
 		$pll_admin = new PLL_Admin( $this->links_model );
 		PLL_WPML_Config::instance()->init();
@@ -122,6 +123,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		add_post_meta( $from, 'bg-color', '#23282d' ); // `copy-once`
 		add_post_meta( $from, 'date-added', 2007 ); // `ignore`
 		add_post_meta( $from, 'a_json_meta', $json ); // `translate` + encoding.
+		add_post_meta( $from, 'an_encoded_meta', $encoded ); // `translate` + multi-encoding.
 
 		$fr = $to = self::factory()->post->create();
 		self::$model->post->set_language( $to, 'fr' );
@@ -130,7 +132,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		// Test encodings.
 		$encodings = apply_filters( 'pll_post_meta_encodings', array(), $from, $to );
 		$this->assertIsArray( $encodings );
-		$this->assertSame( array( 'a_json_meta' => 'json' ), $encodings );
+		$this->assertSame( array( 'a_json_meta' => 'json', 'an_encoded_meta' => 'json, urlencode, base64' ), $encodings );
 
 		// Copy.
 		$pll_admin->links = new PLL_Admin_Links( $pll_admin );
@@ -142,6 +144,7 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '#23282d', get_post_meta( $to, 'bg-color', true ) );
 		$this->assertEmpty( get_post_meta( $to, 'date-added', true ) );
 		$this->assertSame( $json, get_post_meta( $to, 'a_json_meta', true ) );
+		$this->assertSame( $encoded, get_post_meta( $to, 'an_encoded_meta', true ) );
 
 		// Sync.
 		update_post_meta( $to, 'quantity', 2 );
@@ -149,12 +152,14 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		update_post_meta( $to, 'bg-color', '#ffeedd' );
 		update_post_meta( $to, 'date-added', 2008 );
 		update_post_meta( $to, 'a_json_meta', $json ); // `translate` + encoding.
+		update_post_meta( $to, 'an_encoded_meta', $encoded ); // `translate` + multi-encoding.
 
 		$this->assertEquals( 2, get_post_meta( $from, 'quantity', true ) );
 		$this->assertEquals( 'title', get_post_meta( $from, 'custom-title', true ) );
 		$this->assertEquals( '#23282d', get_post_meta( $from, 'bg-color', true ) );
 		$this->assertEquals( 2007, get_post_meta( $from, 'date-added', true ) );
 		$this->assertSame( $json, get_post_meta( $from, 'a_json_meta', true ) );
+		$this->assertSame( $encoded, get_post_meta( $from, 'an_encoded_meta', true ) );
 
 		// Remove custom field and sync.
 		delete_post_meta( $to, 'quantity' );
@@ -162,12 +167,14 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		delete_post_meta( $to, 'bg-color' );
 		delete_post_meta( $to, 'date-added' );
 		delete_post_meta( $to, 'a_json_meta' );
+		delete_post_meta( $to, 'an_encoded_meta' );
 
 		$this->assertEmpty( get_post_meta( $from, 'quantity', true ) );
 		$this->assertEquals( 'title', get_post_meta( $from, 'custom-title', true ) );
 		$this->assertEquals( '#23282d', get_post_meta( $from, 'bg-color', true ) );
 		$this->assertEquals( 2007, get_post_meta( $from, 'date-added', true ) );
 		$this->assertSame( $json, get_post_meta( $from, 'a_json_meta', true ) );
+		$this->assertSame( $encoded, get_post_meta( $from, 'an_encoded_meta', true ) );
 	}
 
 	public function test_custom_term_field() {
@@ -236,6 +243,9 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 			),
 			'custom-description' => 1,
 			'a_json_meta'        => array(
+				'to_translate' => 1,
+			),
+			'an_encoded_meta'    => array(
 				'to_translate' => 1,
 			),
 		);


### PR DESCRIPTION
Follows https://github.com/polylang/polylang-pro/pull/2655.

This PR improves support of encodings of metas in `wpml-config.xml`. This allows to decode/encode in more formats (not limiting to JSON anymore) and multiple consecutive formats.