### PR TITLE
Raise PHPCompatibilityWP version to 3.0.0-alpha2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"wp-coding-standards/wpcs": "^3",
 		"automattic/vipwpcs": "*",
-		"phpcompatibility/phpcompatibility-wp": "*",
+		"phpcompatibility/phpcompatibility-wp": "^3",
 		"yoast/wp-test-utils": "^1.0.0",
 		"rector/rector": "^2",
 		"wpsyntex/wp-phpunit": "dev-master",


### PR DESCRIPTION
This allows to raise PHPCompatibilityWP version to 10.0.0-alpha2 for better handling of recent PHP versions.
See https://core.trac.wordpress.org/ticket/64634 for the context.