### PR TITLE
Fix error when the WXR import files has synchronized posts

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,7 +21,7 @@ extend-ignore-re = [
     # En français dans le texte.
     "Tableau de bord",
     "Etiquette exemple",
-    "<!\\[CDATA\\[non-classe\\]\\]>",
+    "non-classe",
     "\\bicl_lso_",
 ]
 

--- a/src/integrations/wp-importer/wp-import.php
+++ b/src/integrations/wp-importer/wp-import.php
@@ -132,50 +132,50 @@ class PLL_WP_Import extends WP_Import {
 	protected function remap_terms_relations( &$terms ) {
 		global $wpdb;
 
-		$trs = array();
+		$term_relationships = array();
 
 		foreach ( $terms as $term ) {
 			$translations = maybe_unserialize( $term['term_description'] );
 			foreach ( $translations as $slug => $old_id ) {
 				if ( $old_id && ! empty( $this->processed_terms[ $old_id ] ) && $lang = PLL()->model->get_language( $slug ) ) {
 					// Language relationship.
-					$trs[] = array( $this->processed_terms[ $old_id ], $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' ) );
+					$term_relationships[] = array( $this->processed_terms[ $old_id ], $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' ) );
 
 					// Translation relationship.
-					$trs[] = array( $this->processed_terms[ $old_id ], get_term( $this->processed_terms[ $term['term_id'] ], 'term_translations' )->term_taxonomy_id );
+					$term_relationships[] = array( $this->processed_terms[ $old_id ], get_term( $this->processed_terms[ $term['term_id'] ], 'term_translations' )->term_taxonomy_id );
 				}
 			}
 		}
 
 		// Insert term_relationships.
-		if ( ! empty( $trs ) ) {
+		if ( ! empty( $term_relationships ) ) {
 			// Make sure we don't attempt to insert already existing term relationships.
-			$existing_trs = $wpdb->get_results(
+			$existing_term_relationships = $wpdb->get_results(
 				"SELECT tr.object_id, tr.term_taxonomy_id FROM {$wpdb->term_relationships} AS tr
 				INNER JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				WHERE tt.taxonomy IN ( 'term_language', 'term_translations' )"
 			);
 
-			foreach ( $existing_trs as $key => $tr ) {
-				$existing_trs[ $key ] = array( $tr->object_id, $tr->term_taxonomy_id );
+			foreach ( $existing_term_relationships as $key => $tr ) {
+				$existing_term_relationships[ $key ] = array( $tr->object_id, $tr->term_taxonomy_id );
 			}
 
-			$trs = array_udiff(
-				$trs,
-				$existing_trs,
+			$term_relationships = array_udiff(
+				$term_relationships,
+				$existing_term_relationships,
 				function ( $a, $b ) {
 					return strcmp( implode( ',', $a ), implode( ',', $b ) ); // An easy way to compare arrays (ok if values are int or numeric strings).
 				}
 			);
 
-			if ( ! empty( $trs ) ) {
+			if ( ! empty( $term_relationships ) ) {
 				$wpdb->query(
 					$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 						sprintf(
 							"INSERT INTO {$wpdb->term_relationships} ( object_id, term_taxonomy_id ) VALUES %s",
-							implode( ',', array_fill( 0, count( $trs ), '( %d, %d )' ) )
+							implode( ',', array_fill( 0, count( $term_relationships ), '( %d, %d )' ) )
 						),
-						array_merge( ...$trs )
+						array_merge( ...$term_relationships )
 					)
 				);
 			}
@@ -194,7 +194,7 @@ class PLL_WP_Import extends WP_Import {
 		global $wpdb;
 
 		$languages = pll_languages_list();
-		$u         = array();
+		$to_update = array();
 
 		foreach ( $terms as $term ) {
 			$translations     = maybe_unserialize( $term['term_description'] );
@@ -208,22 +208,22 @@ class PLL_WP_Import extends WP_Import {
 			}
 
 			if ( ! empty( $new_translations ) ) {
-				$u['case'][] = array( $this->processed_terms[ $term['term_id'] ], maybe_serialize( $new_translations ) );
-				$u['in'][]   = (int) $this->processed_terms[ $term['term_id'] ];
+				$to_update['case'][] = array( $this->processed_terms[ $term['term_id'] ], maybe_serialize( $new_translations ) );
+				$to_update['in'][]   = (int) $this->processed_terms[ $term['term_id'] ];
 			}
 		}
 
-		if ( ! empty( $u ) ) {
+		if ( ! empty( $to_update ) ) {
 			$wpdb->query(
 				$wpdb->prepare(
 					sprintf(
 						"UPDATE {$wpdb->term_taxonomy}
 						SET description = ( CASE term_id %s END )
 						WHERE term_id IN (%s)",
-						implode( ' ', array_fill( 0, count( $u['case'] ), 'WHEN %d THEN %s' ) ),
-						implode( ',', array_fill( 0, count( $u['in'] ), '%d' ) )
+						implode( ' ', array_fill( 0, count( $to_update['case'] ), 'WHEN %d THEN %s' ) ),
+						implode( ',', array_fill( 0, count( $to_update['in'] ), '%d' ) )
 					),
-					array_merge( array_merge( ...$u['case'] ), $u['in'] )
+					array_merge( array_merge( ...$to_update['case'] ), $to_update['in'] )
 				)
 			);
 		}

--- a/src/integrations/wp-importer/wp-import.php
+++ b/src/integrations/wp-importer/wp-import.php
@@ -83,7 +83,7 @@ class PLL_WP_Import extends WP_Import {
 		}
 
 		// Clean languages cache in case some of them were created during import.
-		PLL()->model->clean_languages_cache();
+		PLL()->model->languages->clean_cache();
 
 		$this->remap_terms_relations( $term_translations );
 		$this->remap_translations( $term_translations, $this->processed_terms );
@@ -107,7 +107,7 @@ class PLL_WP_Import extends WP_Import {
 
 		parent::process_posts();
 
-		PLL()->model->clean_languages_cache(); // To update the posts count in ( cached ) languages list
+		PLL()->model->languages->clean_cache(); // To update the posts count in (cached) languages list.
 
 		$this->remap_translations( $this->post_translations, $this->processed_posts );
 		unset( $this->post_translations );
@@ -123,11 +123,11 @@ class PLL_WP_Import extends WP_Import {
 	}
 
 	/**
-	 * Remaps terms languages
+	 * Remaps terms languages.
 	 *
 	 * @since 1.2
 	 *
-	 * @param array $terms array of terms in 'term_translations' taxonomy
+	 * @param array $terms array of terms in 'term_translations' taxonomy.
 	 */
 	protected function remap_terms_relations( &$terms ) {
 		global $wpdb;
@@ -160,7 +160,13 @@ class PLL_WP_Import extends WP_Import {
 				$existing_trs[ $key ] = array( $tr->object_id, $tr->term_taxonomy_id );
 			}
 
-			$trs = array_diff( $trs, $existing_trs );
+			$trs = array_udiff(
+				$trs,
+				$existing_trs,
+				function ( $a, $b ) {
+					return strcmp( implode( ',', $a ), implode( ',', $b ) ); // An easy way to compare arrays (ok if values are int or numeric strings).
+				}
+			);
 
 			if ( ! empty( $trs ) ) {
 				$wpdb->query(
@@ -177,31 +183,33 @@ class PLL_WP_Import extends WP_Import {
 	}
 
 	/**
-	 * Remaps translations for both posts and terms
+	 * Remaps translations for both posts and terms.
 	 *
 	 * @since 1.2
 	 *
-	 * @param array $terms array of terms in 'post_translations' or 'term_translations' taxonomies
-	 * @param array $processed_objects array of posts or terms processed by WordPress Importer
+	 * @param array $terms             Array of terms in 'post_translations' or 'term_translations' taxonomies?
+	 * @param array $processed_objects Array of posts or terms processed by WordPress Importer.
 	 */
 	protected function remap_translations( &$terms, &$processed_objects ) {
 		global $wpdb;
 
-		$u = array();
+		$languages = pll_languages_list();
+		$u         = array();
 
 		foreach ( $terms as $term ) {
-			$translations = maybe_unserialize( $term['term_description'] );
+			$translations     = maybe_unserialize( $term['term_description'] );
 			$new_translations = array();
-
 			foreach ( $translations as $slug => $old_id ) {
-				if ( $old_id && ! empty( $processed_objects[ $old_id ] ) ) {
+				if ( in_array( $slug, $languages, true ) && $old_id && ! empty( $processed_objects[ $old_id ] ) ) {
 					$new_translations[ $slug ] = $processed_objects[ $old_id ];
+				} else {
+					$new_translations[ $slug ] = $old_id; // Preserve values for all keys which are not our language slugs.
 				}
 			}
 
 			if ( ! empty( $new_translations ) ) {
 				$u['case'][] = array( $this->processed_terms[ $term['term_id'] ], maybe_serialize( $new_translations ) );
-				$u['in'][] = (int) $this->processed_terms[ $term['term_id'] ];
+				$u['in'][]   = (int) $this->processed_terms[ $term['term_id'] ];
 			}
 		}
 

--- a/tests/phpunit/data/test-import.xml
+++ b/tests/phpunit/data/test-import.xml
@@ -16,7 +16,7 @@
 <!-- 7. WordPress will then import each of the posts, pages, comments, categories, etc. -->
 <!--    contained in this file into your site. -->
 
-<!-- generator="WordPress/4.4.1" created="2016-01-30 17:23" -->
+	<!-- generator="WordPress/6.9.4" created="2026-04-08 07:56" -->
 <rss version="2.0"
 	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
 	xmlns:content="http://purl.org/rss/1.0/modules/content/"
@@ -29,34 +29,146 @@
 	<title>Test Import</title>
 	<link>http://localhost/wordpress/test-import</link>
 	<description>Just another WordPress site</description>
-	<pubDate>Sat, 30 Jan 2016 17:23:50 +0000</pubDate>
+	<pubDate>Wed, 08 Apr 2026 07:56:15 +0000</pubDate>
 	<language>en-US</language>
 	<wp:wxr_version>1.2</wp:wxr_version>
-	<wp:base_site_url>http://localhost/wordpress/</wp:base_site_url>
+	<wp:base_site_url>http://localhost/wordpress/test-import</wp:base_site_url>
 	<wp:base_blog_url>http://localhost/wordpress/test-import</wp:base_blog_url>
 
-	<wp:author><wp:author_id>1</wp:author_id><wp:author_login><![CDATA[admin]]></wp:author_login><wp:author_email><![CDATA[frederic.demarle@sfr.fr]]></wp:author_email><wp:author_display_name><![CDATA[admin]]></wp:author_display_name><wp:author_first_name><![CDATA[]]></wp:author_first_name><wp:author_last_name><![CDATA[]]></wp:author_last_name></wp:author>
+	<wp:author><wp:author_id>1</wp:author_id><wp:author_login><![CDATA[admin]]></wp:author_login><wp:author_email><![CDATA[fake@fake.com]]></wp:author_email><wp:author_display_name><![CDATA[admin]]></wp:author_display_name><wp:author_first_name><![CDATA[]]></wp:author_first_name><wp:author_last_name><![CDATA[]]></wp:author_last_name></wp:author>
 
-	<wp:category><wp:term_id>186</wp:term_id><wp:category_nicename><![CDATA[essai]]></wp:category_nicename><wp:category_parent><![CDATA[]]></wp:category_parent><wp:cat_name><![CDATA[Essai]]></wp:cat_name></wp:category>
-	<wp:category><wp:term_id>130</wp:term_id><wp:category_nicename><![CDATA[non-classe]]></wp:category_nicename><wp:category_parent><![CDATA[]]></wp:category_parent><wp:cat_name><![CDATA[Non classé]]></wp:cat_name></wp:category>
-	<wp:category><wp:term_id>184</wp:term_id><wp:category_nicename><![CDATA[test]]></wp:category_nicename><wp:category_parent><![CDATA[]]></wp:category_parent><wp:cat_name><![CDATA[Test]]></wp:cat_name></wp:category>
-	<wp:category><wp:term_id>145</wp:term_id><wp:category_nicename><![CDATA[uncategorized]]></wp:category_nicename><wp:category_parent><![CDATA[]]></wp:category_parent><wp:cat_name><![CDATA[Uncategorized]]></wp:cat_name></wp:category>
-	<wp:term><wp:term_id><![CDATA[{lang_id_1}]]></wp:term_id><wp:term_taxonomy><![CDATA[language]]></wp:term_taxonomy><wp:term_slug><![CDATA[en]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[English]]></wp:term_name><wp:term_description><![CDATA[a:3:{s:6:"locale";s:5:"en_GB";s:3:"rtl";i:0;s:9:"flag_code";s:2:"gb";}]]></wp:term_description><wp:termmeta><wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key><wp:meta_value><![CDATA[a:5:{i:0;a:2:{i:0;s:9:"WordPress";i:1;s:12:"WordPress EN";}i:1;a:2:{i:0;s:5:"j F Y";i:1;s:0:"";}i:2;a:2:{i:0;s:4:"G\hi";i:1;s:0:"";}i:3;a:2:{i:0;s:162:"<!-- wp:woocommerce/products-by-attribute {"attributes":[{"id":22,"attr_slug":"pa_color"},{"id":23,"attr_slug":"pa_color"},{"id":24,"attr_slug":"pa_color"}]} /-->";i:1;s:0:"";}i:4;a:2:{i:0;s:19:"<!-- wp:search /-->";i:1;s:0:"";}}]]></wp:meta_value></wp:termmeta></wp:term>
-	<wp:term><wp:term_id><![CDATA[173]]></wp:term_id><wp:term_taxonomy><![CDATA[term_language]]></wp:term_taxonomy><wp:term_slug><![CDATA[pll_en]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[English]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id><![CDATA[{lang_id_2}]]></wp:term_id><wp:term_taxonomy><![CDATA[language]]></wp:term_taxonomy><wp:term_slug><![CDATA[fr]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[Français]]></wp:term_name><wp:term_description><![CDATA[a:3:{s:6:"locale";s:5:"fr_FR";s:3:"rtl";i:0;s:9:"flag_code";s:2:"fr";}]]></wp:term_description><wp:termmeta><wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key><wp:meta_value><![CDATA[a:5:{i:0;a:2:{i:0;s:9:"WordPress";i:1;s:12:"WordPress FR";}i:1;a:2:{i:0;s:5:"j F Y";i:1;s:0:"";}i:2;a:2:{i:0;s:4:"G\hi";i:1;s:0:"";}i:3;a:2:{i:0;s:162:"<!-- wp:woocommerce/products-by-attribute {"attributes":[{"id":22,"attr_slug":"pa_color"},{"id":23,"attr_slug":"pa_color"},{"id":24,"attr_slug":"pa_color"}]} /-->";i:1;s:0:"";}i:4;a:2:{i:0;s:19:"<!-- wp:search /-->";i:1;s:0:"";}}]]></wp:meta_value></wp:termmeta></wp:term>
-	<wp:term><wp:term_id><![CDATA[175]]></wp:term_id><wp:term_taxonomy><![CDATA[term_language]]></wp:term_taxonomy><wp:term_slug><![CDATA[pll_fr]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[Français]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id><![CDATA[72]]></wp:term_id><wp:term_taxonomy><![CDATA[term_translations]]></wp:term_taxonomy><wp:term_slug><![CDATA[pll_556f4259cb4bc]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[pll_556f4259cb4bc]]></wp:term_name><wp:term_description><![CDATA[a:2:{s:2:"en";i:145;s:2:"fr";i:130;}]]></wp:term_description></wp:term>
-	<wp:term><wp:term_id><![CDATA[185]]></wp:term_id><wp:term_taxonomy><![CDATA[term_translations]]></wp:term_taxonomy><wp:term_slug><![CDATA[pll_56aceccce73e1]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[pll_56aceccce73e1]]></wp:term_name><wp:term_description><![CDATA[a:2:{s:2:"en";i:184;s:2:"fr";i:186;}]]></wp:term_description></wp:term>
-	<wp:term><wp:term_id><![CDATA[188]]></wp:term_id><wp:term_taxonomy><![CDATA[post_translations]]></wp:term_taxonomy><wp:term_slug><![CDATA[pll_56acecea35bef]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[pll_56acecea35bef]]></wp:term_name><wp:term_description><![CDATA[a:2:{s:2:"fr";i:400;s:2:"en";i:398;}]]></wp:term_description></wp:term>
-	<wp:term><wp:term_id><![CDATA[189]]></wp:term_id><wp:term_taxonomy><![CDATA[post_translations]]></wp:term_taxonomy><wp:term_slug><![CDATA[pll_56aced161652a]]></wp:term_slug><wp:term_parent><![CDATA[]]></wp:term_parent><wp:term_name><![CDATA[pll_56aced161652a]]></wp:term_name><wp:term_description><![CDATA[a:2:{s:2:"fr";i:404;s:2:"en";i:402;}]]></wp:term_description></wp:term>
-	<wp:term><wp:term_id>190</wp:term_id><wp:term_taxonomy>nav_menu</wp:term_taxonomy><wp:term_slug><![CDATA[menu_en]]></wp:term_slug><wp:term_name><![CDATA[menu_en]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>191</wp:term_id><wp:term_taxonomy>nav_menu</wp:term_taxonomy><wp:term_slug><![CDATA[menu_fr]]></wp:term_slug><wp:term_name><![CDATA[menu_fr]]></wp:term_name></wp:term>
+	<wp:category>
+		<wp:term_id>2</wp:term_id>
+		<wp:category_nicename><![CDATA[essai]]></wp:category_nicename>
+		<wp:category_parent><![CDATA[]]></wp:category_parent>
+		<wp:cat_name><![CDATA[Essai]]></wp:cat_name>
+	</wp:category>
+	<wp:category>
+		<wp:term_id>3</wp:term_id>
+		<wp:category_nicename><![CDATA[non-classe]]></wp:category_nicename>
+		<wp:category_parent><![CDATA[]]></wp:category_parent>
+		<wp:cat_name><![CDATA[Non classé]]></wp:cat_name>
+	</wp:category>
+	<wp:category>
+		<wp:term_id>4</wp:term_id>
+		<wp:category_nicename><![CDATA[test]]></wp:category_nicename>
+		<wp:category_parent><![CDATA[]]></wp:category_parent>
+		<wp:cat_name><![CDATA[Test]]></wp:cat_name>
+	</wp:category>
+	<wp:category>
+		<wp:term_id>1</wp:term_id>
+		<wp:category_nicename><![CDATA[uncategorized]]></wp:category_nicename>
+		<wp:category_parent><![CDATA[]]></wp:category_parent>
+		<wp:cat_name><![CDATA[Uncategorized]]></wp:cat_name>
+	</wp:category>
+	<wp:term>
+		<wp:term_id><![CDATA[{lang_id_1}]]></wp:term_id>
+		<wp:term_taxonomy><![CDATA[language]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[en]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[English]]></wp:term_name>
+		<wp:term_description><![CDATA[a:3:{s:6:"locale";s:5:"en_GB";s:3:"rtl";i:0;s:9:"flag_code";s:2:"gb";}]]></wp:term_description>
+		<wp:termmeta>
+			<wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key>
+			<wp:meta_value><![CDATA[a:3:{i:0;a:2:{i:0;s:9:"WordPress";i:1;s:12:"WordPress EN";}i:1;a:2:{i:0;s:11:"Test Import";i:1;s:11:"Test Import";}i:2;a:2:{i:0;s:27:"Just another WordPress site";i:1;s:27:"Just another WordPress site";}}]]></wp:meta_value>
+		</wp:termmeta>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>6</wp:term_id>
+		<wp:term_taxonomy><![CDATA[term_language]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_en]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[English]]></wp:term_name>
+		<wp:termmeta>
+			<wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key>
+			<wp:meta_value><![CDATA[a:5:{i:0;a:2:{i:0;s:9:"WordPress";i:1;s:12:"WordPress EN";}i:1;a:2:{i:0;s:5:"j F Y";i:1;s:0:"";}i:2;a:2:{i:0;s:4:"G\hi";i:1;s:0:"";}i:3;a:2:{i:0;s:162:"<!-- wp:woocommerce/products-by-attribute {"attributes":[{"id":22,"attr_slug":"pa_color"},{"id":23,"attr_slug":"pa_color"},{"id":24,"attr_slug":"pa_color"}]} /-->";i:1;s:0:"";}i:4;a:2:{i:0;s:19:"<!-- wp:search /-->";i:1;s:0:"";}}]]></wp:meta_value>
+		</wp:termmeta>
+	</wp:term>
+	<wp:term>
+		<wp:term_id><![CDATA[{lang_id_2}]]></wp:term_id>
+		<wp:term_taxonomy><![CDATA[language]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[fr]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[Français]]></wp:term_name>
+		<wp:term_description><![CDATA[a:3:{s:6:"locale";s:5:"fr_FR";s:3:"rtl";i:0;s:9:"flag_code";s:2:"fr";}]]></wp:term_description>
+		<wp:termmeta>
+			<wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key>
+			<wp:meta_value><![CDATA[a:5:{i:0;a:2:{i:0;s:9:"WordPress";i:1;s:12:"WordPress FR";}i:1;a:2:{i:0;s:5:"j F Y";i:1;s:0:"";}i:2;a:2:{i:0;s:4:"G\hi";i:1;s:0:"";}i:3;a:2:{i:0;s:162:"<!-- wp:woocommerce/products-by-attribute {"attributes":[{"id":22,"attr_slug":"pa_color"},{"id":23,"attr_slug":"pa_color"},{"id":24,"attr_slug":"pa_color"}]} /-->";i:1;s:0:"";}i:4;a:2:{i:0;s:19:"<!-- wp:search /-->";i:1;s:0:"";}}]]></wp:meta_value>
+		</wp:termmeta>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>8</wp:term_id>
+		<wp:term_taxonomy><![CDATA[term_language]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_fr]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[Français]]></wp:term_name>
+		<wp:termmeta>
+			<wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key>
+			<wp:meta_value><![CDATA[a:1:{i:0;a:2:{i:0;s:4:"OVIN";i:1;s:4:"OVIN";}}]]></wp:meta_value>
+		</wp:termmeta>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>9</wp:term_id>
+		<wp:term_taxonomy><![CDATA[term_translations]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_556f4259cb4bc]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[pll_556f4259cb4bc]]></wp:term_name>
+		<wp:term_description><![CDATA[a:2:{s:2:"en";s:1:"1";s:2:"fr";i:3;}]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>10</wp:term_id>
+		<wp:term_taxonomy><![CDATA[term_translations]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_56aceccce73e1]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[pll_56aceccce73e1]]></wp:term_name>
+		<wp:term_description><![CDATA[a:2:{s:2:"en";i:4;s:2:"fr";i:2;}]]></wp:term_description>
+		<wp:termmeta>
+			<wp:meta_key><![CDATA[_pll_strings_translations]]></wp:meta_key>
+			<wp:meta_value><![CDATA[a:1:{i:0;a:2:{i:0;s:4:"OVIN";i:1;s:4:"OVIN";}}]]></wp:meta_value>
+		</wp:termmeta>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>11</wp:term_id>
+		<wp:term_taxonomy><![CDATA[post_translations]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_56acecea35bef]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[pll_56acecea35bef]]></wp:term_name>
+		<wp:term_description><![CDATA[a:2:{s:2:"fr";i:400;s:2:"en";i:398;}]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>12</wp:term_id>
+		<wp:term_taxonomy><![CDATA[post_translations]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_56aced161652a]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[pll_56aced161652a]]></wp:term_name>
+		<wp:term_description><![CDATA[a:2:{s:2:"fr";i:404;s:2:"en";i:402;}]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>16</wp:term_id>
+		<wp:term_taxonomy><![CDATA[post_translations]]></wp:term_taxonomy>
+		<wp:term_slug><![CDATA[pll_69d6065abe959]]></wp:term_slug>
+		<wp:term_parent><![CDATA[]]></wp:term_parent>
+		<wp:term_name><![CDATA[pll_69d6065abe959]]></wp:term_name>
+		<wp:term_description><![CDATA[a:3:{s:2:"en";i:413;s:2:"fr";i:414;s:4:"sync";a:2:{s:2:"fr";s:2:"en";s:2:"en";s:2:"en";}}]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>13</wp:term_id>
+		<wp:term_taxonomy>nav_menu</wp:term_taxonomy>
+		<wp:term_slug><![CDATA[menu_en]]></wp:term_slug>
+		<wp:term_name><![CDATA[menu_en]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>14</wp:term_id>
+		<wp:term_taxonomy>nav_menu</wp:term_taxonomy>
+		<wp:term_slug><![CDATA[menu_fr]]></wp:term_slug>
+		<wp:term_name><![CDATA[menu_fr]]></wp:term_name>
+	</wp:term>
 
-	<generator>https://wordpress.org/?v=4.4.1</generator>
+	<generator>https://wordpress.org/?v=6.9.4</generator>
 
 	<item>
-		<title>Test</title>
-		<link>http://localhost/wordpress/test-import/en/2016/01/30/test/</link>
+		<title><![CDATA[Test]]></title>
+		<link>http://localhost/wordpress/test-import/test/</link>
 		<pubDate>Sat, 30 Jan 2016 17:03:16 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
 		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=398</guid>
@@ -66,6 +178,8 @@
 		<wp:post_id>398</wp:post_id>
 		<wp:post_date><![CDATA[2016-01-30 17:03:16]]></wp:post_date>
 		<wp:post_date_gmt><![CDATA[2016-01-30 17:03:16]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2016-01-30 17:03:16]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2016-01-30 17:03:16]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[open]]></wp:ping_status>
 		<wp:post_name><![CDATA[test]]></wp:post_name>
@@ -84,8 +198,8 @@
 		</wp:postmeta>
 	</item>
 	<item>
-		<title>Essai</title>
-		<link>http://localhost/wordpress/test-import/fr/2016/01/30/essai/</link>
+		<title><![CDATA[Essai]]></title>
+		<link>http://localhost/wordpress/test-import/fr/essai/</link>
 		<pubDate>Sat, 30 Jan 2016 17:03:37 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
 		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=400</guid>
@@ -95,6 +209,8 @@
 		<wp:post_id>400</wp:post_id>
 		<wp:post_date><![CDATA[2016-01-30 17:03:37]]></wp:post_date>
 		<wp:post_date_gmt><![CDATA[2016-01-30 17:03:37]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2016-01-30 17:03:37]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2016-01-30 17:03:37]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[open]]></wp:ping_status>
 		<wp:post_name><![CDATA[essai]]></wp:post_name>
@@ -113,8 +229,8 @@
 		</wp:postmeta>
 	</item>
 	<item>
-		<title>Home</title>
-		<link>http://localhost/wordpress/test-import/en/home/</link>
+		<title><![CDATA[Home]]></title>
+		<link>http://localhost/wordpress/test-import/home/</link>
 		<pubDate>Sat, 30 Jan 2016 17:04:11 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
 		<guid isPermaLink="false">http://localhost/wordpress/test-import/?page_id=402</guid>
@@ -124,6 +240,8 @@
 		<wp:post_id>402</wp:post_id>
 		<wp:post_date><![CDATA[2016-01-30 17:04:11]]></wp:post_date>
 		<wp:post_date_gmt><![CDATA[2016-01-30 17:04:11]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2016-01-30 17:04:11]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2016-01-30 17:04:11]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
 		<wp:post_name><![CDATA[home]]></wp:post_name>
@@ -141,7 +259,7 @@
 		</wp:postmeta>
 	</item>
 	<item>
-		<title>Accueil</title>
+		<title><![CDATA[Accueil]]></title>
 		<link>http://localhost/wordpress/test-import/fr/accueil/</link>
 		<pubDate>Sat, 30 Jan 2016 17:04:21 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
@@ -152,6 +270,8 @@
 		<wp:post_id>404</wp:post_id>
 		<wp:post_date><![CDATA[2016-01-30 17:04:21]]></wp:post_date>
 		<wp:post_date_gmt><![CDATA[2016-01-30 17:04:21]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2016-01-30 17:04:21]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2016-01-30 17:04:21]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
 		<wp:post_name><![CDATA[accueil]]></wp:post_name>
@@ -164,25 +284,27 @@
 		<category domain="language" nicename="fr"><![CDATA[Français]]></category>
 		<category domain="post_translations" nicename="pll_56aced161652a"><![CDATA[pll_56aced161652a]]></category>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_edit_last]]></wp:meta_key>
-			<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_edit_last]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
 	<item>
-		<title></title>
-		<link>http://localhost/wordpress/test-import/2016/01/30/406/</link>
-		<pubDate>Sat, 30 Jan 2016 17:05:00 +0000</pubDate>
+		<title><![CDATA[]]></title>
+		<link>http://localhost/wordpress/test-import/405/</link>
+		<pubDate>Wed, 08 Apr 2026 07:38:14 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=406</guid>
+		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=405</guid>
 		<description></description>
 		<content:encoded><![CDATA[ ]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
-		<wp:post_id>406</wp:post_id>
-		<wp:post_date><![CDATA[2016-01-30 17:05:00]]></wp:post_date>
-		<wp:post_date_gmt><![CDATA[2016-01-30 17:05:00]]></wp:post_date_gmt>
+		<wp:post_id>405</wp:post_id>
+		<wp:post_date><![CDATA[2026-04-08 07:38:14]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2026-04-08 07:38:14]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
-		<wp:post_name><![CDATA[406]]></wp:post_name>
+		<wp:post_name><![CDATA[405]]></wp:post_name>
 		<wp:status><![CDATA[publish]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>1</wp:menu_order>
@@ -191,50 +313,52 @@
 		<wp:is_sticky>0</wp:is_sticky>
 		<category domain="nav_menu" nicename="menu_en"><![CDATA[menu_en]]></category>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
-			<wp:meta_value><![CDATA[post_type]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
+		<wp:meta_value><![CDATA[post_type]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
-			<wp:meta_value><![CDATA[402]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
+		<wp:meta_value><![CDATA[402]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
-			<wp:meta_value><![CDATA[page]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
+		<wp:meta_value><![CDATA[page]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
-			<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
+		<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
 	<item>
-		<title>Language switcher</title>
-		<link>http://localhost/wordpress/test-import/2016/01/30/language-switcher/</link>
-		<pubDate>Sat, 30 Jan 2016 17:05:00 +0000</pubDate>
+		<title><![CDATA[Language switcher]]></title>
+		<link>http://localhost/wordpress/test-import/language-switcher/</link>
+		<pubDate>Wed, 08 Apr 2026 07:38:14 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=407</guid>
+		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=406</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
-		<wp:post_id>407</wp:post_id>
-		<wp:post_date><![CDATA[2016-01-30 17:05:00]]></wp:post_date>
-		<wp:post_date_gmt><![CDATA[2016-01-30 17:05:00]]></wp:post_date_gmt>
+		<wp:post_id>406</wp:post_id>
+		<wp:post_date><![CDATA[2026-04-08 07:38:14]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2026-04-08 07:38:14]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
 		<wp:post_name><![CDATA[language-switcher]]></wp:post_name>
@@ -246,54 +370,56 @@
 		<wp:is_sticky>0</wp:is_sticky>
 		<category domain="nav_menu" nicename="menu_en"><![CDATA[menu_en]]></category>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
-			<wp:meta_value><![CDATA[custom]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
+		<wp:meta_value><![CDATA[custom]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
-			<wp:meta_value><![CDATA[407]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
+		<wp:meta_value><![CDATA[406]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
-			<wp:meta_value><![CDATA[custom]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
+		<wp:meta_value><![CDATA[custom]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
-			<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
+		<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
-			<wp:meta_value><![CDATA[#pll_switcher]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
+		<wp:meta_value><![CDATA[#pll_switcher]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_pll_menu_item]]></wp:meta_key>
-			<wp:meta_value><![CDATA[a:5:{s:22:"hide_if_no_translation";i:0;s:12:"hide_current";i:1;s:10:"force_home";i:0;s:10:"show_flags";i:1;s:10:"show_names";i:0;}]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_pll_menu_item]]></wp:meta_key>
+		<wp:meta_value><![CDATA[a:5:{s:22:"hide_if_no_translation";i:0;s:12:"hide_current";i:1;s:10:"force_home";i:0;s:10:"show_flags";i:1;s:10:"show_names";i:0;}]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
 	<item>
-		<title>Language switcher</title>
-		<link>http://localhost/wordpress/test-import/2016/01/30/language-switcher-2/</link>
-		<pubDate>Sat, 30 Jan 2016 17:05:30 +0000</pubDate>
+		<title><![CDATA[Language switcher]]></title>
+		<link>http://localhost/wordpress/test-import/language-switcher-2/</link>
+		<pubDate>Wed, 08 Apr 2026 07:38:14 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=408</guid>
+		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=407</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
-		<wp:post_id>408</wp:post_id>
-		<wp:post_date><![CDATA[2016-01-30 17:05:30]]></wp:post_date>
-		<wp:post_date_gmt><![CDATA[2016-01-30 17:05:30]]></wp:post_date_gmt>
+		<wp:post_id>407</wp:post_id>
+		<wp:post_date><![CDATA[2026-04-08 07:38:14]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2026-04-08 07:38:14]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
 		<wp:post_name><![CDATA[language-switcher-2]]></wp:post_name>
@@ -305,57 +431,59 @@
 		<wp:is_sticky>0</wp:is_sticky>
 		<category domain="nav_menu" nicename="menu_fr"><![CDATA[menu_fr]]></category>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
-			<wp:meta_value><![CDATA[custom]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
+		<wp:meta_value><![CDATA[custom]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
-			<wp:meta_value><![CDATA[408]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
+		<wp:meta_value><![CDATA[407]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
-			<wp:meta_value><![CDATA[custom]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
+		<wp:meta_value><![CDATA[custom]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
-			<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
+		<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
-			<wp:meta_value><![CDATA[#pll_switcher]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
+		<wp:meta_value><![CDATA[#pll_switcher]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_pll_menu_item]]></wp:meta_key>
-			<wp:meta_value><![CDATA[a:5:{s:22:"hide_if_no_translation";i:0;s:12:"hide_current";i:1;s:10:"force_home";i:0;s:10:"show_flags";i:1;s:10:"show_names";i:0;}]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_pll_menu_item]]></wp:meta_key>
+		<wp:meta_value><![CDATA[a:5:{s:22:"hide_if_no_translation";i:0;s:12:"hide_current";i:1;s:10:"force_home";i:0;s:10:"show_flags";i:1;s:10:"show_names";i:0;}]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
 	<item>
-		<title></title>
-		<link>http://localhost/wordpress/test-import/2016/01/30/409/</link>
-		<pubDate>Sat, 30 Jan 2016 17:05:30 +0000</pubDate>
+		<title><![CDATA[]]></title>
+		<link>http://localhost/wordpress/test-import/408/</link>
+		<pubDate>Wed, 08 Apr 2026 07:38:14 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=409</guid>
+		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=408</guid>
 		<description></description>
 		<content:encoded><![CDATA[ ]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
-		<wp:post_id>409</wp:post_id>
-		<wp:post_date><![CDATA[2016-01-30 17:05:30]]></wp:post_date>
-		<wp:post_date_gmt><![CDATA[2016-01-30 17:05:30]]></wp:post_date_gmt>
+		<wp:post_id>408</wp:post_id>
+		<wp:post_date><![CDATA[2026-04-08 07:38:14]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2026-04-08 07:38:14]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2026-04-08 07:38:14]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
-		<wp:post_name><![CDATA[409]]></wp:post_name>
+		<wp:post_name><![CDATA[408]]></wp:post_name>
 		<wp:status><![CDATA[publish]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>1</wp:menu_order>
@@ -364,37 +492,95 @@
 		<wp:is_sticky>0</wp:is_sticky>
 		<category domain="nav_menu" nicename="menu_fr"><![CDATA[menu_fr]]></category>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
-			<wp:meta_value><![CDATA[post_type]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key>
+		<wp:meta_value><![CDATA[post_type]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_menu_item_parent]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
-			<wp:meta_value><![CDATA[404]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object_id]]></wp:meta_key>
+		<wp:meta_value><![CDATA[404]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
-			<wp:meta_value><![CDATA[page]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_object]]></wp:meta_key>
+		<wp:meta_value><![CDATA[page]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_target]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
-			<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_classes]]></wp:meta_key>
+		<wp:meta_value><![CDATA[a:1:{i:0;s:0:"";}]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_xfn]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
-			<wp:meta_value><![CDATA[]]></wp:meta_value>
+		<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
+		<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
+	</item>
+	<item>
+		<title><![CDATA[Synchronized post]]></title>
+		<link>http://localhost/wordpress/test-import/synchronized-post/</link>
+		<pubDate>Wed, 08 Apr 2026 07:40:10 +0000</pubDate>
+		<dc:creator><![CDATA[admin]]></dc:creator>
+		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=413</guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>413</wp:post_id>
+		<wp:post_date><![CDATA[2026-04-08 07:40:10]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2026-04-08 07:40:10]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2026-04-08 07:40:10]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2026-04-08 07:40:10]]></wp:post_modified_gmt>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:ping_status><![CDATA[open]]></wp:ping_status>
+		<wp:post_name><![CDATA[synchronized-post]]></wp:post_name>
+		<wp:status><![CDATA[publish]]></wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type><![CDATA[post]]></wp:post_type>
+		<wp:post_password><![CDATA[]]></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+		<category domain="language" nicename="en"><![CDATA[English]]></category>
+		<category domain="post_translations" nicename="pll_69d6065abe959"><![CDATA[pll_69d6065abe959]]></category>
+		<category domain="category" nicename="uncategorized"><![CDATA[Uncategorized]]></category>
+		<wp:postmeta>
+			<wp:meta_key><![CDATA[_edit_last]]></wp:meta_key>
+			<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
+	</item>
+	<item>
+		<title><![CDATA[Synchronized post]]></title>
+		<link>http://localhost/wordpress/test-import/fr/synchronized-post-2/</link>
+		<pubDate>Wed, 08 Apr 2026 07:40:10 +0000</pubDate>
+		<dc:creator><![CDATA[admin]]></dc:creator>
+		<guid isPermaLink="false">http://localhost/wordpress/test-import/?p=413</guid>
+		<description></description>
+		<content:encoded><![CDATA[]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>414</wp:post_id>
+		<wp:post_date><![CDATA[2026-04-08 07:40:10]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2026-04-08 07:40:10]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2026-04-08 07:40:10]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2026-04-08 07:40:10]]></wp:post_modified_gmt>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:ping_status><![CDATA[open]]></wp:ping_status>
+		<wp:post_name><![CDATA[synchronized-post-2]]></wp:post_name>
+		<wp:status><![CDATA[publish]]></wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type><![CDATA[post]]></wp:post_type>
+		<wp:post_password><![CDATA[]]></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+		<category domain="language" nicename="fr"><![CDATA[Français]]></category>
+		<category domain="category" nicename="non-classe"><![CDATA[Non classé]]></category>
+		<category domain="post_translations" nicename="pll_69d6065abe959"><![CDATA[pll_69d6065abe959]]></category>
 	</item>
 </channel>
 </rss>


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2980

This PR fixes 2 bugs:
```
PHP Fatal error:  Uncaught TypeError: Cannot access offset of type array in isset or empty in /src/integrations/wp-importer/wp-import.php:197
```
This one is caused by the presence of additional data in the term description for the translation group. The importer expects only the array of translations. But it my contain synchronization information as well as 3rd party data. This is fixed by whitelisting the keys that we manipulate when remapping translation groups. A pair of synchronized posts are added to the update test import file to test the issue.  
 
```
PHP Warning:  Array to string conversion in /src/integrations/wp-importer/wp-import.php on line 163
```
This is a regression introduced by #1577. The `array_diff()` used to compare an array of strings when we have now an array of arrays. Using `array_udiff()` to convert arrays to strings before the comparison fixes the issue. 