### PR TITLE
Fixed a PHP warning triggered by the Composer's API

### DIFF
--- a/tests/phpunit/includes/testcase-object-cache.php
+++ b/tests/phpunit/includes/testcase-object-cache.php
@@ -21,9 +21,10 @@ abstract class PLL_Object_Cache_TestCase extends PLL_UnitTestCase {
 		register_shutdown_function( Closure::fromCallable( array( self::class, 'remove_annihilator' ) ) );
 
 		// Drop in the annihilator.
-		$drop_in_path = \Composer\InstalledVersions::getInstallPath( 'wpsyntex/object-cache-annihilator' ) . '/drop-in.php';
-		require_once $drop_in_path;
+		$drop_in_path = POLYLANG_DIR . '/vendor/wpsyntex/object-cache-annihilator/drop-in.php';
 		copy( $drop_in_path, WP_CONTENT_DIR . '/object-cache.php' );
+		require_once WP_CONTENT_DIR . '/object-cache.php';
+
 		wp_using_ext_object_cache( true );
 		$wp_object_cache = new Object_Cache_Annihilator();
 	}


### PR DESCRIPTION
Using the Composer's API:

```php
\Composer\InstalledVersions::getInstallPath()
```

triggers the following PHP warnings in tests:

```
PHP Warning:  fopen(/polylang/polylang/tmp/plugins/wordpress-importer/php-toolkit/vendor/composer/../composer/InstalledVersions.php): Failed to open stream: No such file or directory in /polylang/polylang/vendor/antecedent/patchwork/src/CodeManipulation/Stream.php on line 151

PHP Warning:  include(/polylang/polylang/tmp/plugins/wordpress-importer/php-toolkit/vendor/composer/../composer/InstalledVersions.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in /polylang/polylang/vendor/composer/ClassLoader.php on line 576

PHP Warning:  include(): Failed opening '/polylang/polylang/tmp/plugins/wordpress-importer/php-toolkit/vendor/composer/../composer/InstalledVersions.php' for inclusion (include_path='.:/usr/share/php') in /polylang/polylang/vendor/composer/ClassLoader.php on line 576

Warning: fopen(/polylang/polylang/tmp/plugins/wordpress-importer/php-toolkit/vendor/composer/../composer/InstalledVersions.php): Failed to open stream: No such file or directory in /polylang/polylang/vendor/antecedent/patchwork/src/CodeManipulation/Stream.php on line 151

Warning: include(/polylang/polylang/tmp/plugins/wordpress-importer/php-toolkit/vendor/composer/../composer/InstalledVersions.php): Failed to open stream: "Patchwork\CodeManipulation\Stream::stream_open" call failed in /polylang/polylang/vendor/composer/ClassLoader.php on line 576

Warning: include(): Failed opening '/polylang/polylang/tmp/plugins/wordpress-importer/php-toolkit/vendor/composer/../composer/InstalledVersions.php' for inclusion (include_path='.:/usr/share/php') in /polylang/polylang/vendor/composer/ClassLoader.php on line 576
```

This happens because the "php toolkit" in WP Importer is supposed to contain a `InstalledVersions.php` file.

The solution suggested here is to not use the Composer's API.