### PR TITLE
Remove useless active_tab property

### DIFF
--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -274,6 +274,10 @@ class PLL_Settings extends PLL_Admin_Base {
 			$this->handle_actions( $action );
 		}
 
+		if ( ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
 		$active_tab = 'mlang' === $_GET['page'] ? 'lang' : substr( sanitize_key( $_GET['page'] ), 6 ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		switch ( $active_tab ) {

--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -12,13 +12,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class PLL_Settings extends PLL_Admin_Base {
 	/**
-	 * Name of the active module.
-	 *
-	 * @var string|null
-	 */
-	protected $active_tab;
-
-	/**
 	 * Array of modules classes.
 	 *
 	 * @var PLL_Settings_Module[]|null
@@ -34,10 +27,6 @@ class PLL_Settings extends PLL_Admin_Base {
 	 */
 	public function __construct( &$links_model ) {
 		parent::__construct( $links_model );
-
-		if ( isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->active_tab = 'mlang' === $_GET['page'] ? 'lang' : substr( sanitize_key( $_GET['page'] ), 6 ); // phpcs:ignore WordPress.Security.NonceVerification
-		}
 
 		PLL_Admin_Strings::init();
 
@@ -276,7 +265,18 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function languages_page() {
-		switch ( $this->active_tab ) {
+		// Handle user input.
+		$action = isset( $_REQUEST['pll_action'] ) && is_string( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
+		} elseif ( ! empty( $action ) ) {
+			$this->handle_actions( $action );
+		}
+
+		$active_tab = 'mlang' === $_GET['page'] ? 'lang' : substr( sanitize_key( $_GET['page'] ), 6 ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		switch ( $active_tab ) {
 			case 'lang':
 				// Prepare the list table of languages
 				$list_table = new PLL_Table_Languages();
@@ -289,18 +289,8 @@ class PLL_Settings extends PLL_Admin_Base {
 				break;
 		}
 
-		// Handle user input.
-		$action = isset( $_REQUEST['pll_action'] ) && is_string( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
-		} elseif ( ! empty( $action ) ) {
-			$this->handle_actions( $action );
-		}
-
-		// Displays the page
-		$modules    = $this->modules;
-		$active_tab = $this->active_tab;
+		// Displays the page.
+		$modules = $this->modules;
 		include __DIR__ . '/view-languages.php';
 	}
 

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -18,11 +18,17 @@ class Settings_Test extends PLL_UnitTestCase {
 	}
 
 	public function set_up() {
-		global $pagenow;
-
 		parent::set_up();
 
-		$pagenow = 'admin.php'; // Set $pagenow so `get_admin_page_parent()` doesn't throw PHP deprecation notice with PHP 8.5.
+		global $pagenow, $hook_suffix, $plugin_page;
+
+		// Setup globals.
+		$_GET['page'] = 'mlang';
+		$pagenow      = 'admin.php'; // Set $pagenow so `get_admin_page_parent()` doesn't throw PHP deprecation notice with PHP 8.5.
+		$hook_suffix  = 'settings_page_mlang';
+		$plugin_page  = 'mlang';
+		get_admin_page_title();
+		set_current_screen();
 
 		// Avoid an API request triggered by wp_get_available_translations() called in languages_page().
 		add_filter( 'pre_site_transient_available_translations', '__return_empty_array' );
@@ -36,13 +42,8 @@ class Settings_Test extends PLL_UnitTestCase {
 
 		// Setup globals.
 		$_GET['lang']           = $lang->term_id;
-		$_GET['page']           = 'mlang';
 		$_GET['pll_action']     = 'edit';
 		$_REQUEST['pll_action'] = 'edit'; // languages_page() tests $_REQUEST.
-		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
-		$GLOBALS['plugin_page'] = 'mlang';
-		get_admin_page_title();
-		set_current_screen();
 
 		ob_start();
 		$links_model = self::$model->get_links_model();
@@ -70,10 +71,6 @@ class Settings_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_notice_for_objects_with_no_lang() {
-		$_GET['page'] = 'mlang';
-		$GLOBALS['hook_suffix'] = 'settings_page_mlang';
-		set_current_screen();
-
 		$links_model = self::$model->get_links_model();
 		new PLL_Settings( $links_model );
 		do_action( 'admin_menu' );


### PR DESCRIPTION
`PLL_Settings::$active_tab` is used in only one method, so it's useless to have it as a property.
Also took the opportunity to fix the Settings test `test_display_settings_errors()` which could not run in isolation due to missing globals. 