### PR TITLE
Fix upgrade

### DIFF
--- a/src/install/activate.php
+++ b/src/install/activate.php
@@ -43,8 +43,8 @@ class PLL_Activate extends PLL_Abstract_Activate {
 
 		if ( ! empty( $options['version'] ) ) {
 			// Check if we will be able to upgrade.
-			if ( version_compare( $options['version'], static::get_plugin_version(), '<' ) ) {
-				( new PLL_Upgrade( $options ) )->can_activate();
+			if ( version_compare( $options['version'], static::get_plugin_version(), '<' ) && ! ( new PLL_Upgrade( $options ) )->can_upgrade() ) {
+				return;
 			}
 		} else {
 			$options['version'] = static::get_plugin_version();

--- a/src/install/upgrade.php
+++ b/src/install/upgrade.php
@@ -82,7 +82,7 @@ class PLL_Upgrade {
 
 		$args = array(
 			'type'           => 'error',
-			'paragraph_wrap' => 'false',
+			'paragraph_wrap' => false,
 		);
 
 		wp_admin_notice( $message, $args );

--- a/src/install/upgrade.php
+++ b/src/install/upgrade.php
@@ -80,7 +80,12 @@ class PLL_Upgrade {
 			)
 		);
 
-		wp_admin_notice( $message, array( 'type' => 'error' ) );
+		$args = array(
+			'type'           => 'error',
+			'paragraph_wrap' => 'false',
+		);
+
+		wp_admin_notice( $message, $args );
 	}
 
 	/**

--- a/src/install/upgrade.php
+++ b/src/install/upgrade.php
@@ -62,14 +62,13 @@ class PLL_Upgrade {
 	}
 
 	/**
-	 * Displays a notice when upgrading from a too old version
+	 * Displays a notice when upgrading from a too old version.
 	 *
 	 * @since 1.0
 	 *
 	 * @return void
 	 */
 	public function admin_notices() {
-		load_plugin_textdomain( 'polylang' );
 		printf(
 			'<div class="error"><p>%s</p><p>%s</p></div>',
 			esc_html__( 'Polylang has been deactivated because you upgraded from a too old version.', 'polylang' ),
@@ -77,7 +76,7 @@ class PLL_Upgrade {
 				/* translators: %1$s and %2$s are Polylang version numbers */
 				esc_html__( 'Before upgrading to %2$s, please upgrade to %1$s.', 'polylang' ),
 				'<strong>2.9</strong>',
-				POLYLANG_VERSION // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_html( POLYLANG_VERSION )
 			)
 		);
 	}

--- a/src/install/upgrade.php
+++ b/src/install/upgrade.php
@@ -69,8 +69,8 @@ class PLL_Upgrade {
 	 * @return void
 	 */
 	public function admin_notices() {
-		printf(
-			'<div class="error"><p>%s</p><p>%s</p></div>',
+		$message = sprintf(
+			'<p>%s</p><p>%s</p>',
 			esc_html__( 'Polylang has been deactivated because you upgraded from a too old version.', 'polylang' ),
 			sprintf(
 				/* translators: %1$s and %2$s are Polylang version numbers */
@@ -79,6 +79,8 @@ class PLL_Upgrade {
 				esc_html( POLYLANG_VERSION )
 			)
 		);
+
+		wp_admin_notice( $message, array( 'type' => 'error' ) );
 	}
 
 	/**

--- a/src/install/upgrade.php
+++ b/src/install/upgrade.php
@@ -30,21 +30,6 @@ class PLL_Upgrade {
 	}
 
 	/**
-	 * Check if upgrade is possible otherwise die to avoid activation
-	 *
-	 * @since 1.2
-	 *
-	 * @return void
-	 */
-	public function can_activate() {
-		if ( ! $this->can_upgrade() ) {
-			ob_start();
-			$this->admin_notices(); // FIXME the error message is displayed two times
-			die( ob_get_contents() ); // phpcs:ignore WordPress.Security.EscapeOutput
-		}
-	}
-
-	/**
 	 * Upgrades if possible otherwise returns false to stop Polylang loading
 	 *
 	 * @since 1.2

--- a/src/install/usable.php
+++ b/src/install/usable.php
@@ -48,8 +48,6 @@ class PLL_Usable {
 	 * @return void
 	 */
 	public static function php_version_notice() {
-		load_plugin_textdomain( 'polylang' ); // Plugin i18n.
-
 		printf(
 			'<div class="error"><p>%s</p></div>',
 			sprintf(
@@ -73,8 +71,6 @@ class PLL_Usable {
 	 */
 	public static function wp_version_notice() {
 		global $wp_version;
-
-		load_plugin_textdomain( 'polylang' ); // Plugin i18n.
 
 		printf(
 			'<div class="error"><p>%s</p></div>',

--- a/src/install/usable.php
+++ b/src/install/usable.php
@@ -49,14 +49,11 @@ class PLL_Usable {
 	 */
 	public static function php_version_notice() {
 		$message = sprintf(
-			'<p>%s</p>',
-			sprintf(
-				/* translators: 1: Plugin name 2: Current PHP version 3: Required PHP version */
-				esc_html__( '%1$s has deactivated itself because you are using an old version of PHP. You are using using PHP %2$s. %1$s requires PHP %3$s.', 'polylang' ),
-				esc_html( static::get_plugin_name() ),
-				esc_html( pll_get_constant( 'PHP_VERSION', '' ) ),
-				esc_html( static::get_min_php_version() )
-			)
+			/* translators: 1: Plugin name 2: Current PHP version 3: Required PHP version */
+			esc_html__( '%1$s has deactivated itself because you are using an old version of PHP. You are using using PHP %2$s. %1$s requires PHP %3$s.', 'polylang' ),
+			esc_html( static::get_plugin_name() ),
+			esc_html( pll_get_constant( 'PHP_VERSION', '' ) ),
+			esc_html( static::get_min_php_version() )
 		);
 
 		wp_admin_notice( $message, array( 'type' => 'error' ) );
@@ -75,14 +72,11 @@ class PLL_Usable {
 		global $wp_version;
 
 		$message = sprintf(
-			'<p>%s</p>',
-			sprintf(
-				/* translators: 1: Plugin name 2: Current WordPress version 3: Required WordPress version */
-				esc_html__( '%1$s has deactivated itself because you are using an old version of WordPress. You are using using WordPress %2$s. %1$s requires at least WordPress %3$s.', 'polylang' ),
-				esc_html( static::get_plugin_name() ),
-				esc_html( $wp_version ),
-				esc_html( static::get_min_wp_version() )
-			)
+			/* translators: 1: Plugin name 2: Current WordPress version 3: Required WordPress version */
+			esc_html__( '%1$s has deactivated itself because you are using an old version of WordPress. You are using using WordPress %2$s. %1$s requires at least WordPress %3$s.', 'polylang' ),
+			esc_html( static::get_plugin_name() ),
+			esc_html( $wp_version ),
+			esc_html( static::get_min_wp_version() )
 		);
 
 		wp_admin_notice( $message, array( 'type' => 'error' ) );

--- a/src/install/usable.php
+++ b/src/install/usable.php
@@ -48,8 +48,8 @@ class PLL_Usable {
 	 * @return void
 	 */
 	public static function php_version_notice() {
-		printf(
-			'<div class="error"><p>%s</p></div>',
+		$message = sprintf(
+			'<p>%s</p>',
 			sprintf(
 				/* translators: 1: Plugin name 2: Current PHP version 3: Required PHP version */
 				esc_html__( '%1$s has deactivated itself because you are using an old version of PHP. You are using using PHP %2$s. %1$s requires PHP %3$s.', 'polylang' ),
@@ -58,6 +58,8 @@ class PLL_Usable {
 				esc_html( static::get_min_php_version() )
 			)
 		);
+
+		wp_admin_notice( $message, array( 'type' => 'error' ) );
 	}
 
 	/**
@@ -72,8 +74,8 @@ class PLL_Usable {
 	public static function wp_version_notice() {
 		global $wp_version;
 
-		printf(
-			'<div class="error"><p>%s</p></div>',
+		$message = sprintf(
+			'<p>%s</p>',
 			sprintf(
 				/* translators: 1: Plugin name 2: Current WordPress version 3: Required WordPress version */
 				esc_html__( '%1$s has deactivated itself because you are using an old version of WordPress. You are using using WordPress %2$s. %1$s requires at least WordPress %3$s.', 'polylang' ),
@@ -82,6 +84,8 @@ class PLL_Usable {
 				esc_html( static::get_min_wp_version() )
 			)
 		);
+
+		wp_admin_notice( $message, array( 'type' => 'error' ) );
 	}
 
 	/**

--- a/src/integrations/wp-importer/wordpress-importer.php
+++ b/src/integrations/wp-importer/wordpress-importer.php
@@ -38,9 +38,6 @@ class PLL_WordPress_Importer {
 	 * @since 1.2
 	 */
 	public function wordpress_importer_init() {
-		$class = new ReflectionClass( 'WP_Import' );
-		load_plugin_textdomain( 'wordpress-importer', false, basename( dirname( $class->getFileName() ) ) . '/languages' );
-
 		$GLOBALS['wp_import'] = new PLL_WP_Import();
 		register_importer( 'wordpress', 'WordPress', __( 'Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'polylang' ), array( $GLOBALS['wp_import'], 'dispatch' ) ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 	}


### PR DESCRIPTION
When upgrading from a very old version (< 1.8), we expect to prevent the plugin activation and display the message
>Polylang has been deactivated because you upgraded from a too old version.
>Before upgrading to 3.9, please upgrade to <strong>2.9</strong>

However (I don't know since which WP version), WP doesn't display anymore our message but the meaningless:
>Plugin could not be activated because it triggered a fatal error.

To reproduce:
- Deactivate the plugin.
- Change the version stored in the option polylang (for ex to 0.9).
- Activate the plugin.

I propose not to prevent activation anymore, to avoid the meaningless WP message but to stop the execution, just displaying the notice.

Additionally, the PR:
- Removes `PLL_Upgrade::can_activate()` now useless.
- Removes all calls to `load_plugin_textdomain()`, mainly found in activation notices (this function is useless for a while now).
- Uses `wp_admin_notice()` to display admin notices (better to rely on WP API).