### PR TITLE
Use `PLL_Language::get_predefined_flag()`

### DIFF
--- a/src/language-factory.php
+++ b/src/language-factory.php
@@ -211,7 +211,7 @@ class PLL_Language_Factory {
 	 * Creates flag_url and flag language properties. Also takes care of custom flag.
 	 *
 	 * @since 1.2
-	 * @since 3.4 Moved from `PLL_Language`to `PLL_Language_Factory` and renamed
+	 * @since 3.4 Moved from `PLL_Language` to `PLL_Language_Factory` and renamed
 	 *            in favor of `get_flag()` (formerly `set_flag()`).
 	 *
 	 * @param string $flag_code Flag code.

--- a/src/language.php
+++ b/src/language.php
@@ -351,6 +351,18 @@ class PLL_Language extends PLL_Language_Deprecated {
 	}
 
 	/**
+	 * Returns a predefined HTML flag.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $flag_code Flag code to render.
+	 * @return string HTML code for the flag.
+	 */
+	public static function get_predefined_flag( $flag_code ) {
+		return self::get_flag_html( self::get_flag_information( $flag_code ) );
+	}
+
+	/**
 	 * Returns the flag information.
 	 *
 	 * @since 2.6
@@ -579,20 +591,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 */
 	public function to_std_class() {
 		return (object) $this->to_array();
-	}
-
-	/**
-	 * Returns a predefined HTML flag.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string $flag_code Flag code to render.
-	 * @return string HTML code for the flag.
-	 */
-	public static function get_predefined_flag( $flag_code ) {
-		$flag = self::get_flag_information( $flag_code );
-
-		return self::get_flag_html( $flag );
 	}
 
 	/**

--- a/src/language.php
+++ b/src/language.php
@@ -351,6 +351,18 @@ class PLL_Language extends PLL_Language_Deprecated {
 	}
 
 	/**
+	 * Returns a predefined HTML flag.
+	 *
+	 * @since 3.4
+	 *
+	 * @param string $flag_code Flag code to render.
+	 * @return string HTML code for the flag.
+	 */
+	public static function get_predefined_flag( $flag_code ) {
+		return self::get_flag_html( self::get_flag_information( $flag_code ) );
+	}
+
+	/**
 	 * Returns the flag information.
 	 *
 	 * @since 2.6
@@ -588,20 +600,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 */
 	public function to_std_class() {
 		return (object) $this->to_array();
-	}
-
-	/**
-	 * Returns a predefined HTML flag.
-	 *
-	 * @since 3.4
-	 *
-	 * @param string $flag_code Flag code to render.
-	 * @return string HTML code for the flag.
-	 */
-	public static function get_predefined_flag( $flag_code ) {
-		$flag = self::get_flag_information( $flag_code );
-
-		return self::get_flag_html( $flag );
 	}
 
 	/**

--- a/src/settings/view-tab-lang.php
+++ b/src/settings/view-tab-lang.php
@@ -130,7 +130,7 @@ defined( 'ABSPATH' ) || exit;
 								printf(
 									'<option value="%s" data-flag-html="%s"%s>%s</option>' . "\n",
 									esc_attr( $code ),
-									esc_html( PLL_Language::get_flag_html( PLL_Language::get_flag_information( $code ) ) ),
+									esc_html( PLL_Language::get_predefined_flag( $code ) ),
 									selected( isset( $edit_lang->flag_code ) && $edit_lang->flag_code === $code, true, false ),
 									esc_html( $label )
 								);

--- a/src/settings/view-tab-lang.php
+++ b/src/settings/view-tab-lang.php
@@ -127,15 +127,16 @@ defined( 'ABSPATH' ) || exit;
 							<?php
 							$flags = include __DIR__ . '/flags.php';
 							foreach ( $flags as $code => $label ) {
-								$flag = PLL_Language::get_flag_information( $code );
-								if ( empty( $flag['url'] ) ) {
+								$flag_html = PLL_Language::get_predefined_flag( $code );
+
+								if ( empty( $flag_html ) ) {
 									continue;
 								}
 
 								printf(
 									'<option value="%s" data-flag-html="%s"%s>%s</option>' . "\n",
 									esc_attr( $code ),
-									esc_html( PLL_Language::get_flag_html( $flag ) ),
+									esc_html( $flag_html ),
 									selected( isset( $edit_lang->flag_code ) && $edit_lang->flag_code === $code, true, false ),
 									esc_html( $label )
 								);


### PR DESCRIPTION
Follows #1864.

This PR calls `PLL_Language::get_predefined_flag()` instead of `PLL_Language::get_flag_html( PLL_Language::get_flag_information() )`, which is exactly what it does.

I also took the initiative to move the method up in the class, next to the methods it uses.