### PR TITLE
Harmonize capabilities error message.

### DIFF
--- a/include/Capabilities/User.php
+++ b/include/Capabilities/User.php
@@ -181,7 +181,7 @@ class User {
 	public function can_translate_or_die( PLL_Language $language ): void {
 		if ( ! $this->can_translate( $language ) ) {
 			/* translators: %s is a language name */
-			wp_die( esc_html( sprintf( __( 'Sorry, you are not allowed to create or edit content in %s.', 'polylang' ), $language->name ) ) );
+			wp_die( esc_html( sprintf( __( 'Sorry, you are not allowed to edit content in %s.', 'polylang' ), $language->name ) ) );
 		}
 	}
 }


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/2780.

## What

This PR harmonizes error message in the Capabilities feature.

The main issue is in `User::can_translate_or_die()` which displays:
> "You are not allowed to do action in English."

This message has weird grammar ("do action") and lacks the "Sorry," prefix used in other similar messages.

---

## Notes

I went through all the capabilities related error messages I could find. If you spot any others that need updating, just let me know!
