### PR TITLE
Fix the settings redirect in Playground

### DIFF
--- a/src/settings/settings-module.php
+++ b/src/settings/settings-module.php
@@ -152,13 +152,13 @@ class PLL_Settings_Module {
 			'deactivate'  => sprintf(
 				'<a title="%s" href="%s">%s</a>',
 				esc_attr__( 'Deactivate this module', 'polylang' ),
-				esc_url( wp_nonce_url( '?page=mlang&tab=modules&pll_action=deactivate&noheader=true&module=' . $this->module, 'pll_deactivate' ) ),
+				esc_url( wp_nonce_url( '?page=mlang_settings&pll_action=deactivate&noheader=true&module=' . $this->module, 'pll_deactivate' ) ),
 				esc_html__( 'Deactivate', 'polylang' )
 			),
 			'activate'    => sprintf(
 				'<a title="%s" href="%s">%s</a>',
 				esc_attr__( 'Activate this module', 'polylang' ),
-				esc_url( wp_nonce_url( '?page=mlang&tab=modules&pll_action=activate&noheader=true&module=' . $this->module, 'pll_activate' ) ),
+				esc_url( wp_nonce_url( '?page=mlang_settings&pll_action=activate&noheader=true&module=' . $this->module, 'pll_activate' ) ),
 				esc_html__( 'Activate', 'polylang' )
 			),
 			'activated'   => esc_html__( 'Activated', 'polylang' ),

--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -355,8 +355,9 @@ class PLL_Settings extends PLL_Admin_Base {
 			set_transient( 'settings_errors', $errors, 30 );
 			$args['settings-updated'] = 1;
 		}
-		// Remove possible 'pll_action' and 'lang' query args from the referer before redirecting
-		wp_safe_redirect( add_query_arg( $args, remove_query_arg( array( 'pll_action', 'lang' ), wp_get_referer() ) ) );
+		// Remove all known query args from the referer before redirecting.
+		$to_remove = array( 'lang', 'module', 'pll_action', 'noheader', '_wpnonce' );
+		wp_safe_redirect( add_query_arg( $args, remove_query_arg( $to_remove, wp_get_referer() ) ) );
 		exit;
 	}
 


### PR DESCRIPTION
This PR fixes an unexpected behavior with Playground.

1. Visit https://my.wordpress.net
2. Install Polylang 
3. Go to Languages > Settings
4. Activate the translation for media
5. :boom: 

The bug occurs: 
- in the languages page (The delete action, Language activation/deactivation in Polylang Pro).
- in the settings page (Media, Detect browser language).

It seems that `wp_get_referer()` doesn't return the expected value as the displayed url is `/wp-admin/admin.php?page=mlang&tab=modules&noheader=true&module=media&_wpnonce=64e1c3589e` instead of the expected `wp-admin/admin.php?page=mlang_settings`.

In this PR:
- Fix the activate/deactivate link (including removal of the tab param which is not used for a (very) long time.
- Remove all known query args from the redirected url. 