### PR TITLE
Increases Polylang comments_clauses filter priority

### DIFF
--- a/include/filters.php
+++ b/include/filters.php
@@ -57,7 +57,7 @@ class PLL_Filters {
 
 		// Filters the comments according to the current language
 		add_action( 'parse_comment_query', array( $this, 'parse_comment_query' ) );
-		add_filter( 'comments_clauses', array( $this, 'comments_clauses' ), 10, 2 );
+		add_filter( 'comments_clauses', array( $this, 'comments_clauses' ), 9, 2 );
 
 		// Filters the get_pages function according to the current language
 		if ( version_compare( $wp_version, '6.3-alpha', '<' ) ) {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-wc/issues/939

Due to this WooCommerce improvement https://github.com/woocommerce/woocommerce/pull/54984

## Why?

Until now the SQL alias `wp_posts_to_exclude_reviews` would be added only on `edit-comments` screen 
See https://github.com/woocommerce/woocommerce/blob/9.8.5/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php#L19-L22

Now, it seems, since the mentioned PR, this alias is also used in other contexts like product edit page.

## How?

Increases the Polylang `comments_clauses` filter priority to run it before the WooCommerce one. It makes useless to know `wp_posts_to_exclude_reviews` to add Polylang join.

An alternative could be:
- keep the `comments_clauses` filter priority as is
- check `wp_posts_to_exclude_reviews` alias already exists
- apply it to Polylang join by replacing this [line](https://github.com/polylang/polylang/blob/3.7.2/include/filters.php#L184) by something like this

```php
if ( ! strpos( $clauses['join'], 'AS wp_posts_to_exclude_reviews' ) ) {
	$clauses['join'] .= $this->model->post->join_clause();
} else {
	$clauses['join'] .= $this->model->post->join_clause( 'wp_posts_to_exclude_reviews' );
}
```



