### PR TITLE
Fixed path to Object Cache Annihilator for PLL Pro

### DIFF
--- a/tests/phpunit/includes/testcase-object-cache.php
+++ b/tests/phpunit/includes/testcase-object-cache.php
@@ -21,7 +21,8 @@ abstract class PLL_Object_Cache_TestCase extends PLL_UnitTestCase {
 		register_shutdown_function( Closure::fromCallable( array( self::class, 'remove_annihilator' ) ) );
 
 		// Drop in the annihilator.
-		$drop_in_path = POLYLANG_DIR . '/vendor/wpsyntex/object-cache-annihilator/drop-in.php';
+		$base_path    = defined( 'WPSYNTEX_PROJECT_PATH' ) ? WPSYNTEX_PROJECT_PATH : POLYLANG_DIR . '/';
+		$drop_in_path = $base_path . 'vendor/wpsyntex/object-cache-annihilator/drop-in.php';
 		copy( $drop_in_path, WP_CONTENT_DIR . '/object-cache.php' );
 		require_once WP_CONTENT_DIR . '/object-cache.php';
 


### PR DESCRIPTION
Fix the fatal error in Polylang Pro's test: `test_object_cache_unavailable_when_a_language_is_added()`. The path changes in PLL Pro.
The issue comes from #1755.