### PR TITLE
Prevent calling `PLL_Settings::handle_actions()` with empty action.

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -169,6 +169,7 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @param string $action The action name.
 	 * @return void
 	 *
+	 * @phpstan-param non-empty-string $action
 	 * @phpstan-return never
 	 */
 	public function handle_actions( string $action ): void {
@@ -294,7 +295,7 @@ class PLL_Settings extends PLL_Admin_Base {
 		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
-		} else {
+		} elseif ( ! empty( $action ) ) {
 			$this->handle_actions( $action );
 		}
 


### PR DESCRIPTION
## What?
Small bug made its way through https://github.com/polylang/polylang/pull/1696.
Settings pages are empty due to `PLL_Settings::handle_actions()` called with empty `$action` parameter in `PLL_Settings::langauges_page()`. This is triggering a redirection (with a PHP warning for already sent headers).

## How?
- Do not call `PLL_Settings::handle_actions()` in `PLL_Settings::langauges_page()` is no `$action` is set.
- Add some PHPStan doc to `PLL_Settings::handle_actions()` forcing non-empty-string type.