### PR TITLE
Improve error management for in `Model\Languages`.

### DIFF
--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -204,13 +204,13 @@ class Languages {
 		);
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the detailed error message */
-			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language.', 'polylang' ) ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
+			return new WP_Error( 'pll_add_language', __( 'Could not add the language.', 'polylang' ) ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the detailed error message */
-			return new WP_Error( 'pll_add_language', __( 'Impossible to set the language order.', 'polylang' ) );
+			return new WP_Error( 'pll_add_language', __( 'Could not set the language order.', 'polylang' ) );
 		}
 
 		// The other language taxonomies.
@@ -338,8 +338,7 @@ class Languages {
 			)
 		);
 		if ( is_wp_error( $result ) ) {
-			/* translators: %s is the error message from the database */
-			return new WP_Error( 'pll_update_language', __( 'Impossible to update the language, error: %s.', 'polylang' ), $result->get_error_message() );
+			return new WP_Error( 'pll_update_language', __( 'Could not update the language.', 'polylang' ) );
 		}
 
 		if ( $old_slug !== $slug ) {
@@ -1025,7 +1024,6 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				/* translators: %s is the error message from the database */
 				$errors->add( 'pll_delete_relationships', __( 'Could not delete relationships.', 'polylang' ) );
 			}
 		}
@@ -1042,7 +1040,6 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				/* translators: %s is the error message from the database */
 				$errors->add( 'pll_delete_terms', __( 'Could not delete translation groups.', 'polylang' ) );
 			}
 
@@ -1056,7 +1053,6 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				/* translators: %s is the error message from the database */
 				$errors->add( 'pll_delete_term_taxonomy', __( 'Could not delete translation groups.', 'polylang' ) );
 			}
 		}
@@ -1074,7 +1070,6 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				/* translators: %s is the error message from the database */
 				$errors->add( 'pll_update_term_taxonomy', __( 'Could not update translation groups.', 'polylang' ), $wpdb->last_error );
 			}
 		}
@@ -1128,7 +1123,7 @@ class Languages {
 					$errors->add(
 						'pll_add_secondary_language_terms',
 						/* translators: %s is a taxonomy name */
-						sprintf( __( 'Could not add secondary %s language taxonomy term.', 'polylang' ), $object->get_tax_language() )
+						sprintf( __( 'Could not add secondary language term for taxonomy %s.', 'polylang' ), $object->get_tax_language() )
 					);
 				}
 				continue;
@@ -1142,7 +1137,7 @@ class Languages {
 					$errors->add(
 						'pll_update_secondary_language_terms',
 						/* translators: %s is a taxonomy name */
-						sprintf( __( 'Could not update secondary %s language taxonomy term.', 'polylang' ), $object->get_tax_language() )
+						sprintf( __( 'Could not update secondary language term for taxonomy %s.', 'polylang' ), $object->get_tax_language() )
 					);
 				}
 			}

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -203,13 +203,13 @@ class Languages {
 			)
 		);
 		if ( is_wp_error( $result ) ) {
-			/* translators: %s is the error message from the database */
+			/* translators: %s is the detailed error message */
 			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language, database error: %s.', 'polylang' ), $result->get_error_message() ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
 		if ( is_wp_error( $result ) ) {
-			/* translators: %s is the error message from the database */
+			/* translators: %s is the detailed error message */
 			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group, database error: %s.', 'polylang' ), $result->get_error_message() );
 		}
 

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -339,7 +339,7 @@ class Languages {
 		);
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the error message from the database */
-			return new WP_Error( 'pll_update_language', __( 'Impossible to update the language, database error: %s.', 'polylang' ), $result->get_error_message() );
+			return new WP_Error( 'pll_update_language', __( 'Impossible to update the language, error: %s.', 'polylang' ), $result->get_error_message() );
 		}
 
 		if ( $old_slug !== $slug ) {

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -204,13 +204,13 @@ class Languages {
 		);
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the detailed error message */
-			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language, error: %s.', 'polylang' ), $result->get_error_message() ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
+			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language.', 'polylang' ) ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the detailed error message */
-			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group, error: %s.', 'polylang' ), $result->get_error_message() );
+			return new WP_Error( 'pll_add_language', __( 'Impossible to set the language order.', 'polylang' ) );
 		}
 
 		// The other language taxonomies.
@@ -1026,7 +1026,7 @@ class Languages {
 			);
 			if ( false === $result ) {
 				/* translators: %s is the error message from the database */
-				$errors->add( 'pll_delete_relationships', __( 'Impossible to delete the relationships, database error: %s.', 'polylang' ), $wpdb->last_error );
+				$errors->add( 'pll_delete_relationships', __( 'Could not delete relationships.', 'polylang' ) );
 			}
 		}
 
