### PR TITLE
Fix fatal error in updater.

### DIFF
--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -398,13 +398,14 @@ class PLL_Plugin_Updater {
 		if ( empty( $edd_api_request_transient ) ) {
 
 			$api_response = $this->api_request( 'plugin_information', $to_send );
+			if ( empty( $api_response ) ) {
+				return $_data;
+			}
 
 			// Expires in 3 hours
 			$this->set_version_info_cache( $api_response );
 
-			if ( false !== $api_response ) {
-				$_data = $api_response;
-			}
+			$_data = $api_response;
 		} else {
 			$_data = $edd_api_request_transient;
 		}

--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -410,10 +410,6 @@ class PLL_Plugin_Updater {
 			$_data = $edd_api_request_transient;
 		}
 
-		if ( empty( $_data ) ) {
-			return $_data;
-		}
-
 		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
 			$_data->sections = $this->convert_object_to_array( $_data->sections );

--- a/install/plugin-updater.php
+++ b/install/plugin-updater.php
@@ -409,6 +409,10 @@ class PLL_Plugin_Updater {
 			$_data = $edd_api_request_transient;
 		}
 
+		if ( empty( $_data ) ) {
+			return $_data;
+		}
+
 		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
 			$_data->sections = $this->convert_object_to_array( $_data->sections );


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2709.

## Why

The bug happens in the following execution flow:

1. **API Request Fails:** When `get_version_from_remote()` encounters an HTTP error (like 401), it returns `false`
2. In `plugins_api_filter()`, the condition `if ( false !== $api_response )` evaluates to false, so `$_data` retains its initial value of `false` come from applying `plugins_api` by WordPress https://github.com/WordPress/wordpress-develop/blob/6.8.2/src/wp-admin/includes/plugin-install.php#L145

> [!NOTE]
> Triggered when clicking on the link `View version x.y.z details` link on the plugins list page in the notice which warns that the plugin has a new version. Also requires that the transient `edd_sl....` doesn't exist or has been expired. It explains why the issue couldn't be reproduced.

<img width="1092" height="693" alt="image" src="https://github.com/user-attachments/assets/4ed9e920-ec5e-4e90-987a-71f69a043bae" />

3.  Later in the code, we attempt to assign properties to `$_data` which is still `false`:
   ```php
   if ( ! isset( $_data->plugin ) ) {
       $_data->plugin = $this->name; // ← Fatal error: $_data is false
   }
   ```

## Fix

Add a safety check to ensure `$_data` contains valid data before attempting property assignments:

### Also

Should we check `$api_response` before:
```php
$api_response = $this->api_request( 'plugin_information', $to_send );

// Expires in 3 hours
$this->set_version_info_cache( $api_response );
```
Because we'll set a empty string in the cache if `$api_response` is set to `false` ?

~~Moreover, should I also do the same PR for the [updater](https://github.com/polylang/updater/blob/main/src/EDD_SL_Plugin_Updater.php#L378) ?~~ (I'll wait for this one to be merged)