### PR TITLE
Updates DeepL supported languages.

### DIFF
--- a/settings/languages.php
+++ b/settings/languages.php
@@ -1269,7 +1269,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'cn',
 		'facebook' => 'zh_CN',
-		'deepl'    => 'ZH',
+		'deepl'    => 'ZH-HANS',
 	),
 	'zh_HK' => array(
 		'code'     => 'zh',
@@ -1278,7 +1278,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'hk',
 		'facebook' => 'zh_HK',
-		'deepl'    => 'ZH',
+		'deepl'    => 'ZH-HANT',
 	),
 	'zh_TW' => array(
 		'code'     => 'zh',
@@ -1287,6 +1287,6 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'tw',
 		'facebook' => 'zh_TW',
-		'deepl'    => 'ZH',
+		'deepl'    => 'ZH-HANT',
 	),
 );

--- a/settings/languages.php
+++ b/settings/languages.php
@@ -362,7 +362,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'ar',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_CL' => array(
 		'code'     => 'es',
@@ -371,7 +371,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'cl',
 		'facebook' => 'es_CL',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_CO' => array(
 		'code'     => 'es',
@@ -380,7 +380,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'co',
 		'facebook' => 'es_CO',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_CR' => array(
 		'code'     => 'es',
@@ -389,7 +389,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'cr',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_DO' => array(
 		'code'     => 'es',
@@ -398,7 +398,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'do',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_EC' => array(
 		'code'     => 'es',
@@ -407,7 +407,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'ec',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_ES' => array(
 		'code'     => 'es',
@@ -425,7 +425,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'gt',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_MX' => array(
 		'code'     => 'es',
@@ -434,7 +434,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'mx',
 		'facebook' => 'es_MX',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_PE' => array(
 		'code'     => 'es',
@@ -443,7 +443,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'pe',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_PR' => array(
 		'code'     => 'es',
@@ -452,7 +452,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'pr',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_UY' => array(
 		'code'     => 'es',
@@ -461,7 +461,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'uy',
 		'facebook' => 'es_LA',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'es_VE' => array(
 		'code'     => 'es',
@@ -470,7 +470,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 've',
 		'facebook' => 'es_VE',
-		'deepl'    => 'ES',
+		'deepl'    => 'ES-419',
 	),
 	'et' => array(
 		'code'     => 'et',

--- a/settings/languages.php
+++ b/settings/languages.php
@@ -619,6 +619,7 @@ return array(
 		'dir'      => 'rtl',
 		'flag'     => 'il',
 		'facebook' => 'he_IL',
+		'deepl'    => 'HE',
 	),
 	'hi_IN' => array(
 		'code'     => 'hi',
@@ -1176,6 +1177,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'th',
 		'facebook' => 'th_TH',
+		'deepl'    => 'TH',
 	),
 	'tl' => array(
 		'code'     => 'tl',
@@ -1255,6 +1257,7 @@ return array(
 		'dir'      => 'ltr',
 		'flag'     => 'vn',
 		'facebook' => 'vi_VN',
+		'deepl'    => 'VI',
 	),
 	'xho' => array(
 		'facebook' => 'xh_ZA',


### PR DESCRIPTION
**Updated Chinese locales:** DeepL now accurately differentiates between Simplified and Traditional Chinese by using `ZH-HANS` and `ZH-HANT` instead of the generic `ZH` locale code.

Also add  **Hebrew**, **Latin American Spanish**, **Thai** and **Vietnamese** even if they are only in the DeepL Pro API.

Ref: https://developers.deepl.com/docs/getting-started/supported-languages