### PR TITLE
Use FQCN for `Options` when the type is used only for PHPStan.

### DIFF
--- a/admin/admin-notices.php
+++ b/admin/admin-notices.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * A class to manage admin notices
  * displayed only to admin, based on 'manage_options' capability
@@ -17,7 +15,7 @@ class PLL_Admin_Notices {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/frontend/canonical.php
+++ b/frontend/canonical.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Manages canonical redirect on frontend.
  *
@@ -14,7 +12,7 @@ class PLL_Canonical {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/frontend/choose-lang.php
+++ b/frontend/choose-lang.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Base class to choose the language
  *
@@ -14,7 +12,7 @@ abstract class PLL_Choose_Lang {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/frontend/frontend-static-pages.php
+++ b/frontend/frontend-static-pages.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Manages the static front page and the page for posts on frontend
  *
@@ -26,7 +24,7 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	/**
 	 * Stores plugin's options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/include/base.php
+++ b/include/base.php
@@ -4,7 +4,6 @@
  */
 
 use WP_Syntex\Polylang\REST\Request;
-use WP_Syntex\Polylang\Options\Options;
 use WP_Syntex\Polylang\Capabilities\Capabilities;
 
 /**
@@ -26,7 +25,7 @@ abstract class PLL_Base {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/include/crud-posts.php
+++ b/include/crud-posts.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Adds actions and filters related to languages when creating, updating or deleting posts.
  * Actions and filters triggered when reading posts are handled separately.
@@ -34,7 +32,7 @@ class PLL_CRUD_Posts {
 	/**
 	 * Reference to the Polylang options array.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/include/crud-terms.php
+++ b/include/crud-terms.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Adds actions and filters related to languages when creating, reading, updating or deleting posts
  * Acts both on frontend and backend
@@ -55,7 +53,7 @@ class PLL_CRUD_Terms {
 	/**
 	 * Reference to the Polylang options array.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/include/filters-links.php
+++ b/include/filters-links.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Manages links filters needed on both frontend and admin
  *
@@ -14,7 +12,7 @@ class PLL_Filters_Links {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/include/filters.php
+++ b/include/filters.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Setup filters common to admin and frontend
  *
@@ -14,7 +12,7 @@ class PLL_Filters {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/include/links-model.php
+++ b/include/links-model.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Links model abstract class.
  *
@@ -21,7 +19,7 @@ abstract class PLL_Links_Model {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/include/links.php
+++ b/include/links.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Manages links related functions
  *
@@ -14,7 +12,7 @@ class PLL_Links {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Manages custom menus translations
  * Common to admin and frontend for the customizer
@@ -15,7 +13,7 @@ class PLL_Nav_Menu {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 
@@ -139,7 +137,7 @@ class PLL_Nav_Menu {
 	 *
 	 * @since 0.9.4
 	 *
-	 * @param array $options Options stored in the option nav_menu_options.
+	 * @param array $options \WP_Syntex\Polylang\Options\Options stored in the option nav_menu_options.
 	 * @return array Modified options.
 	 */
 	public function nav_menu_options( $options ) {

--- a/include/nav-menu.php
+++ b/include/nav-menu.php
@@ -137,7 +137,7 @@ class PLL_Nav_Menu {
 	 *
 	 * @since 0.9.4
 	 *
-	 * @param array $options \WP_Syntex\Polylang\Options\Options stored in the option nav_menu_options.
+	 * @param array $options Options stored in the option nav_menu_options.
 	 * @return array Modified options.
 	 */
 	public function nav_menu_options( $options ) {

--- a/include/translatable-object.php
+++ b/include/translatable-object.php
@@ -4,7 +4,6 @@
  */
 
 use WP_Syntex\Polylang\Model\Languages;
-use WP_Syntex\Polylang\Options\Options;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,7 +29,7 @@ abstract class PLL_Translatable_Object {
 	/**
 	 * Polylang's options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/modules/REST/V1/Settings.php
+++ b/modules/REST/V1/Settings.php
@@ -11,7 +11,6 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use WP_Syntex\Polylang\Model\Languages;
-use WP_Syntex\Polylang\Options\Options;
 use WP_Syntex\Polylang\REST\Abstract_Controller;
 
 defined( 'ABSPATH' ) || exit;
@@ -23,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Settings extends Abstract_Controller {
 	/**
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	private $options;
 

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Handles the core sitemaps for sites using a single domain.
  *
@@ -24,7 +22,7 @@ class PLL_Sitemaps extends PLL_Abstract_Sitemaps {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/modules/sync/sync-post-metas.php
+++ b/modules/sync/sync-post-metas.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * A class to manage copy and synchronization of post metas.
  *
@@ -14,7 +12,7 @@ class PLL_Sync_Post_Metas extends PLL_Sync_Metas {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 

--- a/modules/sync/sync-tax.php
+++ b/modules/sync/sync-tax.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * A class to manage the synchronization of taxonomy terms across posts translations
  *
@@ -15,7 +13,7 @@ class PLL_Sync_Tax {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/modules/sync/sync.php
+++ b/modules/sync/sync.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Manages copy and synchronization of terms and post metas on front
  *
@@ -29,7 +27,7 @@ class PLL_Sync {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	protected $options;
 

--- a/modules/wizard/view-wizard-step-media.php
+++ b/modules/wizard/view-wizard-step-media.php
@@ -6,10 +6,8 @@
  *
  * @since 2.7
  *
- * @var Options $options Polylang's options.
+ * @var \WP_Syntex\Polylang\Options\Options $options Polylang's options.
  */
-
-use WP_Syntex\Polylang\Options\Options;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/settings/settings-module.php
+++ b/settings/settings-module.php
@@ -3,8 +3,6 @@
  * @package Polylang
  */
 
-use WP_Syntex\Polylang\Options\Options;
-
 /**
  * Base class for all settings
  *
@@ -14,7 +12,7 @@ class PLL_Settings_Module {
 	/**
 	 * Stores the plugin options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	public $options;
 


### PR DESCRIPTION
## What?
Generated stubs are broken when the `Options` type is used for properties only to please PHPStan ([see](https://github.com/polylang/polylang-stubs/blob/8e1160d23276b4de48f7a2cdcd61ba69426da7c5/polylang-stubs.php#L14006)).

## How?
Use FQCN when a property needs to be typed as `Options` object without it to be coerced in code.