### PR TITLE
Prevent using unsupported block fields in wpml-config

### DIFF
--- a/src/modules/wpml/wpml-config.php
+++ b/src/modules/wpml/wpml-config.php
@@ -509,6 +509,10 @@ class PLL_WPML_Config {
 				}
 
 				foreach ( $block->children() as $child ) {
+					if ( ! $this->is_supported_field( $child ) ) {
+						continue;
+					}
+
 					$rule      = '';
 					$child_tag = $child->getName();
 
@@ -670,6 +674,10 @@ class PLL_WPML_Config {
 		$sub_attributes = array();
 
 		foreach ( $children as $child ) {
+			if ( ! $this->is_supported_field( $child ) ) {
+				continue;
+			}
+
 			$sub = $this->get_field_attributes( $child );
 
 			if ( empty( $sub ) ) {
@@ -680,6 +688,30 @@ class PLL_WPML_Config {
 		}
 
 		return $sub_attributes;
+	}
+
+	/**
+	 * Tells if the given field is supported.
+	 *
+	 * @since 3.9
+	 *
+	 * @param  SimpleXMLElement $field A XML node.
+	 * @return bool
+	 */
+	protected function is_supported_field( SimpleXMLElement $field ): bool {
+		$child_type = $this->get_field_attribute( $field, 'type' );
+
+		if ( in_array( $child_type, array( 'link', 'post-ids', 'taxonomy-ids' ), true ) ) {
+			return false;
+		}
+
+		if ( $field->getName() !== 'key' ) {
+			return true;
+		}
+
+		$search_method = $this->get_field_attribute( $field, 'search-method' );
+
+		return 'regex' !== $search_method;
 	}
 
 	/**

--- a/src/modules/wpml/wpml-config.php
+++ b/src/modules/wpml/wpml-config.php
@@ -709,9 +709,7 @@ class PLL_WPML_Config {
 			return true;
 		}
 
-		$search_method = $this->get_field_attribute( $field, 'search-method' );
-
-		return 'regex' !== $search_method;
+		return 'regex' !== $this->get_field_attribute( $field, 'search-method' );
 	}
 
 	/**

--- a/src/modules/wpml/wpml-config.php
+++ b/src/modules/wpml/wpml-config.php
@@ -695,10 +695,10 @@ class PLL_WPML_Config {
 	 *
 	 * @since 3.9
 	 *
-	 * @param  SimpleXMLElement $field A XML node.
+	 * @param SimpleXMLElement $field A XML node.
 	 * @return bool
 	 */
-	protected function is_supported_field( SimpleXMLElement $field ): bool {
+	private function is_supported_field( SimpleXMLElement $field ): bool {
 		$child_type = $this->get_field_attribute( $field, 'type' );
 
 		if ( in_array( $child_type, array( 'link', 'post-ids', 'taxonomy-ids' ), true ) ) {

--- a/src/modules/wpml/wpml-config.php
+++ b/src/modules/wpml/wpml-config.php
@@ -699,17 +699,17 @@ class PLL_WPML_Config {
 	 * @return bool
 	 */
 	private function is_supported_field( SimpleXMLElement $field ): bool {
-		$child_type = $this->get_field_attribute( $field, 'type' );
-
-		if ( in_array( $child_type, array( 'link', 'post-ids', 'taxonomy-ids' ), true ) ) {
+		if ( $this->get_field_attribute( $field, 'type' ) !== '' ) {
+			// No `type` supported for now.
 			return false;
 		}
 
-		if ( $field->getName() !== 'key' ) {
-			return true;
+		if ( $field->getName() === 'key' ) {
+			// The only supported `search-method` is `wildcards` (which is the default value).
+			return in_array( $this->get_field_attribute( $field, 'search-method' ), array( '', 'wildcards' ), true );
 		}
 
-		return 'regex' !== $this->get_field_attribute( $field, 'search-method' );
+		return true;
 	}
 
 	/**

--- a/src/modules/wpml/wpml-config.php
+++ b/src/modules/wpml/wpml-config.php
@@ -693,7 +693,7 @@ class PLL_WPML_Config {
 	/**
 	 * Tells if the given field is supported.
 	 *
-	 * @since 3.9
+	 * @since 3.8.4
 	 *
 	 * @param SimpleXMLElement $field A XML node.
 	 * @return bool

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -80,8 +80,21 @@
 			<gutenberg-block type="my-plugin/my-block" translate="1">
 				<xpath>//figure/figcaption</xpath>
 				<xpath>//figure/img/@alt</xpath>
+				<xpath type="link">//a/@href</xpath>
+				<xpath type="post-ids" sub-type="post">//*[@name="foo_form_post_ids"]/@value</xpath>
+				<xpath type="taxonomy-ids" sub-type="category">//*[@name="foo_form_category_ids"]/@value</xpath>
 				<key name="headingTitle" />
 				<key name="text" />
+				<key name="url" type="link" />
+				<key name="PostIds">
+					<key name="*" type="post-ids" sub-type="post" />
+				</key>
+				<key name="TermIds">
+					<key name="*" type="taxonomy-ids" sub-type="category" />
+				</key>
+				<key name="regexData">
+					<key name="/^[^_]\S+$/" search-method="regex" />
+				</key>
 			</gutenberg-block>
 			<gutenberg-block type="my-plugin/my-block-2" translate="1">
 				<xpath>//div/p/a</xpath>

--- a/tests/phpunit/data/wpml-config.xml
+++ b/tests/phpunit/data/wpml-config.xml
@@ -95,6 +95,9 @@
 				<key name="regexData">
 					<key name="/^[^_]\S+$/" search-method="regex" />
 				</key>
+				<key name="wildcardsData">
+					<key name="foo*" search-method="wildcards" />
+				</key>
 			</gutenberg-block>
 			<gutenberg-block type="my-plugin/my-block-2" translate="1">
 				<xpath>//div/p/a</xpath>

--- a/tests/phpunit/tests/test-wpml-config.php
+++ b/tests/phpunit/tests/test-wpml-config.php
@@ -438,8 +438,11 @@ class WPML_Config_Test extends PLL_UnitTestCase {
 		);
 		$expected_parsing_rules_for_attributes = array(
 			'my-plugin/my-block' => array(
-				'headingTitle' => true,
-				'text'         => true,
+				'headingTitle'  => true,
+				'text'          => true,
+				'wildcardsData' => array(
+					'foo*' => true,
+				),
 			),
 			'my-plugin/my-block-2' => array(
 				'iconLabel' => true,


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2952.

This prevents to use unsupported "Gutenberg block" fields in `wpml-config.xml`.

## How

Are excluded:
- Fields with a `link`/`post-ids`/`taxonomy-ids` type.
- `key` fields with a `regex` value for `search-method`.

Related [doc](https://wpml.org/documentation/support/language-configuration-files/make-custom-gutenberg-blocks-translatable/).