### PR TITLE
Handle settings actions after the instantiation of `PLL_Table_String`

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
-	"phpVersion": "8.3",
-	"core": null,
-	"plugins": [ "." ],
+  "phpVersion": "8.3",
+  "core": null,
+  "plugins": [ "." ],
   "mappings": {
     "wp-content/plugins/custom-strings": "./tests/e2e/plugins/custom-strings"
   }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,8 @@
 {
 	"phpVersion": "8.3",
 	"core": null,
-	"plugins": [ "." ]
+	"plugins": [ "." ],
+  "mappings": {
+    "wp-content/plugins/custom-strings": "./tests/e2e/plugins/custom-strings"
+  }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -187,6 +187,8 @@
 	<exclude-pattern>webpack.config.js</exclude-pattern>
 	<exclude-pattern>rector.php</exclude-pattern>
 	<exclude-pattern>coverage/*</exclude-pattern>
+	<exclude-pattern>playwright-report/*</exclude-pattern>
+	<exclude-pattern>test-results/*</exclude-pattern>
 
 	<!-- Specific to Polylang -->
 	<exclude-pattern>bin/*.php</exclude-pattern>

--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -265,19 +265,6 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function languages_page() {
-		// Handle user input.
-		$action = isset( $_REQUEST['pll_action'] ) && is_string( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
-		} elseif ( ! empty( $action ) ) {
-			$this->handle_actions( $action );
-		}
-
-		if ( ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return;
-		}
-
 		$active_tab = 'mlang' === $_GET['page'] ? 'lang' : substr( sanitize_key( $_GET['page'] ), 6 ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		switch ( $active_tab ) {
@@ -291,6 +278,15 @@ class PLL_Settings extends PLL_Admin_Base {
 				$string_table = new PLL_Table_String( $this->model->languages );
 				$string_table->prepare_items();
 				break;
+		}
+
+		// Handle user input.
+		$action = isset( $_REQUEST['pll_action'] ) && is_string( $_REQUEST['pll_action'] ) ? sanitize_key( $_REQUEST['pll_action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+		if ( 'edit' === $action && ! empty( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// phpcs:ignore WordPress.Security.NonceVerification, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$edit_lang = $this->model->get_language( (int) $_GET['lang'] );
+		} elseif ( ! empty( $action ) ) {
+			$this->handle_actions( $action );
 		}
 
 		// Displays the page.

--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -265,6 +265,10 @@ class PLL_Settings extends PLL_Admin_Base {
 	 * @return void
 	 */
 	public function languages_page() {
+		if ( ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return; // Should not happen.
+		}
+
 		$active_tab = 'mlang' === $_GET['page'] ? 'lang' : substr( sanitize_key( $_GET['page'] ), 6 ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		switch ( $active_tab ) {

--- a/tests/e2e/global.setup.mjs
+++ b/tests/e2e/global.setup.mjs
@@ -9,6 +9,9 @@ async function globalSetup( config ) {
 
 	// Set pretty permalink structure.
 	execSync(
+		/*
+		 * Use hard flush to update .htaccess rules as well as rewrite rules in database.
+		 */
 		'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root',
 		{
 			cwd: process.cwd(),

--- a/tests/e2e/global.setup.mjs
+++ b/tests/e2e/global.setup.mjs
@@ -9,7 +9,7 @@ async function globalSetup( config ) {
 
 	// Set pretty permalink structure.
 	execSync(
-		'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --allow-root',
+		'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root',
 		{
 			cwd: process.cwd(),
 			stdio: 'inherit',

--- a/tests/e2e/global.teardown.mjs
+++ b/tests/e2e/global.teardown.mjs
@@ -3,10 +3,13 @@ import { execSync } from 'child_process';
 
 async function globalTeardown() {
 	// Set permalink structure back to default.
-	execSync( 'npx wp-env run tests-cli wp rewrite structure "" --hard --allow-root', {
-		cwd: process.cwd(),
-		stdio: 'ignore',
-	} );
+	execSync(
+		'npx wp-env run tests-cli wp rewrite structure "" --hard --allow-root',
+		{
+			cwd: process.cwd(),
+			stdio: 'ignore',
+		}
+	);
 }
 
 export default globalTeardown;

--- a/tests/e2e/global.teardown.mjs
+++ b/tests/e2e/global.teardown.mjs
@@ -4,6 +4,9 @@ import { execSync } from 'child_process';
 async function globalTeardown() {
 	// Set permalink structure back to default.
 	execSync(
+		/*
+		 * Use hard flush to update .htaccess rules as well as rewrite rules in database.
+		 */
 		'npx wp-env run tests-cli wp rewrite structure "" --hard --allow-root',
 		{
 			cwd: process.cwd(),

--- a/tests/e2e/global.teardown.mjs
+++ b/tests/e2e/global.teardown.mjs
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 
 async function globalTeardown() {
 	// Set permalink structure back to default.
-	execSync( 'npx wp-env run tests-cli wp rewrite structure "" --allow-root', {
+	execSync( 'npx wp-env run tests-cli wp rewrite structure "" --hard --allow-root', {
 		cwd: process.cwd(),
 		stdio: 'ignore',
 	} );

--- a/tests/e2e/plugins/custom-strings/custom-strings.php
+++ b/tests/e2e/plugins/custom-strings/custom-strings.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_action(
-	'admin_init',
+	'init',
 	function () {
 		if ( ! function_exists( 'pll_register_string' ) ) {
 
@@ -33,7 +33,8 @@ add_action(
 			'Polylang E2E',
 			true
 		);
-	}
+	},
+	20
 );
 
 add_filter(

--- a/tests/e2e/plugins/custom-strings/custom-strings.php
+++ b/tests/e2e/plugins/custom-strings/custom-strings.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Custom Strings E2E
+ * Description: Registers Polylang strings for E2E tests and appends them to post content on the frontend.
+ * Version: 0.1.0
+ * License: GPL-2.0-or-later
+ *
+ * @package Polylang-E2E
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action(
+	'admin_init',
+	function () {
+		if ( ! function_exists( 'pll_register_string' ) ) {
+
+			return;
+		}
+
+		pll_register_string(
+			'e2e_custom_greeting',
+			'Hello Polylang E2E',
+			'Polylang E2E',
+			false
+		);
+
+		pll_register_string(
+			'e2e_custom_multiline',
+			"Line one\nLine two",
+			'Polylang E2E',
+			true
+		);
+	}
+);
+
+add_filter(
+	'the_content',
+	function ( $content ) {
+		$single = sprintf(
+			'<p class="pll-e2e-custom-string">%s</p>',
+			pll__( 'Hello Polylang E2E' )
+		);
+
+		$multiline = sprintf(
+			'<div class="pll-e2e-custom-string-multiline">%s</div>',
+			pll__( "Line one\nLine two" )
+		);
+
+		return $content . $single . $multiline;
+	},
+	20
+);

--- a/tests/e2e/plugins/custom-strings/custom-strings.php
+++ b/tests/e2e/plugins/custom-strings/custom-strings.php
@@ -15,11 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action(
 	'init',
 	function () {
-		if ( ! function_exists( 'pll_register_string' ) ) {
-
-			return;
-		}
-
 		pll_register_string(
 			'e2e_custom_greeting',
 			'Hello Polylang E2E',

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -27,7 +27,7 @@ test.describe.serial(
 		test.beforeAll( async ( { requestUtils } ) => {
 			// Site Editor utilities doesn't like pretty permalinks.
 			execSync(
-				'npx wp-env run tests-cli wp rewrite structure "" --allow-root',
+				'npx wp-env run tests-cli wp rewrite structure "" --hard --allow-root',
 				{
 					cwd: process.cwd(),
 					stdio: 'inherit',
@@ -52,7 +52,7 @@ test.describe.serial(
 			await deleteAllLanguages( requestUtils );
 			// Set pretty permalink structure.
 			execSync(
-				'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --allow-root',
+				'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root',
 				{
 					cwd: process.cwd(),
 					stdio: 'inherit',

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -1,6 +1,5 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 import { createLanguage, deleteAllLanguages } from '@wpsyntex/e2e-test-utils';
-import { execSync } from 'child_process';
 
 /**
  * @typedef {import('@playwright/test').Page} Page

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -25,15 +25,6 @@ test.describe.serial(
 		 *     - Create the main Navigation menu in English.
 		 */
 		test.beforeAll( async ( { requestUtils } ) => {
-			// Site Editor utilities doesn't like pretty permalinks.
-			execSync(
-				'npx wp-env run tests-cli wp rewrite structure "" --hard --allow-root',
-				{
-					cwd: process.cwd(),
-					stdio: 'inherit',
-				}
-			);
-
 			await createLanguage( requestUtils, 'en_US' );
 			await createLanguage( requestUtils, 'fr_FR' );
 			await createLanguage( requestUtils, 'de_DE' );
@@ -50,14 +41,6 @@ test.describe.serial(
 		test.afterAll( async ( { requestUtils } ) => {
 			await requestUtils.deleteAllMenus();
 			await deleteAllLanguages( requestUtils );
-			// Set pretty permalink structure.
-			execSync(
-				'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root',
-				{
-					cwd: process.cwd(),
-					stdio: 'inherit',
-				}
-			);
 		} );
 
 		/**

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
-import { createLanguage, deleteAllLanguages } from '@wpsyntex/e2e-test-utils';
+import { createLanguage, deleteAllLanguages, setSetting, resetAllSettings, getAllLanguages } from '@wpsyntex/e2e-test-utils';
+import { execSync } from 'child_process';
 
 /**
  * Covers strings translations in admin and on the frontend.
@@ -13,6 +14,7 @@ test.describe.serial( 'Strings translations', () => {
 	let frenchPostUrl;
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		await setSetting( requestUtils, 'force_lang', 1 );
 		await createLanguage( requestUtils, 'en_US' );
 		await createLanguage( requestUtils, 'fr_FR' );
 	} );
@@ -20,6 +22,7 @@ test.describe.serial( 'Strings translations', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await deleteAllLanguages( requestUtils );
 		await requestUtils.deleteAllPosts();
+		await resetAllSettings( requestUtils );
 	} );
 
 	test.describe( 'Admin', () => {
@@ -219,7 +222,16 @@ test.describe.serial( 'Strings translations', () => {
 			 */
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
+				requestUtils,
 			} ) => {
+				const rewriteStructure = execSync( 'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root', {
+					cwd: process.cwd(),
+					stdio: 'inherit',
+				} );
+
+				await page.goto( 'fr/' );
+
+				console.log( frenchPostUrl );
 				const response = await page.goto( frenchPostUrl );
 
 				expect( response.status() ).toBe( 200 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -215,24 +215,6 @@ test.describe.serial( 'Strings translations', () => {
 		} );
 
 		test.describe( 'Core strings', () => {
-			test( 'Test page language choice', async ( {
-				admin,
-				page,
-			} ) => {
-				await admin.visitAdminPage(
-					'post.php',
-					`post=${ frenchPageId }&action=edit`
-				);
-
-				const postLangChoice = page.locator( 'select[name="post_lang_choice"]' );
-
-				await expect( postLangChoice ).toBeVisible();
-
-				await expect( postLangChoice.locator( 'option:checked' ) ).toHaveText(
-					'Français'
-				);
-			} );
-
 			/**
 			 * Ensures the French translation for `blogname` is used on the French front (document title).
 			 *
@@ -248,6 +230,11 @@ test.describe.serial( 'Strings translations', () => {
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
 			} ) => {
+				execSync( 'npx wp-env run tests-cli wp rewrite flush --allow-root', {
+					cwd: process.cwd(),
+					stdio: 'inherit',
+				} );
+
 				const response = await page.goto( frenchPageUrl );
 
 				expect( response.status() ).toBe( 200 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -12,6 +12,9 @@ test.describe.serial( 'Strings translations', () => {
 	/** @type {string} */
 	let frenchPageUrl;
 
+	/** @type {number} */
+	let frenchPageId;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await createLanguage( requestUtils, 'en_US' );
 		await createLanguage( requestUtils, 'fr_FR' );
@@ -201,7 +204,7 @@ test.describe.serial( 'Strings translations', () => {
 				},
 			} );
 
-			frenchPageUrl = publishedFrenchPage.link;
+			frenchPageId = publishedFrenchPage.id;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -224,7 +227,11 @@ test.describe.serial( 'Strings translations', () => {
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
 			} ) => {
-				const response = await page.goto( '/fr/pll-e2e-strings-page/' );
+				const frenchPage = await requestUtils.rest( {
+					method: 'GET',
+					path: `/wp/v2/pages/${ frenchPageId }`,
+				} );
+				const response = await page.goto( frenchPage.link );
 
 				expect( response.status() ).toBe( 200 );
 
@@ -254,6 +261,7 @@ test.describe.serial( 'Strings translations', () => {
 			test( 'French translation of custom string appears on the frontend', async ( {
 				page,
 			} ) => {
+				frenchPageUrl = frenchPageUrl.replace( '/', '/fr/' );
 				await page.goto( frenchPageUrl );
 
 				await expect(

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -231,6 +231,7 @@ test.describe.serial( 'Strings translations', () => {
 					method: 'GET',
 					path: `/wp/v2/pages/${ frenchPageId }`,
 				} );
+				console.log( frenchPage );
 				const response = await page.goto( frenchPage.link );
 
 				expect( response.status() ).toBe( 200 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -224,6 +224,9 @@ test.describe.serial( 'Strings translations', () => {
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
 			} ) => {
+				console.log( frenchPageUrl );
+				console.log( await page.url() );
+
 				await page.goto( frenchPageUrl );
 
 				await expect( page ).toHaveTitle( /polylang FR/ );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
 import { createLanguage, deleteAllLanguages } from '@wpsyntex/e2e-test-utils';
+import { execSync } from 'child_process';
 
 /**
  * Covers strings translations in admin and on the frontend.
@@ -225,6 +226,10 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 				requestUtils,
 			} ) => {
+				const rewriteRules = execSync('npx wp-env run tests-cli wp rewrite list --allow-root');
+
+				console.log( rewriteRules );
+
 				const response = await page.goto( frenchPageUrl );
 
 				expect( response.status() ).toBe( 200 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -201,7 +201,6 @@ test.describe.serial( 'Strings translations', () => {
 				lang: 'fr',
 			} );
 
-			console.log( publishedFrenchPage );
 			frenchPageUrl = publishedFrenchPage.link;
 		} );
 
@@ -228,7 +227,7 @@ test.describe.serial( 'Strings translations', () => {
 			} ) => {
 				const rewriteRules = execSync('npx wp-env run tests-cli wp rewrite list --allow-root');
 
-				console.log( rewriteRules );
+				console.log( 'REWRITE RULES', rewriteRules );
 
 				const response = await page.goto( frenchPageUrl );
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -226,6 +226,7 @@ test.describe.serial( 'Strings translations', () => {
 			 */
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
+				requestUtils,
 			} ) => {
 				const frenchPage = await requestUtils.rest( {
 					method: 'GET',

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -202,11 +202,7 @@ test.describe.serial( 'Strings translations', () => {
 			} );
 
 			frenchPageUrl = publishedFrenchPage.link;
-
-			execSync('npx wp-env run tests-cli wp rewrite flush --allow-root', {
-				cwd: process.cwd(),
-				stdio: 'inherit',
-			});
+			frenchPageId = publishedFrenchPage.id;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -230,7 +226,7 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 				requestUtils,
 			} ) => {
-				const response = await page.goto( frenchPageUrl );
+				const response = await page.goto( '/?p=' + frenchPageId );
 
 				expect( response.status() ).toBe( 200 );
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -201,12 +201,11 @@ test.describe.serial( 'Strings translations', () => {
 				},
 			} );
 
-			frenchPageUrl = `/?page_id=${ publishedFrenchPage.id }`;
+			frenchPageUrl = publishedFrenchPage.link;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
 			await requestUtils.deactivatePlugin( 'custom-strings-e2e' );
-			await requestUtils.deleteAllPages();
 		} );
 
 		test.describe( 'Core strings', () => {

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -1,0 +1,280 @@
+// @ts-check
+import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+import { createLanguage, deleteAllLanguages } from '@wpsyntex/e2e-test-utils';
+
+/**
+ * Covers strings translations in admin and on the frontend (admin tests run before frontend tests in this file).
+ */
+test.describe( 'Strings translations', () => {
+	/** @type {string} */
+	let frenchPageUrl;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await createLanguage( requestUtils, 'en_US' );
+		await createLanguage( requestUtils, 'fr_FR' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await deleteAllLanguages( requestUtils );
+		await requestUtils.deleteAllPages();
+	} );
+
+	test.describe( 'Admin', () => {
+		test.describe( 'Core strings', () => {
+			/**
+			 * Ensures the blogname string is translatable in "Translations" screen.
+			 *
+			 * Prerequisites:
+			 *     - English (en_US) and French (fr_FR) languages exist.
+			 *
+			 * Steps:
+			 *     - Go to the "Translations" screen filtered to the WooCommerce group.
+			 *     - Check that the blogname string is visible.
+			 *     - Focus the French translation field for that row.
+			 *     - Fill in the input with the "polylang FR" value.
+			 *     - Click the "Save Changes" button.
+			 *     - Check that the "polylang FR" string is visible in the "Translations" screen.
+			 */
+			test( 'Blogname core string should be translatable', async ( {
+				page,
+			} ) => {
+				await page.goto(
+					'wp-admin/admin.php?page=mlang_strings&s&group=WooCommerce&paged=1'
+				);
+				await expect(
+					page.getByRole( 'cell', { name: 'blogname' } )
+				).toBeVisible();
+
+				await page
+					.getByRole( 'row', { name: 'Select polylang polylang' } )
+					.getByLabel( 'Français' )
+					.click();
+				await page
+					.getByRole( 'row', { name: 'Select polylang polylang' } )
+					.getByLabel( 'Français' )
+					.fill( 'polylang FR' );
+
+				await page
+					.getByRole( 'button', { name: 'Save Changes' } )
+					.click();
+				await expect(
+					page.getByRole( 'cell', {
+						name: 'polylang FR',
+					} )
+				).toBeVisible();
+			} );
+		} );
+
+		test.describe( 'Custom strings plugin', () => {
+			test.beforeAll( async ( { requestUtils } ) => {
+				await requestUtils.activatePlugin( 'custom-strings-e2e' );
+			} );
+
+			test.afterAll( async ( { requestUtils } ) => {
+				await requestUtils.deactivatePlugin( 'custom-strings-e2e' );
+			} );
+
+			/**
+			 * Ensures the registered string appears on the Translations screen (filtered by group).
+			 *
+			 * Prerequisites:
+			 *     - English (en_US) and French (fr_FR) languages exist.
+			 *     - The Custom Strings E2E test plugin is active (registers `Hello Polylang E2E` on admin load).
+			 *
+			 * Steps:
+			 *     - Go to the "Translations" screen filtered to the "Polylang E2E" group.
+			 *     - Check that the string and name cells show the expected values.
+			 *     - Fill the French translation and save (read on the frontend below).
+			 */
+			test( 'Custom string is listed in admin and can be translated', async ( {
+				admin,
+			} ) => {
+				await admin.visitAdminPage(
+					'admin.php',
+					`page=mlang_strings&group=${ encodeURIComponent(
+						'Polylang E2E'
+					) }`
+				);
+
+				await expect(
+					admin.page.getByRole( 'cell', {
+						name: 'Hello Polylang E2E',
+						exact: true,
+					} )
+				).toBeVisible();
+				await expect(
+					admin.page.getByRole( 'cell', {
+						name: 'e2e_custom_greeting',
+						exact: true,
+					} )
+				).toBeVisible();
+
+				const stringRow = admin.page
+					.getByRole( 'row' )
+					.filter( { hasText: 'Hello Polylang E2E' } );
+
+				await stringRow
+					.getByLabel( 'Français' )
+					.fill( 'Bonjour Polylang E2E FR' );
+				await admin.page
+					.getByRole( 'button', { name: 'Save Changes' } )
+					.click();
+
+				await expect( stringRow.getByLabel( 'Français' ) ).toHaveValue(
+					'Bonjour Polylang E2E FR'
+				);
+			} );
+
+			/**
+			 * Ensures the multiline string uses a textarea in admin and can be translated.
+			 *
+			 * Prerequisites:
+			 *     - English (en_US) and French (fr_FR) languages exist.
+			 *     - The Custom Strings E2E test plugin is active (registers a multiline string).
+			 *
+			 * Steps:
+			 *     - Go to the "Translations" screen filtered to the "Polylang E2E" group.
+			 *     - Find the multiline row and check the French field is a textarea.
+			 *     - Fill the French translation and save (read on the frontend below).
+			 */
+			test( 'Multiline custom string is listed in admin and can be translated', async ( {
+				admin,
+			} ) => {
+				await admin.visitAdminPage(
+					'admin.php',
+					`page=mlang_strings&group=${ encodeURIComponent(
+						'Polylang E2E'
+					) }`
+				);
+
+				const multilineRow = admin.page
+					.getByRole( 'row' )
+					.filter( { hasText: 'Line one' } )
+					.filter( { hasText: 'Line two' } );
+
+				await expect(
+					multilineRow.getByRole( 'cell', {
+						name: 'e2e_custom_multiline',
+					} )
+				).toBeVisible();
+
+				const frenchField = multilineRow.getByLabel( 'Français' );
+
+				await expect( frenchField ).toHaveAttribute(
+					'name',
+					/translation\[fr\]/
+				);
+
+				await frenchField.fill( 'Ligne un\nLigne deux' );
+				await admin.page
+					.getByRole( 'button', { name: 'Save Changes' } )
+					.click();
+
+				const frenchFieldAfterSave = admin.page
+					.getByRole( 'row' )
+					.filter( { hasText: 'Line one' } )
+					.filter( { hasText: 'Line two' } )
+					.getByLabel( 'Français' );
+
+				await expect( frenchFieldAfterSave ).toHaveValue(
+					'Ligne un\nLigne deux'
+				);
+			} );
+		} );
+	} );
+
+	test.describe( 'Frontend', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin( 'custom-strings-e2e' );
+
+			const publishedFrenchPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/pages',
+				data: {
+					title: 'PLL E2E strings page',
+					content: '<p>PLL E2E page body</p>',
+					status: 'publish',
+					lang: 'fr',
+				},
+			} );
+
+			frenchPageUrl = publishedFrenchPage.link;
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin( 'custom-strings-e2e' );
+		} );
+
+		test.describe( 'Core strings', () => {
+			/**
+			 * Ensures the French translation for `blogname` is used on the French front (document title).
+			 *
+			 * Prerequisites:
+			 *     - The admin test above saved the French blogname as "polylang FR".
+			 *     - English and French languages exist.
+			 *
+			 * Steps:
+			 *     - Open the French home URL (`/fr/`).
+			 *     - Check that the document title contains the French site title.
+			 */
+			test( 'Blogname French translation appears on the frontend', async ( {
+				page,
+			} ) => {
+				await page.goto( frenchPageUrl );
+
+				await expect(
+					page
+						.getByRole( 'banner' )
+						.getByRole( 'link', { name: 'polylang FR' } )
+				).toBeVisible();
+			} );
+		} );
+
+		test.describe( 'Custom strings plugin', () => {
+			/**
+			 * Ensures the custom string French translation appears on the frontend via the_content output.
+			 *
+			 * Prerequisites:
+			 *     - The admin test above saved the French translation "Bonjour Polylang E2E FR".
+			 *     - This section's `beforeAll` activated the plugin and created a published French page.
+			 *
+			 * Steps:
+			 *     - Open the French page on the frontend.
+			 *     - Check that the appended paragraph shows the French translation.
+			 */
+			test( 'French translation of custom string appears on the frontend', async ( {
+				page,
+			} ) => {
+				await page.goto( frenchPageUrl );
+
+				await expect(
+					page.locator( '.pll-e2e-custom-string' )
+				).toHaveText( 'Bonjour Polylang E2E FR' );
+			} );
+
+			/**
+			 * Ensures the multiline custom string French translation appears on the frontend.
+			 *
+			 * Prerequisites:
+			 *     - The admin test above saved the French multiline translation.
+			 *     - This section's `beforeAll` activated the plugin and created a published French page.
+			 *
+			 * Steps:
+			 *     - Open the French page on the frontend.
+			 *     - Check that the multiline block shows the French lines.
+			 */
+			test( 'French translation of multiline custom string appears on the frontend', async ( {
+				page,
+			} ) => {
+				await page.goto( frenchPageUrl );
+
+				await expect(
+					page.locator( '.pll-e2e-custom-string-multiline' )
+				).toContainText( 'Ligne un' );
+				await expect(
+					page.locator( '.pll-e2e-custom-string-multiline' )
+				).toContainText( 'Ligne deux' );
+			} );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
 import { createLanguage, deleteAllLanguages } from '@wpsyntex/e2e-test-utils';
-import { execSync } from 'child_process';
 
 /**
  * Covers strings translations in admin and on the frontend.
@@ -11,10 +10,7 @@ import { execSync } from 'child_process';
  */
 test.describe.serial( 'Strings translations', () => {
 	/** @type {string} */
-	let frenchPageUrl;
-
-	/** @type {number} */
-	let frenchPageId;
+	let frenchPostUrl;
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		await createLanguage( requestUtils, 'en_US' );
@@ -23,7 +19,7 @@ test.describe.serial( 'Strings translations', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await deleteAllLanguages( requestUtils );
-		await requestUtils.deleteAllPages();
+		await requestUtils.deleteAllPosts();
 	} );
 
 	test.describe( 'Admin', () => {
@@ -194,20 +190,14 @@ test.describe.serial( 'Strings translations', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.activatePlugin( 'custom-strings-e2e' );
 
-			const publishedFrenchPage = await requestUtils.createPage( {
-				title: 'PLL E2E strings page',
-				content: '<p>PLL E2E page body</p>',
+			const publishedFrenchPost = await requestUtils.createPost( {
+				title: 'PLL E2E strings post',
+				content: '<p>PLL E2E post body</p>',
 				status: 'publish',
 				lang: 'fr',
 			} );
 
-			frenchPageId = publishedFrenchPage.id;
-			frenchPageUrl = publishedFrenchPage.link;
-
-			execSync( 'npx wp-env run tests-cli wp option delete rewrite_rules --allow-root', {
-				cwd: process.cwd(),
-				stdio: 'inherit',
-			} );
+			frenchPostUrl = publishedFrenchPost.link;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -223,19 +213,14 @@ test.describe.serial( 'Strings translations', () => {
 			 *     - English and French languages exist.
 			 *
 			 * Steps:
-			 *     - Open the French page URL created in `beforeAll`.
+			 *     - Open the French post URL created in `beforeAll`.
 			 *     - Check that the document title includes the French site title (WordPress appends site name on singular views).
 			 *     - Check that the header site title block shows "polylang FR" (block themes: `header` + `.wp-block-site-title`).
 			 */
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
 			} ) => {
-				execSync( 'npx wp-env run tests-cli wp rewrite flush --allow-root', {
-					cwd: process.cwd(),
-					stdio: 'inherit',
-				} );
-
-				const response = await page.goto( frenchPageUrl );
+				const response = await page.goto( frenchPostUrl );
 
 				expect( response.status() ).toBe( 200 );
 
@@ -256,16 +241,16 @@ test.describe.serial( 'Strings translations', () => {
 			 *
 			 * Prerequisites:
 			 *     - The admin test above saved the French translation "Bonjour Polylang E2E FR".
-			 *     - This section's `beforeAll` activated the plugin and created a published French page.
+			 *     - This section's `beforeAll` activated the plugin and created a published French post.
 			 *
 			 * Steps:
-			 *     - Open the French page on the frontend.
+			 *     - Open the French post on the frontend.
 			 *     - Check that the appended paragraph shows the French translation.
 			 */
 			test( 'French translation of custom string appears on the frontend', async ( {
 				page,
 			} ) => {
-				await page.goto( frenchPageUrl );
+				await page.goto( frenchPostUrl );
 
 				await expect(
 					page.locator( '.pll-e2e-custom-string' )
@@ -277,16 +262,16 @@ test.describe.serial( 'Strings translations', () => {
 			 *
 			 * Prerequisites:
 			 *     - The admin test above saved the French multiline translation.
-			 *     - This section's `beforeAll` activated the plugin and created a published French page.
+			 *     - This section's `beforeAll` activated the plugin and created a published French post.
 			 *
 			 * Steps:
-			 *     - Open the French page on the frontend.
+			 *     - Open the French post on the frontend.
 			 *     - Check that the multiline block shows the French lines.
 			 */
 			test( 'French translation of multiline custom string appears on the frontend', async ( {
 				page,
 			} ) => {
-				await page.goto( frenchPageUrl );
+				await page.goto( frenchPostUrl );
 
 				await expect(
 					page.locator( '.pll-e2e-custom-string-multiline' )

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -55,14 +55,14 @@ test.describe.serial( 'Strings translations', () => {
 					page.getByRole( 'cell', { name: 'blogname' } )
 				).toBeVisible();
 
-				await page
+				const blognameRow = page
 					.getByRole( 'row', { name: 'Select polylang polylang' } )
-					.getByLabel( 'Français' )
-					.click();
-				await page
-					.getByRole( 'row', { name: 'Select polylang polylang' } )
-					.getByLabel( 'Français' )
-					.fill( 'polylang FR' );
+					.getByLabel( 'Français' );
+
+				await blognameRow.click();
+				await blognameRow.fill( 'polylang FR' );
+
+				await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 
 				await page
 					.getByRole( 'button', { name: 'Save Changes' } )

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -201,11 +201,12 @@ test.describe.serial( 'Strings translations', () => {
 				},
 			} );
 
-			frenchPageUrl = publishedFrenchPage.link;
+			frenchPageUrl = `/?page_id=${ publishedFrenchPage.id }`;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
 			await requestUtils.deactivatePlugin( 'custom-strings-e2e' );
+			await requestUtils.deleteAllPages();
 		} );
 
 		test.describe( 'Core strings', () => {

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -201,7 +201,13 @@ test.describe.serial( 'Strings translations', () => {
 				lang: 'fr',
 			} );
 
+			frenchPageId = publishedFrenchPage.id;
 			frenchPageUrl = publishedFrenchPage.link;
+
+			execSync( 'npx wp-env run tests-cli wp option delete rewrite_rules --allow-root', {
+				cwd: process.cwd(),
+				stdio: 'inherit',
+			} );
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -209,15 +215,24 @@ test.describe.serial( 'Strings translations', () => {
 		} );
 
 		test.describe( 'Core strings', () => {
-			test( 'Test home pages', async ( {
+			test( 'Test page language choice', async ( {
+				admin,
 				page,
 			} ) => {
-				const response = await page.goto( '/' );
-				expect( response.status() ).toBe( 200 );
+				await admin.visitAdminPage(
+					'post.php',
+					`post=${ frenchPageId }&action=edit`
+				);
 
-				const frResponse = await page.goto( 'fr/' );
-				expect( frResponse.status() ).toBe( 200 );
+				const postLangChoice = page.locator( 'select[name="post_lang_choice"]' );
+
+				await expect( postLangChoice ).toBeVisible();
+
+				await expect( postLangChoice.locator( 'option:checked' ) ).toHaveText(
+					'Français'
+				);
 			} );
+
 			/**
 			 * Ensures the French translation for `blogname` is used on the French front (document title).
 			 *
@@ -232,7 +247,6 @@ test.describe.serial( 'Strings translations', () => {
 			 */
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
-				requestUtils,
 			} ) => {
 				const response = await page.goto( frenchPageUrl );
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -202,7 +202,6 @@ test.describe.serial( 'Strings translations', () => {
 			} );
 
 			frenchPageUrl = publishedFrenchPage.link;
-			frenchPageId = publishedFrenchPage.id;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -210,6 +209,15 @@ test.describe.serial( 'Strings translations', () => {
 		} );
 
 		test.describe( 'Core strings', () => {
+			test( 'Test home pages', async ( {
+				page,
+			} ) => {
+				const response = await page.goto( '/' );
+				expect( response.status() ).toBe( 200 );
+
+				const frResponse = await page.goto( '/fr/' );
+				expect( frResponse.status() ).toBe( 200 );
+			} );
 			/**
 			 * Ensures the French translation for `blogname` is used on the French front (document title).
 			 *
@@ -226,7 +234,7 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 				requestUtils,
 			} ) => {
-				const response = await page.goto( '/?p=' + frenchPageId );
+				const response = await page.goto( frenchPageUrl );
 
 				expect( response.status() ).toBe( 200 );
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -193,15 +193,11 @@ test.describe.serial( 'Strings translations', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.activatePlugin( 'custom-strings-e2e' );
 
-			const publishedFrenchPage = await requestUtils.rest( {
-				method: 'POST',
-				path: '/wp/v2/pages',
-				data: {
-					title: 'PLL E2E strings page',
-					content: '<p>PLL E2E page body</p>',
-					status: 'publish',
-					lang: 'fr',
-				},
+			const publishedFrenchPage = await requestUtils.createPage( {
+				title: 'PLL E2E strings page',
+				content: '<p>PLL E2E page body</p>',
+				status: 'publish',
+				lang: 'fr',
 			} );
 
 			frenchPageId = publishedFrenchPage.id;

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -6,7 +6,6 @@ import {
 	setSetting,
 	resetAllSettings,
 } from '@wpsyntex/e2e-test-utils';
-import { execSync } from 'child_process';
 
 /**
  * Covers strings translations in admin and on the frontend.

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -217,18 +217,22 @@ test.describe.serial( 'Strings translations', () => {
 			 *     - English and French languages exist.
 			 *
 			 * Steps:
-			 *     - Open the French home URL (`/fr/`).
-			 *     - Check that the document title contains the French site title.
+			 *     - Open the French page URL created in `beforeAll`.
+			 *     - Check that the document title includes the French site title (WordPress appends site name on singular views).
+			 *     - Check that the header site title block shows "polylang FR" (block themes: `header` + `.wp-block-site-title`).
 			 */
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
 			} ) => {
 				await page.goto( frenchPageUrl );
 
+				await expect( page ).toHaveTitle( /polylang FR/ );
+
 				await expect(
 					page
-						.getByRole( 'banner' )
-						.getByRole( 'link', { name: 'polylang FR' } )
+						.locator( 'header' )
+						.locator( '.wp-block-site-title' )
+						.getByText( 'polylang FR', { exact: true } )
 				).toBeVisible();
 			} );
 		} );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -49,7 +49,7 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 			} ) => {
 				await page.goto(
-					'wp-admin/admin.php?page=mlang_strings&s&group=WooCommerce&paged=1'
+					'wp-admin/admin.php?page=mlang_strings&paged=1'
 				);
 				await expect(
 					page.getByRole( 'cell', { name: 'blogname' } )

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -225,9 +225,12 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 				requestUtils,
 			} ) => {
-				const rewriteRules = execSync('npx wp-env run tests-cli wp rewrite list --allow-root');
+				const rewriteRules = execSync('npx wp-env run tests-cli wp rewrite list --allow-root --match=http://localhost:8889/fr/pll-e2e-strings-page/', {
+					cwd: process.cwd(),
+					stdio: 'inherit',
+				});
 
-				console.log( 'REWRITE RULES', rewriteRules );
+				console.log( 'REWRITE RULES STRUCTURE', rewriteRules );
 
 				const response = await page.goto( frenchPageUrl );
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -19,14 +19,6 @@ test.describe.serial( 'Strings translations', () => {
 	let frenchPostUrl;
 
 	test.beforeAll( async ( { requestUtils } ) => {
-		execSync(
-			'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root',
-			{
-				cwd: process.cwd(),
-				stdio: 'inherit',
-			}
-		);
-
 		await setSetting( requestUtils, 'force_lang', 1 );
 		await createLanguage( requestUtils, 'en_US' );
 		await createLanguage( requestUtils, 'fr_FR' );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -62,7 +62,9 @@ test.describe.serial( 'Strings translations', () => {
 				await blognameRow.click();
 				await blognameRow.fill( 'polylang FR' );
 
-				await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+				await page
+					.getByRole( 'button', { name: 'Save Changes' } )
+					.click();
 
 				await page
 					.getByRole( 'button', { name: 'Save Changes' } )

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -215,7 +215,7 @@ test.describe.serial( 'Strings translations', () => {
 				const response = await page.goto( '/' );
 				expect( response.status() ).toBe( 200 );
 
-				const frResponse = await page.goto( '/fr/' );
+				const frResponse = await page.goto( 'fr/' );
 				expect( frResponse.status() ).toBe( 200 );
 			} );
 			/**

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -1,6 +1,11 @@
 // @ts-check
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
-import { createLanguage, deleteAllLanguages, setSetting, resetAllSettings, getAllLanguages } from '@wpsyntex/e2e-test-utils';
+import {
+	createLanguage,
+	deleteAllLanguages,
+	setSetting,
+	resetAllSettings,
+} from '@wpsyntex/e2e-test-utils';
 import { execSync } from 'child_process';
 
 /**
@@ -14,6 +19,14 @@ test.describe.serial( 'Strings translations', () => {
 	let frenchPostUrl;
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		execSync(
+			'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root',
+			{
+				cwd: process.cwd(),
+				stdio: 'inherit',
+			}
+		);
+
 		await setSetting( requestUtils, 'force_lang', 1 );
 		await createLanguage( requestUtils, 'en_US' );
 		await createLanguage( requestUtils, 'fr_FR' );
@@ -222,16 +235,7 @@ test.describe.serial( 'Strings translations', () => {
 			 */
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
-				requestUtils,
 			} ) => {
-				const rewriteStructure = execSync( 'npx wp-env run tests-cli wp rewrite structure "/%postname%/" --hard --allow-root', {
-					cwd: process.cwd(),
-					stdio: 'inherit',
-				} );
-
-				await page.goto( 'fr/' );
-
-				console.log( frenchPostUrl );
 				const response = await page.goto( frenchPostUrl );
 
 				expect( response.status() ).toBe( 200 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -202,6 +202,11 @@ test.describe.serial( 'Strings translations', () => {
 			} );
 
 			frenchPageUrl = publishedFrenchPage.link;
+
+			execSync('npx wp-env run tests-cli wp rewrite flush --allow-root', {
+				cwd: process.cwd(),
+				stdio: 'inherit',
+			});
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -225,13 +230,6 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 				requestUtils,
 			} ) => {
-				const rewriteRules = execSync('npx wp-env run tests-cli wp rewrite list --allow-root --match=http://localhost:8889/fr/pll-e2e-strings-page/', {
-					cwd: process.cwd(),
-					stdio: 'inherit',
-				});
-
-				console.log( 'REWRITE RULES STRUCTURE', rewriteRules );
-
 				const response = await page.goto( frenchPageUrl );
 
 				expect( response.status() ).toBe( 200 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -224,10 +224,9 @@ test.describe.serial( 'Strings translations', () => {
 			test( 'Blogname French translation appears on the frontend', async ( {
 				page,
 			} ) => {
-				console.log( frenchPageUrl );
-				console.log( await page.url() );
+				const response = await page.goto( '/fr/pll-e2e-strings-page/' );
 
-				await page.goto( frenchPageUrl );
+				expect( response.status() ).toBe( 200 );
 
 				await expect( page ).toHaveTitle( /polylang FR/ );
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -3,9 +3,12 @@ import { expect, test } from '@wordpress/e2e-test-utils-playwright';
 import { createLanguage, deleteAllLanguages } from '@wpsyntex/e2e-test-utils';
 
 /**
- * Covers strings translations in admin and on the frontend (admin tests run before frontend tests in this file).
+ * Covers strings translations in admin and on the frontend.
+ *
+ * Serial execution is required: frontend assertions depend on translations saved in admin tests
+ * and on a shared WordPress database state.
  */
-test.describe( 'Strings translations', () => {
+test.describe.serial( 'Strings translations', () => {
 	/** @type {string} */
 	let frenchPageUrl;
 

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -200,7 +200,8 @@ test.describe.serial( 'Strings translations', () => {
 				lang: 'fr',
 			} );
 
-			frenchPageId = publishedFrenchPage.id;
+			console.log( publishedFrenchPage );
+			frenchPageUrl = publishedFrenchPage.link;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
@@ -224,12 +225,7 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 				requestUtils,
 			} ) => {
-				const frenchPage = await requestUtils.rest( {
-					method: 'GET',
-					path: `/wp/v2/pages/${ frenchPageId }`,
-				} );
-				console.log( frenchPage );
-				const response = await page.goto( frenchPage.link );
+				const response = await page.goto( frenchPageUrl );
 
 				expect( response.status() ).toBe( 200 );
 
@@ -259,7 +255,6 @@ test.describe.serial( 'Strings translations', () => {
 			test( 'French translation of custom string appears on the frontend', async ( {
 				page,
 			} ) => {
-				frenchPageUrl = frenchPageUrl.replace( '/', '/fr/' );
 				await page.goto( frenchPageUrl );
 
 				await expect(

--- a/tests/phpunit/tests/test-settings.php
+++ b/tests/phpunit/tests/test-settings.php
@@ -1,6 +1,7 @@
 <?php
 
 class Settings_Test extends PLL_UnitTestCase {
+	use PLL_Handle_WP_Redirect_Trait;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory
@@ -118,5 +119,35 @@ class Settings_Test extends PLL_UnitTestCase {
 		$out = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $out, 'ERROR' ) );
+	}
+
+	/**
+	 * Bug introduced in 3.9-dev.
+	 */
+	public function test_strings_are_saved_when_submitted() {
+		$lang = self::$model->get_language( 'fr' );
+
+		PLL_Admin_Strings::register_string( 'Test', 'Some string' );
+
+		$_GET['page'] = 'mlang_strings';
+		$_POST = array(
+			'pll_action' => 'string-translation',
+			'_wpnonce_string-translation' => wp_create_nonce( 'string-translation' ),
+			'submit' => 'Save changes',
+			'translation' => array(
+				'fr' => array(
+					md5( 'Some string' ) => 'The translation',
+				),
+			),
+		);
+
+		$_REQUEST = array_merge( $_GET, $_POST );
+
+		$links_model = self::$model->get_links_model();
+		$this->assert_redirect( array( new PLL_Settings( $links_model ), 'languages_page' ) );
+
+		$mo = new PLL_MO();
+		$mo->import_from_db( $lang );
+		$this->assertSame( 'The translation', $mo->translate( 'Some string' ) );
 	}
 }


### PR DESCRIPTION
Partially reverts #1852

The initial goal of this PR (removal of the useless prop) was ok. But moving actions handling was a big mistake.
Indeed the saving of strings translations is hooked to `mlang_action_string-translation` in `PLL_Table_String` so this class must be instantiated before handling actions. 
