### PR TITLE
Create a GitHub workflow to add "needs triage" label to new issues.

### DIFF
--- a/.github/workflows/new-issue-workflow.yml
+++ b/.github/workflows/new-issue-workflow.yml
@@ -1,0 +1,19 @@
+name: Add issue labels.
+
+on:
+    issues:
+        types:
+            - opened
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: needs triage


### PR DESCRIPTION
## What?
All in the title.