### PR TITLE
Remove lodash dependency.

### DIFF
--- a/js/src/blocks/language-switcher-edit.js
+++ b/js/src/blocks/language-switcher-edit.js
@@ -3,11 +3,6 @@
  */
 
 /**
- * External dependencies
- */
-import { assign } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { ToggleControl } from '@wordpress/components';
@@ -39,9 +34,10 @@ export function createLanguageSwitcherEdit( props ) {
 
 			if ( 'show_names' === propName || 'show_flags' === propName ) {
 				if ( value && forcedAttributeUnchecked ) {
-					updatedAttributes = assign( updatedAttributes, {
+					updatedAttributes = {
+						...updatedAttributes,
 						[ forcedAttributeName ]: forcedAttributeUnchecked,
-					} );
+					};
 				}
 			}
 			setAttributes( updatedAttributes );

--- a/js/src/lib/confirmation-modal.js
+++ b/js/src/lib/confirmation-modal.js
@@ -6,8 +6,6 @@ const languagesList = jQuery( '.post_lang_choice' );
 
 // Dialog box for alerting the user about a risky changing.
 export const initializeConfirmationModal = () => {
-	// We can't use underscore or lodash in this common code because it depends of the context classic or block editor.
-	// Classic editor underscore is loaded, Block editor lodash is loaded.
 	const { __ } = wp.i18n;
 
 	// Create dialog container.

--- a/src/modules/Blocks/Language_Switcher/Abstract_Block.php
+++ b/src/modules/Blocks/Language_Switcher/Abstract_Block.php
@@ -150,7 +150,6 @@ abstract class Abstract_Block {
 				'wp-element',
 				'wp-i18n',
 				'wp-server-side-render',
-				'lodash',
 			),
 			POLYLANG_VERSION,
 			true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,6 @@ function configureWebpack( options ) {
 		libraryName: 'polylang',
 		isProduction,
 		wpDependencies,
-		additionalExternals: { lodash: 'lodash' },
 		sassLoadPaths: [
 			path.resolve(
 				workingDirectory,


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/1837.

## What

Remove lodash dependency from Polylang.

## Why

Gutenberg definitively removed its lodash dependency ([WordPress/gutenberg#41373](https://github.com/WordPress/gutenberg/pull/52571)).
## How

- `language-switcher-edit.js` : the only actual lodash usage (`assign`) is replaced by a native object spread
- `Abstract_Block.php` : `'lodash'` removed from the `wp_register_script` dependencies array
- `webpack.config.js` : `additionalExternals: { lodash: 'lodash' }` removed since lodash is no longer externalized
- `confirmation-modal.js` : obsolete comment about lodash removed
