### PR TITLE
Hide internal language tax query and translate late post IDs

### DIFF
--- a/src/frontend/frontend-auto-translate.php
+++ b/src/frontend/frontend-auto-translate.php
@@ -34,6 +34,7 @@ class PLL_Frontend_Auto_Translate {
 		$this->curlang = &$polylang->curlang;
 
 		add_action( 'parse_query', array( $this, 'translate_included_ids_in_query' ), 100 ); // After all Polylang filters.
+		add_action( 'pre_get_posts', array( $this, 'translate_included_post_ids_in_query' ), 10000 ); // After third-party query changes.
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ), 20, 2 );
 	}
 
@@ -198,6 +199,36 @@ class PLL_Frontend_Auto_Translate {
 			$qv['pagename'] = get_page_uri( $tr_id );
 		}
 
+		$this->translate_included_post_ids( $qv );
+	}
+
+	/**
+	 * Filters a posts query to automatically translate included post IDs after third-party query changes.
+	 *
+	 * @since 3.9
+	 *
+	 * @param WP_Query $query WP_Query object.
+	 * @return void
+	 */
+	public function translate_included_post_ids_in_query( $query ) {
+		$qv = &$query->query_vars;
+
+		if ( empty( $this->curlang ) || ( ! empty( $qv['post_type'] ) && ! $this->model->is_translated_post_type( $qv['post_type'] ) ) ) {
+			return;
+		}
+
+		$this->translate_included_post_ids( $qv );
+	}
+
+	/**
+	 * Translates included and excluded post IDs in a posts query.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $qv WP_Query query vars.
+	 * @return void
+	 */
+	protected function translate_included_post_ids( &$qv ) {
 		// Array of post ids
 		// post_parent__in & post_parent__not_in since WP 3.6
 		foreach ( array( 'post__in', 'post__not_in', 'post_parent__in', 'post_parent__not_in' ) as $key ) { // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn

--- a/src/frontend/frontend-auto-translate.php
+++ b/src/frontend/frontend-auto-translate.php
@@ -33,8 +33,24 @@ class PLL_Frontend_Auto_Translate {
 		$this->model = &$polylang->model;
 		$this->curlang = &$polylang->curlang;
 
-		add_action( 'parse_query', array( $this, 'translate_included_ids_in_query' ), 100 ); // After all Polylang filters.
 		add_action( 'pre_get_posts', array( $this, 'translate_included_post_ids_in_query' ), 10000 ); // After third-party query changes.
+
+		if ( wp_doing_ajax() ) {
+			$this->add_query_hooks();
+		} else {
+			add_action( 'template_redirect', array( $this, 'add_query_hooks' ), 7 ); // Not before 'check_canonical_url'.
+		}
+	}
+
+	/**
+	 * Adds the auto-translation hooks for query vars and term query args.
+	 *
+	 * @since 3.9
+	 *
+	 * @return void
+	 */
+	public function add_query_hooks() {
+		add_action( 'parse_query', array( $this, 'translate_included_ids_in_query' ), 100 ); // After all Polylang filters.
 		add_filter( 'get_terms_args', array( $this, 'get_terms_args' ), 20, 2 );
 	}
 
@@ -213,7 +229,7 @@ class PLL_Frontend_Auto_Translate {
 	public function translate_included_post_ids_in_query( $query ) {
 		$qv = &$query->query_vars;
 
-		if ( empty( $this->curlang ) || ( ! empty( $qv['post_type'] ) && ! $this->model->is_translated_post_type( $qv['post_type'] ) ) ) {
+		if ( empty( $this->curlang ) || isset( $qv['lang'] ) || ( ! empty( $qv['post_type'] ) && ! $this->model->is_translated_post_type( $qv['post_type'] ) ) ) {
 			return;
 		}
 

--- a/src/frontend/frontend-filters-links.php
+++ b/src/frontend/frontend-filters-links.php
@@ -261,7 +261,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 * @return string
 	 */
 	public function home_url( $url, $path ) {
-		if ( ! ( did_action( 'template_redirect' ) || did_action( 'login_init' ) ) || rtrim( $url, '/' ) != $this->links_model->home ) {
+		if ( ! ( did_action( 'parse_request' ) || did_action( 'login_init' ) ) || rtrim( $url, '/' ) != $this->links_model->home ) {
 			return $url;
 		}
 

--- a/src/frontend/frontend-filters-links.php
+++ b/src/frontend/frontend-filters-links.php
@@ -261,7 +261,7 @@ class PLL_Frontend_Filters_Links extends PLL_Filters_Links {
 	 * @return string
 	 */
 	public function home_url( $url, $path ) {
-		if ( ! ( did_action( 'parse_request' ) || did_action( 'login_init' ) ) || rtrim( $url, '/' ) != $this->links_model->home ) {
+		if ( ! ( ( did_action( 'parse_request' ) && ! is_admin() ) || did_action( 'template_redirect' ) || did_action( 'login_init' ) ) || rtrim( $url, '/' ) != $this->links_model->home ) {
 			return $url;
 		}
 

--- a/src/frontend/frontend.php
+++ b/src/frontend/frontend.php
@@ -245,6 +245,10 @@ class PLL_Frontend extends PLL_Base {
 	 * @return void
 	 */
 	public function hide_language_tax_query( $query ) {
+		if ( ! $query->tax_query instanceof WP_Tax_Query ) {
+			return;
+		}
+
 		if ( empty( $query->tax_query->queries ) || ! is_array( $query->tax_query->queries ) ) {
 			return;
 		}

--- a/src/frontend/frontend.php
+++ b/src/frontend/frontend.php
@@ -93,11 +93,7 @@ class PLL_Frontend extends PLL_Base {
 
 		// Filters posts by language
 		add_action( 'parse_query', array( $this, 'parse_query' ), 6 );
-
-		// Not before 'check_canonical_url'
-		if ( ! defined( 'PLL_AUTO_TRANSLATE' ) || PLL_AUTO_TRANSLATE ) {
-			add_action( 'template_redirect', array( $this, 'auto_translate' ), 7 );
-		}
+		add_action( 'pre_get_posts', array( $this, 'hide_language_tax_query' ), 1 );
 
 		add_action( 'admin_bar_menu', array( $this, 'remove_customize_admin_bar' ), 41 ); // After WP_Admin_Bar::add_menus
 
@@ -159,8 +155,7 @@ class PLL_Frontend extends PLL_Base {
 		$this->canonical = new PLL_Canonical( $this );
 		add_action( 'template_redirect', array( $this->canonical, 'check_canonical_url' ), 4 );
 
-		// Auto translate for Ajax
-		if ( ( ! defined( 'PLL_AUTO_TRANSLATE' ) || PLL_AUTO_TRANSLATE ) && wp_doing_ajax() ) {
+		if ( ! defined( 'PLL_AUTO_TRANSLATE' ) || PLL_AUTO_TRANSLATE ) {
 			$this->auto_translate();
 		}
 	}
@@ -239,6 +234,48 @@ class PLL_Frontend extends PLL_Base {
 				unset( $query->queried_object ); // FIXME useless?
 			}
 		}
+	}
+
+	/**
+	 * Hides Polylang's internal language tax query from third-party pre_get_posts callbacks.
+	 *
+	 * @since 3.9
+	 *
+	 * @param WP_Query $query WP_Query object.
+	 * @return void
+	 */
+	public function hide_language_tax_query( $query ) {
+		if ( empty( $query->tax_query->queries ) || ! is_array( $query->tax_query->queries ) ) {
+			return;
+		}
+
+		$query->tax_query->queries = $this->remove_language_tax_query( $query->tax_query->queries );
+		unset( $query->tax_query->queried_terms['language'] );
+	}
+
+	/**
+	 * Removes the internal language tax query recursively.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $queries Tax query clauses.
+	 * @return array Tax query clauses without Polylang's internal language query.
+	 */
+	protected function remove_language_tax_query( $queries ) {
+		foreach ( $queries as $key => $tax_query ) {
+			if ( ! is_array( $tax_query ) ) {
+				continue;
+			}
+
+			if ( isset( $tax_query['taxonomy'] ) && 'language' === $tax_query['taxonomy'] ) {
+				unset( $queries[ $key ] );
+				continue;
+			}
+
+			$queries[ $key ] = $this->remove_language_tax_query( $tax_query );
+		}
+
+		return $queries;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -190,14 +190,15 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_recent_posts_widget_post_ids_added_on_pre_get_posts() {
+		// Starting with 'essai2' to avoid 'essai' being a substring match of 'essai2'.
 		$posts = self::factory()->post->create_translated(
-			array( 'post_title' => 'test', 'lang' => 'en' ),
-			array( 'post_title' => 'essai', 'lang' => 'fr' )
+			array( 'post_title' => 'test2', 'lang' => 'en' ),
+			array( 'post_title' => 'essai2', 'lang' => 'fr' )
 		);
 
-		$controls = self::factory()->post->create_translated(
-			array( 'post_title' => 'control', 'lang' => 'en' ),
-			array( 'post_title' => 'controle', 'lang' => 'fr' )
+		self::factory()->post->create_translated(
+			array( 'post_title' => 'test3', 'lang' => 'en' ),
+			array( 'post_title' => 'essai3', 'lang' => 'fr' )
 		);
 
 		$exclude_post = function ( $query ) use ( $posts ) {
@@ -226,8 +227,8 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 			remove_action( 'pre_get_posts', $exclude_post, 20 );
 		}
 
-		$this->assertStringContainsString( 'controle', $output );
-		$this->assertStringNotContainsString( 'essai', $output );
+		$this->assertStringContainsString( 'essai3', $output );
+		$this->assertStringNotContainsString( 'essai2', $output );
 	}
 
 	public function test_page() {

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -189,6 +189,47 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $expected, get_posts( array( 'post__in' => array( $posts['en'] ) ) ) );
 	}
 
+	public function test_recent_posts_widget_post_ids_added_on_pre_get_posts() {
+		$posts = self::factory()->post->create_translated(
+			array( 'post_title' => 'test', 'lang' => 'en' ),
+			array( 'post_title' => 'essai', 'lang' => 'fr' )
+		);
+
+		$controls = self::factory()->post->create_translated(
+			array( 'post_title' => 'control', 'lang' => 'en' ),
+			array( 'post_title' => 'controle', 'lang' => 'fr' )
+		);
+
+		$exclude_post = function ( $query ) use ( $posts ) {
+			if ( ! $query->is_main_query() && $query->get( 'ignore_sticky_posts' ) && $query->get( 'no_found_rows' ) ) {
+				$query->set( 'post__not_in', array( $posts['en'] ) );
+			}
+		};
+
+		add_action( 'pre_get_posts', $exclude_post, 20 );
+
+		try {
+			$widget = new WP_Widget_Recent_Posts();
+
+			ob_start();
+			$widget->widget(
+				array(
+					'before_widget' => '',
+					'after_widget'  => '',
+					'before_title'  => '',
+					'after_title'   => '',
+				),
+				array( 'number' => 2 )
+			);
+			$output = ob_get_clean();
+		} finally {
+			remove_action( 'pre_get_posts', $exclude_post, 20 );
+		}
+
+		$this->assertStringContainsString( 'controle', $output );
+		$this->assertStringNotContainsString( 'essai', $output );
+	}
+
 	public function test_page() {
 		$parents = self::factory()->post->create_translated(
 			array( 'post_type' => 'page', 'post_title' => 'test_parent', 'lang' => 'en' ),

--- a/tests/phpunit/tests/test-filters-links.php
+++ b/tests/phpunit/tests/test-filters-links.php
@@ -217,7 +217,7 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 
 		// For home_url filter
 		$this->frontend->links = new PLL_Frontend_Links( $this->frontend );
-		$GLOBALS['wp_actions']['template_redirect'] = 1;
+		$GLOBALS['wp_actions']['parse_request'] = 1;
 
 		$this->frontend->curlang = self::$model->get_language( 'en' );
 		$doc = new DomDocument();
@@ -228,6 +228,8 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'http://example.org/', $a->item( 0 )->getAttribute( 'href' ) );
 
 		$this->frontend->curlang = self::$model->get_language( 'fr' );
+		$this->assertEquals( 'http://example.org/', home_url( '/' ) );
+
 		$doc = new DomDocument();
 		$doc->loadHTML( get_custom_logo() );
 		$xpath = new DOMXpath( $doc );
@@ -236,6 +238,6 @@ class Filters_Links_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'http://example.org/fr/', $a->item( 0 )->getAttribute( 'href' ) );
 
 		remove_theme_mod( 'custom_logo' );
-		unset( $GLOBALS['wp_actions']['template_redirect'] );
+		unset( $GLOBALS['wp_actions']['parse_request'] );
 	}
 }

--- a/tests/phpunit/tests/test-query.php
+++ b/tests/phpunit/tests/test-query.php
@@ -77,6 +77,30 @@ class Query_Test extends PLL_UnitTestCase {
 	}
 
 	/**
+	 * Checks if a tax query contains the language taxonomy.
+	 *
+	 * @param array $queries Tax query clauses.
+	 * @return bool True if the language taxonomy is found.
+	 */
+	protected function has_language_tax_query( $queries ) {
+		foreach ( $queries as $query ) {
+			if ( ! is_array( $query ) ) {
+				continue;
+			}
+
+			if ( isset( $query['taxonomy'] ) && 'language' === $query['taxonomy'] ) {
+				return true;
+			}
+
+			if ( $this->has_language_tax_query( $query ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Creates english and french posts along with two terms.
 	 * Also creates posts without terms.
 	 *
@@ -659,6 +683,33 @@ class Query_Test extends PLL_UnitTestCase {
 		$this->assertEquals( array( get_post( $en ) ), $query->posts );
 
 		$query = new WP_Query( array( 'post_type' => 'any', 'lang' => 'fr' ) );
+		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
+	}
+
+	public function test_language_tax_query_hidden_from_pre_get_posts() {
+		// Posts
+		$en = self::factory()->post->create();
+		self::$model->post->set_language( $en, 'en' );
+
+		$fr = self::factory()->post->create();
+		self::$model->post->set_language( $fr, 'fr' );
+
+		$this->frontend->curlang = self::$model->get_language( 'fr' );
+
+		$tax_queries = array();
+		$inspect_query = function ( $query ) use ( &$tax_queries ) {
+			$tax_queries = $query->tax_query->queries;
+		};
+
+		add_action( 'pre_get_posts', $inspect_query, 20 );
+
+		try {
+			$query = new WP_Query( array( 'post_type' => 'post' ) );
+		} finally {
+			remove_action( 'pre_get_posts', $inspect_query, 20 );
+		}
+
+		$this->assertFalse( $this->has_language_tax_query( $tax_queries ) );
 		$this->assertEquals( array( get_post( $fr ) ), $query->posts );
 	}
 


### PR DESCRIPTION
Fixes #1870

### Summary

This PR fixes two frontend timing issues that occur after Polylang has enough context to know the current language.

Changes included:

- instantiate `PLL_Frontend_Auto_Translate` when the frontend language is defined so the late post ID translation pass is available before SQL generation;
- add a late `pre_get_posts` pass so post ID arrays added by third-party callbacks are translated before SQL generation;
- hide Polylang's internal `language` taxonomy from `$query->tax_query` during `pre_get_posts`, while keeping the query vars intact so WordPress rebuilds the language tax query before SQL generation;
- let `PLL_Frontend_Filters_Links::home_url()` evaluate its existing allowlist/blocklist after `parse_request` on non-admin requests while keeping the existing `template_redirect` behavior.

### Why this is safe

This does not make Polylang filter arbitrary plugin calls to `home_url()` by default.

The existing allowlist/blocklist still controls whether `home_url()` is filtered. A non-allowlisted direct call still returns the original home URL. The change only allows already-allowlisted callbacks to work on non-admin requests after the request has been parsed and before `template_redirect`, without changing behavior at or after `template_redirect`.

### Why this is needed

`PLL_Frontend_Auto_Translate` already translates post ID query vars, but it does so on `parse_query`. WordPress and third-party code commonly adjust query vars later on `pre_get_posts`; WP Core's `WP_Widget_Recent_Posts` query is a simple reproduction path through its secondary `WP_Query`.

Also, Polylang's internal `language` taxonomy can appear in `$query->tax_query` during `pre_get_posts`. That causes third-party query inspection to treat the query as if the site owner had requested a non-public taxonomy. The language constraint is still needed for SQL, but WordPress rebuilds tax queries from query vars after `pre_get_posts`, so it is safe to hide the object-level internal taxonomy from callbacks.

Without this, integrations that modify WordPress queries have to manually translate IDs or whitelist Polylang internals.

### Tests

Added/updated tests for both timing cases:

- `Auto_Translate_Test::test_recent_posts_widget_post_ids_added_on_pre_get_posts()` verifies that a default-language ID added to `post__not_in` on core's Recent Posts widget query is translated to the current language before SQL generation.
- `Query_Test::test_language_tax_query_hidden_from_pre_get_posts()` verifies that `pre_get_posts` callbacks do not see Polylang's internal `language` taxonomy while the final SQL query still returns only the current language.
- `Filters_Links_Test::test_get_custom_logo()` now verifies that `home_url()` can be filtered after `parse_request`, while a non-allowlisted direct `home_url()` call still returns the original URL.
