### PR TITLE
Re-align icons in wizard

### DIFF
--- a/src/modules/wizard/css/wizard.css
+++ b/src/modules/wizard/css/wizard.css
@@ -510,6 +510,7 @@ body {
 
 .pll-wizard .button .dashicons{
 	vertical-align: middle;
+	line-height: 1;
 }
 .rtl .dashicons-arrow-right-alt2:before {
 	content: "\f341";


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2938.

## What

Icons in the wizard appeared too low.

## Why

Because of [this change](https://github.com/WordPress/WordPress/blob/bb5bbfa16e45ef921deeeabddd22ea9bfdd2e4a8/wp-includes/css/buttons.css#L115) from [this commit](https://github.com/WordPress/WordPress/commit/cc0fed354707bda984d8aacee4bc7cf4d8569991).

## How

Force a `line-height: 1`.