### PR TITLE
Fix conflict with the plugin Groups

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -289,11 +289,26 @@ class PLL_Filters {
 	 * @return array
 	 */
 	public function fix_privacy_policy_page_editing( $caps, $cap, $user_id, $args ) {
-		if ( in_array( $cap, array( 'edit_page', 'edit_post', 'delete_page', 'delete_post' ) ) ) {
-			$privacy_page = get_option( 'wp_page_for_privacy_policy' );
-			if ( $privacy_page && array_intersect( $args, $this->model->post->get_translations( $privacy_page ) ) ) {
-				$caps = array_merge( $caps, map_meta_cap( 'manage_privacy_options', $user_id ) );
-			}
+		if ( ! in_array( $cap, array( 'edit_page', 'edit_post', 'delete_page', 'delete_post' ), true ) ) {
+			return $caps;
+		}
+
+		if ( empty( $args[0] ) ) {
+			return $caps;
+		}
+
+		/*
+		 * We expect a post ID, but nothing prevents to receive a `WP_Post`,
+		 * so let make sure we manipulate a post ID in any case.
+		 */
+		$post = get_post( $args[0] );
+		if ( ! $post ) {
+			return $caps;
+		}
+
+		$privacy_page = get_option( 'wp_page_for_privacy_policy' );
+		if ( $privacy_page && in_array( $post->ID, $this->model->post->get_translations( $privacy_page ), true ) ) {
+			$caps = array_merge( $caps, map_meta_cap( 'manage_privacy_options', $user_id ) );
 		}
 
 		return $caps;


### PR DESCRIPTION
We expect that the second parameter of calls to `current_user_can()` is an ID of an abject when checking a meta capability. This is how it's documented in https://developer.wordpress.org/reference/functions/current_user_can/#description

However the way it is coded, nothing in WordPress prevents to pass a `WP_Post` object instead of a post ID. See https://github.com/WordPress/WordPress/blob/6.9.4/wp-includes/capabilities.php#L209

So to avoid a fatal error if a developer exploits this loose typing, then we must also expect to receive a post ID or `WP_Post` object. 
