### PR TITLE
Introduce functions to register and enqueue scripts and styles

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -172,3 +172,81 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
 
 	return 'GET' === $request->get_method() && 'edit' === $request->get_param( 'context' );
 }
+
+/**
+ * Enqueues a JS script.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the script (without the extension).
+ * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
+ * @param array $args     {
+ *     Optional. An array of additional script loading strategies. Default empty array.
+ *
+ *     @type string    $strategy      Optional. If provided, may be either 'defer' or 'async'.
+ *     @type bool      $in_footer     Optional. Whether to print the script in the footer. Default 'false'.
+ *     @type string    $fetchpriority Optional. The fetch priority for the script. Default 'auto'.
+ * }
+ * @return void
+ */
+function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array() ): void {
+	pll_register_script( $name, $dependencies, $args );
+	wp_scripts()->enqueue( 'pll-' . $name );
+}
+
+/**
+ * Registers a JS script.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the script (without the extension).
+ * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
+ * @param array $args     {
+ *     Optional. An array of additional script loading strategies. Default empty array.
+ *
+ *     @type string    $strategy      Optional. If provided, may be either 'defer' or 'async'.
+ *     @type bool      $in_footer     Optional. Whether to print the script in the footer. Default 'false'.
+ *     @type string    $fetchpriority Optional. The fetch priority for the script. Default 'auto'.
+ * }
+ * @return void
+ */
+function pll_register_script( string $name, array $dependencies = array(), array $args = array() ): void {
+	$handle  = 'pll-' . $name;
+	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	$file    = '/js/build/' . $name . $suffix . '.js';
+	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
+	$version = filemtime( POLYLANG_ROOT_DIR . $file );
+	wp_register_script( $handle, $src, $dependencies, $version, $args );
+}
+
+/**
+ * Enqueues a CSS stylesheet.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
+ * @return void
+ */
+function pll_enqueue_style( string $name, array $dependencies = array() ): void {
+	pll_register_style( $name, $dependencies );
+	wp_styles()->enqueue( 'pll-' . $name );
+}
+
+/**
+ * Registers a CSS stylesheet.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
+ * @return void
+ */
+function pll_register_style( string $name, array $dependencies = array() ): void {
+	$handle  = 'pll-' . $name;
+	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	$file    = '/js/build/' . $name . $suffix . '.css';
+	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
+	$version = filemtime( POLYLANG_ROOT_DIR . $file );
+	wp_register_style( $handle, $src, $dependencies, $version );
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -176,9 +176,11 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
 /**
  * Enqueues a JS script.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the script (without the extension).
+ * @param string   $handle       The handle of the script.
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
  * @param array $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
@@ -189,17 +191,19 @@ function pll_is_edit_rest_request( WP_REST_Request $request ): bool {
  * }
  * @return void
  */
-function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array() ): void {
-	pll_register_script( $name, $dependencies, $args );
-	wp_scripts()->enqueue( 'pll-' . $name );
+function pll_enqueue_script( string $handle, array $dependencies = array(), array $args = array() ): void {
+	pll_register_script( $handle, $dependencies, $args );
+	wp_scripts()->enqueue( $handle );
 }
 
 /**
  * Registers a JS script.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the script (without the extension).
+ * @param string   $handle       The handle of the script.
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
  * @param array $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
@@ -210,10 +214,9 @@ function pll_enqueue_script( string $name, array $dependencies = array(), array 
  * }
  * @return void
  */
-function pll_register_script( string $name, array $dependencies = array(), array $args = array() ): void {
-	$handle  = 'pll-' . $name;
+function pll_register_script( string $handle, array $dependencies = array(), array $args = array() ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/js/build/' . $name . $suffix . '.js';
+	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.js';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = filemtime( POLYLANG_ROOT_DIR . $file );
 	wp_register_script( $handle, $src, $dependencies, $version, $args );
@@ -222,30 +225,33 @@ function pll_register_script( string $name, array $dependencies = array(), array
 /**
  * Enqueues a CSS stylesheet.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string   $handle       The handle of the stylesheet.
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
  * @return void
  */
-function pll_enqueue_style( string $name, array $dependencies = array() ): void {
-	pll_register_style( $name, $dependencies );
-	wp_styles()->enqueue( 'pll-' . $name );
+function pll_enqueue_style( string $handle, array $dependencies = array() ): void {
+	pll_register_style( $handle, $dependencies );
+	wp_styles()->enqueue( $handle );
 }
 
 /**
  * Registers a CSS stylesheet.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string   $handle       The handle of the stylesheet.
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
  * @return void
  */
-function pll_register_style( string $name, array $dependencies = array() ): void {
-	$handle  = 'pll-' . $name;
+function pll_register_style( string $handle, array $dependencies = array() ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/js/build/' . $name . $suffix . '.css';
+	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = filemtime( POLYLANG_ROOT_DIR . $file );
 	wp_register_style( $handle, $src, $dependencies, $version );

--- a/src/functions.php
+++ b/src/functions.php
@@ -201,11 +201,12 @@ function pll_sanitize_ids( $ids ): array {
  *     @type bool      $in_footer     Optional. Whether to print the script in the footer. Default 'false'.
  *     @type string    $fetchpriority Optional. The fetch priority for the script. Default 'auto'.
  * }
+ * @param string   $prefix       Optional. Prefix to use for the script handle. Default 'pll-'.
  * @return void
  */
-function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array() ): void {
+function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array(), string $prefix = 'pll-' ): void {
 	pll_register_script( $name, $dependencies, $args );
-	wp_scripts()->enqueue( 'pll-' . $name );
+	wp_scripts()->enqueue( $prefix . $name );
 }
 
 /**
@@ -222,15 +223,15 @@ function pll_enqueue_script( string $name, array $dependencies = array(), array 
  *     @type bool      $in_footer     Optional. Whether to print the script in the footer. Default 'false'.
  *     @type string    $fetchpriority Optional. The fetch priority for the script. Default 'auto'.
  * }
+ * @param string   $prefix       Optional. Prefix to use for the script handle. Default 'pll-'.
  * @return void
  */
-function pll_register_script( string $name, array $dependencies = array(), array $args = array() ): void {
-	$handle  = 'pll-' . $name;
+function pll_register_script( string $name, array $dependencies = array(), array $args = array(), string $prefix = 'pll-' ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 	$file    = '/js/build/' . $name . $suffix . '.js';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
-	wp_register_script( $handle, $src, $dependencies, (string) $version, $args );
+	wp_register_script( $prefix . $name, $src, $dependencies, (string) $version, $args );
 }
 
 /**
@@ -240,11 +241,12 @@ function pll_register_script( string $name, array $dependencies = array(), array
  *
  * @param string   $name         The filename of the stylesheet (without the extension).
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
+ * @param string   $prefix       Optional. Prefix to use for the stylesheet handle. Default 'pll-'.
  * @return void
  */
-function pll_enqueue_style( string $name, array $dependencies = array() ): void {
+function pll_enqueue_style( string $name, array $dependencies = array(), string $prefix = 'pll-' ): void {
 	pll_register_style( $name, $dependencies );
-	wp_styles()->enqueue( 'pll-' . $name );
+	wp_styles()->enqueue( $prefix . $name );
 }
 
 /**
@@ -254,13 +256,13 @@ function pll_enqueue_style( string $name, array $dependencies = array() ): void 
  *
  * @param string   $name         The filename of the stylesheet (without the extension).
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
+ * @param string   $prefix       Optional. Prefix to use for the stylesheet handle. Default 'pll-'.
  * @return void
  */
-function pll_register_style( string $name, array $dependencies = array() ): void {
-	$handle  = 'pll-' . $name;
+function pll_register_style( string $name, array $dependencies = array(), string $prefix = 'pll-' ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 	$file    = '/css/build/' . $name . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
-	wp_register_style( $handle, $src, $dependencies, (string) $version );
+	wp_register_style( $prefix . $name, $src, $dependencies, (string) $version );
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -190,11 +190,9 @@ function pll_sanitize_ids( $ids ): array {
 /**
  * Enqueues a JS script.
  *
- * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
- *
  * @since 3.9
  *
- * @param string   $handle       The handle of the script.
+ * @param string   $name         The filename of the script (without the extension).
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
  * @param array    $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
@@ -205,19 +203,17 @@ function pll_sanitize_ids( $ids ): array {
  * }
  * @return void
  */
-function pll_enqueue_script( string $handle, array $dependencies = array(), array $args = array() ): void {
-	pll_register_script( $handle, $dependencies, $args );
-	wp_scripts()->enqueue( $handle );
+function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array() ): void {
+	pll_register_script( $name, $dependencies, $args );
+	wp_scripts()->enqueue( 'pll-' . $name );
 }
 
 /**
  * Registers a JS script.
  *
- * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
- *
  * @since 3.9
  *
- * @param string   $handle       The handle of the script.
+ * @param string   $name         The filename of the script (without the extension).
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
  * @param array    $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
@@ -228,9 +224,10 @@ function pll_enqueue_script( string $handle, array $dependencies = array(), arra
  * }
  * @return void
  */
-function pll_register_script( string $handle, array $dependencies = array(), array $args = array() ): void {
+function pll_register_script( string $name, array $dependencies = array(), array $args = array() ): void {
+	$handle  = 'pll-' . $name;
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.js';
+	$file    = '/js/build/' . $name . $suffix . '.js';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
 	wp_register_script( $handle, $src, $dependencies, (string) $version, $args );
@@ -239,33 +236,30 @@ function pll_register_script( string $handle, array $dependencies = array(), arr
 /**
  * Enqueues a CSS stylesheet.
  *
- * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
- *
  * @since 3.9
  *
- * @param string   $handle       The handle of the stylesheet.
+ * @param string   $name         The filename of the stylesheet (without the extension).
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
  * @return void
  */
-function pll_enqueue_style( string $handle, array $dependencies = array() ): void {
-	pll_register_style( $handle, $dependencies );
-	wp_styles()->enqueue( $handle );
+function pll_enqueue_style( string $name, array $dependencies = array() ): void {
+	pll_register_style( $name, $dependencies );
+	wp_styles()->enqueue( 'pll-' . $name );
 }
 
 /**
  * Registers a CSS stylesheet.
  *
- * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
- *
  * @since 3.9
  *
- * @param string   $handle       The handle of the stylesheet.
+ * @param string   $name         The filename of the stylesheet (without the extension).
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
  * @return void
  */
-function pll_register_style( string $handle, array $dependencies = array() ): void {
+function pll_register_style( string $name, array $dependencies = array() ): void {
+	$handle  = 'pll-' . $name;
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/css/build/' . substr( $handle, 4 ) . $suffix . '.css';
+	$file    = '/css/build/' . $name . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
 	wp_register_style( $handle, $src, $dependencies, (string) $version );

--- a/src/functions.php
+++ b/src/functions.php
@@ -265,7 +265,7 @@ function pll_enqueue_style( string $handle, array $dependencies = array() ): voi
  */
 function pll_register_style( string $handle, array $dependencies = array() ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.css';
+	$file    = '/css/build/' . substr( $handle, 4 ) . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
 	wp_register_style( $handle, $src, $dependencies, (string) $version );

--- a/src/functions.php
+++ b/src/functions.php
@@ -187,7 +187,7 @@ function pll_sanitize_ids( $ids ): array {
 	return array_filter( array_map( 'pll_sanitize_id', $ids ) );
 }
 
-/*
+/**
  * Enqueues a JS script.
  *
  * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
@@ -196,7 +196,7 @@ function pll_sanitize_ids( $ids ): array {
  *
  * @param string   $handle       The handle of the script.
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
- * @param array $args     {
+ * @param array    $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *
  *     @type string    $strategy      Optional. If provided, may be either 'defer' or 'async'.
@@ -219,7 +219,7 @@ function pll_enqueue_script( string $handle, array $dependencies = array(), arra
  *
  * @param string   $handle       The handle of the script.
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
- * @param array $args     {
+ * @param array    $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *
  *     @type string    $strategy      Optional. If provided, may be either 'defer' or 'async'.
@@ -233,7 +233,7 @@ function pll_register_script( string $handle, array $dependencies = array(), arr
 	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.js';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
-	wp_register_script( $handle, $src, $dependencies, $version, $args );
+	wp_register_script( $handle, $src, $dependencies, (string) $version, $args );
 }
 
 /**
@@ -268,5 +268,5 @@ function pll_register_style( string $handle, array $dependencies = array() ): vo
 	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
-	wp_register_style( $handle, $src, $dependencies, $version );
+	wp_register_style( $handle, $src, $dependencies, (string) $version );
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -190,9 +190,11 @@ function pll_sanitize_ids( $ids ): array {
 /*
  * Enqueues a JS script.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the script (without the extension).
+ * @param string   $handle       The handle of the script.
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
  * @param array $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
@@ -203,17 +205,19 @@ function pll_sanitize_ids( $ids ): array {
  * }
  * @return void
  */
-function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array() ): void {
-	pll_register_script( $name, $dependencies, $args );
-	wp_scripts()->enqueue( 'pll-' . $name );
+function pll_enqueue_script( string $handle, array $dependencies = array(), array $args = array() ): void {
+	pll_register_script( $handle, $dependencies, $args );
+	wp_scripts()->enqueue( $handle );
 }
 
 /**
  * Registers a JS script.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the script (without the extension).
+ * @param string   $handle       The handle of the script.
  * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
  * @param array $args     {
  *     Optional. An array of additional script loading strategies. Default empty array.
@@ -224,10 +228,9 @@ function pll_enqueue_script( string $name, array $dependencies = array(), array 
  * }
  * @return void
  */
-function pll_register_script( string $name, array $dependencies = array(), array $args = array() ): void {
-	$handle  = 'pll-' . $name;
+function pll_register_script( string $handle, array $dependencies = array(), array $args = array() ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/js/build/' . $name . $suffix . '.js';
+	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.js';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = filemtime( POLYLANG_ROOT_DIR . $file );
 	wp_register_script( $handle, $src, $dependencies, $version, $args );
@@ -236,30 +239,33 @@ function pll_register_script( string $name, array $dependencies = array(), array
 /**
  * Enqueues a CSS stylesheet.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string   $handle       The handle of the stylesheet.
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
  * @return void
  */
-function pll_enqueue_style( string $name, array $dependencies = array() ): void {
-	pll_register_style( $name, $dependencies );
-	wp_styles()->enqueue( 'pll-' . $name );
+function pll_enqueue_style( string $handle, array $dependencies = array() ): void {
+	pll_register_style( $handle, $dependencies );
+	wp_styles()->enqueue( $handle );
 }
 
 /**
  * Registers a CSS stylesheet.
  *
+ * The filename is evaluated by removing the first 4 characters of the handle (`pll-` or `pll_`).
+ *
  * @since 3.9
  *
- * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string   $handle       The handle of the stylesheet.
  * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
  * @return void
  */
-function pll_register_style( string $name, array $dependencies = array() ): void {
-	$handle  = 'pll-' . $name;
+function pll_register_style( string $handle, array $dependencies = array() ): void {
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-	$file    = '/js/build/' . $name . $suffix . '.css';
+	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
 	$version = filemtime( POLYLANG_ROOT_DIR . $file );
 	wp_register_style( $handle, $src, $dependencies, $version );

--- a/src/functions.php
+++ b/src/functions.php
@@ -232,7 +232,7 @@ function pll_register_script( string $handle, array $dependencies = array(), arr
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.js';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
-	$version = filemtime( POLYLANG_ROOT_DIR . $file );
+	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
 	wp_register_script( $handle, $src, $dependencies, $version, $args );
 }
 
@@ -267,6 +267,6 @@ function pll_register_style( string $handle, array $dependencies = array() ): vo
 	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 	$file    = '/js/build/' . substr( $handle, 4 ) . $suffix . '.css';
 	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
-	$version = filemtime( POLYLANG_ROOT_DIR . $file );
+	$version = WP_DEBUG ? time() : POLYLANG_VERSION;
 	wp_register_style( $handle, $src, $dependencies, $version );
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -186,3 +186,81 @@ function pll_sanitize_ids( $ids ): array {
 
 	return array_filter( array_map( 'pll_sanitize_id', $ids ) );
 }
+
+/*
+ * Enqueues a JS script.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the script (without the extension).
+ * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
+ * @param array $args     {
+ *     Optional. An array of additional script loading strategies. Default empty array.
+ *
+ *     @type string    $strategy      Optional. If provided, may be either 'defer' or 'async'.
+ *     @type bool      $in_footer     Optional. Whether to print the script in the footer. Default 'false'.
+ *     @type string    $fetchpriority Optional. The fetch priority for the script. Default 'auto'.
+ * }
+ * @return void
+ */
+function pll_enqueue_script( string $name, array $dependencies = array(), array $args = array() ): void {
+	pll_register_script( $name, $dependencies, $args );
+	wp_scripts()->enqueue( 'pll-' . $name );
+}
+
+/**
+ * Registers a JS script.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the script (without the extension).
+ * @param string[] $dependencies Optional. An array of registered script handles this script depends on.
+ * @param array $args     {
+ *     Optional. An array of additional script loading strategies. Default empty array.
+ *
+ *     @type string    $strategy      Optional. If provided, may be either 'defer' or 'async'.
+ *     @type bool      $in_footer     Optional. Whether to print the script in the footer. Default 'false'.
+ *     @type string    $fetchpriority Optional. The fetch priority for the script. Default 'auto'.
+ * }
+ * @return void
+ */
+function pll_register_script( string $name, array $dependencies = array(), array $args = array() ): void {
+	$handle  = 'pll-' . $name;
+	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	$file    = '/js/build/' . $name . $suffix . '.js';
+	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
+	$version = filemtime( POLYLANG_ROOT_DIR . $file );
+	wp_register_script( $handle, $src, $dependencies, $version, $args );
+}
+
+/**
+ * Enqueues a CSS stylesheet.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
+ * @return void
+ */
+function pll_enqueue_style( string $name, array $dependencies = array() ): void {
+	pll_register_style( $name, $dependencies );
+	wp_styles()->enqueue( 'pll-' . $name );
+}
+
+/**
+ * Registers a CSS stylesheet.
+ *
+ * @since 3.9
+ *
+ * @param string   $name         The filename of the stylesheet (without the extension).
+ * @param string[] $dependencies Optional. An array of registered stylesheet handles this stylesheet depends on.
+ * @return void
+ */
+function pll_register_style( string $name, array $dependencies = array() ): void {
+	$handle  = 'pll-' . $name;
+	$suffix  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	$file    = '/js/build/' . $name . $suffix . '.css';
+	$src     = plugins_url( $file, POLYLANG_ROOT_FILE );
+	$version = filemtime( POLYLANG_ROOT_DIR . $file );
+	wp_register_style( $handle, $src, $dependencies, $version );
+}


### PR DESCRIPTION
The goal is to avoid to repeat ourselves.

Some decisions:
- We manipulate handles (prefixed) instead of filenames.
- The version is replaced by the time when `WP_DEBUG` is `true`. We don't use `SCRIPT_DEBUG` because this variable is intentionally set to `false` by the test team. 