### PR TITLE
Fix PHP warnings and improve nav menus option display in Site Health.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,12 +115,6 @@ parameters:
 			path: src/Options/Abstract_Option.php
 
 		-
-			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Options/Abstract_Option.php
-
-		-
 			message: '#^Cannot access offset ''polylang'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1

--- a/src/Options/Abstract_Option.php
+++ b/src/Options/Abstract_Option.php
@@ -322,19 +322,14 @@ abstract class Abstract_Option {
 	 *
 	 * @since 3.8
 	 *
-	 * @param array $array An array of formatted data.
+	 * @param array<scalar> $array An array of formatted data.
 	 * @return string
 	 */
 	protected function format_array_for_site_health_info( array $array ): string {
 		array_walk(
 			$array,
 			function ( &$value, $key ) {
-				if ( is_array( $value ) ) {
-					$ids = implode( ' , ', $value );
-					$value = "$key => [$ids]";
-				} else {
-					$value = "$key => [$value]";
-				}
+				$value = "$key => [$value]";
 			}
 		);
 		return implode( ', ', $array );

--- a/src/Options/Abstract_Option.php
+++ b/src/Options/Abstract_Option.php
@@ -329,9 +329,10 @@ abstract class Abstract_Option {
 		array_walk(
 			$array,
 			function ( &$value, $key ) {
-				$value = "$key => [$value]";
+				$value = "$key => $value";
 			}
 		);
-		return implode( ', ', $array );
+
+		return '[' . implode( ', ', $array ) . ']';
 	}
 }

--- a/src/Options/Abstract_Option.php
+++ b/src/Options/Abstract_Option.php
@@ -331,12 +331,12 @@ abstract class Abstract_Option {
 			function ( &$value, $key ) {
 				if ( is_array( $value ) ) {
 					$ids = implode( ' , ', $value );
-					$value = "$key => $ids";
+					$value = "$key => [$ids]";
 				} else {
-					$value = "$key => $value";
+					$value = "$key => [$value]";
 				}
 			}
 		);
-		return implode( ' | ', $array );
+		return implode( ', ', $array );
 	}
 }

--- a/src/Options/Business/Nav_Menus.php
+++ b/src/Options/Business/Nav_Menus.php
@@ -60,7 +60,6 @@ class Nav_Menus extends Abstract_Option {
 		$parts = array();
 		foreach ( $nav_menus[ $current_theme ] as $location => $lang ) {
 			if ( empty( $lang ) ) {
-				/* translators: 1: menu location slug, 2: status when no menu is assigned */
 				$parts[] = sprintf( '%1$s: %2$s', $location, __( 'Not used', 'polylang' ) );
 			} else {
 				$parts[] = sprintf(

--- a/src/Options/Business/Nav_Menus.php
+++ b/src/Options/Business/Nav_Menus.php
@@ -57,18 +57,21 @@ class Nav_Menus extends Abstract_Option {
 			return array();
 		}
 
-		$fields = array();
+		$parts = array();
 		foreach ( $nav_menus[ $current_theme ] as $location => $lang ) {
-			$fields[ $location ]['label'] = sprintf( 'menu: %s', $location );
-
 			if ( empty( $lang ) ) {
-				/* translators: default value when a menu location is not used. */
-				$fields[ $location ]['value'] = __( 'Not used', 'polylang' );
+				/* translators: 1: menu location slug, 2: status when no menu is assigned */
+				$parts[] = sprintf( '%1$s: %2$s', $location, __( 'Not used', 'polylang' ) );
 			} else {
-				$fields[ $location ]['value'] = $this->format_array_for_site_health_info( $lang );
+				$parts[] = sprintf(
+					'%1$s: %2$s',
+					$location,
+					$this->format_array_for_site_health_info( $lang )
+				);
 			}
 		}
-		return $fields;
+
+		return $this->format_single_value_for_site_health_info( implode( ' | ', $parts ) );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Fixes #1860 

To reproduce :
- Polylang 3.8.2
- Two languages
- Activate classic theme (needs old menus)
- Create one menu per language
- Visit `http://localhost:8888/wp-admin/site-health.php?tab=debug#health-check-section-pll_options`
- See the warnings

## How?
- Ensure to always have `label` and  `value` keys set in `Nav_Menus::get_site_health_info` by calling `Abstract_Option::format_single_value_for_site_health_info` before returning the piece of information.
- Improve array formatting in `Abstract_Option::format_array_for_site_health_info()` (use brackets to format menu array containing language slugs as keys and post IDs as values).