### PR TITLE
Improve `save_translations()` by requiring full array of translations when linking posts across languages.

### DIFF
--- a/include/translated-object.php
+++ b/include/translated-object.php
@@ -169,7 +169,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 			$this->delete_translation( $id );
 		}
 
-		// Check ID we need to create or update the translation group.
+		// Check if we need to create or update the translation group.
 		if ( ! $this->should_update_translation_group( $id, $translations ) ) {
 			return $translations;
 		}
@@ -184,10 +184,17 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 		} else {
 			// Take care not to overwrite extra data stored in the description field, if any.
 			$group = (int) $term->term_id;
-			$descr = maybe_unserialize( $term->description );
-			$descr = is_array( $descr ) ? array_diff_key( $descr, $old_translations ) : array(); // Remove old translations.
-			$descr = array_merge( $descr, $translations ); // Add new one.
-			wp_update_term( $group, $this->tax_translations, array( 'description' => maybe_serialize( $descr ) ) );
+			$existing_translations = maybe_unserialize( $term->description );
+			$existing_translations = is_array( $existing_translations ) ? $existing_translations : array();
+
+			// Find and unlink translations that are part of the old group but not the new one.
+			$removed_translations = array_diff_assoc( $existing_translations, $translations );
+			foreach ( $removed_translations as $id ) {
+				$this->delete_translation( $id );
+			}
+
+			// Update the term description with the new, correct set of translations.
+			wp_update_term( $group, $this->tax_translations, array( 'description' => maybe_serialize( $translations ) ) );
 		}
 
 		// Link all translations to the new term.


### PR DESCRIPTION
## What

This PR updates the `save_translations()` function to require the **full array of translations** when linking posts across languages. Partial translations array is no longer sufficient to maintain existing links.

## Why

This change makes the translation behavior more predictable and explicit.

## Fix

Previously, when creating or updating a post (see the example via the REST API), it was enough to pass only one existing translation in the `translations` parameter to link them together.

**Example (before):**
```php
post_en => 1 
post_fr => 2
```

```http
POST /wp/v2/posts?title=post_de&lang=de&translations[en]=1
```

This would successfully link the new German post to the English post with ID `1`, and preserve the existing translation structure (e.g., if the English post was already linked to a French one).

### Now:

To ensure all translations remain linked correctly, we **must provide the full set of translations** we want to be linked.

**Example (now):**

```http
POST /wp/v2/posts?title=post_de&lang=de&translations[en]=1&translations[fr]=2
```

This will link the new German post with both the English (`ID 1`) and French (`ID 2`).

If we omit existing translations, they will be unlinked.

**Bad example:**

```http
POST /wp/v2/posts?title=post de&lang=de&translations[en]=1
```

This will **only link** the new German post to the English one, and the French post (ID `2`) will be removed from the translation group.

## Notes

* This affects all endpoints using `save_translations()`.