### PR TITLE
Ignore `wp_verify_nonce()` PHPStan error globally.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,12 +91,6 @@ parameters:
 			path: admin/admin-filters-post.php
 
 		-
-			message: '#^Parameter \#1 \$nonce of function wp_verify_nonce expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: admin/admin-filters-post.php
-
-		-
 			message: '#^Parameter \#1 \$posts of function update_post_caches expects array\<WP_Post\>, array\<WP_Post\>\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -136,12 +130,6 @@ parameters:
 			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, ''absint'' given\.$#'
 			identifier: argument.type
 			count: 1
-			path: admin/admin-filters-term.php
-
-		-
-			message: '#^Parameter \#1 \$nonce of function wp_verify_nonce expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 4
 			path: admin/admin-filters-term.php
 
 		-
@@ -202,12 +190,6 @@ parameters:
 			message: '#^Parameter \#1 \$locations of method PLL_Admin_Nav_Menu\:\:update_nav_menu_locations\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 3
-			path: admin/admin-nav-menu.php
-
-		-
-			message: '#^Parameter \#1 \$nonce of function wp_verify_nonce expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 4
 			path: admin/admin-nav-menu.php
 
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -84,3 +84,7 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: admin/admin-filters-columns.php
+
+		# Ignored globally
+		-
+			message: '#^Parameter \#1 \$nonce of function wp_verify_nonce expects string, mixed given\.$#'


### PR DESCRIPTION
We chose to ignore this error globally.