### PR TITLE
[Capabilities] Introduce `User::can_translate_all()`

### DIFF
--- a/include/Capabilities/User.php
+++ b/include/Capabilities/User.php
@@ -108,13 +108,16 @@ class User {
 			return true;
 		}
 
-		$caps = array_map(
-			static function ( $slug ) {
-				return "translate_{$slug}";
-			},
-			$languages
-		);
-		return empty( array_diff( $caps, $this->get_language_caps() ) );
+		foreach ( $languages as $language_slug ) {
+			if ( ! isset( $this->can_translate[ $language_slug ] ) ) {
+				$this->can_translate[ $language_slug ] = $this->user->has_cap( "translate_{$language_slug}" );
+			}
+			if ( ! $this->can_translate[ $language_slug ] ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Needed by https://github.com/polylang/polylang-pro/pull/2788.

Also:
- New method `get_id()`: also needed in PLL Pro. We could have `get(): WP_User` instead.
- `can_translate()` doesn't have to use `has_cap()`: `in_array()` is enough and is more efficient.

> [!NOTE]
> I chose to use an array of language slugs:
> - Slugs is what PLL Pro provides in the case it is used: no need to create language objects and then use their slug.
> - We don't need to make sure the given languages exist.
> - An array of objects doesn't improve type-hinting.