### PR TITLE
Introduce `pll_sanitize_id()`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -73,6 +73,7 @@
 		<properties>
 			<property name="customUnslashingSanitizingFunctions" type="array">
 				<element value="wp_verify_nonce"/>
+				<element value="pll_sanitize_id"/>
 			</property>
 		</properties>
 	</rule>

--- a/src/functions.php
+++ b/src/functions.php
@@ -162,7 +162,7 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
  * @param mixed $id A supposedly numeric ID.
  * @return int A positive integer. `0` for non numeric values and negative integers.
  *
- * @phpstan-return int<0,max>
+ * @phpstan-return positive-int
  */
 function pll_sanitize_id( $id ): int {
 	return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;

--- a/src/functions.php
+++ b/src/functions.php
@@ -185,7 +185,7 @@ function pll_sanitize_id( $id ) {
  *
  * @phpstan-return array<positive-int>
  */
-function pll_sanitize_ids_list( $ids ) {
+function pll_sanitize_ids( $ids ) {
 	if ( empty( $ids ) || ! is_array( $ids ) ) {
 		return array();
 	}

--- a/src/functions.php
+++ b/src/functions.php
@@ -152,3 +152,43 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
 
 	return 'GET' === $request->get_method() && 'edit' === $request->get_param( 'context' );
 }
+
+/**
+ * Sanitizes an ID as positive integer.
+ * Kind of similar to `absint()`, but rejects negative integers instead of making them positive.
+ *
+ * @since 3.8
+ *
+ * @param mixed $id A supposedly numeric ID.
+ * @return int A positive integer. `0` for non numeric values and negative integers.
+ *
+ * @phpstan-return int<0,max>
+ */
+function pll_sanitize_id( $id ) {
+	$options = array(
+		'options' => array(
+			'min_range' => 1,
+			'default'   => 0,
+		),
+	);
+	return filter_var( $id, FILTER_VALIDATE_INT, $options );
+}
+
+/**
+ * Sanitizes an array of IDs as positive integers.
+ * `0` values are removed.
+ *
+ * @since 3.8
+ *
+ * @param mixed $ids A supposedly array of numeric IDs.
+ * @return int[]
+ *
+ * @phpstan-return array<positive-int>
+ */
+function pll_sanitize_ids_list( $ids ) {
+	if ( empty( $ids ) || ! is_array( $ids ) ) {
+		return array();
+	}
+
+	return array_filter( array_map( 'pll_sanitize_id', $ids ) );
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -157,35 +157,29 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
  * Sanitizes an ID as positive integer.
  * Kind of similar to `absint()`, but rejects negative integers instead of making them positive.
  *
- * @since 3.8
+ * @since 3.9
  *
  * @param mixed $id A supposedly numeric ID.
  * @return int A positive integer. `0` for non numeric values and negative integers.
  *
  * @phpstan-return int<0,max>
  */
-function pll_sanitize_id( $id ) {
-	$options = array(
-		'options' => array(
-			'min_range' => 1,
-			'default'   => 0,
-		),
-	);
-	return filter_var( $id, FILTER_VALIDATE_INT, $options );
+function pll_sanitize_id( $id ): int {
+	return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
 }
 
 /**
  * Sanitizes an array of IDs as positive integers.
  * `0` values are removed.
  *
- * @since 3.8
+ * @since 3.9
  *
  * @param mixed $ids A supposedly array of numeric IDs.
  * @return int[]
  *
  * @phpstan-return array<positive-int>
  */
-function pll_sanitize_ids( $ids ) {
+function pll_sanitize_ids( $ids ): array {
 	if ( empty( $ids ) || ! is_array( $ids ) ) {
 		return array();
 	}

--- a/src/functions.php
+++ b/src/functions.php
@@ -162,7 +162,7 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
  * @param mixed $id A supposedly numeric ID.
  * @return int A positive integer. `0` for non numeric values and negative integers.
  *
- * @phpstan-return positive-int
+ * @phpstan-return int<0, max>
  */
 function pll_sanitize_id( $id ): int {
 	return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;

--- a/src/translatable-object.php
+++ b/src/translatable-object.php
@@ -254,7 +254,7 @@ abstract class PLL_Translatable_Object {
 	 * @return array<int,WP_Term> Array of terms with object ID as key.
 	 */
 	protected function get_object_terms( array $object_ids, string $taxonomy ) {
-		$object_ids = pll_sanitize_ids_list( $object_ids );
+		$object_ids = pll_sanitize_ids( $object_ids );
 		if ( empty( $object_ids ) ) {
 			return array();
 		}
@@ -465,7 +465,7 @@ abstract class PLL_Translatable_Object {
 
 		$object_ids = $this->query_objects_with_no_lang( $language_ids, $limit, $args );
 
-		return array_values( pll_sanitize_ids_list( $object_ids ) );
+		return array_values( pll_sanitize_ids( $object_ids ) );
 	}
 
 	/**

--- a/src/translatable-object.php
+++ b/src/translatable-object.php
@@ -176,7 +176,7 @@ abstract class PLL_Translatable_Object {
 	 *              the object).
 	 */
 	public function set_language( $id, $lang ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return false;
@@ -210,7 +210,7 @@ abstract class PLL_Translatable_Object {
 	 *                            ID is invalid.
 	 */
 	public function get_language( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return false;
@@ -235,7 +235,7 @@ abstract class PLL_Translatable_Object {
 	 * @return void
 	 */
 	public function delete_language( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return;
@@ -254,7 +254,7 @@ abstract class PLL_Translatable_Object {
 	 * @return array<int,WP_Term> Array of terms with object ID as key.
 	 */
 	protected function get_object_terms( array $object_ids, string $taxonomy ) {
-		$object_ids = $this->sanitize_int_ids_list( $object_ids );
+		$object_ids = pll_sanitize_ids_list( $object_ids );
 		if ( empty( $object_ids ) ) {
 			return array();
 		}
@@ -465,7 +465,7 @@ abstract class PLL_Translatable_Object {
 
 		$object_ids = $this->query_objects_with_no_lang( $language_ids, $limit, $args );
 
-		return array_values( $this->sanitize_int_ids_list( $object_ids ) );
+		return array_values( pll_sanitize_ids_list( $object_ids ) );
 	}
 
 	/**
@@ -497,42 +497,6 @@ abstract class PLL_Translatable_Object {
 		$this->set_to_cache( $key, $object_ids );
 
 		return $object_ids;
-	}
-
-	/**
-	 * Sanitizes an ID as positive integer.
-	 * Kind of similar to `absint()`, but rejects negative integers instead of making them positive.
-	 *
-	 * @since 3.2
-	 *
-	 * @param mixed $id A supposedly numeric ID.
-	 * @return int A positive integer. `0` for non numeric values and negative integers.
-	 *
-	 * @phpstan-return int<0,max>
-	 */
-	public function sanitize_int_id( $id ) {
-		return is_numeric( $id ) && $id >= 1 ? abs( (int) $id ) : 0;
-	}
-
-	/**
-	 * Sanitizes an array of IDs as positive integers.
-	 * `0` values are removed.
-	 *
-	 * @since 3.2
-	 *
-	 * @param mixed $ids An array of numeric IDs.
-	 * @return int[]
-	 *
-	 * @phpstan-return array<positive-int>
-	 */
-	public function sanitize_int_ids_list( $ids ) {
-		if ( empty( $ids ) || ! is_array( $ids ) ) {
-			return array();
-		}
-
-		$ids = array_map( array( $this, 'sanitize_int_id' ), $ids );
-
-		return array_filter( $ids );
 	}
 
 	/**

--- a/src/translated-object.php
+++ b/src/translated-object.php
@@ -91,7 +91,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 			return false;
 		}
 
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		$translations = $this->get_translations( $id );
 
@@ -116,7 +116,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	public function get_translations_from_term_id( $term_id ) {
-		$term_id = $this->sanitize_int_id( $term_id );
+		$term_id = pll_sanitize_id( $term_id );
 
 		if ( empty( $term_id ) ) {
 			return array();
@@ -147,7 +147,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	public function save_translations( $id, array $translations = array() ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return array();
@@ -220,7 +220,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @return void
 	 */
 	public function delete_translation( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return;
@@ -260,7 +260,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	public function get_translations( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return array();
@@ -281,7 +281,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @phpstan-return array<non-empty-string, positive-int>
 	 */
 	public function get_raw_translations( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return array();
@@ -326,7 +326,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @phpstan-return int<0, max>
 	 */
 	public function get( $id, $lang ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return 0;
@@ -356,7 +356,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @return bool
 	 */
 	public function current_user_can_synchronize( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return false;
@@ -497,7 +497,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 
 		// Make sure values are clean before working with them.
 		/** @phpstan-var array<non-empty-string, positive-int> $translations */
-		$translations = $this->sanitize_int_ids_list( $translations );
+		$translations = pll_sanitize_ids_list( $translations );
 
 		if ( 'save' === $context ) {
 			/**
@@ -518,7 +518,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 			$translations = $valid_translations;
 		}
 
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return $translations;

--- a/src/translated-object.php
+++ b/src/translated-object.php
@@ -497,7 +497,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 
 		// Make sure values are clean before working with them.
 		/** @phpstan-var array<non-empty-string, positive-int> $translations */
-		$translations = pll_sanitize_ids_list( $translations );
+		$translations = pll_sanitize_ids( $translations );
 
 		if ( 'save' === $context ) {
 			/**

--- a/src/translated-post.php
+++ b/src/translated-post.php
@@ -131,7 +131,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @return void
 	 */
 	public function delete_translation( $id ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return;
@@ -249,7 +249,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @phpstan-param non-empty-string $context
 	 */
 	public function current_user_can_read( $id, $context = 'view' ) {
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return false;

--- a/src/translated-term.php
+++ b/src/translated-term.php
@@ -263,7 +263,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @phpstan-param array<positive-int> $ids
 	 */
 	public function clean_term_cache( $ids ) {
-		clean_object_term_cache( pll_sanitize_ids_list( $ids ), 'term' );
+		clean_object_term_cache( pll_sanitize_ids( $ids ), 'term' );
 	}
 
 	/**

--- a/src/translated-term.php
+++ b/src/translated-term.php
@@ -107,7 +107,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 			return false;
 		}
 
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		// Add translation group for correct WXR export.
 		$translations = $this->get_translations( $id );
@@ -155,7 +155,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	public function delete_translation( $id ) {
 		global $wpdb;
 
-		$id = $this->sanitize_int_id( $id );
+		$id = pll_sanitize_id( $id );
 
 		if ( empty( $id ) ) {
 			return;
@@ -263,7 +263,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @phpstan-param array<positive-int> $ids
 	 */
 	public function clean_term_cache( $ids ) {
-		clean_object_term_cache( $this->sanitize_int_ids_list( $ids ), 'term' );
+		clean_object_term_cache( pll_sanitize_ids_list( $ids ), 'term' );
 	}
 
 	/**

--- a/tests/phpunit/tests/Cache/test-Object_With_No_Lang.php
+++ b/tests/phpunit/tests/Cache/test-Object_With_No_Lang.php
@@ -87,13 +87,13 @@ class Test_Object_With_No_Lang extends PLL_Object_Cache_TestCase {
 			$key          = md5( maybe_serialize( $lang_ids ) . maybe_serialize( array() ) . $limit );
 			$last_changed = wp_cache_get_last_changed( $cache_type );
 			$cache_key    = "{$cache_type}_no_lang:{$key}:{$last_changed}";
-			$object_ids   = $this->pll_env->model->$type->sanitize_int_ids_list(
+			$object_ids   = pll_sanitize_ids(
 				wp_cache_get( $cache_key, $cache_type )
 			);
 		} else {
 			$key          = "{$cache_type}_no_lang:" . md5( maybe_serialize( $lang_ids ) . maybe_serialize( array() ) . $limit );
 			$last_changed = wp_cache_get_last_changed( $cache_type );
-			$object_ids   = $this->pll_env->model->$type->sanitize_int_ids_list(
+			$object_ids   = pll_sanitize_ids(
 				wp_cache_get_salted( $key, $cache_type, $last_changed )
 			);
 		}

--- a/tests/phpunit/tests/test-functions.php
+++ b/tests/phpunit/tests/test-functions.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Test class for Polylang functions.
+ */
+class Functions_Test extends PHPUnit_Framework_TestCase {
+
+	public function test_sanitize_id() {
+		$this->assertSame( 0, pll_sanitize_id( null ) );
+		$this->assertSame( 0, pll_sanitize_id( array() ) );
+		$this->assertSame( 0, pll_sanitize_id( array( 100 ) ) );
+		$this->assertSame( 0, pll_sanitize_id( (object) array() ) );
+		$this->assertSame( 0, pll_sanitize_id( (object) array( 100 ) ) );
+		$this->assertSame( 100, pll_sanitize_id( 100 ) );
+		$this->assertSame( 0, pll_sanitize_id( -100 ) );
+		$this->assertSame( 100, pll_sanitize_id( 100.0 ) );
+		$this->assertSame( 100, pll_sanitize_id( 100.1 ) );
+		$this->assertSame( 100, pll_sanitize_id( '100' ) );
+		$this->assertSame( 0, pll_sanitize_id( '-100' ) );
+		$this->assertSame( 100, pll_sanitize_id( '100.0' ) );
+		$this->assertSame( 100, pll_sanitize_id( '100.1' ) );
+		$this->assertSame( 0, pll_sanitize_id( 'true' ) );
+		$this->assertSame( 0, pll_sanitize_id( 'false' ) );
+		$this->assertSame( 0, pll_sanitize_id( true ) );
+		$this->assertSame( 0, pll_sanitize_id( false ) );
+	}
+
+	public function test_sanitize_ids() {
+		$inputs = array(
+			null,
+			array(),
+			array( 101 ),
+			(object) array(),
+			(object) array( 102 ),
+			111,
+			-112,
+			113.0,
+			114.1,
+			'121',
+			'-122',
+			'123.0',
+			'124.1',
+			'true',
+			'false',
+			true,
+			false,
+		);
+
+		$expected = array(
+			111,
+			113,
+			114,
+			121,
+			123,
+			124,
+		);
+
+		$this->assertSame( $expected, array_values( pll_sanitize_ids( $inputs ) ) ); // Use `array_values()` to re-index.
+	}
+}

--- a/tests/phpunit/tests/test-functions.php
+++ b/tests/phpunit/tests/test-functions.php
@@ -23,6 +23,7 @@ class Functions_Test extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 0, pll_sanitize_id( 'false' ) );
 		$this->assertSame( 0, pll_sanitize_id( true ) );
 		$this->assertSame( 0, pll_sanitize_id( false ) );
+		$this->assertSame( 0, pll_sanitize_id( fn( $x ) => $x ) );
 	}
 
 	public function test_sanitize_ids() {
@@ -44,6 +45,7 @@ class Functions_Test extends PHPUnit_Framework_TestCase {
 			'false',
 			true,
 			false,
+			fn( $x ) => $x,
 		);
 
 		$expected = array(


### PR DESCRIPTION
... together with `pll_sanitize_ids()` in replacement of `PLL_Translatable_Object` equivalent methods.

Closes https://github.com/polylang/polylang-pro/issues/2804

- These functions will be easier to use outside the class of the replaced methods.
- `pll_sanitize_id` is added to WPCS config as an unslashing + sanitizing function.
- Uses internal PHP filter instead of a custom algorithm.

### To be discussed 
The proposed filter results in a different behavior in some cases
| Input | Before | This PR |
|-|-|-|
| `true` | 0 | 1 |
| `array()` | 0 | `false` WTF?|
| `10.1` | 10 | 0 |

Alternative 1: We can eliminate the type issue with arrays with:
```php
	$options = array(
		'options' => array(
			'min_range' => 1,
		),
	);
	return filter_var( $id, FILTER_VALIDATE_INT, $options ) ?: 0;
```
Alternative 2: We can eliminate floats including `10.0` with:
```php
	return is_numeric( $id ) && ! is_float( $id ) && $id >= 1 ? (int) $id : 0;
```