### PR TITLE
Support encoding for block attributes in `wpml-config.xml`

### DIFF
--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -10,9 +10,7 @@ on:
       - '**.yml'
       - '**.sh'
   pull_request:
-    branches:
-      - master
-      - wpml-config-multi-encodings
+    branches: master
     paths:
       - '**.php'
       - 'phpunit.xml'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches: master
   pull_request:
-    branches:
-      - master
-      - wpml-config-multi-encodings
+    branches: master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches: master
   pull_request:
-    branches:
-      - master
-      - wpml-config-multi-encodings
+    branches: master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2612.

Requires #1679 and https://github.com/polylang/polylang-pro/pull/2660.

This PR allows to decode block attributes via the `wpml-config.xml` file.

How to:

```xml
<wpml-config>
	<gutenberg-blocks>
		<gutenberg-block type="my-plugin/my-block" translate="1">
			<key name="my-attribute" encoding="json">
				<key name="text" />
			</key>
		</gutenberg-block>
	</gutenberg-blocks>
</wpml-config>
```

> [!IMPORTANT]
> 1. The `encoding` attribute is supported only on the first level of `<key>` (like WPML).
> 2. The value of `json` means "a URL-encoded JSON": this is a specifity from WPML, while it should be `json,urlencode`. This is different from using the filter `pll_block_attribute_encodings` directly (in the filter we must use `json,urlencode` to get the same result).
> 3. All the other formats (`base64` etc) are not supported in this context.