### PR TITLE
Improve the message when activating a second instance of Polylang

### DIFF
--- a/polylang.php
+++ b/polylang.php
@@ -45,12 +45,29 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 
 	if ( is_plugin_active( plugin_basename( __FILE__ ) ) ) {
 		deactivate_plugins( plugin_basename( __FILE__ ) ); // Deactivate this plugin.
-		// WP does not allow us to send a custom meaningful message, so just tell the plugin has been deactivated.
-		wp_safe_redirect( add_query_arg( 'deactivate', 'true', remove_query_arg( 'activate' ) ) );
+		wp_safe_redirect( add_query_arg( 'pll_two_activations', 'true', remove_query_arg( 'activate' ) ) );
 		exit;
 	}
 	return;
 }
+
+add_action(
+	'admin_head',
+	function () {
+		if ( 'plugins.php' !== $GLOBALS['pagenow'] || ! isset( $_GET['pll_two_activations'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$_SERVER['REQUEST_URI'] = remove_query_arg( 'pll_two_activations', $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$updated_notice_args = array(
+			'id'                 => 'message',
+			'additional_classes' => array( 'error' ),
+			'dismissible'        => true,
+		);
+		wp_admin_notice( __( 'You can\'t activate Polylang and Polylang Pro at the same time.', 'polylang' ), $updated_notice_args );
+	}
+);
+
 
 // Go on loading the plugin.
 define( 'POLYLANG_VERSION', '3.8-dev' );

--- a/polylang.php
+++ b/polylang.php
@@ -54,7 +54,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 					'additional_classes' => array( 'error' ),
 					'dismissible'        => true,
 				);
-				wp_admin_notice( __( 'Polylang and Polylang Pro cannot be activated at the same time.', 'polylang' ), $updated_notice_args );
+				wp_admin_notice( __( 'Polylang hasn\'t been activated: Polylang and Polylang Pro cannot be activated at the same time.', 'polylang' ), $updated_notice_args );
 			}
 		);
 	}

--- a/polylang.php
+++ b/polylang.php
@@ -47,7 +47,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 
 		add_action(
 			'load-plugins.php',
-			function () {
+			static function () {
 				unset( $_GET['activate'] ); // Prevent WP to display its 'Plugin activated.' message.
 				$updated_notice_args = array(
 					'id'                 => 'message',

--- a/polylang.php
+++ b/polylang.php
@@ -50,9 +50,8 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 			static function () {
 				unset( $_GET['activate'] ); // Prevent WP to display its 'Plugin activated.' message.
 				$updated_notice_args = array(
-					'id'                 => 'message',
-					'additional_classes' => array( 'error' ),
-					'dismissible'        => true,
+					'type'        => 'error',
+					'dismissible' => true,
 				);
 				wp_admin_notice( __( 'Polylang hasn\'t been activated: Polylang and Polylang Pro cannot be activated at the same time.', 'polylang' ), $updated_notice_args );
 			}

--- a/polylang.php
+++ b/polylang.php
@@ -41,33 +41,25 @@ defined( 'ABSPATH' ) || exit;
 if ( defined( 'POLYLANG_VERSION' ) ) {
 	// The user is attempting to activate a second plugin instance, typically Polylang and Polylang Pro.
 	require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	require_once ABSPATH . 'wp-includes/pluggable.php';
 
 	if ( is_plugin_active( plugin_basename( __FILE__ ) ) ) {
 		deactivate_plugins( plugin_basename( __FILE__ ) ); // Deactivate this plugin.
-		wp_safe_redirect( add_query_arg( 'pll_two_activations', 'true', remove_query_arg( 'activate' ) ) );
-		exit;
+
+		add_action(
+			'load-plugins.php',
+			function () {
+				unset( $_GET['activate'] ); // Prevent WP to display its 'Plugin activated.' message.
+				$updated_notice_args = array(
+					'id'                 => 'message',
+					'additional_classes' => array( 'error' ),
+					'dismissible'        => true,
+				);
+				wp_admin_notice( __( 'Polylang and Polylang Pro cannot be activated at the same time.', 'polylang' ), $updated_notice_args );
+			}
+		);
 	}
 	return;
 }
-
-add_action(
-	'admin_head',
-	function () {
-		if ( 'plugins.php' !== $GLOBALS['pagenow'] || ! isset( $_GET['pll_two_activations'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return;
-		}
-
-		$_SERVER['REQUEST_URI'] = remove_query_arg( 'pll_two_activations', $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$updated_notice_args = array(
-			'id'                 => 'message',
-			'additional_classes' => array( 'error' ),
-			'dismissible'        => true,
-		);
-		wp_admin_notice( __( 'You can\'t activate Polylang and Polylang Pro at the same time.', 'polylang' ), $updated_notice_args );
-	}
-);
-
 
 // Go on loading the plugin.
 define( 'POLYLANG_VERSION', '3.8-dev' );


### PR DESCRIPTION
When Polylang is already activated and we activate Polylang Pro, Polylang is automatically activated and the message "Plugin activated is displayed".

When Polylang Pro is already activated and we attempt to activate Polylang, the plugin is not activated. We used to display the message "Plugin deactivated" taken from the list of WordPress available messages.

This PR improves this message to display "You can't activate Polylang and Polylang Pro at the same time." (exact message to be discussed). This is now an error message (to be discussed if a warning is more appropriate).