### PR TITLE
Refactor `term_exists_by_slug()` to use `get_terms()`.

### DIFF
--- a/include/model.php
+++ b/include/model.php
@@ -309,7 +309,7 @@ class PLL_Model {
 
 		$terms = get_terms( $args );
 
-		return ! empty( $terms ) && is_array( $terms ) ? (int) $terms[0] : 0;
+		return ! empty( $terms ) && is_array( $terms ) ? (int) reset( $terms ) : 0;
 	}
 
 	/**


### PR DESCRIPTION
Following https://github.com/polylang/polylang/pull/1790.

## What

Refactors `PLL_Model::term_exists_by_slug()` to use WordPress `get_terms()`  instead of direct SQL queries.

## Why

As suggested in [this comment](https://github.com/polylang/polylang/pull/1790#discussion_r2686674985), we can now rewrite `term_exists_by_slug()` to use WP functions instead of direct SQL, which was not possible in older WP versions.

## Fix

Replace SQL query with `get_terms()` call.

## Tests

All existing tests pass.

The method is tested indirectly through slug related tests in `Slugs_Test` since it's used by `PLL_Term_Slug::get_suffixed_slug()`.