### PR TITLE
Open language arguments management.

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -162,7 +162,7 @@ class Languages {
 	 * } $args
 	 */
 	public function add( $args ) {
-		$args['rtl']        = $args['rtl'] ?? $args['is_rtl'] ?? false;
+		$args['rtl']        = $args['rtl'] ?? $args['is_rtl'] ?? null;
 		$args['flag']       = $args['flag'] ?? $args['flag_code'] ?? null;
 		$args['term_group'] = $args['term_group'] ?? 0;
 

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -297,7 +297,7 @@ class Languages {
 		$args['flag']       = $args['flag'] ?? $args['flag_code'] ?? $lang->flag_code;
 		$args['term_group'] = $args['term_group'] ?? $lang->term_group;
 
-		$errors = $this->validate_lang( $args );
+		$errors = $this->validate_lang( $args, $lang );
 		if ( $errors->has_errors() ) {
 			return $errors;
 		}

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -757,6 +757,7 @@ class Languages {
 	 * @return array|false Array of language arguments or false if the locale is invalid.
 	 *
 	 * @phpstan-param array{locale: string, name?: string, slug?: string, is_rtl?: bool, flag_code?: string, term_group?: int, no_default_cat?: bool} $args
+	 * @phpstan-return array{locale: string, name: string, slug: string, rtl: bool, flag: string, term_group: int|numeric-string, no_default_cat: bool}
 	 */
 	public function get_language_args_from_locale( array $args ) {
 		if ( isset( $args['name'], $args['slug'], $args['is_rtl'], $args['flag_code'] ) ) {

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -871,6 +871,8 @@ class Languages {
 			// Create a new language.
 			if ( ! isset( $args['locale'] ) ) {
 				$errors->add( 'pll_missing_locale', __( 'Locale is required', 'polylang' ) );
+
+				return $errors;
 			} else {
 				$languages = include POLYLANG_DIR . '/settings/languages.php';
 				if ( ! empty( $languages[ $args['locale'] ] ) ) {

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -136,16 +136,16 @@ class Languages {
 	 * @param array $args {
 	 *   Arguments used to create the language.
 	 *
-	 *   @type string $name           Language name (used only for display).
-	 *   @type string $slug           Language code (ideally 2-letters ISO 639-1 language code).
 	 *   @type string $locale         WordPress locale. If something wrong is used for the locale, the .mo files will
 	 *                                not be loaded...
-	 *   @type bool   $rtl            True if rtl language, false otherwise.
-	 *   @type bool   $is_rtl         True if rtl language, false otherwise. Will be converted to rtl.
-	 *   @type int    $term_group     Language order when displayed.
+	 *   @type string $name           Optional. Language name (used only for display). Default to the language name from {@see settings/languages.php}.
+	 *   @type string $slug           Optional. Language code (ideally 2-letters ISO 639-1 language code). Default to the language code from {@see settings/languages.php}.
+	 *   @type bool   $rtl            Optional. True if rtl language, false otherwise. Default is false.
+	 *   @type bool   $is_rtl         Optional. True if rtl language, false otherwise. Will be converted to rtl. Default is false.
+	 *   @type int    $term_group     Optional. Language order when displayed. Default is 0.
 	 *   @type string $flag           Optional. Country code, {@see settings/flags.php}.
 	 *   @type string $flag_code      Optional. Country code, {@see settings/flags.php}. Will be converted to flag.
-	 *   @type bool   $no_default_cat Optional. If set, no default category will be created for this language.
+	 *   @type bool   $no_default_cat Optional. If set, no default category will be created for this language. Default is false.
 	 * }
 	 * @return true|WP_Error True success, a `WP_Error` otherwise.
 	 *
@@ -162,9 +162,9 @@ class Languages {
 	 * } $args
 	 */
 	public function add( $args ) {
-		if ( ! isset( $args['locale'] ) ) {
-			return new WP_Error( 'pll_missing_locale', __( 'Locale is required', 'polylang' ) );
-		}
+		$args['rtl']        = $args['rtl'] ?? $args['is_rtl'] ?? false;
+		$args['flag']       = $args['flag'] ?? $args['flag_code'] ?? null;
+		$args['term_group'] = $args['term_group'] ?? 0;
 
 		if ( ! empty( $args['locale'] ) && ( ! isset( $args['name'] ) || ! isset( $args['slug'] ) ) ) {
 			$languages = include POLYLANG_DIR . '/settings/languages.php';
@@ -176,10 +176,6 @@ class Languages {
 				$args['flag'] = $args['flag'] ?? $found['flag'];
 			}
 		}
-
-		$args['rtl']        = $args['rtl'] ?? $args['is_rtl'] ?? false;
-		$args['flag']       = $args['flag'] ?? $args['flag_code'] ?? '';
-		$args['term_group'] = $args['term_group'] ?? 0;
 
 		$errors = $this->validate_lang( $args );
 		if ( $errors->has_errors() ) {
@@ -259,13 +255,13 @@ class Languages {
 	 *   Arguments used to modify the language.
 	 *
 	 *   @type int    $lang_id    ID of the language to modify.
-	 *   @type string $name       Language name (used only for display).
-	 *   @type string $slug       Language code (ideally 2-letters ISO 639-1 language code).
-	 *   @type string $locale     WordPress locale. If something wrong is used for the locale, the .mo files will
+	 *   @type string $name       Optional. Language name (used only for display).
+	 *   @type string $slug       Optional. Language code (ideally 2-letters ISO 639-1 language code).
+	 *   @type string $locale     Optional. WordPress locale. If something wrong is used for the locale, the .mo files will
 	 *                            not be loaded...
-	 *   @type bool   $rtl        True if rtl language, false otherwise.
-	 *   @type bool   $is_rtl     True if rtl language, false otherwise. Will be converted to rtl.
-	 *   @type int    $term_group Language order when displayed.
+	 *   @type bool   $rtl        Optional. True if rtl language, false otherwise.
+	 *   @type bool   $is_rtl     Optional. True if rtl language, false otherwise. Will be converted to rtl.
+	 *   @type int    $term_group Optional. Language order when displayed.
 	 *   @type string $flag       Optional, country code, {@see settings/flags.php}.
 	 *   @type string $flag_code  Optional. Country code, {@see settings/flags.php}. Will be converted to flag.
 	 * }

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -757,7 +757,7 @@ class Languages {
 	 * @return array|false Array of language arguments or false if the locale is invalid.
 	 *
 	 * @phpstan-param array{locale: string, name?: string, slug?: string, is_rtl?: bool, flag_code?: string, term_group?: int, no_default_cat?: bool} $args
-	 * @phpstan-return array{locale: string, name: string, slug: string, rtl: bool, flag: string, term_group: int|numeric-string, no_default_cat: bool}
+	 * @phpstan-return array{locale: string, name: string, slug: string, rtl: bool, flag: string, term_group: int|numeric-string, no_default_cat: bool}|false
 	 */
 	public function get_language_args_from_locale( array $args ) {
 		if ( isset( $args['name'], $args['slug'], $args['is_rtl'], $args['flag_code'] ) ) {

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -747,6 +747,47 @@ class Languages {
 		}
 	}
 
+
+	/**
+	 * Returns the language arguments from the locale and additional arguments.
+	 *
+	 * @since 3.8
+	 *
+	 * @param array $args Arguments to create a language.
+	 * @return array|false Array of language arguments or false if the locale is invalid.
+	 *
+	 * @phpstan-param array{locale: string, name?: string, slug?: string, is_rtl?: bool, flag_code?: string, term_group?: int, no_default_cat?: bool} $args
+	 */
+	public function get_language_args_from_locale( array $args ) {
+		if ( isset( $args['name'], $args['slug'], $args['is_rtl'], $args['flag_code'] ) ) {
+			return array(
+				'locale'         => $args['locale'],
+				'name'           => $args['name'],
+				'slug'           => $args['slug'],
+				'rtl'            => $args['is_rtl'],
+				'flag'           => $args['flag_code'],
+				'term_group'     => $args['term_group'] ?? 0,
+				'no_default_cat' => $args['no_default_cat'] ?? false,
+			);
+		}
+
+		$languages = include POLYLANG_DIR . '/settings/languages.php';
+
+		if ( empty( $languages[ $args['locale'] ] ) ) {
+			return false;
+		}
+
+		return array(
+			'locale'         => $args['locale'],
+			'name'           => $args['name'] ?? $languages[ $args['locale'] ]['name'],
+			'slug'           => $args['slug'] ?? $languages[ $args['locale'] ]['code'],
+			'rtl'            => $args['is_rtl'] ?? 'rtl' === $languages[ $args['locale'] ]['dir'],
+			'flag'           => $args['flag_code'] ?? $languages[ $args['locale'] ]['flag'],
+			'term_group'     => $args['term_group'] ?? 0,
+			'no_default_cat' => $args['no_default_cat'] ?? false,
+		);
+	}
+
 	/**
 	 * Builds the language metas into an array and serializes it, to be stored in the term description.
 	 *

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -188,15 +188,6 @@ class Languages extends Abstract_Controller {
 			return $this->add_status_to_error( $result );
 		}
 
-		// Ensure locale exists before accessing it
-		if ( ! isset( $args['locale'] ) ) {
-			return new WP_Error(
-				'rest_missing_locale',
-				__( 'Locale is required', 'polylang' ),
-				array( 'status' => 400 )
-			);
-		}
-
 		/** @var PLL_Language */
 		$language = $this->languages->get( $args['locale'] );
 		return $this->prepare_item_for_response( $language, $request );

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -172,7 +172,7 @@ class Languages extends Abstract_Controller {
 
 		/**
 		 * @phpstan-var array{
-		 *    locale?: non-empty-string,
+		 *    locale: non-empty-string,
 		 *    slug?: non-empty-string,
 		 *    name?: non-empty-string,
 		 *    is_rtl?: bool,
@@ -461,7 +461,6 @@ class Languages extends Abstract_Controller {
 					'type'        => 'string',
 					'pattern'     => Languages_Model::LOCALE_PATTERN,
 					'context'     => array( 'view', 'edit' ),
-					'required'    => true,
 				),
 				'w3c'             => array(
 					'description' => __( 'W3C Locale for the language (for example: en-US).', 'polylang' ),
@@ -635,6 +634,7 @@ class Languages extends Abstract_Controller {
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 		$schema = $this->get_item_schema();
 		if ( WP_REST_Server::CREATABLE !== $method ) {
+			$schema['properties']['locale']['required'] = true;
 			unset( $schema['properties']['no_default_cat'] );
 		}
 		return rest_get_endpoint_args_for_schema( $schema, $method );

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -252,7 +252,7 @@ class Languages extends Abstract_Controller {
 		 * } $args
 		 */
 		$args            = $request->get_params();
-		$args['lang_id'] = $args['term_id'];
+		$args['lang_id'] = $language->term_id;
 		$update = $this->languages->update( $args );
 
 		if ( is_wp_error( $update ) ) {

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -680,7 +680,8 @@ class Languages extends Abstract_Controller {
 		}
 
 		// Create a language.
-		if ( empty( $request['locale'] ) ) {
+		$args = $request->get_params();
+		if ( empty( $args['locale'] ) ) {
 			// Should not happen.
 			return new WP_Error(
 				'rest_invalid_locale',
@@ -689,40 +690,17 @@ class Languages extends Abstract_Controller {
 			);
 		}
 
-		if ( isset( $request['name'], $request['slug'], $request['is_rtl'], $request['flag_code'] ) ) {
-			return (object) array(
-				'name'           => $request['name'],
-				'slug'           => $request['slug'],
-				'locale'         => $request['locale'],
-				'rtl'            => $request['is_rtl'],
-				'flag'           => $request['flag_code'],
-				'term_group'     => $request['term_group'] ?? 0,
-				'no_default_cat' => $request['no_default_cat'] ?? false,
-			);
-		}
+		$args = $this->languages->get_language_args_from_locale( $args );
 
-		// Create a language from our default list with only the locale.
-		$languages = include POLYLANG_DIR . '/settings/languages.php';
-
-		if ( empty( $languages[ $request['locale'] ] ) ) {
+		if ( false === $args ) {
 			return new WP_Error(
-				'pll_rest_invalid_locale',
+				'rest_invalid_locale',
 				__( 'The locale is invalid.', 'polylang' ),
 				array( 'status' => 400 )
 			);
 		}
 
-		$language = (object) $languages[ $request['locale'] ];
-
-		return (object) array(
-			'name'           => $request['name'] ?? $language->name,
-			'slug'           => $request['slug'] ?? $language->code,
-			'locale'         => $request['locale'],
-			'rtl'            => $request['is_rtl'] ?? 'rtl' === $language->dir,
-			'flag'           => $request['flag_code'] ?? $language->flag,
-			'term_group'     => $request['term_group'] ?? 0,
-			'no_default_cat' => $request['no_default_cat'] ?? false,
-		);
+		return (object) $args;
 	}
 
 	/**

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -189,7 +189,7 @@ class Languages extends Abstract_Controller {
 		}
 
 		/** @var PLL_Language */
-		$language = $this->languages->get( $args['locale'] ); // @phpstan-ignore-line $args['locale'] is set at this point.
+		$language = $this->languages->get( $args['locale'] );
 		return $this->prepare_item_for_response( $language, $request );
 	}
 

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -634,9 +634,11 @@ class Languages extends Abstract_Controller {
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 		$schema = $this->get_item_schema();
 		if ( WP_REST_Server::CREATABLE !== $method ) {
-			$schema['properties']['locale']['required'] = true;
 			unset( $schema['properties']['no_default_cat'] );
+		} else {
+			$schema['properties']['locale']['required'] = true;
 		}
+
 		return rest_get_endpoint_args_for_schema( $schema, $method );
 	}
 

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -188,6 +188,15 @@ class Languages extends Abstract_Controller {
 			return $this->add_status_to_error( $result );
 		}
 
+		// Ensure locale exists before accessing it
+		if ( ! isset( $args['locale'] ) ) {
+			return new WP_Error(
+				'rest_missing_locale',
+				__( 'Locale is required', 'polylang' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		/** @var PLL_Language */
 		$language = $this->languages->get( $args['locale'] );
 		return $this->prepare_item_for_response( $language, $request );

--- a/modules/REST/V1/Languages.php
+++ b/modules/REST/V1/Languages.php
@@ -641,51 +641,6 @@ class Languages extends Abstract_Controller {
 	}
 
 	/**
-	 * Prepares one language for create or update operation.
-	 *
-	 * @since 3.7
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return object|WP_Error The prepared language, or WP_Error object on failure.
-	 *
-	 * @phpstan-template T of array
-	 * @phpstan-param WP_REST_Request<T> $request
-	 */
-	protected function prepare_item_for_database( $request ) {
-		if ( isset( $request['term_id'] ) ) {
-			// Update a language.
-			$language = $this->get_language( $request );
-
-			if ( is_wp_error( $language ) ) {
-				return $language;
-			}
-
-			return (object) array(
-				'lang_id'    => $language->term_id,
-				'name'       => $request['name'] ?? $language->name,
-				'slug'       => $request['slug'] ?? $language->slug,
-				'locale'     => $request['locale'] ?? $language->locale,
-				'rtl'        => $request['is_rtl'] ?? (bool) $language->is_rtl,
-				'flag'       => $request['flag_code'] ?? $language->flag_code,
-				'term_group' => $request['term_group'] ?? $language->term_group,
-			);
-		}
-
-		// Create a language.
-		$args = $request->get_params();
-		if ( empty( $args['locale'] ) ) {
-			// Should not happen.
-			return new WP_Error(
-				'rest_invalid_locale',
-				__( 'The locale is invalid.', 'polylang' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return (object) $args;
-	}
-
-	/**
 	 * Tells if languages can be edited.
 	 *
 	 * @since 3.7

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -47,8 +47,3 @@ parameters:
 			count: 1
 			path: include/mo.php
 
-		# Ignored because the locale is always set at end of create_item() method.
-		-
-			message: "#^Offset 'locale' does not exist on array{locale\\?: non-empty-string, slug\\?: non-empty-string, name\\?: non-empty-string, is_rtl\\?: bool, term_group\\?: int, flag\\?: non-empty-string, no_default_cat\\?: bool}\\.$#"
-			count: 1
-			path: modules/REST/V1/Languages.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,3 +46,9 @@ parameters:
 			message: "#^Static property PLL_MO\\:\\:\\$cache \\(PLL_Cache\\<array\\>\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: include/mo.php
+
+		# Ignored because the locale is always set at end of create_item() method.
+		-
+			message: "#^Offset 'locale' does not exist on array{locale\\?: non-empty-string, slug\\?: non-empty-string, name\\?: non-empty-string, is_rtl\\?: bool, term_group\\?: int, flag\\?: non-empty-string, no_default_cat\\?: bool}\\.$#"
+			count: 1
+			path: modules/REST/V1/Languages.php

--- a/tests/phpunit/tests/Model/Languages/test-CRUD.php
+++ b/tests/phpunit/tests/Model/Languages/test-CRUD.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Model\Languages;
+
+use PLL_UnitTestCase;
+use WP_Syntex\Polylang\Model\Languages;
+use WP_Syntex\Polylang\Options\Options;
+use PLL_Translatable_Objects;
+use PLL_Cache;
+use PLL_Language;
+use WP_Error;
+
+class Test_CRUD extends PLL_UnitTestCase {
+
+	private $languages;
+
+	public function set_up() {
+		parent::set_up();
+
+		$options         = self::create_options();
+		$this->languages = new Languages(
+			$options,
+			new PLL_Translatable_Objects(),
+			new PLL_Cache()
+		);
+	}
+
+	public function test_create_language() {
+		$args = array(
+			'name'       => 'English',
+			'slug'       => 'en',
+			'locale'     => 'en_US',
+			'rtl'        => false,
+			'flag'       => 'us',
+			'term_group' => 1,
+		);
+
+		$result = $this->languages->add( $args );
+
+		$this->assertTrue( $result );
+
+		$language = $this->languages->get( 'en' );
+		$this->assertInstanceOf( PLL_Language::class, $language );
+		$this->assertSame( 'English', $language->name );
+		$this->assertSame( 'en', $language->slug );
+		$this->assertSame( 'en_US', $language->locale );
+		$this->assertSame( 0, $language->is_rtl );
+		$this->assertSame( 1, $language->term_group );
+		$this->assertSame( 'us', $language->flag_code );
+
+		$default = $this->languages->get_default();
+		$this->assertInstanceOf( PLL_Language::class, $default );
+		$this->assertSame( 'en', $default->slug );
+	}
+
+	public function test_create_language_with_minimal_args() {
+		$args = array(
+			'locale' => 'fr_FR',
+		);
+
+		$result = $this->languages->add( $args );
+
+		$this->assertTrue( $result );
+
+		$language = $this->languages->get( 'fr' );
+		$this->assertInstanceOf( PLL_Language::class, $language );
+		$this->assertSame( 'Français', $language->name );
+		$this->assertSame( 'fr', $language->slug );
+		$this->assertSame( 'fr_FR', $language->locale );
+		$this->assertSame( 0, $language->is_rtl );
+		$this->assertSame( 0, $language->term_group );
+	}
+
+	public function test_create_rtl_language() {
+		$args = array(
+			'name'       => 'العربية',
+			'slug'       => 'ar',
+			'locale'     => 'ar',
+			'rtl'        => true,
+			'flag'       => 'arab',
+			'term_group' => 2,
+		);
+
+		$result = $this->languages->add( $args );
+
+		$this->assertTrue( $result );
+
+		$language = $this->languages->get( 'ar' );
+		$this->assertInstanceOf( PLL_Language::class, $language );
+		$this->assertSame( 1, $language->is_rtl );
+	}
+
+	public function test_create_language_with_invalid_locale() {
+		$args = array(
+			'name'   => 'Invalid',
+			'slug'   => 'inv',
+			'locale' => 'invalid_locale',
+		);
+
+		$result = $this->languages->add( $args );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'pll_invalid_locale', $result->get_error_code() );
+	}
+
+	public function test_create_language_with_invalid_slug() {
+		$args = array(
+			'name'   => 'Invalid',
+			'slug'   => '123invalid',
+			'locale' => 'en_US',
+		);
+
+		$result = $this->languages->add( $args );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'pll_invalid_slug', $result->get_error_code() );
+	}
+
+	public function test_create_language_with_duplicate_slug() {
+		$args1 = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$this->languages->add( $args1 );
+
+		$args2 = array(
+			'name'   => 'French',
+			'slug'   => 'en',
+			'locale' => 'fr_FR',
+		);
+
+		$result = $this->languages->add( $args2 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'pll_non_unique_slug', $result->get_error_code() );
+	}
+
+	public function test_read_language_by_slug() {
+		$args = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$this->languages->add( $args );
+
+		$language = $this->languages->get( 'en' );
+
+		$this->assertInstanceOf( PLL_Language::class, $language );
+		$this->assertSame( 'en', $language->slug );
+	}
+
+	public function test_read_language_by_locale() {
+		$args = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$this->languages->add( $args );
+
+		$language = $this->languages->get( 'en_US' );
+
+		$this->assertInstanceOf( PLL_Language::class, $language );
+		$this->assertSame( 'en_US', $language->locale );
+	}
+
+	public function test_read_nonexistent_language() {
+		$language = $this->languages->get( 'nonexistent' );
+
+		$this->assertFalse( $language );
+	}
+
+	public function test_get_languages_list() {
+		$args1 = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$args2 = array(
+			'name'   => 'French',
+			'slug'   => 'fr',
+			'locale' => 'fr_FR',
+		);
+
+		$this->languages->add( $args1 );
+		$this->languages->add( $args2 );
+
+		$languages = $this->languages->get_list();
+
+		$this->assertIsArray( $languages );
+		$this->assertCount( 2, $languages );
+
+		$slugs = $this->languages->get_list( array( 'fields' => 'slug' ) );
+		$this->assertContains( 'en', $slugs );
+		$this->assertContains( 'fr', $slugs );
+	}
+
+	public function test_update_language() {
+		$args = array(
+			'name'       => 'English',
+			'slug'       => 'en',
+			'locale'     => 'en_US',
+			'rtl'        => false,
+			'term_group' => 1,
+		);
+		$this->languages->add( $args );
+		$language = $this->languages->get( 'en' );
+
+		$update_args = array(
+			'lang_id'    => $language->term_id,
+			'name'       => 'English Updated',
+			'slug'       => 'en_updated',
+			'locale'     => 'en_GB',
+			'rtl'        => false,
+			'term_group' => 2,
+		);
+
+		$result = $this->languages->update( $update_args );
+
+		$this->assertTrue( $result );
+
+		$updated_language = $this->languages->get( 'en_updated' );
+		$this->assertInstanceOf( PLL_Language::class, $updated_language );
+		$this->assertSame( 'English Updated', $updated_language->name );
+		$this->assertSame( 'en_updated', $updated_language->slug );
+		$this->assertSame( 'en_GB', $updated_language->locale );
+		$this->assertSame( 2, $updated_language->term_group );
+	}
+
+	public function test_update_language_with_same_slug() {
+		$args = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$this->languages->add( $args );
+		$language = $this->languages->get( 'en' );
+
+		$update_args = array(
+			'lang_id'    => $language->term_id,
+			'name'       => 'English Updated',
+			'slug'   => 'en',
+			'locale' => 'en_GB',
+		);
+
+		$result = $this->languages->update( $update_args );
+		$this->assertTrue( $result );
+	}
+
+	public function test_update_nonexistent_language() {
+		$update_args = array(
+			'lang_id' => 99999,
+			'name'    => 'Updated',
+		);
+
+		$result = $this->languages->update( $update_args );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'pll_invalid_language_id', $result->get_error_code() );
+	}
+
+	public function test_update_language_with_invalid_data() {
+		$args = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$this->languages->add( $args );
+		$language = $this->languages->get( 'en' );
+
+		$update_args = array(
+			'lang_id' => $language->term_id,
+			'locale'  => 'invalid_locale',
+		);
+
+		$result = $this->languages->update( $update_args );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'pll_invalid_locale', $result->get_error_code() );
+	}
+
+	public function test_delete_language() {
+		$args1 = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$args2 = array(
+			'name'   => 'French',
+			'slug'   => 'fr',
+			'locale' => 'fr_FR',
+		);
+
+		$this->languages->add( $args1 );
+		$this->languages->add( $args2 );
+
+		$languages = $this->languages->get_list();
+		$this->assertCount( 2, $languages );
+
+		$language = $this->languages->get( 'fr' );
+		$result = $this->languages->delete( $language->term_id );
+
+		$this->assertTrue( $result );
+
+		$deleted_language = $this->languages->get( 'fr' );
+		$this->assertFalse( $deleted_language );
+
+		$remaining_language = $this->languages->get( 'en' );
+		$this->assertInstanceOf( PLL_Language::class, $remaining_language );
+
+		$default = $this->languages->get_default();
+		$this->assertInstanceOf( PLL_Language::class, $default );
+		$this->assertSame( 'en', $default->slug );
+	}
+
+	public function test_delete_default_language() {
+		$args1 = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$args2 = array(
+			'name'   => 'French',
+			'slug'   => 'fr',
+			'locale' => 'fr_FR',
+		);
+
+		$this->languages->add( $args1 );
+		$this->languages->add( $args2 );
+
+		$default = $this->languages->get_default();
+		$this->assertSame( 'en', $default->slug );
+
+		$result = $this->languages->delete( $default->term_id );
+
+		$this->assertTrue( $result );
+
+		$new_default = $this->languages->get_default();
+		$this->assertInstanceOf( PLL_Language::class, $new_default );
+		$this->assertSame( 'fr', $new_default->slug );
+	}
+
+	public function test_delete_nonexistent_language() {
+		$result = $this->languages->delete( 666 );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_get_default_language() {
+		$default = $this->languages->get_default();
+		$this->assertFalse( $default );
+
+		$args = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$this->languages->add( $args );
+
+		$default = $this->languages->get_default();
+		$this->assertInstanceOf( PLL_Language::class, $default );
+		$this->assertSame( 'en', $default->slug );
+	}
+
+	public function test_update_default_language() {
+		$args1 = array(
+			'name'   => 'English',
+			'slug'   => 'en',
+			'locale' => 'en_US',
+		);
+		$args2 = array(
+			'name'   => 'French',
+			'slug'   => 'fr',
+			'locale' => 'fr_FR',
+		);
+
+		$this->languages->add( $args1 );
+		$this->languages->add( $args2 );
+
+		$default = $this->languages->get_default();
+		$this->assertSame( 'en', $default->slug );
+
+		$result = $this->languages->update_default( 'fr' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertFalse( $result->has_errors() );
+
+		$new_default = $this->languages->get_default();
+		$this->assertSame( 'fr', $new_default->slug );
+	}
+}

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -8,7 +8,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->pll_env = ( new PLL_Context_Settings() )->get();
 	}
 
-	public function test_add_and_delete_language() {
+	public function test_add_and_delete_language_have_consistent_behavior() {
 		// First language.
 		$args = array(
 			'name'       => 'English',
@@ -74,62 +74,6 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$lang = $this->pll_env->model->get_language( 'ar' );
 		$this->pll_env->model->delete_language( $lang->term_id );
 		$this->assertEquals( array(), $this->pll_env->model->get_languages_list() );
-	}
-
-	/**
-	 * Bug fixed in 2.3.
-	 */
-	public function test_unique_language_code_if_same_as_locale() {
-		// First language.
-		$args = array(
-			'name'       => 'العربية',
-			'slug'       => 'a', // Intentional mistake.
-			'locale'     => 'ar',
-			'rtl'        => 1,
-			'flag'       => 'arab',
-			'term_group' => 1,
-		);
-
-		$this->assertTrue( $this->pll_env->model->add_language( $args ) );
-
-		$lang = $this->pll_env->model->get_language( 'ar' );
-		$args['lang_id'] = $lang->term_id;
-		$args['slug'] = 'ar';
-		$this->assertTrue( $this->pll_env->model->update_language( $args ) );
-
-		$this->pll_env->model->delete_language( $lang->term_id );
-	}
-
-	public function test_invalid_languages() {
-		$args = array(
-			'name'       => '',
-			'slug'       => 'en',
-			'locale'     => 'en_US',
-			'rtl'        => 0,
-			'flag'       => 'us',
-			'term_group' => 1,
-		);
-
-		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'The language must have a name' );
-
-		$args['name'] = 'English';
-		$args['locale'] = 'EN';
-
-		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'Enter a valid WordPress locale' );
-
-		$args['locale'] = 'en-US';
-
-		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'Enter a valid WordPress locale' );
-
-		$args['locale'] = 'en_US';
-		$args['slug'] = 'EN';
-
-		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'The language code contains invalid characters' );
-
-		$args['slug'] = 'en';
-		$args['flag'] = 'en';
-
-		$this->assertWPError( $this->pll_env->model->add_language( $args ), 'The flag does not exist' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-create-delete-languages.php
+++ b/tests/phpunit/tests/test-create-delete-languages.php
@@ -59,7 +59,7 @@ class Create_Delete_Languages_Test extends PLL_UnitTestCase {
 		$this->assertEqualSetsWithIndex( array( 'ar', 'en' ), $this->pll_env->model->get_languages_list( array( 'fields' => 'slug' ) ) );
 
 		// Attempt to create a language with the same slug as an existing one.
-		$this->pll_env->model->add_language( array( 'slug' => 'en-gb', 'locale' => 'en_GB' ) );
+		$this->pll_env->model->add_language( array( 'slug' => 'en', 'locale' => 'en_GB' ) );
 		$lang = $this->pll_env->model->get_language( 'en' );
 		$this->assertEquals( 'en_US', $lang->locale );
 		$this->assertFalse( $this->pll_env->model->get_language( 'en_GB' ) );


### PR DESCRIPTION
## What?
Make language arguments management reusable.
Motivated by https://github.com/polylang/polylang-pro/pull/2653#discussion_r2251762193

## How?
- Create `Languages::get_language_args_from_locale()` with code mostly from `Languages` REST controller.
- Use it in `Languages` REST controller.
- Add proper PHPUnit test for `Model\Languges` CRUD.