### PR TITLE
Preserve empty query string and do not override existing query param in PLL_Filter_REST_Routes::add_query_parameters.

### DIFF
--- a/src/filter-rest-routes.php
+++ b/src/filter-rest-routes.php
@@ -74,8 +74,14 @@ class PLL_Filter_REST_Routes {
 			// Sort query params to put it in the same order as the preloading middleware does
 			ksort( $query_params );
 
-			// Replace the key by the correct path with query params reordered
-			$sorted_path = add_query_arg( urlencode_deep( $query_params ), $path_parts['path'] );
+			// Replace the key by the correct path with query params reordered.
+			// Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
+			$sorted_query = build_query( urlencode_deep( $query_params ) );
+			$sorted_path  = $path_parts['path'];
+
+			if ( '' !== $sorted_query ) {
+				$sorted_path .= '?' . $sorted_query;
+			}
 
 			if ( is_array( $path ) ) {
 				$preload_paths[ $k ][0] = $sorted_path;

--- a/src/filter-rest-routes.php
+++ b/src/filter-rest-routes.php
@@ -79,11 +79,11 @@ class PLL_Filter_REST_Routes {
 			// Sort query params to put it in the same order as the preloading middleware does
 			ksort( $query_params );
 
-			// Replace the key by the correct path with query params reordered.
-			// Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
 			$sorted_query = build_query( urlencode_deep( $query_params ) );
 			$sorted_path  = $path_parts['path'];
 
+			// Replace the key by the correct path with query params reordered.
+			// Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
 			if ( '' !== $sorted_query ) {
 				$sorted_path .= '?' . $sorted_query;
 			}

--- a/src/filter-rest-routes.php
+++ b/src/filter-rest-routes.php
@@ -79,11 +79,11 @@ class PLL_Filter_REST_Routes {
 			// Sort query params to put it in the same order as the preloading middleware does
 			ksort( $query_params );
 
+            // Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
 			$sorted_query = build_query( urlencode_deep( $query_params ) );
 			$sorted_path  = $path_parts['path'];
 
 			// Replace the key by the correct path with query params reordered.
-			// Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
 			if ( '' !== $sorted_query ) {
 				$sorted_path .= '?' . $sorted_query;
 			}

--- a/src/filter-rest-routes.php
+++ b/src/filter-rest-routes.php
@@ -68,6 +68,11 @@ class PLL_Filter_REST_Routes {
 
 			// Add params in query params
 			foreach ( $args as $key => $value ) {
+				if ( array_key_exists( $key, $query_params ) ) {
+					// Don't override existing query params.
+					continue;
+				}
+
 				$query_params[ $key ] = $value;
 			}
 

--- a/src/filter-rest-routes.php
+++ b/src/filter-rest-routes.php
@@ -79,7 +79,7 @@ class PLL_Filter_REST_Routes {
 			// Sort query params to put it in the same order as the preloading middleware does
 			ksort( $query_params );
 
-            // Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
+			// Uses `build_query()` instead of `add_query_arg()` to preserve empty values as `key=`.
 			$sorted_query = build_query( urlencode_deep( $query_params ) );
 			$sorted_path  = $path_parts['path'];
 

--- a/tests/phpunit/includes/testcase-preload-paths.php
+++ b/tests/phpunit/includes/testcase-preload-paths.php
@@ -1,11 +1,10 @@
 <?php
 
 abstract class PLL_Preload_Paths_TestCase extends PLL_UnitTestCase {
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
 
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+		$factory->language->create_many( 2 );
 	}
 
 	public function set_up() {


### PR DESCRIPTION
## What?
Required by https://github.com/polylang/polylang-pro/pull/2994
There is two problem at once here:
- `add_query_arg()` is used to add parameters to preload paths, but it rewrite `key=` to `key` in the query string.
It is usually not a problem, but preload paths are cache in the browser and `apiFetch` cache middleware use `normalizePath` to canonicalize paths and then compare them. While `apiFetch` adds `key=` instead of `key` for empty string parameters. Leading to cache miss.
- `PLL_Filter_REST_Routes::add_query_parameters` override existing query parameters, leading to missed cache hit because if a path is added with `lang=` it'll be replace by `lang=current_lang_slug`.

## How?
- Use `build_query` directly instead of `add_query_arg()` to preserve `key=` queries.
- Check a parameter doesn't already exist in the preloaded path before adding it.