### PR TITLE
Requires Polylang API in test

### DIFF
--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -19,6 +19,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		self::create_language( 'de_DE_formal' );
 		self::create_language( 'es_ES' );
 
+		self::require_api();
+		
 		self::$editor = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 


### PR DESCRIPTION
To be able to run `Admin_Filters_Post_Test` class alone on local environment.
Specifically `Admin_Filters_Post_Test::test_languages_meta_box_for_media()` fails due to the call to `PLL()` function in `PLL_Translated_Post::create_media_translation()` 

See https://github.com/polylang/polylang/blob/3.7.3/include/translated-post.php#L351

```shell
composer test -- --filter Admin_Filters_Post_Test
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
Testing Polylang 3.8-dev with WordPress 6.8.2...
PHPUnit 9.6.28 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...........E....                                                  16 / 16 (100%)

Time: 00:01.781, Memory: 109.00 MB

There was 1 error:

1) Admin_Filters_Post_Test::test_languages_meta_box_for_media
Error: Call to undefined function PLL()

/home/manu/Documents/Boulot/code/polylang/include/translated-post.php:347
/home/manu/Documents/Boulot/code/polylang/tests/phpunit/tests/test-admin-filters-post.php:350

ERRORS!
Tests: 16, Assertions: 63, Errors: 1.
Script vendor/bin/phpunit handling the test event returned with error code 2
```