### PR TITLE
Fix non expiring cache of `count_posts()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -859,12 +859,6 @@ parameters:
 			path: src/mo.php
 
 		-
-			message: '#^Method PLL_Model\:\:count_posts\(\) should return int\<0, max\> but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/model.php
-
-		-
 			message: '#^Method PLL_Model\:\:get_links_model\(\) should return PLL_Links_Model but returns object\.$#'
 			identifier: return.type
 			count: 1

--- a/src/model.php
+++ b/src/model.php
@@ -620,7 +620,7 @@ class PLL_Model {
 	 * @since 3.9
 	 *
 	 * @param string $cache_key The cache key.
-	 * @return mixed The counts grouped per language, false if the cache is empty.
+	 * @return array|false The counts grouped per language, false if the cache is empty.
 	 */
 	private function get_counts_cache( string $cache_key ) {
 		$last_changed = wp_cache_get_last_changed( 'posts' );
@@ -628,10 +628,12 @@ class PLL_Model {
 		if ( ! function_exists( 'wp_cache_get_salted' ) ) {
 			// Backward compatibility with WordPress < 6.9.
 			$cache_key = "{$cache_key}:{$last_changed}";
-			return wp_cache_get( $cache_key, 'posts' );
+			$counts    = wp_cache_get( $cache_key, 'posts' );
+		} else {
+			$counts = wp_cache_get_salted( $cache_key, 'posts', $last_changed );
 		}
 
-		return wp_cache_get_salted( $cache_key, 'posts', $last_changed );
+		return is_array( $counts ) ? $counts : false;
 	}
 
 	/**
@@ -643,7 +645,7 @@ class PLL_Model {
 	 * @param int[]  $counts    The number of posts grouped per language.
 	 * @return bool True if the value has been stored, false otherwise.
 	 */
-	private function set_counts_cache( $cache_key, array $counts ) {
+	private function set_counts_cache( $cache_key, array $counts ): bool {
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 
 		if ( ! function_exists( 'wp_cache_set_salted' ) ) {


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/1967

In `PLL_Model::count_post()`, the cache doesn't expire. This is an issue for sites using object cache.
This PR proposes to salt the cache key with `wp_cache_get_last_changed()`.
The 2 private methods are introduced to handle the backward compatibility with WP < 6.9. They could be removed in the future when we will stop supporting WP 6.8 and older.