### PR TITLE
Switcher visitor proposal

### DIFF
--- a/src/modules/Switcher/Element/Current_Language_Element.php
+++ b/src/modules/Switcher/Element/Current_Language_Element.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Current_Language_Element implements Element {
+	/**
+	 * @var array
+	 */
+	private $row = array();
+
+	public function __construct( array $row = array() ) {}
+
+	public function accept( Visitor $visitor ): string {}
+
+	public function get_url(): string {}
+
+	public function to_array(): array {}
+}

--- a/src/modules/Switcher/Element/Element.php
+++ b/src/modules/Switcher/Element/Element.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+interface Element {
+	public function accept( Visitor $visitor ): string;
+
+	public function get_url(): string;
+
+	public function to_array(): array;
+}

--- a/src/modules/Switcher/Element/No_Content_Element.php
+++ b/src/modules/Switcher/Element/No_Content_Element.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class No_Content_Element implements Element {
+	/**
+	 * @var array
+	 */
+	private $row = array();
+
+	public function __construct( array $row = array() ) {}
+
+	public function accept( Visitor $visitor ): string {}
+
+	public function get_url(): string {}
+
+	public function to_array(): array {}
+}

--- a/src/modules/Switcher/Element/No_Translations_Element.php
+++ b/src/modules/Switcher/Element/No_Translations_Element.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class No_Translations_Element implements Element {
+	/**
+	 * @var array
+	 */
+	private $row = array();
+
+	public function __construct( array $row = array() ) {}
+
+	public function accept( Visitor $visitor ): string {}
+
+	public function get_url(): string {}
+
+	public function to_array(): array {}
+}

--- a/src/modules/Switcher/Settings.php
+++ b/src/modules/Switcher/Settings.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Settings {
+	/**
+	 * @var array
+	 */
+	private $options = array();
+
+	public function __construct( array $options = array() ) {}
+
+	public function get_visitor(): Visitor {}
+}

--- a/src/modules/Switcher/Switcher.php
+++ b/src/modules/Switcher/Switcher.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Switcher {
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * @var Visitor|null
+	 */
+	private $visitor;
+
+	/**
+	 * @var Element[]
+	 */
+	private $elements = array();
+
+	public function __construct( Settings $settings ) {}
+
+	public function print(): string {}
+
+	public function to_array(): array {}
+}

--- a/src/modules/Switcher/Visitor/Dropdown_List_Visitor.php
+++ b/src/modules/Switcher/Visitor/Dropdown_List_Visitor.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Dropdown_List_Visitor implements Visitor {
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	public function __construct( Settings $settings ) {}
+
+	/**
+	 * @param Element[] $elements
+	 */
+	public function walk( array $elements ): string {}
+
+	public function visit_current_language( Current_Language_Element $element ): string {}
+
+	public function visit_without_translations( No_Translations_Element $element ): string {}
+
+	public function visit_without_content( No_Content_Element $element ): string {}
+}

--- a/src/modules/Switcher/Visitor/Horizontal_List_Visitor.php
+++ b/src/modules/Switcher/Visitor/Horizontal_List_Visitor.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Horizontal_List_Visitor implements Visitor {
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	public function __construct( Settings $settings ) {}
+
+	/**
+	 * @param Element[] $elements
+	 */
+	public function walk( array $elements ): string {}
+
+	public function visit_current_language( Current_Language_Element $element ): string {}
+
+	public function visit_without_translations( No_Translations_Element $element ): string {}
+
+	public function visit_without_content( No_Content_Element $element ): string {}
+}

--- a/src/modules/Switcher/Visitor/Select_List_Visitor.php
+++ b/src/modules/Switcher/Visitor/Select_List_Visitor.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Select_List_Visitor implements Visitor {
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	public function __construct( Settings $settings ) {}
+
+	/**
+	 * @param Element[] $elements
+	 */
+	public function walk( array $elements ): string {}
+
+	public function visit_current_language( Current_Language_Element $element ): string {}
+
+	public function visit_without_translations( No_Translations_Element $element ): string {}
+
+	public function visit_without_content( No_Content_Element $element ): string {}
+}

