### PR TITLE
Remove wpcom_vip_get_page_by_path()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1,30 +1,10 @@
 <?php
 /**
  * @package Polylang
- */
-
-/**
- * Define wordpress.com VIP equivalent of uncached functions
+ *
  * WordPress backward compatibility functions
- * and miscellaneous utility functions
+ * and miscellaneous utility functions.
  */
-
-if ( ! function_exists( 'wpcom_vip_get_page_by_path' ) ) {
-	/**
-	 * Retrieves a page given its path.
-	 *
-	 * @since 2.8.3
-	 *
-	 * @param string       $page_path Page path.
-	 * @param string       $output    Optional. The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which correspond to
-	 *                                a WP_Post object, an associative array, or a numeric array, respectively. Default OBJECT.
-	 * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
-	 * @return WP_Post|array|null WP_Post (or array) on success, or null on failure.
-	 */
-	function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
-		return get_page_by_path( $page_path, $output, $post_type ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
-	}
-}
 
 /**
  * Determines whether we should load the cache compatibility

--- a/src/integrations/wpseo/wpseo.php
+++ b/src/integrations/wpseo/wpseo.php
@@ -266,7 +266,7 @@ class PLL_WPSEO {
 			// Exclude cases where a post type archive is attached to a page (ex: WooCommerce).
 			$slug = ( true === $post_type_obj->has_archive ) ? $post_type_obj->rewrite['slug'] : $post_type_obj->has_archive;
 
-			if ( ! wpcom_vip_get_page_by_path( $slug ) ) {
+			if ( ! get_page_by_path( $slug ) ) {
 				// The post type archive in the current language is already added by WPSEO.
 				$languages = wp_list_filter( $languages, array( 'slug' => pll_current_language() ), 'NOT' );
 


### PR DESCRIPTION
This function has been deprecated since the release of WP 6.1.