### PR TITLE
Fix conflict with Yoast Duplicate Post

### DIFF
--- a/changelog/1536
+++ b/changelog/1536
@@ -1,0 +1,1 @@
+* Pro Fix synchronized posts deleted when using "Rewrite & Republish" in Yoast Duplicate Post. Props @krokodok #1536

--- a/src/integrations/duplicate-post/duplicate-post.php
+++ b/src/integrations/duplicate-post/duplicate-post.php
@@ -48,7 +48,7 @@ class PLL_Duplicate_Post {
 	 * @param string[] $keys List of meta keys.
 	 * @return string[]
 	 */
-	public function exclude_post_metas( $keys ) {
+	public function exclude_post_metas( $keys ): array {
 		$to_remove = array(
 			'_dp_original',
 			'_dp_is_rewrite_republish_copy',
@@ -68,7 +68,7 @@ class PLL_Duplicate_Post {
 	 * @param int $post_id The original post's ID.
 	 * @return void
 	 */
-	public function after_rewriting( $copy_id, $post_id ) {
+	public function after_rewriting( $copy_id, $post_id ): void {
 		$language     = pll_get_post_language( $post_id );
 		$translations = pll_get_post_translations( $post_id );
 

--- a/src/integrations/duplicate-post/duplicate-post.php
+++ b/src/integrations/duplicate-post/duplicate-post.php
@@ -16,6 +16,7 @@ class PLL_Duplicate_Post {
 	 */
 	public function init() {
 		add_filter( 'option_duplicate_post_taxonomies_blacklist', array( $this, 'taxonomies_blacklist' ) );
+		add_filter( 'pll_copy_post_metas', array( $this, 'exclude_post_metas' ) );
 	}
 
 	/**
@@ -33,5 +34,26 @@ class PLL_Duplicate_Post {
 
 		$taxonomies[] = 'post_translations';
 		return $taxonomies;
+	}
+
+	/**
+	 * Exclude Duplicate Post metas from the copy/synchronization.
+	 *
+	 * This avoids synchronized posts to be deleted when using "Rewrite & Republish".
+	 *
+	 * @since 3.9
+	 *
+	 * @param string[] $keys List of meta keys.
+	 * @return string[]
+	 */
+	public function exclude_post_metas( $keys ) {
+		$to_remove = array(
+			'_dp_original',
+			'_dp_is_rewrite_republish_copy',
+			'_dp_has_rewrite_republish_copy',
+			'_dp_creation_date_gmt',
+		);
+
+		return array_diff( $keys, $to_remove );
 	}
 }

--- a/src/integrations/duplicate-post/duplicate-post.php
+++ b/src/integrations/duplicate-post/duplicate-post.php
@@ -17,6 +17,8 @@ class PLL_Duplicate_Post {
 	public function init() {
 		add_filter( 'option_duplicate_post_taxonomies_blacklist', array( $this, 'taxonomies_blacklist' ) );
 		add_filter( 'pll_copy_post_metas', array( $this, 'exclude_post_metas' ) );
+
+		add_action( 'duplicate_post_after_rewriting', array( $this, 'after_rewriting' ), 20, 2 );
 	}
 
 	/**
@@ -55,5 +57,22 @@ class PLL_Duplicate_Post {
 		);
 
 		return array_diff( $keys, $to_remove );
+	}
+
+	/**
+	 * Fixes the translations group just after a post is republished.
+	 *
+	 * @since 3.9
+	 *
+	 * @param int $copy_id The copy's ID.
+	 * @param int $post_id The original post's ID.
+	 * @return void
+	 */
+	public function after_rewriting( $copy_id, $post_id ) {
+		$language     = pll_get_post_language( $post_id );
+		$translations = pll_get_post_translations( $post_id );
+
+		$translations[ $language ] = $post_id;
+		pll_save_post_translations( $translations );
 	}
 }

--- a/src/translated-object.php
+++ b/src/translated-object.php
@@ -405,9 +405,7 @@ abstract class PLL_Translated_Object extends PLL_Translatable_Object {
 	 * @phpstan-param array<non-empty-string, positive-int> $translations
 	 */
 	protected function should_update_translation_group( $id, $translations ) {
-		// Don't do anything if no translations have been added to the group.
-		$old_translations = $this->get_translations( $id ); // Includes at least $id itself.
-		return ! empty( array_diff_assoc( $translations, $old_translations ) );
+		return count( $translations ) > 1;
 	}
 
 	/**

--- a/src/translated-term.php
+++ b/src/translated-term.php
@@ -279,15 +279,7 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @phpstan-param array<non-empty-string, positive-int> $translations
 	 */
 	protected function should_update_translation_group( $id, $translations ) {
-		// Don't do anything if no translations have been added to the group.
-		$old_translations = $this->get_translations( $id );
-		if ( count( $translations ) > 1 && ! empty( array_diff_assoc( $translations, $old_translations ) ) ) {
-			return true;
-		}
-
-		// But we need a translation group for terms to allow relationships remap when importing from a WXR file
-		$term = $this->get_object_term( $id, $this->tax_translations );
-		return empty( $term ) || ! empty( array_diff_assoc( $translations, $old_translations ) );
+		return true;
 	}
 
 	/**

--- a/src/translated-term.php
+++ b/src/translated-term.php
@@ -279,7 +279,13 @@ class PLL_Translated_Term extends PLL_Translated_Object implements PLL_Translata
 	 * @phpstan-param array<non-empty-string, positive-int> $translations
 	 */
 	protected function should_update_translation_group( $id, $translations ) {
-		return true;
+		if ( count( $translations ) > 1 ) {
+			return true;
+		}
+
+		$old_translations = $this->get_translations( $id );
+		$term             = $this->get_object_term( $id, $this->tax_translations );
+		return empty( $term ) || ! empty( array_diff_assoc( $translations, $old_translations ) );
 	}
 
 	/**


### PR DESCRIPTION
Fix #1536 

Fix synchronized posts deleted when using "Rewrite & Republish" by excluding post metas from the copy/synchronizations as suggested.

Also fixes the broken translations group when a post is republished.
To reproduce :
1. Create 2 translated posts (not necessarily synchronized), Let say English and French.
2. In the list table click on "Rewrite & Republish", let say for the English post. 
3. Once the editor is open, click on Republish.
4. Visit the posts list table and see how the French post has lost its link to the English post. 
<img width="960" height="331" alt="image" src="https://github.com/user-attachments/assets/0efb2604-6e7d-49e2-940c-3916bf59da01" />

To fix the issue, I had to partially revert a28f803d0a79ee6e0c535060cd7978e8b741a776. Indeed Duplicate Post breaks the translations group, but it's not possible to repair it (seen from the English post, the translations look ok, so if we attempted to repair it `should_update_translation_group()` would return false). So need to always update the translation group if we want to be able to repair it (I excluded only one case for terms when the translation group only includes one term). See [the test](https://github.com/polylang/polylang/blob/3.8.2/tests/phpunit/tests/test-translated-term.php#L223) which pushed me to exclude this specific case. 