--- a/src/modules/Switcher/Visitor/Vertical_List_Visitor.php
+++ b/src/modules/Switcher/Visitor/Vertical_List_Visitor.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+class Vertical_List_Visitor implements Visitor {
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	public function __construct( Settings $settings ) {}
+
+	/**
+	 * @param Element[] $elements
+	 */
+	public function walk( array $elements ): string {}
+
+	public function visit_current_language( Current_Language_Element $element ): string {}
+
+	public function visit_without_translations( No_Translations_Element $element ): string {}
+
+	public function visit_without_content( No_Content_Element $element ): string {}
+}

--- a/src/modules/Switcher/Visitor/Visitor.php
+++ b/src/modules/Switcher/Visitor/Visitor.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher;
+
+interface Visitor {
+	/**
+	 * @param Element[] $elements
+	 */
+	public function walk( array $elements ): string;
+
+	public function visit_current_language( Current_Language_Element $element ): string;
+
+	public function visit_without_translations( No_Translations_Element $element ): string;
+
+	public function visit_without_content( No_Content_Element $element ): string;
+}

--- a/src/modules/Switcher/Visitor/Visitor.php
+++ b/src/modules/Switcher/Visitor/Visitor.php
@@ -11,6 +11,8 @@ interface Visitor {
 	 */
 	public function walk( array $elements ): string;
 
+	public function visit( Element $element ): string;
+
 	public function visit_current_language( Current_Language_Element $element ): string;
 
 	public function visit_without_translations( No_Translations_Element $element ): string;

--- a/switcher.md
+++ b/switcher.md
@@ -105,45 +105,14 @@ classDiagram
 
     Element ..> Visitor : accept()
 
-    note for Switcher
-        Builds Element rows internally
-        from Settings and context.
-        Gets Visitor from
-        settings.get_visitor().
-        print() delegates to
-        visitor.walk( elements ).
-        to_array() maps elements to
-        raw row arrays.
-    end note
-
-    note for Settings
-        Switcher options, backward
-        compatibility, adaptor wiring.
-        Exposes get_visitor() to
-        build the right Visitor.
-    end note
-
-    note for Element
-        Base interface for typed rows.
-        Concrete classes encode row
-        semantics (current language,
-        no translations, no content)
-        plus URL for href/value and
-        raw serialization via to_array().
-    end note
-
-    note for Visitor
-        walk(elements) takes Element[]
-        (language rows). It loops each
-        Element, calls accept() which
-        dispatches to matching
-        visit_*() method for the row
-        string, then merges fragments
-        with presentation wrapper (e.g.
-        ul/select shell). Parameter
-        elements is the full list.
-    end note
 ```
+
+Design notes:
+
+- `Switcher` builds `Element[]` internally from `Settings` + runtime context, then calls `visitor.walk( elements )` in `print()` or `element->to_array()` in `to_array()`.
+- `Settings` contains options / backward-compatibility adaptors and provides the concrete visitor through `get_visitor()`.
+- `Element` is a typed row contract (`Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`) with `accept(Visitor)`, `get_url()`, and `to_array()`.
+- `Visitor::walk( Element[] elements )` loops rows and dispatches per element type to `visit_current_language`, `visit_without_translations`, or `visit_without_content`.
 
 ## `walk()` on `Visitor`
 

--- a/switcher.md
+++ b/switcher.md
@@ -1,0 +1,245 @@
+# Language switcher rendering architecture
+
+UML below models a **Visitor-based** rendering pipeline: `Switcher` is the facade that owns configuration (`Settings`), **materializes** a list of typed `Element` instances internally (from `Settings` and runtime context), then fetches a concrete `Visitor` via `Settings::get_visitor()` for the desired presentation (horizontal list, vertical list, dropdown, `<select>`, ...). Presentation lives in visitor implementations; the concrete `Element` class captures row semantics (`Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`) and exposes the row URL via `get_url()`. The facade has two output entry points: `print()` returns a **string** (HTML/markup) through `Visitor::walk( Element[] )`, while `to_array()` returns the raw data structure matching the internal `Element[]`.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    direction TB
+
+    class Switcher {
+        -Settings settings
+        -Visitor visitor
+        -Element[] elements
+        +__construct(Settings settings) void
+        +print() string
+        +to_array() array
+    }
+
+    class Settings {
+        +get_visitor() Visitor
+    }
+
+    class Element {
+        <<interface>>
+        +accept(Visitor visitor) string
+        +get_url() string
+        +to_array() array
+    }
+
+    class Current_Language_Element {
+        <<implements Element>>
+        +accept(Visitor visitor) string
+        +get_url() string
+        +to_array() array
+    }
+
+    class No_Translations_Element {
+        <<implements Element>>
+        +accept(Visitor visitor) string
+        +get_url() string
+        +to_array() array
+    }
+
+    class No_Content_Element {
+        <<implements Element>>
+        +accept(Visitor visitor) string
+        +get_url() string
+        +to_array() array
+    }
+
+    class Visitor {
+        <<interface>>
+        +walk(Element[] elements) string
+        +visit_current_language(Current_Language_Element element) string
+        +visit_without_translations(No_Translations_Element element) string
+        +visit_without_content(No_Content_Element element) string
+    }
+
+    class Horizontal_List_Visitor {
+        <<implements Visitor>>
+        +walk(Element[] elements) string
+        +visit_current_language(Current_Language_Element element) string
+        +visit_without_translations(No_Translations_Element element) string
+        +visit_without_content(No_Content_Element element) string
+    }
+
+    class Vertical_List_Visitor {
+        <<implements Visitor>>
+        +walk(Element[] elements) string
+        +visit_current_language(Current_Language_Element element) string
+        +visit_without_translations(No_Translations_Element element) string
+        +visit_without_content(No_Content_Element element) string
+    }
+
+    class Dropdown_List_Visitor {
+        <<implements Visitor>>
+        +walk(Element[] elements) string
+        +visit_current_language(Current_Language_Element element) string
+        +visit_without_translations(No_Translations_Element element) string
+        +visit_without_content(No_Content_Element element) string
+    }
+
+    class Select_List_Visitor {
+        <<implements Visitor>>
+        +walk(Element[] elements) string
+        +visit_current_language(Current_Language_Element element) string
+        +visit_without_translations(No_Translations_Element element) string
+        +visit_without_content(No_Content_Element element) string
+    }
+
+    Switcher "1" *-- "1" Settings
+    Settings ..> Visitor : get_visitor()
+    Switcher ..> Visitor : obtained via Settings
+    Switcher "1" *-- "0..*" Element
+
+    Visitor <|.. Horizontal_List_Visitor
+    Visitor <|.. Vertical_List_Visitor
+    Visitor <|.. Dropdown_List_Visitor
+    Visitor <|.. Select_List_Visitor
+
+    Element <|.. Current_Language_Element
+    Element <|.. No_Translations_Element
+    Element <|.. No_Content_Element
+
+    Element ..> Visitor : accept()
+
+    note for Switcher
+        Builds Element rows internally
+        from Settings and context.
+        Gets Visitor from
+        settings.get_visitor().
+        print() delegates to
+        visitor.walk( elements ).
+        to_array() maps elements to
+        raw row arrays.
+    end note
+
+    note for Settings
+        Switcher options, backward
+        compatibility, adaptor wiring.
+        Exposes get_visitor() to
+        build the right Visitor.
+    end note
+
+    note for Element
+        Base interface for typed rows.
+        Concrete classes encode row
+        semantics (current language,
+        no translations, no content)
+        plus URL for href/value and
+        raw serialization via to_array().
+    end note
+
+    note for Visitor
+        walk(elements) takes Element[]
+        (language rows). It loops each
+        Element, calls accept() which
+        dispatches to matching
+        visit_*() method for the row
+        string, then merges fragments
+        with presentation wrapper (e.g.
+        ul/select shell). Parameter
+        elements is the full list.
+    end note
+```
+
+## `walk()` on `Visitor`
+
+`walk( elements )` receives the complete `Element[]` that `Switcher` built internally. The visitor owns the iteration: for each `Element`, it drives rendering (typically `element->accept( $this )`, which forwards to the matching typed method: `visit_current_language`, `visit_without_translations`, or `visit_without_content`), accumulates each row's `string`, and returns one combined `string` for the whole switcher (opening/closing tags, separators, etc.). Different concrete visitors implement different `walk()` strategies (horizontal list shell vs `<select>` vs dropdown markup, etc.) while sharing the same typed per-row contracts.
+
+## Element sub-types
+
+All concrete element classes implement the `Element` interface.
+
+| Element | Description |
+|---------|-------------|
+| **Current_Language_Element** | Represents the row for the currently active language. |
+| **No_Translations_Element** | Represents a language row where translated content is unavailable. |
+| **No_Content_Element** | Represents a row where the language link/content is empty or unavailable. |
+
+## Visitor sub-types
+
+All concrete visitor classes implement the `Visitor` interface.
+
+| Visitor | Description |
+|---------|-------------|
+| **Horizontal_List_Visitor** | Renders the switcher as a horizontal list (e.g. inline `<ul>` or row). Walks elements and emits left-to-right list chrome plus per-row output based on each typed `Element` variant. |
+| **Vertical_List_Visitor** | Same data model as the horizontal visitor, but list markup and spacing target a stacked vertical block. |
+| **Dropdown_List_Visitor** | Renders a dropdown or flyout (not a native `<select>`): toggle control, menu container, and items derived from each `Element`. |
+| **Select_List_Visitor** | Renders a `<select>` (or equivalent): opening/closing `<select>`, `<option>` rows, and row state driven by typed `Element` variants plus `Settings`. |
+
+## Print flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Settings
+    participant Switcher
+    participant Visitor
+    participant Element
+
+    Client->>Switcher: __construct(settings)
+    Client->>Switcher: print()
+    Switcher->>Switcher: build Element[] internally (Settings, context)
+    Switcher->>Settings: get_visitor()
+    Settings-->>Switcher: Visitor
+    Switcher->>Visitor: walk(elements)
+    loop inside walk for each Element
+        Visitor->>Element: accept(visitor)
+        Element->>Visitor: visit_current_language(this) / visit_without_translations(this) / visit_without_content(this)
+        Visitor-->>Visitor: append fragment
+    end
+    Visitor-->>Switcher: string (full HTML block)
+    Switcher-->>Client: string (full HTML)
+```
+
+## `to_array()` flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Switcher
+    participant Element
+
+    Client->>Switcher: to_array()
+    Switcher->>Switcher: build Element[] internally (Settings, context)
+    loop for each Element
+        Switcher->>Element: to_array()
+        Element-->>Switcher: row array
+        Switcher-->>Switcher: append row array
+    end
+    Switcher-->>Client: array (raw rows)
+```
+
+## Facade usage
+
+Illustrative client code: build `Settings`, construct `Switcher` with it, then call either `print()` for HTML or `to_array()` for raw rows. `Element` rows are created inside the facade from `Settings` and request context; `Visitor` is fetched internally through `Settings::get_visitor()`.
+
+```php
+// Configuration: options, backward compatibility, adaptors.
+$settings = new Settings( array( /*...*/ ) );
+
+$switcher = new Switcher( $settings );
+
+// Internally: build Element[] from $settings/context, get Visitor from $settings->get_visitor(), then $html = $visitor->walk( $elements ).
+$html = $switcher->print();
+
+return $html;
+```
+
+```php
+$rows = $switcher->to_array();
+
+return $rows; // Raw switcher data.
+```
+
+## Legend
+
+| Concept | Role |
+|--------|------|
+| `Switcher` | Entry point: builds `Element[]` internally; in `print()`, fetches Visitor via `Settings::get_visitor()`, returns HTML through `Visitor::walk( elements )`; `to_array()` returns raw rows. |
+| `Settings` | Options, backward compatibility, adaptors; exposes `get_visitor()` and global rendering rules. |
+| `Element` | One row/language node with `accept(Visitor)`, `get_url()`, and `to_array()`. Concrete classes are `Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`. |
+| `Visitor` | Strategy per presentation; `walk( Element[] )` loops rows and assembles final output via typed methods `visit_current_language`, `visit_without_translations`, `visit_without_content`. |

--- a/switcher.md
+++ b/switcher.md
@@ -1,6 +1,6 @@
 # Language switcher rendering architecture
 
-UML below models a **Visitor-based** rendering pipeline: `Switcher` is the facade that owns configuration (`Settings`), **materializes** a list of typed `Element` instances internally (from `Settings` and runtime context), then fetches a concrete `Visitor` via `Settings::get_visitor()` for the desired presentation (horizontal list, vertical list, dropdown, `<select>`, ...). Presentation lives in visitor implementations; the concrete `Element` class captures row semantics (`Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`) and exposes the row URL via `get_url()`. The facade has two output entry points: `print()` returns a **string** (HTML/markup) through `Visitor::walk( Element[] )`, while `to_array()` returns the raw data structure matching the internal `Element[]`.
+UML below models a **Visitor-based** rendering pipeline: `Switcher` is the facade that owns configuration (`Settings`), **materializes** a list of `Element` instances internally (from `Settings` and runtime context), then fetches a concrete `Visitor` via `Settings::get_visitor()` for the desired presentation (horizontal list, vertical list, dropdown, `<select>`, ...). Presentation lives in visitor implementations. Rows are modeled as `Element` implementations: typed variants (`Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`) dispatch to `visit_current_language`, `visit_without_translations`, or `visit_without_content`; a plain row uses the base `visit( Element )` contract. Each row exposes the URL via `get_url()`. The facade has two output entry points: `print()` returns a **string** (HTML/markup) through `Visitor::walk( Element[] )`, while `to_array()` returns the raw data structure matching the internal `Element[]`.
 
 ## Class diagram
 
@@ -52,6 +52,7 @@ classDiagram
     class Visitor {
         <<interface>>
         +walk(Element[] elements) string
+        +visit(Element element) string
         +visit_current_language(Current_Language_Element element) string
         +visit_without_translations(No_Translations_Element element) string
         +visit_without_content(No_Content_Element element) string
@@ -60,6 +61,7 @@ classDiagram
     class Horizontal_List_Visitor {
         <<implements Visitor>>
         +walk(Element[] elements) string
+        +visit(Element element) string
         +visit_current_language(Current_Language_Element element) string
         +visit_without_translations(No_Translations_Element element) string
         +visit_without_content(No_Content_Element element) string
@@ -68,6 +70,7 @@ classDiagram
     class Vertical_List_Visitor {
         <<implements Visitor>>
         +walk(Element[] elements) string
+        +visit(Element element) string
         +visit_current_language(Current_Language_Element element) string
         +visit_without_translations(No_Translations_Element element) string
         +visit_without_content(No_Content_Element element) string
@@ -76,6 +79,7 @@ classDiagram
     class Dropdown_List_Visitor {
         <<implements Visitor>>
         +walk(Element[] elements) string
+        +visit(Element element) string
         +visit_current_language(Current_Language_Element element) string
         +visit_without_translations(No_Translations_Element element) string
         +visit_without_content(No_Content_Element element) string
@@ -84,6 +88,7 @@ classDiagram
     class Select_List_Visitor {
         <<implements Visitor>>
         +walk(Element[] elements) string
+        +visit(Element element) string
         +visit_current_language(Current_Language_Element element) string
         +visit_without_translations(No_Translations_Element element) string
         +visit_without_content(No_Content_Element element) string
@@ -111,12 +116,12 @@ Design notes:
 
 - `Switcher` builds `Element[]` internally from `Settings` + runtime context, then calls `visitor.walk( elements )` in `print()` or `element->to_array()` in `to_array()`.
 - `Settings` contains options / backward-compatibility adaptors and provides the concrete visitor through `get_visitor()`.
-- `Element` is a typed row contract (`Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`) with `accept(Visitor)`, `get_url()`, and `to_array()`.
-- `Visitor::walk( Element[] elements )` loops rows and dispatches per element type to `visit_current_language`, `visit_without_translations`, or `visit_without_content`.
+- `Element` is the row contract (`accept(Visitor)`, `get_url()`, `to_array()`). Typed implementations call `visit_current_language`, `visit_without_translations`, or `visit_without_content`; a plain `Element` calls `visit( Element )`.
+- `Visitor::walk( Element[] elements )` loops rows; each `accept()` forwards to `visit( Element )` and/or the matching typed `visit_*` method.
 
 ## `walk()` on `Visitor`
 
-`walk( elements )` receives the complete `Element[]` that `Switcher` built internally. The visitor owns the iteration: for each `Element`, it drives rendering (typically `element->accept( $this )`, which forwards to the matching typed method: `visit_current_language`, `visit_without_translations`, or `visit_without_content`), accumulates each row's `string`, and returns one combined `string` for the whole switcher (opening/closing tags, separators, etc.). Different concrete visitors implement different `walk()` strategies (horizontal list shell vs `<select>` vs dropdown markup, etc.) while sharing the same typed per-row contracts.
+`walk( elements )` receives the complete `Element[]` that `Switcher` built internally. The visitor owns the iteration: for each `Element`, it drives rendering via `element->accept( $this )`, which forwards either to the base `visit( Element )` (simple / non-discriminated row) or to a typed hook (`visit_current_language`, `visit_without_translations`, `visit_without_content`). It accumulates each row's `string` and returns one combined `string` for the whole switcher (opening/closing tags, separators, etc.). Different concrete visitors implement different `walk()` strategies (horizontal list shell vs `<select>` vs dropdown markup, etc.) while sharing the same per-row contracts.
 
 ## Element sub-types
 
@@ -127,6 +132,8 @@ All concrete element classes implement the `Element` interface.
 | **Current_Language_Element** | Represents the row for the currently active language. |
 | **No_Translations_Element** | Represents a language row where translated content is unavailable. |
 | **No_Content_Element** | Represents a row where the language link/content is empty or unavailable. |
+
+Any other concrete `Element` (not one of the three above) is rendered through `Visitor::visit( Element )` from `accept(Visitor)`.
 
 ## Visitor sub-types
 
@@ -157,12 +164,14 @@ sequenceDiagram
     Switcher->>Visitor: walk(elements)
     loop inside walk for each Element
         Visitor->>Element: accept(visitor)
-        Element->>Visitor: visit_current_language(this) / visit_without_translations(this) / visit_without_content(this)
+        Element->>Visitor: visit(this) or visit_* (typed)
         Visitor-->>Visitor: append fragment
     end
     Visitor-->>Switcher: string (full HTML block)
     Switcher-->>Client: string (full HTML)
 ```
+
+Plain `Element` implementations call `visit( Element )`; typed classes call the corresponding `visit_*` method.
 
 ## `to_array()` flow
 
@@ -211,4 +220,4 @@ return $rows; // Raw switcher data.
 | `Switcher` | Entry point: builds `Element[]` internally; in `print()`, fetches Visitor via `Settings::get_visitor()`, returns HTML through `Visitor::walk( elements )`; `to_array()` returns raw rows. |
 | `Settings` | Options, backward compatibility, adaptors; exposes `get_visitor()` and global rendering rules. |
 | `Element` | One row/language node with `accept(Visitor)`, `get_url()`, and `to_array()`. Concrete classes are `Current_Language_Element`, `No_Translations_Element`, `No_Content_Element`. |
-| `Visitor` | Strategy per presentation; `walk( Element[] )` loops rows and assembles final output via typed methods `visit_current_language`, `visit_without_translations`, `visit_without_content`. |
+| `Visitor` | Strategy per presentation; `walk( Element[] )` loops rows and assembles output via `visit( Element )` for plain rows and typed methods `visit_current_language`, `visit_without_translations`, `visit_without_content` where applicable. |


### PR DESCRIPTION
## What?
Add a Visitor-based switcher architecture proposal in `switcher.md`, including UML diagram and flow charts for:

- `Switcher::print()` (HTML rendering)
- `Switcher::to_array()` (raw data output)
- typed `Element` variants + typed `Visitor` dispatch

> [!NOTE]
This PR is documentation-only. See `switcher.md` for full details.

> [!NOTE]
The heavy usage of interfaces is only here to show purposes and types. It can be replaced with abstract classes during full implementation.