### PR TITLE
Add translator capabilities filtering for inline edit and terms management.

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -376,16 +376,13 @@ class PLL_Admin_Filters_Term {
 		// Security check as 'wp_update_term' can be called from outside WP admin.
 		check_admin_referer( 'pll_language', '_pll_nonce' );
 
-		$translations = $this->model->term->get_translations( $term_id );
-		if ( ! isset( $_POST['term_tr_lang'] ) || ! is_array( $_POST['term_tr_lang'] ) ) {
-			return $translations;
-		}
+		$translations = array();
 
-		// Make sure a translator won't edit translations they're not allowed to.
-		$sent_translations = array_map( 'absint', $_POST['term_tr_lang'] );
-		foreach ( $this->model->languages->filter( 'translator' )->get_list() as $lang ) {
-			if ( isset( $sent_translations[ $lang->slug ] ) ) {
-				$translations[ $lang->slug ] = $sent_translations[ $lang->slug ];
+		// Save translations after checking the translated term is in the right language ( as well as cast id to int ).
+		if ( isset( $_POST['term_tr_lang'] ) ) {
+			foreach ( array_map( 'absint', $_POST['term_tr_lang'] ) as $lang => $tr_id ) {
+				$tr_lang = $this->model->term->get_language( $tr_id );
+				$translations[ $lang ] = $tr_lang && $tr_lang->slug == $lang ? $tr_id : 0;
 			}
 		}
 

--- a/admin/view-translations-term.php
+++ b/admin/view-translations-term.php
@@ -27,14 +27,10 @@ else {
 ?>
 <table class="widefat term-translations"  id="<?php echo isset( $term_id ) ? 'edit' : 'add'; ?>-term-translations">
 	<?php
-	$authorized_slugs = $this->model->languages->filter( 'translator' )->get_list( array( 'fields' => 'slug' ) );
 	foreach ( $this->model->get_languages_list() as $language ) {
 		if ( $language->term_id == $lang->term_id ) {
 			continue;
 		}
-
-		// Check if the user is allowed to translate this language.
-		$is_authorized = in_array( $language->slug, $authorized_slugs, true );
 
 		// Look for any existing translation in this language
 		// Take care not to propose a self link
@@ -84,7 +80,7 @@ else {
 					esc_html__( 'Translation', 'polylang' ),
 					$translation_exists ? (int) $translation->term_id : 0,
 					$translation_exists ? esc_attr( $translation->name ) : '',
-					disabled( ! empty( $disabled ) || ! $is_authorized, true, false ),
+					disabled( empty( $disabled ), false, false ),
 					esc_attr( $language->get_locale( 'display' ) ),
 					( $language->is_rtl ? 'rtl' : 'ltr' )
 				);


### PR DESCRIPTION
Add support for translator capabilities filtering in inline/quick edit and terms management interfaces.

For term creation : when creating a new term, if the user's preferred language is not in their list of authorized languages, it now defaults to the first available language in the filtered list. 
This ensures the language dropdown flag displays correctly on initial page load, as the selected language must exist in the filtered languages list for the flag to render properly.

Also prevent modifying terms translations in the save callback.