### PR TITLE
Replace direct DB query by get_terms()

### DIFF
--- a/admin/admin-filters-term.php
+++ b/admin/admin-filters-term.php
@@ -315,7 +315,7 @@ class PLL_Admin_Filters_Term {
 
 				// Get all terms with the same name.
 				if ( $term instanceof WP_Term ) {
-					$term_ids = get_terms( array( 'taconomy' => $taxonomy, 'name' => $term->name, 'hide_empty' => false, 'fields' => 'ids' ) );
+					$term_ids = get_terms( array( 'taxonomy' => $taxonomy, 'name' => $term->name, 'hide_empty' => false, 'fields' => 'ids' ) );
 
 					// If we have several terms with the same name, they are translations of each other.
 					if ( is_array( $term_ids ) && count( $term_ids ) > 1 ) {


### PR DESCRIPTION
In the past, WP did not provide a function to get all terms with the same name. This is no longer an issue . This PR replaces a direct DB query by a call to `get_terms()`.

NB: this part of the code is already tested by [`test_create_term_from_post_bulk_edit()`](https://github.com/polylang/polylang/blob/3.7.4/tests/phpunit/tests/test-admin-filters-term.php#L124).