@@ -1043,7 +1043,7 @@ class Languages {
 			);
 			if ( false === $result ) {
 				/* translators: %s is the error message from the database */
-				$errors->add( 'pll_delete_terms', __( 'Impossible to delete the terms, database error: %s.', 'polylang' ), $wpdb->last_error );
+				$errors->add( 'pll_delete_terms', __( 'Could not delete translation groups.', 'polylang' ) );
 			}
 
 			$result = $wpdb->query(
@@ -1057,7 +1057,7 @@ class Languages {
 			);
 			if ( false === $result ) {
 				/* translators: %s is the error message from the database */
-				$errors->add( 'pll_delete_term_taxonomy', __( 'Impossible to delete the term taxonomy, database error: %s.', 'polylang' ), $wpdb->last_error );
+				$errors->add( 'pll_delete_term_taxonomy', __( 'Could not delete translation groups.', 'polylang' ) );
 			}
 		}
 
@@ -1075,7 +1075,7 @@ class Languages {
 			);
 			if ( false === $result ) {
 				/* translators: %s is the error message from the database */
-				$errors->add( 'pll_update_term_taxonomy', __( 'Impossible to update the term taxonomy, database error: %s.', 'polylang' ), $wpdb->last_error );
+				$errors->add( 'pll_update_term_taxonomy', __( 'Could not update translation groups.', 'polylang' ), $wpdb->last_error );
 			}
 		}
 
@@ -1125,7 +1125,11 @@ class Languages {
 				// Attempt to repair the language if a term has been deleted by a database cleaning tool.
 				$result = wp_insert_term( $name, $object->get_tax_language(), array( 'slug' => $slug ) );
 				if ( is_wp_error( $result ) ) {
-					$errors->add( 'pll_add_secondary_language_terms', $result->get_error_message() );
+					$errors->add(
+						'pll_add_secondary_language_terms',
+						/* translators: %s is a taxonomy name */
+						sprintf( __( 'Could not add secondary %s language taxonomy term.', 'polylang' ), $object->get_tax_language() )
+					);
 				}
 				continue;
 			}
@@ -1135,7 +1139,11 @@ class Languages {
 				// Something has changed.
 				$result = wp_update_term( $term_id, $object->get_tax_language(), array( 'slug' => $slug, 'name' => $name ) );
 				if ( is_wp_error( $result ) ) {
-					$errors->add( 'pll_update_secondary_language_terms', $result->get_error_message() );
+					$errors->add(
+						'pll_update_secondary_language_terms',
+						/* translators: %s is a taxonomy name */
+						sprintf( __( 'Could not update secondary %s lanuage taxonomy term.', 'polylang' ), $object->get_tax_language() )
+					);
 				}
 			}
 		}

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -194,7 +194,7 @@ class Languages {
 		 * } $args
 		 */
 		// First the language taxonomy.
-		$r = wp_insert_term(
+		$result = wp_insert_term(
 			$args['name'],
 			'language',
 			array(
@@ -202,11 +202,15 @@ class Languages {
 				'description' => $this->build_metas( $args ),
 			)
 		);
-		if ( is_wp_error( $r ) ) {
+		if ( is_wp_error( $result ) ) {
 			// Avoid an ugly fatal error if something went wrong (reported once in the forum).
 			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language.', 'polylang' ) );
 		}
-		wp_update_term( (int) $r['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
+
+		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group.', 'polylang' ) );
+		}
 
 		// The other language taxonomies.
 		$this->update_secondary_language_terms( $args['slug'], $args['name'] );
@@ -316,7 +320,7 @@ class Languages {
 		// Update the language itself.
 		$this->update_secondary_language_terms( $args['slug'], $args['name'], $lang );
 
-		wp_update_term(
+		$result = wp_update_term(
 			$lang->get_tax_prop( 'language', 'term_id' ),
 			'language',
 			array(
@@ -326,6 +330,9 @@ class Languages {
 				'term_group'  => (int) $args['term_group'],
 			)
 		);
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error( 'pll_update_language', __( 'Impossible to update the language.', 'polylang' ) );
+		}
 
 		if ( $old_slug !== $slug ) {
 			// Update the language slug in translations.

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -203,13 +203,14 @@ class Languages {
 			)
 		);
 		if ( is_wp_error( $result ) ) {
-			// Avoid an ugly fatal error if something went wrong (reported once in the forum).
-			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language.', 'polylang' ) );
+			/* translators: %s is the error message from the database */
+			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language, database error: %s.', 'polylang' ), $result->get_error_message() ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group.', 'polylang' ) );
+			/* translators: %s is the error message from the database */
+			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group, database error: %s.', 'polylang' ), $result->get_error_message() );
 		}
 
 		// The other language taxonomies.

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -1142,7 +1142,7 @@ class Languages {
 					$errors->add(
 						'pll_update_secondary_language_terms',
 						/* translators: %s is a taxonomy name */
-						sprintf( __( 'Could not update secondary %s lanuage taxonomy term.', 'polylang' ), $object->get_tax_language() )
+						sprintf( __( 'Could not update secondary %s language taxonomy term.', 'polylang' ), $object->get_tax_language() )
 					);
 				}
 			}

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -203,7 +203,7 @@ class Languages {
 			)
 		);
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'pll_add_language', __( 'Could not add the language.', 'polylang' ) ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
+			return new WP_Error( 'pll_add_language', __( 'Could not add the language.', 'polylang' ) );
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -204,13 +204,13 @@ class Languages {
 		);
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the detailed error message */
-			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language, database error: %s.', 'polylang' ), $result->get_error_message() ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
+			return new WP_Error( 'pll_add_language', __( 'Impossible to add the language, error: %s.', 'polylang' ), $result->get_error_message() ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
 		if ( is_wp_error( $result ) ) {
 			/* translators: %s is the detailed error message */
-			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group, database error: %s.', 'polylang' ), $result->get_error_message() );
+			return new WP_Error( 'pll_add_language', __( 'Impossible to set the term group, error: %s.', 'polylang' ), $result->get_error_message() );
 		}
 
 		// The other language taxonomies.

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -946,6 +946,8 @@ class Languages {
 	 * @since 3.7 Moved from `PLL_Admin_Model::update_translations()` to `WP_Syntex\Polylang\Model\Languages::update_translations()`.
 	 *            Visibility changed from public to protected.
 	 *
+	 * @global $wpdb wpdb global instance.
+	 *
 	 * @param string $old_slug The old language slug.
 	 * @param string $new_slug Optional, the new language slug, if not set it means that the language has been deleted.
 	 * @return WP_Error
@@ -1021,7 +1023,8 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				$errors->add( 'pll_delete_relationships', __( 'Impossible to delete the relationships.', 'polylang' ) );
+				/* translators: %s is the error message from the database */
+				$errors->add( 'pll_delete_relationships', __( 'Impossible to delete the relationships, database error: %s.', 'polylang' ), $wpdb->last_error );
 			}
 		}
 
@@ -1037,7 +1040,8 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				$errors->add( 'pll_delete_terms', __( 'Impossible to delete the terms.', 'polylang' ) );
+				/* translators: %s is the error message from the database */
+				$errors->add( 'pll_delete_terms', __( 'Impossible to delete the terms, database error: %s.', 'polylang' ), $wpdb->last_error );
 			}
 
 			$result = $wpdb->query(
@@ -1050,7 +1054,8 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				$errors->add( 'pll_delete_term_taxonomy', __( 'Impossible to delete the term taxonomy.', 'polylang' ) );
+				/* translators: %s is the error message from the database */
+				$errors->add( 'pll_delete_term_taxonomy', __( 'Impossible to delete the term taxonomy, database error: %s.', 'polylang' ), $wpdb->last_error );
 			}
 		}
 
