### PR TITLE
Feat: Add custom filter for Admin columns visibility

### DIFF
--- a/admin/admin-filters-columns.php
+++ b/admin/admin-filters-columns.php
@@ -42,12 +42,25 @@ class PLL_Admin_Filters_Columns {
 		// Hide the column of the filtered language.
 		add_filter( 'hidden_columns', array( $this, 'hidden_columns' ) ); // Since WP 4.4.
 
-		// Add the language and translations columns in 'All Posts', 'All Pages' and 'Media library' panels.
-		foreach ( $this->model->get_translated_post_types() as $type ) {
-			// Use the latest filter late as some plugins purely overwrite what's done by others :(
-			// Specific case for media.
-			add_filter( 'manage_' . ( 'attachment' == $type ? 'upload' : 'edit-' . $type ) . '_columns', array( $this, 'add_post_column' ), 100 );
-			add_action( 'manage_' . ( 'attachment' == $type ? 'media' : $type . '_posts' ) . '_custom_column', array( $this, 'post_column' ), 10, 2 );
+		/**
+		 * Filters the admin columns, decides if they
+		 * should be visible or not. Useful for admin pages with
+		 * lots of language translations.
+		 *
+		 * @since TBD
+		 *
+		 * @param boolean $visibility True or false.
+		 */
+		$is_admin_columns_visible = (bool) apply_filters( 'pll_admin_columns_visibility', true );
+
+		if ( $is_admin_columns_visible ) {
+			// Add the language and translations columns in 'All Posts', 'All Pages' and 'Media library' panels.
+			foreach ( $this->model->get_translated_post_types() as $type ) {
+				// Use the latest filter late as some plugins purely overwrite what's done by others :(
+				// Specific case for media.
+				add_filter( 'manage_' . ( 'attachment' == $type ? 'upload' : 'edit-' . $type ) . '_columns', array( $this, 'add_post_column' ), 100 );
+				add_action( 'manage_' . ( 'attachment' == $type ? 'media' : $type . '_posts' ) . '_custom_column', array( $this, 'post_column' ), 10, 2 );
+			}
 		}
 
 		// Quick edit and bulk edit.

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,10 @@ Wherever third party code has been used, credit has been given in the code’s c
 
 == Changelog ==
 
+= TBD =
+
+* Add: filter `pll_admin_columns_visibility` to show/hide language translations on admin page.
+
 = 3.7.3 (2025-06-16) =
 
 * Pro: Always display ACF translation settings for field groups formerly translated in versions older than 3.7


### PR DESCRIPTION
This PR resolves [1723](https://github.com/polylang/polylang/issues/1723).

## Description / Background Context

At the moment, if a user has lots of language translations in place, the post title becomes unreadable. This is because the language translation column proceeds to take over the whole horizontal space on the admin page.

Given that the admin page is limited in size, it only makes sense to have a filter in place to switch this off so that the post titles can be once again legible.

<img width="1566" height="740" alt="screenshot-1" src="https://github.com/user-attachments/assets/6ad07467-4817-4079-b173-7429b13d0cec" />

---

NB: This is different from using the custom screen options to switch off language options. This filter provides a way for administrators to switch this OFF permanently so that users don't go and accidentally switch it back ON.


```php
add_filter( 'pll_admin_columns_visibility' function( $is_visible ) {
   $screen = get_current_screen();

   if ( isset( $screen ) && 'post' === $screen->post_type ) {
      return false;
   }

   return $is_visible;
}
```

## Testing Instructions

1. Pull PR to local.
2. Add custom filter shown above to your theme's `functions.php` file.
3. Proceed to post admin page.
4. Observe that Polylang admin columns are now hidden.