### PR TITLE
Remove inline editor welcome guide handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@wordpress/e2e-test-utils-playwright": "^1.41.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
-    "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils",
+    "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils#disable-editor-welcome-guides-in-global-setup",
     "@wpsyntex/polylang-build-scripts": "^2.1.0",
     "babel-loader": "^8.4.1",
     "clean-webpack-plugin": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@wordpress/e2e-test-utils-playwright": "^1.41.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
-    "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils#disable-editor-welcome-guides-in-global-setup",
+    "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils",
     "@wpsyntex/polylang-build-scripts": "^2.1.0",
     "babel-loader": "^8.4.1",
     "clean-webpack-plugin": "^4.0.0",

--- a/tests/e2e/specs/widgets/language-switcher-widget.spec.js
+++ b/tests/e2e/specs/widgets/language-switcher-widget.spec.js
@@ -52,7 +52,6 @@ test.describe(
 		 *
 		 * Steps:
 		 *     - Go to "Appearance" > "Widgets".
-		 *     - Dismiss the welcome guide if present.
 		 *     - Add a Language Switcher block.
 		 *     - Verify the block is displayed without the "block has encountered an error" message.
 		 *     - Verify the block preview lists English and French.
@@ -66,15 +65,6 @@ test.describe(
 
 			// Wait for the block editor to load.
 			await page.waitForSelector( '.edit-widgets-header' );
-
-			// Close the welcome guide if it appears.
-			const closeButton = page.locator(
-				'.edit-widgets-welcome-guide button[aria-label="Close"]'
-			);
-			if ( ( await closeButton.count() ) > 0 ) {
-				await closeButton.click();
-				await page.waitForTimeout( 300 );
-			}
 
 			// Open Block Inserter.
 			await page


### PR DESCRIPTION
Following https://github.com/polylang/polylang-pro/pull/2984#discussion_r3050662642.

Depends on https://github.com/polylang/e2e-test-utils/pull/8.

## What
Remove the close-button pattern for the widget editor welcome guide from `language-switcher-widget.spec.js`.

## Why
Welcome guides are now disabled globally in `e2e-test-utils` global setup.

Handling them inline was redundant and added noise.

## How
Deletion of the relevant lines. No logic change.