@@ -1067,7 +1072,8 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				$errors->add( 'pll_update_term_taxonomy', __( 'Impossible to update the term taxonomy.', 'polylang' ) );
+				/* translators: %s is the error message from the database */
+				$errors->add( 'pll_update_term_taxonomy', __( 'Impossible to update the term taxonomy, database error: %s.', 'polylang' ), $wpdb->last_error );
 			}
 		}
 

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -203,13 +203,11 @@ class Languages {
 			)
 		);
 		if ( is_wp_error( $result ) ) {
-			/* translators: %s is the detailed error message */
 			return new WP_Error( 'pll_add_language', __( 'Could not add the language.', 'polylang' ) ); // Avoid an ugly fatal error if something went wrong (reported once in the forum).
 		}
 
 		$result = wp_update_term( (int) $result['term_id'], 'language', array( 'term_group' => (int) $args['term_group'] ) ); // Can't set the term group directly in `wp_insert_term()`.
 		if ( is_wp_error( $result ) ) {
-			/* translators: %s is the detailed error message */
 			return new WP_Error( 'pll_add_language', __( 'Could not set the language order.', 'polylang' ) );
 		}
 
@@ -1070,7 +1068,7 @@ class Languages {
 				)
 			);
 			if ( false === $result ) {
-				$errors->add( 'pll_update_term_taxonomy', __( 'Could not update translation groups.', 'polylang' ), $wpdb->last_error );
+				$errors->add( 'pll_update_term_taxonomy', __( 'Could not update translation groups.', 'polylang' ) );
 			}
 		}
 

--- a/include/Model/Languages.php
+++ b/include/Model/Languages.php
@@ -338,7 +338,8 @@ class Languages {
 			)
 		);
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'pll_update_language', __( 'Impossible to update the language.', 'polylang' ) );
+			/* translators: %s is the error message from the database */
+			return new WP_Error( 'pll_update_language', __( 'Impossible to update the language, database error: %s.', 'polylang' ), $result->get_error_message() );
 		}
 
 		if ( $old_slug !== $slug ) {


### PR DESCRIPTION
## What?
Improve `Model\Languages::add()` and `Model\Languages::update()` API.
Prop @Chouby in Slack: https://wpsyntex.slack.com/archives/C017SSTK4KY/p1756457865061609

## Why?
Low-level errors (from `wp_inster_term()` or `wp_update_term()` for instance) are not managed properly.

## How?
- Make errors from `wp_inster_term()` and `wp_update_term()` bubble in `Model\Languages::add()` and `Model\Languages::update()`.
- Improve `Model\Languages::update_secondary_language_terms()` and `Model\Languages::update_translations()` so they both return `WP_Error` as well and thus benefiting `Model\Languages::add()` and `Model\Languages::update()`.