### PR TITLE
Tests: fix `Admin_Menu_Test` failure due to `global $menu` scope issue.

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -214,9 +214,7 @@ trait PLL_UnitTestCase_Trait {
 	 * @return array
 	 */
 	protected function require_wp_menus( $trigger_hooks = true ) {
-		global $submenu, $wp_filter;
-		global $_wp_submenu_nopriv;
-		global $menu;
+		global $menu, $submenu, $wp_filter, $_wp_submenu_nopriv;
 
 		if ( isset( static::$submenu ) ) {
 			$submenu = static::$submenu;


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang/actions/runs/22862894722/job/66321647604?pr=1828.

## What
Add `global $menu;` to `require_wp_menus()` in `testcase-trait.php`.

## Why
`Admin_Menu_Test` is failing on WP nightly with:
```
Invalid argument supplied for foreach()
wp-admin/includes/menu.php:52
```
A recent WP commit (see https://github.com/WordPress/wordpress-develop/commit/826b02416577f039d337a970df5947588d65a814) added an explicit `global $menu, $submenu, $compat;` declaration in `wp-admin/includes/menu.php`.

The root cause is a PHP scoping issue: `require_wp_menus()` is a class method, so `wp-admin/menu.php` runs in the method's local scope.
Its `$menu` assignments therefore never touch `$GLOBALS['menu']`, leaving it empty.

Before this WP change, `includes/menu.php` had no `global` declaration and naturally used the local `$menu`, this fix made it start fetching the empty `$GLOBALS['menu']` instead, causing the `foreach` to fail.

This issue is test-only: in a real WP request, `wp-admin/menu.php` is always loaded from the global scope.

## How
Declaring `global $menu` in `require_wp_menus()` before the `require_once` ensures `wp-admin/menu.php` writes directly into `$GLOBALS['menu']`, which `includes/menu.php` then finds correctly populated. This fix is backward compatible.