### PR TITLE
Support new DeepL languages.

### DIFF
--- a/settings/languages.php
+++ b/settings/languages.php
@@ -635,7 +635,7 @@ return array(
 		'name'     => 'Afaan Oromoo',
 		'dir'      => 'ltr',
 		'flag'     => 'et',
-		'w3c'      => 'om',
+		'w3c'      => 'gax',
 		'facebook' => 'om_ET',
 		'deepl'    => 'OM',
 	),


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2812.

## What

This PR adds support for languages recently promoted by DeepL and completes existing language stubs.

## Fix

  - Added DeepL language codes for many languages that were recently promoted from beta to production status by DeepL. 
  - Added some languages that were available in WordPress (but not yet in Polylang and some not in DeepL, I just took the opportunity to add them).
  - Completed some stub entries with missing fields (now that the languages are available on translate WordPress).

## Questions

### The flag choices I wondered about:

#### Regional Flags (currently use national flags)

**bre (Breton)** : Uses 'fr'
**scn (Sicilian)** : Uses 'it'
**lmo (Lombard)** : Uses 'it'

Users can add custom regional flags if desired.
However, for consistency with our existing regional flags (catalonia, basque, occitania, veneto, wales, scotland...), should we consider adding official support for brittany, sicily, and lombardy flags or is it ok this way ?

#### National Flag Choices

**hau (Hausa)** : 'ng' (Nigeria) over 'ne' (Niger).
It follows Facebook locale `ha_NG` and larger speaker population, though Niger made Hausa sole official language in 2025 (replacing French).

**tir (Tigrinya)** : 'et' (Ethiopia) over 'er' (Eritrea). Seems to be a larger speaker population.

**ba (Bashkir)** : 'ru' for consistency with `sah` (Yakut) and `tt_RU` (Tatar).

**lin (Lingala)** : 'cd' (DR Congo) per Facebook locale `ln_CD`.

---

## Known Issue (to be fixed in follow-up PR)

There is an issue in `Services/Deepl.php` with the `get_source_code()` method:

```php
return substr( static::get_target_code( $language ), 0, 2 );
```

Problem: Codes with 3+ letters without hyphens are incorrectly truncated:
- `CEB` (Cebuano) : returns `CE` instead of `CEB` ❌
- `CKB` (Kurdish Sorani) : returns `CK` instead of `CKB` ❌

Translations FROM Cebuano or Kurdish Sorani will fail because DeepL receives an invalid source code.

This will be addressed in a follow-up PR that fixes the `get_source_code()` logic to handle 3-letter codes properly.