### PR TITLE
Only add translatable content IDs to AJAX filter data.

### DIFF
--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -320,7 +320,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 		if ( ! empty( $tag_ID ) ) {
 			$term = get_term( (int) $tag_ID );
-			if ( $term instanceof WP_Term && $this->model->->taxonomies->is_translated( $term->taxonomy ) ) {
+			if ( $term instanceof WP_Term && $this->model->taxonomies->is_translated( $term->taxonomy ) ) {
 				$params['pll_term_id'] = (int) $tag_ID;
 			}
 		}

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -312,11 +312,17 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 		$params = array( 'pll_ajax_backend' => 1 );
 		if ( ! empty( $post_ID ) ) {
-			$params = array_merge( $params, array( 'pll_post_id' => (int) $post_ID ) );
+			$post = get_post( (int) $post_ID );
+			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
+				$params['pll_post_id'] = (int) $post_ID;
+			}
 		}
 
 		if ( ! empty( $tag_ID ) ) {
-			$params = array_merge( $params, array( 'pll_term_id' => (int) $tag_ID ) );
+			$term = get_term( (int) $tag_ID );
+			if ( $term instanceof WP_Term && $this->model->is_translated_taxonomy( $term->taxonomy ) ) {
+				$params['pll_term_id'] = (int) $tag_ID;
+			}
 		}
 
 		/**

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -312,11 +312,11 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 		$params = array( 'pll_ajax_backend' => 1 );
 		if ( $post instanceof WP_Post && $this->model->post_types->is_translated( $post->post_type ) ) {
-			$params['pll_post_id'] = (int) $post->ID;
+			$params['pll_post_id'] = $post->ID;
 		}
 
 		if ( $tag instanceof WP_Term && $this->model->taxonomies->is_translated( $tag->taxonomy ) ) {
-			$params['pll_term_id'] = (int) $tag->term_id;
+			$params['pll_term_id'] = $tag->term_id;
 		}
 
 		/**

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -313,14 +313,14 @@ abstract class PLL_Admin_Base extends PLL_Base {
 		$params = array( 'pll_ajax_backend' => 1 );
 		if ( ! empty( $post_ID ) ) {
 			$post = get_post( (int) $post_ID );
-			if ( $post instanceof WP_Post && $this->model->is_translated_post_type( $post->post_type ) ) {
+			if ( $post instanceof WP_Post && $this->model->post_types->is_translated( $post->post_type ) ) {
 				$params['pll_post_id'] = (int) $post_ID;
 			}
 		}
 
 		if ( ! empty( $tag_ID ) ) {
 			$term = get_term( (int) $tag_ID );
-			if ( $term instanceof WP_Term && $this->model->is_translated_taxonomy( $term->taxonomy ) ) {
+			if ( $term instanceof WP_Term && $this->model->->taxonomies->is_translated( $term->taxonomy ) ) {
 				$params['pll_term_id'] = (int) $tag_ID;
 			}
 		}

--- a/admin/admin-base.php
+++ b/admin/admin-base.php
@@ -308,21 +308,15 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * @return array
 	 */
 	public function get_ajax_filter_data(): array {
-		global $post_ID, $tag_ID;
+		global $post, $tag;
 
 		$params = array( 'pll_ajax_backend' => 1 );
-		if ( ! empty( $post_ID ) ) {
-			$post = get_post( (int) $post_ID );
-			if ( $post instanceof WP_Post && $this->model->post_types->is_translated( $post->post_type ) ) {
-				$params['pll_post_id'] = (int) $post_ID;
-			}
+		if ( $post instanceof WP_Post && $this->model->post_types->is_translated( $post->post_type ) ) {
+			$params['pll_post_id'] = (int) $post->ID;
 		}
 
-		if ( ! empty( $tag_ID ) ) {
-			$term = get_term( (int) $tag_ID );
-			if ( $term instanceof WP_Term && $this->model->taxonomies->is_translated( $term->taxonomy ) ) {
-				$params['pll_term_id'] = (int) $tag_ID;
-			}
+		if ( $tag instanceof WP_Term && $this->model->taxonomies->is_translated( $tag->taxonomy ) ) {
+			$params['pll_term_id'] = (int) $tag->term_id;
 		}
 
 		/**


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2715.

### What
Currently, `pll_post_id` and `pll_term_id` are automatically added to all admin AJAX requests via `get_ajax_filter_data()`, even when the content isn't translatable.

### Fix
- Check if post type is translatable before adding `pll_post_id`.
- Check if taxonomy is translatable before adding `pll_term_id`.
- Simplify array assignment (direct assignment vs `array_merge()`)