### PR TITLE
Removes use of PLL() function that could be not declared

### DIFF
--- a/include/Options/Business/Language_Taxonomies.php
+++ b/include/Options/Business/Language_Taxonomies.php
@@ -5,6 +5,8 @@
 
 namespace WP_Syntex\Polylang\Options\Business;
 
+use PLL_Translatable_Objects;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -36,11 +38,16 @@ class Language_Taxonomies extends Abstract_Object_Types {
 	 * @phpstan-return array<non-falsy-string>
 	 */
 	protected function get_object_types(): array {
+		$translatable_objects = new PLL_Translatable_Objects();
+
 		/** @phpstan-var array<non-falsy-string> */
 		return array_diff(
-			PLL()->model->translatable_objects->get_taxonomy_names( array( 'language' ) ),
+			$translatable_objects->get_taxonomy_names( array( 'language' ) ),
 			// Exclude the post and term language taxonomies from the list.
-			array( PLL()->model->post->get_tax_language(), PLL()->model->term->get_tax_language() )
+			array(
+				$translatable_objects->get( 'post' )->get_tax_language(),
+				$translatable_objects->get( 'term' )->get_tax_language(),
+			)
 		);
 	}
 

--- a/include/translatable-objects.php
+++ b/include/translatable-objects.php
@@ -28,7 +28,7 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	 *
 	 * @phpstan-var array<non-empty-string, PLL_Translatable_Object>
 	 */
-	private $objects = array();
+	private static $objects = array();
 
 	/**
 	 * Registers a translatable object.
@@ -52,10 +52,10 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 		}
 
 		if ( ! isset( $this->objects[ $object->get_type() ] ) ) {
-			$this->objects[ $object->get_type() ] = $object;
+			self::$objects[ $object->get_type() ] = $object;
 		}
 
-		return $this->objects[ $object->get_type() ];
+		return self::$objects[ $object->get_type() ];
 	}
 
 	/**
@@ -69,7 +69,7 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	 */
 	#[\ReturnTypeWillChange]
 	public function getIterator() {
-		return new ArrayIterator( $this->objects );
+		return new ArrayIterator( self::$objects );
 	}
 
 	/**
@@ -89,11 +89,11 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	 * )
 	 */
 	public function get( $object_type ) {
-		if ( ! isset( $this->objects[ $object_type ] ) ) {
+		if ( ! isset( self::$objects[ $object_type ] ) ) {
 			return null;
 		}
 
-		return $this->objects[ $object_type ];
+		return self::$objects[ $object_type ];
 	}
 
 	/**
@@ -106,7 +106,7 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	 * @phpstan-return array<non-empty-string, PLL_Translatable_Object>
 	 */
 	public function get_secondary_translatable_objects() {
-		return array_diff_key( $this->objects, array( $this->main_type => null ) );
+		return array_diff_key( self::$objects, array( $this->main_type => null ) );
 	}
 
 	/**
@@ -123,7 +123,7 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	public function get_taxonomy_names( $filter = array( 'language', 'translations' ) ) {
 		$taxonomies = array();
 
-		foreach ( $this->objects as $object ) {
+		foreach ( self::$objects as $object ) {
 			if ( in_array( 'language', $filter, true ) ) {
 				$taxonomies[] = $object->get_tax_language();
 			}

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -128,6 +128,7 @@ trait PLL_UnitTestCase_Trait {
 	 */
 	public static function wpTearDownAfterClass() {
 		self::delete_all_languages();
+		self::reset_translatable_objects_registry();
 	}
 
 	/**
@@ -286,5 +287,12 @@ trait PLL_UnitTestCase_Trait {
 		if ( ! file_exists( $path ) ) {
 			self::markTestSkipped( $message );
 		}
+	}
+
+	protected static function reset_translatable_objects_registry() {
+		$reflection = new ReflectionClass( PLL_Translatable_Objects::class );
+		$property   = $reflection->getProperty('objects');
+		$property->setAccessible(true);
+		$property->setValue( null, array() );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -19,6 +19,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'es_ES' );
 
+		self::require_api();
+
 		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 


### PR DESCRIPTION
For the moment, the goal of this PR is to share what we study inspired by the @chouby [comment](https://github.com/polylang/polylang-pro/issues/2713#issuecomment-3204839229)


1. Instantiate a new `PLL_Translatable_Objects` instead of accessing the `PLL_Model` property. To make this work, we should use static properties to be able to share them among all instances (we can register translatable objects in one instance and read them in another one).

2. Make `get_tax_language()` static methods should be easy.

Point 1:
It could work. This what the

Point2:
It isn't necessary because if the `PLL_Translatable_Objects::$objects` is now shared for each instance, all translatable object instances are accessible and then `their get_tax_language()` method too.
It is something similar we already done [here](https://github.com/polylang/polylang/blob/master/include/Model/Languages.php#L736-L742) with the `PLL_Translatable_Objects` instance stored in Polylang model.

For the moment, a lot of tests break caused by these changes.