### PR TITLE
Harmonize flags in admin

### DIFF
--- a/changelog/2950
+++ b/changelog/2950
@@ -1,0 +1,1 @@
+* Harmonize flags across the administration area and improve their accessibility #2950

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -933,7 +933,7 @@ parameters:
 		-
 			message: '#^@readonly property cannot have a default value\.$#'
 			identifier: property.readOnlyByPhpDocDefaultValue
-			count: 8
+			count: 7
 			path: src/language.php
 
 		-
@@ -952,10 +952,6 @@ parameters:
 			message: '#^Property PLL_Language\:\:\$fallbacks \(list\<non\-empty\-string\>\) does not accept array\<non\-empty\-string\>\.$#'
 			identifier: assign.propertyType
 			count: 1
-			path: src/language.php
-
-		-
-			message: '#^@readonly property PLL_Language\:\:\$admin_flag is assigned outside of the constructor\.$#'
 			path: src/language.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -933,7 +933,7 @@ parameters:
 		-
 			message: '#^@readonly property cannot have a default value\.$#'
 			identifier: property.readOnlyByPhpDocDefaultValue
-			count: 7
+			count: 8
 			path: src/language.php
 
 		-
@@ -952,6 +952,10 @@ parameters:
 			message: '#^Property PLL_Language\:\:\$fallbacks \(list\<non\-empty\-string\>\) does not accept array\<non\-empty\-string\>\.$#'
 			identifier: assign.propertyType
 			count: 1
+			path: src/language.php
+
+		-
+			message: '#^@readonly property PLL_Language\:\:\$cache is assigned outside of the constructor\.$#'
 			path: src/language.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -955,7 +955,7 @@ parameters:
 			path: src/language.php
 
 		-
-			message: '#^@readonly property PLL_Language\:\:\$cache is assigned outside of the constructor\.$#'
+			message: '#^@readonly property PLL_Language\:\:\$admin_flag is assigned outside of the constructor\.$#'
 			path: src/language.php
 
 		-

--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -569,7 +569,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 				array(
 					'parent' => 'languages',
 					'id'     => $lang->slug,
-					'title'  => $lang->flag . esc_html( $lang->name ),
+					'title'  => sprintf( '%s %s', $lang->get_admin_flag( 'minimal' ), esc_html( $lang->name ) ),
 					'href'   => esc_url( add_query_arg( 'lang', $lang->slug, remove_query_arg( 'paged' ) ) ),
 					'meta'   => 'all' === $lang->slug ? array() : array( 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ),
 				)

--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -569,7 +569,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 				array(
 					'parent' => 'languages',
 					'id'     => $lang->slug,
-					'title'  => sprintf( '%s %s', $lang->get_admin_flag( 'no-screen-reader' ), esc_html( $lang->name ) ),
+					'title'  => sprintf( '%s %s', $lang->get_admin_flag( 'aria-hidden' ), esc_html( $lang->name ) ),
 					'href'   => esc_url( add_query_arg( 'lang', $lang->slug, remove_query_arg( 'paged' ) ) ),
 					'meta'   => 'all' === $lang->slug ? array() : array( 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ),
 				)

--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -569,7 +569,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 				array(
 					'parent' => 'languages',
 					'id'     => $lang->slug,
-					'title'  => sprintf( '%s %s', $lang->get_admin_flag( 'minimal' ), esc_html( $lang->name ) ),
+					'title'  => sprintf( '%s %s', $lang->get_admin_flag( 'no-screen-reader' ), esc_html( $lang->name ) ),
 					'href'   => esc_url( add_query_arg( 'lang', $lang->slug, remove_query_arg( 'paged' ) ) ),
 					'meta'   => 'all' === $lang->slug ? array() : array( 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ),
 				)

--- a/src/admin/admin-classic-editor.php
+++ b/src/admin/admin-classic-editor.php
@@ -265,7 +265,7 @@ class PLL_Admin_Classic_Editor {
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag ) );
+		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag() ) );
 
 		// Sample permalink
 		$x->Add( array( 'what' => 'permalink', 'data' => get_sample_permalink_html( $post->ID ) ) );

--- a/src/admin/admin-classic-editor.php
+++ b/src/admin/admin-classic-editor.php
@@ -265,7 +265,7 @@ class PLL_Admin_Classic_Editor {
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag() ) );
+		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag( 'no-screen-reader' ) ) );
 
 		// Sample permalink
 		$x->Add( array( 'what' => 'permalink', 'data' => get_sample_permalink_html( $post->ID ) ) );

--- a/src/admin/admin-classic-editor.php
+++ b/src/admin/admin-classic-editor.php
@@ -265,7 +265,7 @@ class PLL_Admin_Classic_Editor {
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag( 'no-screen-reader' ) ) );
+		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag( 'aria-hidden' ) ) );
 
 		// Sample permalink
 		$x->Add( array( 'what' => 'permalink', 'data' => get_sample_permalink_html( $post->ID ) ) );

--- a/src/admin/admin-filters-columns.php
+++ b/src/admin/admin-filters-columns.php
@@ -85,7 +85,7 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[ 'language_' . $language->slug ] = $this->links->get_flag_html( $language ) . '<span class="screen-reader-text">' . esc_html( $language->name ) . '</span>';
+			$columns[ 'language_' . $language->slug ] = $language->get_admin_flag();
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/src/admin/admin-filters-term.php
+++ b/src/admin/admin-filters-term.php
@@ -509,7 +509,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag ) );
+		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag() ) );
 
 		$x->send();
 	}

