### PR TITLE
Filters categories per post language in Quick Edit.

### DIFF
--- a/js/src/post.js
+++ b/js/src/post.js
@@ -64,6 +64,7 @@ jQuery(
 											$.each(
 												terms,
 												function ( i ) {
+													// Backward compatibility with WordPress < 6.7.
 													// Support both old (WP < 6.7) and new (WP >= 6.7) ID formats.
 													// Old format: category-123 (WordPress < 6.7).
 													// New format: in-category-123-1 (WordPress >= 6.7).


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2848.

## What 

The categories check list in quick edit is not filtered per post language.

## Why

WordPress 6.7 changed the HTML structure for category  in quick edit:
- Before WP 6.7: `<li id="category-{ID}">`
- After WP 6.7: `<li id="in-category-{ID}-1">`

This broke category filtering by language in quick edit because the JS selector only matched the old format.

## Fix
Updated the category selector in `js/src/post/quick-edit.js` to support both formats.

This ensures backward compatibility with older WP versions while supporting the new 6.7+ format.

Tests e2e are coming in a PLL Pro PR.