### PR TITLE
Fix error in `WP_Syntex\Polylang\REST\Request::get_object_type()`.

### DIFF
--- a/modules/REST/Request.php
+++ b/modules/REST/Request.php
@@ -213,10 +213,14 @@ class Request {
 			return $type;
 		}
 
-		$callback = $this->handler['callback'] ?? null;
-		if ( is_array( $callback ) && reset( $callback ) instanceof WP_REST_Posts_Controller ) {
+		if ( ! is_array( $this->handler['callback'] ) ) {
+			return null;
+		}
+
+		$controller = reset( $this->handler['callback'] );
+		if ( $controller instanceof WP_REST_Posts_Controller ) {
 			return 'post';
-		} elseif ( is_array( $callback ) && reset( $callback ) instanceof WP_REST_Terms_Controller ) {
+		} elseif ( $controller instanceof WP_REST_Terms_Controller ) {
 			return 'term';
 		}
 


### PR DESCRIPTION
## What?
Prevent `Error: Cannot use object of type Closure as array` in  `WP_Syntex\Polylang\REST\Request::get_object_type()`.
Raised in PLLWC PHPUnit tests (`Previewed_Emails_Test::test_previewed_email_subject_string`).

## How?
Ensure callback in request handler is an array before checking for controller classes.