### PR TITLE
Fix some regression in WPML API.

### DIFF
--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -187,7 +187,7 @@ if ( ! function_exists( 'icl_object_id' ) ) {
 		}
 
 		if ( empty( $ulanguage_code ) ) {
-			return null;
+			return $return_original_if_missing ? $element_id : null;
 		}
 
 		if ( 'nav_menu' === $element_type ) {
@@ -205,10 +205,6 @@ if ( ! function_exists( 'icl_object_id' ) ) {
 			$tr_id = PLL()->model->post->get_translation( $element_id, $ulanguage_code );
 		} elseif ( pll_is_translated_taxonomy( $element_type ) ) {
 			$tr_id = PLL()->model->term->get_translation( $element_id, $ulanguage_code );
-		}
-
-		if ( ! isset( $tr_id ) ) {
-			return $element_id; // WPML doesn't honor $return_original_if_missing if the post type or taxonomy is not translated.
 		}
 
 		if ( empty( $tr_id ) ) {
@@ -247,15 +243,20 @@ if ( ! function_exists( 'wpml_get_language_information' ) ) {
 	 *
 	 * @param null $empty   optional, not used
 	 * @param int  $post_id optional, post id, defaults to current post
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	function wpml_get_language_information( $empty = null, $post_id = null ) {
-		if ( empty( $post_id ) ) {
+		if ( is_null( $post_id ) ) {
 			$post_id = get_the_ID();
 		}
-
 		if ( empty( $post_id ) ) {
-			return array();
+			return new WP_Error( 'missing_id', __( 'Missing post ID', 'polylang' ) );
+		}
+
+		$post = get_post( $post_id );
+		if ( empty( $post ) ) {
+			// translators: Post id.
+			return new WP_Error( 'missing_post', sprintf( __( 'No such post for ID = %d', 'polylang' ), $post_id ) );
 		}
 
 		$lang = PLL()->model->post->get_language( $post_id );
@@ -392,10 +393,10 @@ if ( ! function_exists( 'icl_get_default_language' ) ) {
 	 *
 	 * @since 1.0.5
 	 *
-	 * @return string default language code
+	 * @return string|false default language code
 	 */
 	function icl_get_default_language() {
-		return (string) pll_default_language();
+		return pll_default_language();
 	}
 }
 
@@ -407,10 +408,10 @@ if ( ! function_exists( 'wpml_get_default_language' ) ) {
 	 *
 	 * @since 1.8.2
 	 *
-	 * @return string default language code
+	 * @return string|false default language code
 	 */
 	function wpml_get_default_language() {
-		return (string) pll_default_language();
+		return pll_default_language();
 	}
 }
 

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -209,7 +209,15 @@ if ( ! function_exists( 'icl_object_id' ) ) {
 			return $element_id; // WPML doesn't honor $return_original_if_missing if the post type or taxonomy is not translated, @see {SitePress::get_object_id()}.
 		}
 
-		return $return_original_if_missing && empty( $tr_id ) ? $element_id : (int) $tr_id;
+		if ( empty( $tr_id ) ) {
+			if ( $return_original_if_missing ) {
+				return $element_id;
+			}
+
+			return null;
+		}
+
+		return (int) $tr_id;
 	}
 }
 

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -205,13 +205,11 @@ if ( ! function_exists( 'icl_object_id' ) ) {
 			$tr_id = PLL()->model->post->get_translation( $element_id, $ulanguage_code );
 		} elseif ( pll_is_translated_taxonomy( $element_type ) ) {
 			$tr_id = PLL()->model->term->get_translation( $element_id, $ulanguage_code );
+		} else {
+			return $element_id; // WPML doesn't honor $return_original_if_missing if the post type or taxonomy is not translated, @see {SitePress::get_object_id()}.
 		}
 
-		if ( empty( $tr_id ) ) {
-			return $return_original_if_missing ? $element_id : null;
-		}
-
-		return (int) $tr_id;
+		return $return_original_if_missing && empty( $tr_id ) ? $element_id : (int) $tr_id;
 	}
 }
 

--- a/modules/wpml/wpml-legacy-api.php
+++ b/modules/wpml/wpml-legacy-api.php
@@ -252,7 +252,7 @@ if ( ! function_exists( 'wpml_get_language_information' ) ) {
 	 * @return array|WP_Error
 	 */
 	function wpml_get_language_information( $empty = null, $post_id = null ) {
-		if ( is_null( $post_id ) ) {
+		if ( null === $post_id ) {
 			$post_id = get_the_ID();
 		}
 		if ( empty( $post_id ) ) {

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -340,23 +340,12 @@ class WPML_Test extends PLL_UnitTestCase {
 			return;
 		}
 
-		$args = array(
-			'lang' => $lang,
+		$translated_posts = self::factory()->$object_kind->create_translated(
+			array_merge( $args, array( 'lang' => 'en' ) ),
+			array_merge( $args, array( 'lang' => $lang ) ),
 		);
-		if ( 'post' === $object_kind ) {
-			$args['post_type'] = $object_type;
-		} else {
-			$args['taxonomy'] = $object_type;
-		}
-		$translated_object_id = self::factory()->$object_kind->create( $args );
-		self::$model->$object_kind->save_translations(
-			$translated_object_id,
-			array(
-				'en'  => $object_id,
-				$lang => $translated_object_id,
-			)
-		);
-
+		$object_id            = $translated_posts['en'];
+		$translated_object_id = $translated_posts[ $lang ];
 		$expect_translated_id = ! empty( $lang ) && 'en' !== $lang;
 		$expect_id            = $expect_translated_id ? $translated_object_id : ( $return_original_if_missing ? $object_id : null );
 

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -280,8 +280,8 @@ class WPML_Test extends PLL_UnitTestCase {
 	 *           [ "term", "post_tag", "en", "de", false ]
 	 *           [ "term", "post_tag", "en", "chti", false ]
 	 *           [ "term", "post_tag", "en", "chti", true ]
-	 *           [ "post", "something", "en", "fr", true ]
-	 *           [ "post", "something", "en", "fr", false ]
+	 *           [ "post", "untranslated_cpt", "en", "fr", true ]
+	 *           [ "post", "untranslated_cpt", "en", "fr", false ]
 	 *
 	 * @param string $object_kind                The kind of object to test.
 	 * @param string $object_type                The type of object to test.
@@ -292,11 +292,11 @@ class WPML_Test extends PLL_UnitTestCase {
 	 * @return void
 	 */
 	public function test_wpml_object_id( $object_kind, $object_type, $curlang, $lang, $return_original_if_missing ) {
-		if ( 'something' === $object_type ) {
+		if ( 'untranslated_cpt' === $object_type ) {
 			if ( 'post' === $object_kind ) {
-				register_post_type( 'something' );
+				register_post_type( 'untranslated_cpt' );
 			} else {
-				register_taxonomy( 'something', 'post' );
+				register_taxonomy( 'untranslated_cpt', 'post' );
 			}
 		}
 
@@ -319,7 +319,7 @@ class WPML_Test extends PLL_UnitTestCase {
 			|| ( 'en' === $curlang && empty( $lang ) )
 			|| 'en' === $lang;
 
-		if ( 'something' === $object_type && ! $return_original_if_missing ) {
+		if ( 'untranslated_cpt' === $object_type && ! $return_original_if_missing ) {
 			// Special case for untranslatable object types, where WPML does'n honor `$return_original_if_missing` and always returns the original id.
 			$expect_original_id = true;
 		}
@@ -335,7 +335,7 @@ class WPML_Test extends PLL_UnitTestCase {
 			)
 		);
 
-		if ( ! self::$model->get_language( $lang ) || 'en' === $lang || 'something' === $object_type ) {
+		if ( ! self::$model->get_language( $lang ) || 'en' === $lang || 'untranslated_cpt' === $object_type ) {
 			// No tests needed with translated entities if no language is set, is the default one or if the object type is untranslatable.
 			return;
 		}

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -342,7 +342,7 @@ class WPML_Test extends PLL_UnitTestCase {
 
 		$translated_posts = self::factory()->$object_kind->create_translated(
 			array_merge( $args, array( 'lang' => 'en' ) ),
-			array_merge( $args, array( 'lang' => $lang ) ),
+			array_merge( $args, array( 'lang' => $lang ) )
 		);
 		$object_id            = $translated_posts['en'];
 		$translated_object_id = $translated_posts[ $lang ];

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -155,6 +155,19 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertFalse( $lang['different_language'] );
 	}
 
+	public function test_wpml_post_language_details_unhappy_path() {
+		$frontend = new PLL_Frontend( $this->links_model );
+		$GLOBALS['polylang'] = $frontend;
+
+		$result = apply_filters( 'wpml_post_language_details', null, PHP_INT_MAX );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'missing_post', $result->get_error_code() );
+
+		$result = apply_filters( 'wpml_post_language_details', null, null );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'missing_id', $result->get_error_code() );
+	}
+
 	public function test_wpml_language_code() {
 		$frontend = new PLL_Frontend( $this->links_model );
 		$GLOBALS['polylang'] = $frontend;

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -266,31 +266,6 @@ class WPML_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '<a href="http://example.org/fr/test-fr/">test fr</a>', ob_get_clean() );
 	}
 
-	public function test_wpml_object_id_with_curlang_always_set() {
-		$frontend = new PLL_Frontend( $this->links_model );
-		$GLOBALS['polylang'] = $frontend;
-
-		$frontend->curlang = self::$model->get_language( 'fr' );
-
-		$en = self::factory()->post->create( array( 'post_type' => 'page' ) );
-		self::$model->post->set_language( $en, 'en' );
-
-		$fr = self::factory()->post->create( array( 'post_type' => 'page' ) );
-		self::$model->post->set_language( $fr, 'fr' );
-
-		self::$model->post->save_translations( $en, compact( 'fr' ) );
-
-		$this->assertEquals( $fr, apply_filters( 'wpml_object_id', $fr, 'page' ) );
-		$this->assertEquals( $fr, apply_filters( 'wpml_object_id', $en, 'page' ) );
-		$this->assertEquals( $en, apply_filters( 'wpml_object_id', $fr, 'page', false, 'en' ) );
-
-		$cat = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
-		self::$model->term->set_language( $cat, 'en' );
-
-		$this->assertNull( apply_filters( 'wpml_object_id', $cat, 'category' ) );
-		$this->assertEquals( $cat, apply_filters( 'wpml_object_id', $cat, 'category', true ) );
-	}
-
 	/**
 	 * @testWith [ "post", "post", "en", "", true ]
 	 *           [ "post", "post", "en", "fr", true ]
@@ -301,6 +276,7 @@ class WPML_Test extends PLL_UnitTestCase {
 	 *           [ "term", "category", "en", "fr", false ]
 	 *           [ "term", "category", "en", "en", false ]
 	 *           [ "term", "category", "", "", false ]
+	 *           [ "term", "category", "en", "", true ]
 	 *           [ "term", "post_tag", "en", "de", false ]
 	 *           [ "term", "post_tag", "en", "chti", false ]
 	 *           [ "term", "post_tag", "en", "chti", true ]


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2661
Enhance WPML API facade.

## Why?
Some changes from https://github.com/polylang/polylang/pull/1559/ were introducing regressions regarding WPML API behavior.

## How?
- `icl_object_id()` does honors `$return_original_if_missing` if the taxonomy or post type is not translated as well as if no language has been found. See `SitePress::get_object_id()`.
- `wpml_get_language_information()` returns `WP_Error` when something goes wrong and check `$post_id` is `null` (and not just empty, which slightly changes the behavior).
- `wpml_get_default_language()` and `icl_get_default_language()` return `false` when no language is found. See `SitePress::get_default_language()`.