### PR TITLE
Readonly property cannot have a default value

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -925,12 +925,6 @@ parameters:
 			path: src/language-factory.php
 
 		-
-			message: '#^@readonly property cannot have a default value\.$#'
-			identifier: property.readOnlyByPhpDocDefaultValue
-			count: 7
-			path: src/language.php
-
-		-
 			message: '#^PHPDoc tag @var with type array\{tax\: non\-empty\-string, field\: ''count''\|''term_id''\|''term_taxonomy_id''\} is not subtype of native type array\{0\: non\-falsy\-string, tax\: non\-empty\-string, 1\: non\-empty\-string, field\: ''count''\|''term_id''\|''term_taxonomy_id'', 2\: ''count''\|''term_id''\|''term_taxonomy_id''\}\.$#'
 			identifier: varTag.nativeType
 			count: 1

--- a/src/language.php
+++ b/src/language.php
@@ -111,7 +111,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @var string
 	 */
-	public $facebook = '';
+	public $facebook;
 
 	/**
 	 * Home URL in this language.
@@ -147,7 +147,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @phpstan-var int<0, max>
 	 */
-	public $page_on_front = 0;
+	public $page_on_front;
 
 	/**
 	 * ID of the page for posts in this language (set from pll_additional_language_data filter).
@@ -156,7 +156,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @phpstan-var int<0, max>
 	 */
-	public $page_for_posts = 0;
+	public $page_for_posts;
 
 	/**
 	 * Code of the flag.
@@ -190,21 +190,21 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @var string
 	 */
-	public $custom_flag_url = '';
+	public $custom_flag_url;
 
 	/**
 	 * HTML markup of the custom flag if it exists.
 	 *
 	 * @var string
 	 */
-	public $custom_flag = '';
+	public $custom_flag;
 
 	/**
 	 * Whether or not the language is active. Default `true`.
 	 *
 	 * @var bool
 	 */
-	public $active = true;
+	public $active;
 
 	/**
 	 * List of WordPress language locales. Ex: array( 'en_GB' ).
@@ -213,7 +213,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *
 	 * @phpstan-var list<non-empty-string>
 	 */
-	public $fallbacks = array();
+	public $fallbacks;
 
 	/**
 	 * Whether the language is the default one.
@@ -293,7 +293,18 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 * @phpstan-param LanguageData $language_data
 	 */
 	public function __construct( array $language_data ) {
-		foreach ( $language_data as $prop => $value ) {
+		// Default values for optional params.
+		$defaults = array(
+			'facebook'        => '',
+			'page_on_front'   => 0,
+			'page_for_posts'  => 0,
+			'custom_flag_url' => '',
+			'custom_flag'     => '',
+			'active'          => true,
+			'fallbacks'       => array(),
+		);
+
+		foreach ( array_merge( $defaults, $language_data ) as $prop => $value ) {
 			$this->$prop = $value;
 		}
 

--- a/src/language.php
+++ b/src/language.php
@@ -34,9 +34,9 @@
  *     flag: non-empty-string,
  *     custom_flag_url?: string,
  *     custom_flag?: string,
- *     page_on_front: int<0, max>,
- *     page_for_posts: int<0, max>,
- *     active: bool,
+ *     page_on_front?: int<0, max>,
+ *     page_for_posts?: int<0, max>,
+ *     active?: bool,
  *     fallbacks?: array<non-empty-string>,
  *     is_default: bool
  * }
@@ -285,8 +285,8 @@ class PLL_Language extends PLL_Language_Deprecated {
 	 *     @type string   $custom_flag     Optional. HTML markup of the custom flag if it exists.
 	 *     @type int      $page_on_front   Optional. ID of the page on front in this language.
 	 *     @type int      $page_for_posts  Optional. ID of the page for posts in this language.
-	 *     @type bool     $active          Whether or not the language is active. Default `true`.
-	 *     @type string[] $fallbacks       List of WordPress language locales. Ex: array( 'en_GB' ).
+	 *     @type bool     $active          Optional. Whether or not the language is active. Default `true`.
+	 *     @type string[] $fallbacks       Optional. List of WordPress language locales. Ex: array( 'en_GB' ).
 	 *     @type bool     $is_default      Whether or not the language is the default one.
 	 * }
 	 *


### PR DESCRIPTION
Fix the PHPStan error.

I selected to initialize the default values in the constructor of `PLL_Language`. This could also have been done in the factory. To be discussed.