### PR TITLE
Return `User_Interface` instead of `NOOP` to please PHPStan with generated stubs.

### DIFF
--- a/include/Capabilities/User/Creator.php
+++ b/include/Capabilities/User/Creator.php
@@ -27,9 +27,9 @@ class Creator implements Creator_Interface {
 	 * @since 3.8
 	 *
 	 * @param WP_User $user The user to decorate.
-	 * @return NOOP New instance of NOOP.
+	 * @return User_Interface Instance of `NOOP`.
 	 */
-	public function get( WP_User $user ): NOOP {
+	public function get( WP_User $user ): User_Interface {
 		if ( $this->instance && $user->ID === $this->instance->get_id() ) {
 			return $this->instance;
 		}


### PR DESCRIPTION
All in the title.
Should fix https://github.com/polylang/polylang-phpstan/actions/runs/21513981148/job/61987688929?pr=19#step:5:10
And fix https://github.com/polylang/polylang-pro/actions/runs/21510943074/job/61977648539#step:3:306

> [!NOTE]
> I've opened an issue in `php-stubs/generator` https://github.com/php-stubs/generator/issues/40 to see if this can be fixed during stub generation instead.
> If the issue is addressed, we'll be able to revert this PR.