--- a/src/admin/admin-filters-term.php
+++ b/src/admin/admin-filters-term.php
@@ -509,7 +509,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag() ) );
+		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag( 'no-screen-reader' ) ) );
 
 		$x->send();
 	}

--- a/src/admin/admin-filters-term.php
+++ b/src/admin/admin-filters-term.php
@@ -509,7 +509,7 @@ class PLL_Admin_Filters_Term {
 		}
 
 		// Flag
-		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag( 'no-screen-reader' ) ) );
+		$x->Add( array( 'what' => 'flag', 'data' => $lang->get_admin_flag( 'aria-hidden' ) ) );
 
 		$x->send();
 	}

--- a/src/admin/admin-links.php
+++ b/src/admin/admin-links.php
@@ -198,7 +198,7 @@ class PLL_Admin_Links extends PLL_Links {
 	 */
 	private function get_edit_item_link_html( string $url, PLL_Language $language, int $item_id, string $item_name, string $mode ): string {
 		if ( 'list_current' === $mode ) {
-			$flag  = $this->get_flag_html( $language );
+			$flag  = $language->get_admin_flag( 'minimal' );
 			$class = 'pll_column_flag';
 		} else {
 			$flag  = '';
@@ -334,18 +334,6 @@ class PLL_Admin_Links extends PLL_Links {
 
 		$url = (string) get_edit_term_link( $term->term_id, $term->taxonomy, $post_type );
 		return $this->get_edit_item_link_html( $url, $language, $term->term_id, $term->name, $mode );
-	}
-
-	/**
-	 * Returns the language flag or the language slug if there is no flag.
-	 *
-	 * @since 3.8
-	 *
-	 * @param PLL_Language $language PLL_Language object.
-	 * @return string
-	 */
-	public function get_flag_html( PLL_Language $language ): string {
-		return $language->flag ?: sprintf( '<abbr>%s</abbr>', esc_html( $language->slug ) );
 	}
 
 	/**

--- a/src/admin/admin-links.php
+++ b/src/admin/admin-links.php
@@ -198,7 +198,7 @@ class PLL_Admin_Links extends PLL_Links {
 	 */
 	private function get_edit_item_link_html( string $url, PLL_Language $language, int $item_id, string $item_name, string $mode ): string {
 		if ( 'list_current' === $mode ) {
-			$flag  = $language->get_admin_flag( 'minimal' );
+			$flag  = $language->get_admin_flag( 'no-screen-reader' );
 			$class = 'pll_column_flag';
 		} else {
 			$flag  = '';

--- a/src/admin/admin-links.php
+++ b/src/admin/admin-links.php
@@ -198,7 +198,7 @@ class PLL_Admin_Links extends PLL_Links {
 	 */
 	private function get_edit_item_link_html( string $url, PLL_Language $language, int $item_id, string $item_name, string $mode ): string {
 		if ( 'list_current' === $mode ) {
-			$flag  = $language->get_admin_flag( 'no-screen-reader' );
+			$flag  = $language->get_admin_flag( 'aria-hidden' );
 			$class = 'pll_column_flag';
 		} else {
 			$flag  = '';

--- a/src/admin/view-translations-media.php
+++ b/src/admin/view-translations-media.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 		?>
 		<tr>
-			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->flag; // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
+			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->get_admin_flag( 'minimal' ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
 			<td class = "pll-media-edit-column">
 				<?php
 				if ( $translation instanceof WP_Post ) {

--- a/src/admin/view-translations-media.php
+++ b/src/admin/view-translations-media.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 		?>
 		<tr>
-			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->get_admin_flag( 'no-screen-reader' ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
+			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->get_admin_flag( 'aria-hidden' ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
 			<td class = "pll-media-edit-column">
 				<?php
 				if ( $translation instanceof WP_Post ) {

--- a/src/admin/view-translations-media.php
+++ b/src/admin/view-translations-media.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 		?>
 		<tr>
-			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->get_admin_flag( 'minimal' ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
+			<td class = "pll-media-language-column"><span class = "pll-translation-flag"><?php echo $language->get_admin_flag( 'no-screen-reader' ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span><?php echo esc_html( $language->name ); ?></td>
 			<td class = "pll-media-edit-column">
 				<?php
 				if ( $translation instanceof WP_Post ) {

--- a/src/admin/view-translations-post.php
+++ b/src/admin/view-translations-post.php
@@ -40,7 +40,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 		?>
 		<tr>
-			<th class = "pll-language-column"><?php echo $language->flag ?: esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></th>
+			<th class = "pll-language-column"><?php echo $language->get_admin_flag(); // phpcs:ignore WordPress.Security.EscapeOutput ?></th>
 			<td class = "hidden"><?php echo $add_link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<td class = "pll-edit-column pll-column-icon"><?php echo $link; // phpcs:ignore WordPress.Security.EscapeOutput ?></td>
 			<?php

--- a/src/admin/view-translations-term.php
+++ b/src/admin/view-translations-term.php
@@ -53,7 +53,7 @@ else {
 		?>
 		<tr>
 			<th class = "pll-language-column">
-				<span class = "pll-translation-flag"><?php echo $language->flag ?: esc_html( $language->slug ); // phpcs:ignore WordPress.Security.EscapeOutput ?></span>
+				<span class = "pll-translation-flag"><?php echo $language->get_admin_flag(); // phpcs:ignore WordPress.Security.EscapeOutput ?></span>
 				<?php
 				printf(
 					'<span class="pll-language-name%1$s">%2$s</span>',

--- a/src/language-factory.php
+++ b/src/language-factory.php
@@ -183,6 +183,30 @@ class PLL_Language_Factory {
 			unset( $data['fallbacks'] );
 		}
 
+		$data['admin_flag'] = array();
+
+		if ( ! empty( $data['flag'] ) ) {
+			$data['admin_flag']['aria-hidden'] = str_replace( '<img', '<img aria-hidden="true" tabindex="-1"', $data['flag'] );
+			$data['admin_flag']['']            = str_replace(
+				'<img',
+				sprintf(
+					'<img lang="%1$s" dir="%2$s"',
+					esc_attr( $data['w3c'] ),
+					$data['is_rtl'] ? 'rtl' : 'ltr'
+				),
+				$data['flag']
+			);
+		} else {
+			$data['admin_flag']['aria-hidden'] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $data['slug'] ) ) );
+			$data['admin_flag']['']            = sprintf(
+				'<abbr title="%1$s" lang="%2$s" dir="%3$s">%4$s</abbr>',
+				esc_attr( $data['name'] ),
+				esc_attr( $data['w3c'] ),
+				$data['is_rtl'] ? 'rtl' : 'ltr',
+				esc_html( strtoupper( $data['slug'] ) )
+			);
+		}
+
 		/**
 		 * @var LanguageData
 		 */

--- a/src/language.php
+++ b/src/language.php
@@ -475,6 +475,51 @@ class PLL_Language extends PLL_Language_Deprecated {
 	}
 
 	/**
+	 * Returns the language flag or the language slug if there is no flag.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string $context Optional. Allows to modify the markup depending on how the flag is used. Possible values are:
+	 *                        - `full`: the flag has everything,
+	 *                        - `minimal`: the flag is preceded or followed by a text that would make it redundant.
+	 *                        Default is `full`.
+	 * @return string
+	 *
+	 * @phpstan-param 'full'|'minimal' $context
+	 */
+	public function get_admin_flag( string $context = 'full' ): string {
+		if ( ! empty( $this->flag ) ) {
+			if ( 'minimal' === $context ) {
+				// Hidden from screen readers.
+				return str_replace( '<img ', '<img aria-hidden="true" tabindex="-1" ', $this->flag );
+			}
+
+			return str_replace(
+				'<img ',
+				sprintf(
+					'<img lang="%1$s" dir="%2$s" ',
+					esc_attr( $this->get_locale( 'display' ) ),
+					$this->is_rtl ? 'rtl' : 'ltr'
+				),
+				$this->flag
+			);
+		}
+
+		if ( 'minimal' === $context ) {
+			// Hidden from screen readers.
+			return sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
+		}
+
+		return sprintf(
+			'<abbr title="%1$s" lang="%2$s" dir="%3$s">%4$s</abbr>',
+			esc_attr( $this->name ),
+			esc_attr( $this->get_locale( 'display' ) ),
+			$this->is_rtl ? 'rtl' : 'ltr',
+			esc_html( strtoupper( $this->slug ) )
+		);
+	}
+
+	/**
 	 * Returns the html of the custom flag if any, or the default flag otherwise.
 	 *
 	 * @since 2.8

--- a/src/language.php
+++ b/src/language.php
@@ -473,17 +473,17 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @since 3.9
 	 *
-	 * @param string $context Optional. Allows to modify the markup depending on how the flag is used. Possible values are:
-	 *                        - `full`: the flag has everything,
-	 *                        - `minimal`: the flag is preceded or followed by a text that would make it redundant.
-	 *                        Default is `full`.
+	 * @param string $mode Optional. Allows to modify the markup depending on how the flag is used. Possible values are:
+	 *                     - `screen-reader`: the flag can be seen by screen readers,
+	 *                     - `no-screen-reader`: the flag is hidden from screen readers: it is preceded or followed by a
+	 *                     text (language name for example) that would make it redundant. Default is `screen-reader`.
 	 * @return string
 	 *
-	 * @phpstan-param 'full'|'minimal' $context
+	 * @phpstan-param 'screen-reader'|'no-screen-reader' $mode
 	 */
-	public function get_admin_flag( string $context = 'full' ): string {
+	public function get_admin_flag( string $mode = 'screen-reader' ): string {
 		if ( ! empty( $this->flag ) ) {
-			if ( 'minimal' === $context ) {
+			if ( 'no-screen-reader' === $mode ) {
 				// Hidden from screen readers.
 				return str_replace( '<img ', '<img aria-hidden="true" tabindex="-1" ', $this->flag );
 			}
@@ -499,7 +499,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 			);
 		}
 
-		if ( 'minimal' === $context ) {
+		if ( 'no-screen-reader' === $mode ) {
 			// Hidden from screen readers.
 			return sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
 		}

--- a/src/language.php
+++ b/src/language.php
@@ -23,15 +23,15 @@
  *     slug: non-empty-string,
  *     locale: non-empty-string,
  *     w3c: non-empty-string,
- *     flag_code: non-empty-string,
+ *     flag_code: string,
  *     term_group: int,
  *     is_rtl: int<0, 1>,
  *     facebook?: string,
  *     home_url: non-empty-string,
  *     search_url: non-empty-string,
  *     host: non-empty-string,
- *     flag_url: non-empty-string,
- *     flag: non-empty-string,
+ *     flag_url: string,
+ *     flag: string,
  *     custom_flag_url?: string,
  *     custom_flag?: string,
  *     page_on_front: int<0, max>,
@@ -162,8 +162,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * Code of the flag.
 	 *
 	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
 	 */
 	public $flag_code;
 
@@ -171,8 +169,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * URL of the flag. Always set to the main domain.
 	 *
 	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
 	 */
 	public $flag_url;
 
@@ -180,8 +176,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * HTML markup of the flag.
 	 *
 	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
 	 */
 	public $flag;
 

--- a/src/language.php
+++ b/src/language.php
@@ -292,9 +292,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-param LanguageData $language_data
 	 */
 	public function __construct( array $language_data ) {
-		/** @phpstan-var LanguageData */
-		$language_data = array_diff_key( $language_data, array( 'cache' => array() ) );
-
 		foreach ( $language_data as $prop => $value ) {
 			$this->$prop = $value;
 		}
@@ -613,7 +610,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 */
 	public function to_array( $context = 'display' ) {
 		$language = get_object_vars( $this );
-		$language = array_diff_key( $language, array( 'cache' => array() ) );
+		unset( $language['cache'] );
 
 		if ( 'db' !== $context ) {
 			$language['home_url']   = $this->get_home_url();

--- a/src/language.php
+++ b/src/language.php
@@ -493,12 +493,12 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 		if ( ! empty( $this->flag ) ) {
 			if ( 'no-screen-reader' === $mode ) {
-				$this->cache['admin_flag'][ $mode ] = str_replace( '<img ', '<img aria-hidden="true" tabindex="-1" ', $this->flag );
+				$this->cache['admin_flag'][ $mode ] = str_replace( '<img', '<img aria-hidden="true" tabindex="-1"', $this->flag );
 			} else {
 				$this->cache['admin_flag'][ $mode ] = str_replace(
-					'<img ',
+					'<img',
 					sprintf(
-						'<img lang="%1$s" dir="%2$s" ',
+						'<img lang="%1$s" dir="%2$s"',
 						esc_attr( $this->get_locale( 'display' ) ),
 						$this->is_rtl ? 'rtl' : 'ltr'
 					),

--- a/src/language.php
+++ b/src/language.php
@@ -251,6 +251,11 @@ class PLL_Language extends PLL_Language_Deprecated {
 	protected $term_props;
 
 	/**
+	 * @var array
+	 */
+	private $cache = array();
+
+	/**
 	 * Constructor: builds a language object given the corresponding data.
 	 *
 	 * @since 1.2
@@ -287,6 +292,9 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-param LanguageData $language_data
 	 */
 	public function __construct( array $language_data ) {
+		/** @phpstan-var LanguageData */
+		$language_data = array_diff_key( $language_data, array( 'cache' => array() ) );
+
 		foreach ( $language_data as $prop => $value ) {
 			$this->$prop = $value;
 		}
@@ -482,35 +490,41 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-param 'screen-reader'|'no-screen-reader' $mode
 	 */
 	public function get_admin_flag( string $mode = 'screen-reader' ): string {
+		if ( isset( $this->cache['admin_flag'][ $mode ] ) ) {
+			return $this->cache['admin_flag'][ $mode ];
+		}
+
 		if ( ! empty( $this->flag ) ) {
 			if ( 'no-screen-reader' === $mode ) {
 				// Hidden from screen readers.
-				return str_replace( '<img ', '<img aria-hidden="true" tabindex="-1" ', $this->flag );
+				$this->cache['admin_flag'][ $mode ] = str_replace( '<img ', '<img aria-hidden="true" tabindex="-1" ', $this->flag );
+			} else {
+				$this->cache['admin_flag'][ $mode ] = str_replace(
+					'<img ',
+					sprintf(
+						'<img lang="%1$s" dir="%2$s" ',
+						esc_attr( $this->get_locale( 'display' ) ),
+						$this->is_rtl ? 'rtl' : 'ltr'
+					),
+					$this->flag
+				);
 			}
-
-			return str_replace(
-				'<img ',
-				sprintf(
-					'<img lang="%1$s" dir="%2$s" ',
-					esc_attr( $this->get_locale( 'display' ) ),
-					$this->is_rtl ? 'rtl' : 'ltr'
-				),
-				$this->flag
-			);
+			return $this->cache['admin_flag'][ $mode ];
 		}
 
 		if ( 'no-screen-reader' === $mode ) {
 			// Hidden from screen readers.
-			return sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
+			$this->cache['admin_flag'][ $mode ] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
+		} else {
+			$this->cache['admin_flag'][ $mode ] = sprintf(
+				'<abbr title="%1$s" lang="%2$s" dir="%3$s">%4$s</abbr>',
+				esc_attr( $this->name ),
+				esc_attr( $this->get_locale( 'display' ) ),
+				$this->is_rtl ? 'rtl' : 'ltr',
+				esc_html( strtoupper( $this->slug ) )
+			);
 		}
-
-		return sprintf(
-			'<abbr title="%1$s" lang="%2$s" dir="%3$s">%4$s</abbr>',
-			esc_attr( $this->name ),
-			esc_attr( $this->get_locale( 'display' ) ),
-			$this->is_rtl ? 'rtl' : 'ltr',
-			esc_html( strtoupper( $this->slug ) )
-		);
+		return $this->cache['admin_flag'][ $mode ];
 	}
 
 	/**
@@ -599,6 +613,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 */
 	public function to_array( $context = 'display' ) {
 		$language = get_object_vars( $this );
+		$language = array_diff_key( $language, array( 'cache' => array() ) );
 
 		if ( 'db' !== $context ) {
 			$language['home_url']   = $this->get_home_url();

--- a/src/language.php
+++ b/src/language.php
@@ -38,7 +38,8 @@
  *     page_for_posts: int<0, max>,
  *     active: bool,
  *     fallbacks?: array<non-empty-string>,
- *     is_default: bool
+ *     is_default: bool,
+ *     admin_flag: array{'aria-hidden': non-empty-string, '': non-empty-string}
  * }
  */
 class PLL_Language extends PLL_Language_Deprecated {
@@ -252,8 +253,10 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 	/**
 	 * @var array
+	 *
+	 * @phpstan-var array{'aria-hidden': non-empty-string, '': non-empty-string}
 	 */
-	private $admin_flag = array();
+	private $admin_flag;
 
 	/**
 	 * Constructor: builds a language object given the corresponding data.
@@ -287,6 +290,8 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *     @type bool     $active          Whether or not the language is active. Default `true`.
 	 *     @type string[] $fallbacks       List of WordPress language locales. Ex: array( 'en_GB' ).
 	 *     @type bool     $is_default      Whether or not the language is the default one.
+	 *     @type array    $admin_flag      An array containing the keys `''` (empty string) for the "normal" flag, and
+	 *                                     `'aria-hidden'` for the flag hidden to screen readers.
 	 * }
 	 *
 	 * @phpstan-param LanguageData $language_data
@@ -488,38 +493,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-param ''|'aria-hidden' $mode
 	 */
 	public function get_admin_flag( string $mode = '' ): string {
-		if ( isset( $this->admin_flag[ $mode ] ) ) {
-			return $this->admin_flag[ $mode ];
-		}
-
-		if ( ! empty( $this->flag ) ) {
-			if ( 'aria-hidden' === $mode ) {
-				$this->admin_flag[ $mode ] = str_replace( '<img', '<img aria-hidden="true" tabindex="-1"', $this->flag );
-			} else {
-				$this->admin_flag[ $mode ] = str_replace(
-					'<img',
-					sprintf(
-						'<img lang="%1$s" dir="%2$s"',
-						esc_attr( $this->get_locale( 'display' ) ),
-						$this->is_rtl ? 'rtl' : 'ltr'
-					),
-					$this->flag
-				);
-			}
-			return $this->admin_flag[ $mode ];
-		}
-
-		if ( 'aria-hidden' === $mode ) {
-			$this->admin_flag[ $mode ] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
-		} else {
-			$this->admin_flag[ $mode ] = sprintf(
-				'<abbr title="%1$s" lang="%2$s" dir="%3$s">%4$s</abbr>',
-				esc_attr( $this->name ),
-				esc_attr( $this->get_locale( 'display' ) ),
-				$this->is_rtl ? 'rtl' : 'ltr',
-				esc_html( strtoupper( $this->slug ) )
-			);
-		}
 		return $this->admin_flag[ $mode ];
 	}
 

--- a/src/language.php
+++ b/src/language.php
@@ -493,7 +493,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 		if ( ! empty( $this->flag ) ) {
 			if ( 'no-screen-reader' === $mode ) {
-				// Hidden from screen readers.
 				$this->cache['admin_flag'][ $mode ] = str_replace( '<img ', '<img aria-hidden="true" tabindex="-1" ', $this->flag );
 			} else {
 				$this->cache['admin_flag'][ $mode ] = str_replace(
@@ -510,7 +509,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 		}
 
 		if ( 'no-screen-reader' === $mode ) {
-			// Hidden from screen readers.
 			$this->cache['admin_flag'][ $mode ] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
 		} else {
 			$this->cache['admin_flag'][ $mode ] = sprintf(

--- a/src/language.php
+++ b/src/language.php
@@ -479,20 +479,21 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @since 3.9
 	 *
 	 * @param string $mode Optional. Allows to modify the markup depending on how the flag is used. Possible values are:
-	 *                     - `screen-reader`: the flag can be seen by screen readers,
-	 *                     - `no-screen-reader`: the flag is hidden from screen readers: it is preceded or followed by a
-	 *                     text (language name for example) that would make it redundant. Default is `screen-reader`.
+	 *                     - Empty string: the flag can be seen by screen readers,
+	 *                     - `aria-hidden`: the flag is hidden from screen readers: it is preceded or followed by a
+	 *                     text (language name for example) that would make the information redundant.
+	 *                     Default is an empty string.
 	 * @return string
 	 *
-	 * @phpstan-param 'screen-reader'|'no-screen-reader' $mode
+	 * @phpstan-param ''|'aria-hidden' $mode
 	 */
-	public function get_admin_flag( string $mode = 'screen-reader' ): string {
+	public function get_admin_flag( string $mode = '' ): string {
 		if ( isset( $this->cache['admin_flag'][ $mode ] ) ) {
 			return $this->cache['admin_flag'][ $mode ];
 		}
 
 		if ( ! empty( $this->flag ) ) {
-			if ( 'no-screen-reader' === $mode ) {
+			if ( 'aria-hidden' === $mode ) {
 				$this->cache['admin_flag'][ $mode ] = str_replace( '<img', '<img aria-hidden="true" tabindex="-1"', $this->flag );
 			} else {
 				$this->cache['admin_flag'][ $mode ] = str_replace(
@@ -508,7 +509,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 			return $this->cache['admin_flag'][ $mode ];
 		}
 
-		if ( 'no-screen-reader' === $mode ) {
+		if ( 'aria-hidden' === $mode ) {
 			$this->cache['admin_flag'][ $mode ] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
 		} else {
 			$this->cache['admin_flag'][ $mode ] = sprintf(

--- a/src/language.php
+++ b/src/language.php
@@ -253,7 +253,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	/**
 	 * @var array
 	 */
-	private $cache = array();
+	private $admin_flag = array();
 
 	/**
 	 * Constructor: builds a language object given the corresponding data.
@@ -488,15 +488,15 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-param ''|'aria-hidden' $mode
 	 */
 	public function get_admin_flag( string $mode = '' ): string {
-		if ( isset( $this->cache['admin_flag'][ $mode ] ) ) {
-			return $this->cache['admin_flag'][ $mode ];
+		if ( isset( $this->admin_flag[ $mode ] ) ) {
+			return $this->admin_flag[ $mode ];
 		}
 
 		if ( ! empty( $this->flag ) ) {
 			if ( 'aria-hidden' === $mode ) {
-				$this->cache['admin_flag'][ $mode ] = str_replace( '<img', '<img aria-hidden="true" tabindex="-1"', $this->flag );
+				$this->admin_flag[ $mode ] = str_replace( '<img', '<img aria-hidden="true" tabindex="-1"', $this->flag );
 			} else {
-				$this->cache['admin_flag'][ $mode ] = str_replace(
+				$this->admin_flag[ $mode ] = str_replace(
 					'<img',
 					sprintf(
 						'<img lang="%1$s" dir="%2$s"',
@@ -506,13 +506,13 @@ class PLL_Language extends PLL_Language_Deprecated {
 					$this->flag
 				);
 			}
-			return $this->cache['admin_flag'][ $mode ];
+			return $this->admin_flag[ $mode ];
 		}
 
 		if ( 'aria-hidden' === $mode ) {
-			$this->cache['admin_flag'][ $mode ] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
+			$this->admin_flag[ $mode ] = sprintf( '<abbr aria-hidden="true" tabindex="-1">%s</abbr>', esc_html( strtoupper( $this->slug ) ) );
 		} else {
-			$this->cache['admin_flag'][ $mode ] = sprintf(
+			$this->admin_flag[ $mode ] = sprintf(
 				'<abbr title="%1$s" lang="%2$s" dir="%3$s">%4$s</abbr>',
 				esc_attr( $this->name ),
 				esc_attr( $this->get_locale( 'display' ) ),
@@ -520,7 +520,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 				esc_html( strtoupper( $this->slug ) )
 			);
 		}
-		return $this->cache['admin_flag'][ $mode ];
+		return $this->admin_flag[ $mode ];
 	}
 
 	/**
@@ -609,7 +609,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 */
 	public function to_array( $context = 'display' ) {
 		$language = get_object_vars( $this );
-		unset( $language['cache'] );
+		unset( $language['admin_flag'] );
 
 		if ( 'db' !== $context ) {
 			$language['home_url']   = $this->get_home_url();

--- a/src/modules/wizard/view-wizard-step-home-page.php
+++ b/src/modules/wizard/view-wizard-step-home-page.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 		printf(
 			/* translators: %s is the language of the front page ( flag, native name and locale ) */
 			esc_html__( 'Its language is : %s.', 'polylang' ),
-			$home_page_language->flag . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$home_page_language->get_admin_flag( 'minimal' ) . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 		?>
 	<br />
@@ -60,7 +60,7 @@ defined( 'ABSPATH' ) || exit;
 		<tr>
 			<td>
 				<?php
-				echo $language->flag;  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $language->get_admin_flag( 'minimal' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $language->name ) . ' ' . esc_html( $language->locale ) . ' ';
 				?>
 				<?php if ( $language->is_default ) : ?>
@@ -105,7 +105,7 @@ defined( 'ABSPATH' ) || exit;
 		<tr>
 			<td>
 				<?php
-				echo $lg->flag;  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $lg->get_admin_flag( 'minimal' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $lg->name ) . ' ' . esc_html( $lg->locale ) . ' ';
 				?>
 				<?php if ( $lg->is_default ) : ?>

--- a/src/modules/wizard/view-wizard-step-home-page.php
+++ b/src/modules/wizard/view-wizard-step-home-page.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 		printf(
 			/* translators: %s is the language of the front page ( flag, native name and locale ) */
 			esc_html__( 'Its language is : %s.', 'polylang' ),
-			$home_page_language->get_admin_flag( 'no-screen-reader' ) . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$home_page_language->get_admin_flag( 'aria-hidden' ) . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 		?>
 	<br />
@@ -60,7 +60,7 @@ defined( 'ABSPATH' ) || exit;
 		<tr>
 			<td>
 				<?php
-				echo $language->get_admin_flag( 'no-screen-reader' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $language->get_admin_flag( 'aria-hidden' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $language->name ) . ' ' . esc_html( $language->locale ) . ' ';
 				?>
 				<?php if ( $language->is_default ) : ?>
@@ -105,7 +105,7 @@ defined( 'ABSPATH' ) || exit;
 		<tr>
 			<td>
 				<?php
-				echo $lg->get_admin_flag( 'no-screen-reader' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $lg->get_admin_flag( 'aria-hidden' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $lg->name ) . ' ' . esc_html( $lg->locale ) . ' ';
 				?>
 				<?php if ( $lg->is_default ) : ?>

--- a/src/modules/wizard/view-wizard-step-home-page.php
+++ b/src/modules/wizard/view-wizard-step-home-page.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 		printf(
 			/* translators: %s is the language of the front page ( flag, native name and locale ) */
 			esc_html__( 'Its language is : %s.', 'polylang' ),
-			$home_page_language->get_admin_flag( 'minimal' ) . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$home_page_language->get_admin_flag( 'no-screen-reader' ) . ' <strong>' . esc_html( $home_page_language->name ) . ' ' . esc_html( $home_page_language->locale ) . '</strong>' //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 		?>
 	<br />
@@ -60,7 +60,7 @@ defined( 'ABSPATH' ) || exit;
 		<tr>
 			<td>
 				<?php
-				echo $language->get_admin_flag( 'minimal' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $language->get_admin_flag( 'no-screen-reader' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $language->name ) . ' ' . esc_html( $language->locale ) . ' ';
 				?>
 				<?php if ( $language->is_default ) : ?>
@@ -105,7 +105,7 @@ defined( 'ABSPATH' ) || exit;
 		<tr>
 			<td>
 				<?php
-				echo $lg->get_admin_flag( 'minimal' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $lg->get_admin_flag( 'no-screen-reader' );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo ' ' . esc_html( $lg->name ) . ' ' . esc_html( $lg->locale ) . ' ';
 				?>
 				<?php if ( $lg->is_default ) : ?>

--- a/src/modules/wizard/view-wizard-step-languages.php
+++ b/src/modules/wizard/view-wizard-step-languages.php
@@ -79,10 +79,10 @@ $languages_list = array_diff_key(
 	<?php
 	foreach ( $existing_languages as $lg ) {
 		printf(
-			'<tr><td>%3$s<span>%2$s - %1$s</span> %4$s</td></tr>' . "\n",
+			'<tr><td>%3$s <span>%2$s - %1$s</span> %4$s</td></tr>' . "\n",
 			esc_attr( $lg->locale ),
 			esc_html( $lg->name ),
-			$lg->flag, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$lg->get_admin_flag( 'minimal' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$lg->is_default ? ' <span class="icon-default-lang"><span class="screen-reader-text">' . esc_html__( 'Default language', 'polylang' ) . '</span></span>' : ''
 		);
 	}

--- a/src/modules/wizard/view-wizard-step-languages.php
+++ b/src/modules/wizard/view-wizard-step-languages.php
@@ -82,7 +82,7 @@ $languages_list = array_diff_key(
 			'<tr><td>%3$s <span>%2$s - %1$s</span> %4$s</td></tr>' . "\n",
 			esc_attr( $lg->locale ),
 			esc_html( $lg->name ),
-			$lg->get_admin_flag( 'no-screen-reader' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$lg->get_admin_flag( 'aria-hidden' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$lg->is_default ? ' <span class="icon-default-lang"><span class="screen-reader-text">' . esc_html__( 'Default language', 'polylang' ) . '</span></span>' : ''
 		);
 	}

--- a/src/modules/wizard/view-wizard-step-languages.php
+++ b/src/modules/wizard/view-wizard-step-languages.php
@@ -82,7 +82,7 @@ $languages_list = array_diff_key(
 			'<tr><td>%3$s <span>%2$s - %1$s</span> %4$s</td></tr>' . "\n",
 			esc_attr( $lg->locale ),
 			esc_html( $lg->name ),
-			$lg->get_admin_flag( 'minimal' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$lg->get_admin_flag( 'no-screen-reader' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$lg->is_default ? ' <span class="icon-default-lang"><span class="screen-reader-text">' . esc_html__( 'Default language', 'polylang' ) . '</span></span>' : ''
 		);
 	}

--- a/src/modules/wizard/view-wizard-step-untranslated-contents.php
+++ b/src/modules/wizard/view-wizard-step-untranslated-contents.php
@@ -25,10 +25,10 @@ $languages_list = $model->languages->get_list();
 		<?php
 		foreach ( $languages_list as $lg ) {
 			printf(
-				'<option value="%1$s" data-flag-html="%3$s" data-language-name="%2$s"%4$s>%2$s - %1$s</option>' . "\n",
+				'<option value="%1$s" data-flag-html="%3$s " data-language-name="%2$s"%4$s>%2$s - %1$s</option>' . "\n",
 				esc_attr( $lg->locale ),
 				esc_html( $lg->name ),
-				esc_html( $lg->flag ),
+				esc_html( $lg->get_admin_flag( 'minimal' ) ),
 				$lg->is_default ? ' selected="selected"' : ''
 			);
 		}

--- a/src/modules/wizard/view-wizard-step-untranslated-contents.php
+++ b/src/modules/wizard/view-wizard-step-untranslated-contents.php
@@ -28,7 +28,7 @@ $languages_list = $model->languages->get_list();
 				'<option value="%1$s" data-flag-html="%3$s " data-language-name="%2$s"%4$s>%2$s - %1$s</option>' . "\n",
 				esc_attr( $lg->locale ),
 				esc_html( $lg->name ),
-				esc_html( $lg->get_admin_flag( 'no-screen-reader' ) ),
+				esc_html( $lg->get_admin_flag( 'aria-hidden' ) ),
 				$lg->is_default ? ' selected="selected"' : ''
 			);
 		}

--- a/src/modules/wizard/view-wizard-step-untranslated-contents.php
+++ b/src/modules/wizard/view-wizard-step-untranslated-contents.php
@@ -28,7 +28,7 @@ $languages_list = $model->languages->get_list();
 				'<option value="%1$s" data-flag-html="%3$s " data-language-name="%2$s"%4$s>%2$s - %1$s</option>' . "\n",
 				esc_attr( $lg->locale ),
 				esc_html( $lg->name ),
-				esc_html( $lg->get_admin_flag( 'minimal' ) ),
+				esc_html( $lg->get_admin_flag( 'no-screen-reader' ) ),
 				$lg->is_default ? ' selected="selected"' : ''
 			);
 		}

--- a/src/settings/table-languages.php
+++ b/src/settings/table-languages.php
@@ -73,8 +73,11 @@ class PLL_Table_Languages extends WP_List_Table {
 			case 'count':
 				return $item->get_tax_prop( 'language', $column_name );
 
+			case 'flag':
+				return $item->get_admin_flag();
+
 			default:
-				return $item->$column_name; // Flag.
+				return $item->$column_name;
 		}
 	}
 

--- a/src/settings/table-languages.php
+++ b/src/settings/table-languages.php
@@ -75,6 +75,9 @@ class PLL_Table_Languages extends WP_List_Table {
 
 			case 'flag':
 				return $item->get_admin_flag();
+
+			default:
+				return '';
 		}
 	}
 

--- a/src/settings/table-languages.php
+++ b/src/settings/table-languages.php
@@ -75,9 +75,6 @@ class PLL_Table_Languages extends WP_List_Table {
 
 			case 'flag':
 				return $item->get_admin_flag();
-
-			default:
-				return $item->$column_name;
 		}
 	}
 

--- a/src/walker-dropdown.php
+++ b/src/walker-dropdown.php
@@ -87,7 +87,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 			$lang = reset( $current );
 			$output = sprintf(
 				'<span class="pll-select-flag">%s</span>',
-				empty( $lang->flag ) ? esc_html( $lang->slug ) : $lang->flag
+				$lang->get_admin_flag()
 			);
 		}
 

--- a/src/walker-dropdown.php
+++ b/src/walker-dropdown.php
@@ -87,7 +87,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 			$lang = reset( $current );
 			$output = sprintf(
 				'<span class="pll-select-flag">%s</span>',
-				$lang->get_admin_flag( 'no-screen-reader' )
+				$lang->get_admin_flag( 'aria-hidden' )
 			);
 		}
 

--- a/src/walker-dropdown.php
+++ b/src/walker-dropdown.php
@@ -87,7 +87,7 @@ class PLL_Walker_Dropdown extends PLL_Walker {
 			$lang = reset( $current );
 			$output = sprintf(
 				'<span class="pll-select-flag">%s</span>',
-				$lang->get_admin_flag()
+				$lang->get_admin_flag( 'no-screen-reader' )
 			);
 		}
 


### PR DESCRIPTION
Fixes partially https://github.com/polylang/polylang-pro/issues/2950 (similar work has been done in [PLL Pro](https://github.com/polylang/polylang-pro/pull/2992)).

## How

This introduces the method `PLL_Language::get_admin_flag()`, which is the admin version of `PLL_Language::get_display_flag()`. It is meant to be used in admin in two contexts:

1. `PLL_Language::get_admin_flag()` when the flag is not in a link: the flag must convey the language information. In this case, the attributes `lang` and `dir` are added because the `alt` attribute contains the name of the language.
2. `PLL_Language::get_admin_flag( 'minimal' )` when the flag is displayed in a link (the link already contain the information to convey) or next to text that already conveys the information: in this case the flag is only decorative. Note: in this case the attribute `tabindex="-1"` is added but I'm not entirely sure it is useful since these tags should not be focusable to start with.

Also important, if the flag is empty then a `<abbr>` tag is displayed instead.

## Example markups

In the following examples the `style`, `width`, and `height` attributes have been removed to make the markup more readable but are still printed.

### Posts list: table heading

The flag is not in a link, it must convey the information (via the `alt` attribute):

```html
<th scope="col" id="language_fr" class="manage-column column-language_fr">
	<img lang="fr-FR" dir="ltr" alt="Français" src="...">
</th>
```

If the flag is not available, the information is conveyed via the `title` attribute:

```html
<th scope="col" id="language_fr" class="manage-column column-language_fr">
	<abbr lang="fr-FR" dir="ltr" title="Français">FR</abbr>
</th>
```

### Posts list: cell content

The flag is in a link. The link has a `title` attribute and the link contains a "screen reader text". The flag is hidden to screen readers:

```html
<a href="..." class="pll_column_flag" title="Un article">
	<span class="screen-reader-text">Modifier cet élément en Français</span>
	<img aria-hidden="true" tabindex="-1" src="..." alt="Français">
</a>
```

With no flag:

```html
<a href="..." class="pll_column_flag" title="Un article">
	<span class="screen-reader-text">Modifier cet élément en Français</span>
	<abbr aria-hidden="true" tabindex="-1">FR</abbr>
</a>
```

### Media editor: classic metabox

The flag is not in a link but it preceeds language information. In this case I think the flag should not convey information:

```html
<td class="pll-media-language-column">
	<span class="pll-translation-flag">
		<img aria-hidden="true" tabindex="-1" src="..." alt="English">
	</span>
	English
</td>
```