### PR TITLE
Prevent warnings in `PLL_Canonical::get_queried_term_id()`.

### DIFF
--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -174,7 +174,7 @@ class PLL_Canonical {
 		$queried_terms = $tax_query->queried_terms;
 		$taxonomy = $this->get_queried_taxonomy( $tax_query );
 
-		if ( ! is_array( $queried_terms[ $taxonomy ]['terms'] ) ) {
+		if ( ! isset( $queried_terms[ $taxonomy ]['terms'] ) || ! is_array( $queried_terms[ $taxonomy ]['terms'] ) ) {
 			return 0;
 		}
 		$field = $queried_terms[ $taxonomy ]['field'];

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -177,6 +177,11 @@ class PLL_Canonical {
 		if ( ! isset( $queried_terms[ $taxonomy ]['terms'] ) || ! is_array( $queried_terms[ $taxonomy ]['terms'] ) ) {
 			return 0;
 		}
+
+		if ( ! isset( $queried_terms[ $taxonomy ]['field'] ) ) {
+			return 0;
+		}
+
 		$field = $queried_terms[ $taxonomy ]['field'];
 		$term  = reset( $queried_terms[ $taxonomy ]['terms'] );
 		$lang  = isset( $queried_terms['language']['terms'] ) ? reset( $queried_terms['language']['terms'] ) : '';


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/2673

## How?
- Check for `terms`.
- Took the opportunity to check for `field` key as well.