### PR TITLE
Introduce POLYLANG_ROOT_DIR constant

### DIFF
--- a/polylang.php
+++ b/polylang.php
@@ -68,11 +68,12 @@ define( 'PLL_MIN_PHP_VERSION', '7.4' );
 define( 'POLYLANG_FILE', __FILE__ );
 define( 'POLYLANG_DIR', __DIR__ );
 
-// Whether we are using Polylang or Polylang Pro, get the filename of the plugin in use.
+// The filename of the plugin in use, whether it is Polylang or Polylang Pro.
 if ( ! defined( 'POLYLANG_ROOT_FILE' ) ) {
 	define( 'POLYLANG_ROOT_FILE', __FILE__ );
 }
 
+// The root directory of the plugin in use, whether it is Polylang or Polylang Pro.
 if ( ! defined( 'POLYLANG_ROOT_DIR' ) ) {
 	define( 'POLYLANG_ROOT_DIR', __DIR__ );
 }

--- a/polylang.php
+++ b/polylang.php
@@ -73,6 +73,10 @@ if ( ! defined( 'POLYLANG_ROOT_FILE' ) ) {
 	define( 'POLYLANG_ROOT_FILE', __FILE__ );
 }
 
+if ( ! defined( 'POLYLANG_ROOT_DIR' ) ) {
+	define( 'POLYLANG_ROOT_DIR', __DIR__ );
+}
+
 if ( ! defined( 'POLYLANG_BASENAME' ) ) {
 	define( 'POLYLANG_BASENAME', plugin_basename( __FILE__ ) ); // Plugin name as known by WP.
 	require __DIR__ . '/vendor/autoload.php';

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -1060,7 +1060,7 @@ class Languages {
 		}
 
 		// Validate flag.
-		if ( ! empty( $args['flag'] ) && ! is_readable( POLYLANG_DIR . '/vendor/wpsyntex/flags/' . $args['flag'] . '.svg' ) ) {
+		if ( ! empty( $args['flag'] ) && ! is_readable( POLYLANG_ROOT_DIR . '/vendor/wpsyntex/flags/' . $args['flag'] . '.svg' ) ) {
 			$flag = PLL_Language::get_flag_information( $args['flag'] );
 
 			if ( ! empty( $flag['url'] ) ) {

--- a/src/language.php
+++ b/src/language.php
@@ -384,9 +384,9 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 		// Polylang builtin flags.
 		$file = "/vendor/wpsyntex/flags/{$code}.svg";
-		if ( is_readable( POLYLANG_DIR . $file ) ) {
+		if ( is_readable( POLYLANG_ROOT_DIR . $file ) ) {
 			$default_flag = array(
-				'url'    => plugins_url( $file, POLYLANG_FILE ),
+				'url'    => plugins_url( $file, POLYLANG_ROOT_FILE ),
 				'src'    => '',
 				'width'  => 18,
 				'height' => 12,
@@ -394,7 +394,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 			// If base64 encoded flags are preferred.
 			if ( pll_get_constant( 'PLL_ENCODED_FLAGS', true ) ) {
-				$content = file_get_contents( POLYLANG_DIR . $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$content = file_get_contents( POLYLANG_ROOT_DIR . $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 				if ( ! empty( $content ) ) {
 					$default_flag['src'] = 'data:image/svg+xml,' . self::encode_svg( $content );

--- a/tests/phpunit/tests/test-flags.php
+++ b/tests/phpunit/tests/test-flags.php
@@ -41,7 +41,7 @@ class Flags_Test extends PLL_UnitTestCase {
 
 	public function test_default_flag() {
 		$lang = self::$model->get_language( 'en' );
-		$this->assertEquals( plugins_url( '/vendor/wpsyntex/flags/us.svg', POLYLANG_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.
+		$this->assertEquals( plugins_url( '/vendor/wpsyntex/flags/us.svg', POLYLANG_ROOT_FILE ), $lang->get_display_flag_url() ); // Bug fixed in 2.8.1.
 		$this->assertEquals( 1, preg_match( '#<img src="data:image\/svg\+xml,(.+)" alt="English" width="18" height="12" style="(.+)" \/>#', $lang->get_display_flag() ) );
 	}
 

--- a/tests/phpunit/tests/test-switcher.php
+++ b/tests/phpunit/tests/test-switcher.php
@@ -62,7 +62,7 @@ class Switcher_Test extends PLL_UnitTestCase {
 		$this->assertEquals( 'English', $arr['en']['name'] );
 		$this->assertEquals( 'en-US', $arr['en']['locale'] );
 		$this->assertEquals( 'en', $arr['en']['slug'] );
-		$this->assertEquals( plugins_url( '/vendor/wpsyntex/flags/us.svg', POLYLANG_FILE ), $arr['en']['flag'] );
+		$this->assertEquals( plugins_url( '/vendor/wpsyntex/flags/us.svg', POLYLANG_ROOT_FILE ), $arr['en']['flag'] );
 
 		// Other arguments
 		$args = array_merge(

--- a/tests/phpunit/tests/test-wpml.php
+++ b/tests/phpunit/tests/test-wpml.php
@@ -79,7 +79,7 @@ class WPML_Test extends PLL_UnitTestCase {
 			'missing'          => 0,
 			'translated_name'  => '',
 			'language_code'    => 'fr',
-			'country_flag_url' => plugins_url( '/vendor/wpsyntex/flags/fr.svg', POLYLANG_FILE ),
+			'country_flag_url' => plugins_url( '/vendor/wpsyntex/flags/fr.svg', POLYLANG_ROOT_FILE ),
 			'url'              => home_url( "?page_id={$fr}&lang=fr" ),
 		);
 


### PR DESCRIPTION
Follow-up of #1864

With the flags introduced as a dependency, we now need to access to the vendor directory from Polylang, whether Polylang is standalone plugin or a dependency of Polylang Pro. It's convenient to introduce a `POLYLANG_ROOT_DIR` constant similar to the existing `POLYLANG_ROOT_FILE`.

- Use this new constant to access the flags in the vendor directory.
- Fix the flags URLs for Polylang Pro, by replacing `POLYLANG_ROOT_FILE` instead of `POLYLANG_FILE` as second param of `plugins_url()`.