### PR TITLE
Add ESLint on Gutenberg blocks JS source code.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,19 +1,5 @@
 {
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
-	"ignorePatterns": [
-		"js/src/admin.js",
-		"js/src/block-editor.js",
-		"js/src/classic-editor.js",
-		"js/src/lib/**",
-		"js/src/media.js",
-		"js/src/nav-menu.js",
-		"js/src/post.js",
-		"js/src/settings.js",
-		"js/src/term.js",
-		"js/src/user.js",
-		"js/src/widgets.js",
-		"src/modules/wizard/js/languages-step.js"
-	],
 	"settings": {
 		"import/core-modules": [
 			"@wordpress/block-editor",

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,53 @@
 {
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
+	"ignorePatterns": [
+		"js/src/admin.js",
+		"js/src/block-editor.js",
+		"js/src/classic-editor.js",
+		"js/src/lib/**",
+		"js/src/media.js",
+		"js/src/nav-menu.js",
+		"js/src/post.js",
+		"js/src/settings.js",
+		"js/src/term.js",
+		"js/src/user.js",
+		"js/src/widgets.js",
+		"src/modules/wizard/js/languages-step.js"
+	],
+	"settings": {
+		"import/core-modules": [
+			"@wordpress/block-editor",
+			"@wordpress/blocks",
+			"@wordpress/components",
+			"@wordpress/element",
+			"@wordpress/hooks",
+			"@wordpress/i18n"
+		]
+	},
+	"rules": {
+		"jsdoc/no-undefined-types": [
+			1,
+			{
+				"definedTypes": [ "React", "ReactElement", "APIFetchOptions" ]
+			}
+		],
+		"camelcase": [
+			2,
+			{
+				"allow": [ "pll_block_editor_blocks_settings", "show_flags", "show_names" ],
+				"properties": "never",
+				"ignoreDestructuring": true
+			}
+		]
+	},
 	"globals": {
-		"pllDescriptionData": true
+		"pll_block_editor_blocks_settings": true,
+		"pllDefaultLanguage": true
+	},
+	"env": {
+		"browser": true
+	},
+	"parserOptions": {
+		"requireConfigFile": false
 	}
 }

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -39,12 +39,13 @@ jobs:
       with:
         filters: |
           js:
+            - 'js/src/blocks/**/*.js'
             - 'tests/e2e/**/*.{js,mjs,cjs}'
 
-    - name: Run ESLint only on e2e tests files for now...
+    - name: Run ESLint on blocks JS source files and e2e tests
       uses: polylang/actions/eslint@main
       if: ${{ steps.filter.outputs.js == 'true' }}
       with:
         do-js: true
-        js-path: './tests/e2e'
+        js-path: './js/src/blocks ./tests/e2e'
         do-style: false

--- a/js/src/blocks/language-switcher/components/switcher-container.js
+++ b/js/src/blocks/language-switcher/components/switcher-container.js
@@ -8,7 +8,10 @@ import { useContext } from '@wordpress/element';
  */
 import { LanguagesContext } from '../../languages-context';
 import { SwitcherUI } from './switcher-ui';
-import { useCurrentLanguage, useCuratedLanguages } from '@wpsyntex/polylang-react-library';
+import {
+	useCurrentLanguage,
+	useCuratedLanguages,
+} from '@wpsyntex/polylang-react-library';
 
 /**
  * Switcher container component.

--- a/js/src/blocks/navigation-language-switcher/components/navigation-switcher-container.js
+++ b/js/src/blocks/navigation-language-switcher/components/navigation-switcher-container.js
@@ -8,7 +8,10 @@ import { useContext } from '@wordpress/element';
  */
 import { LanguagesContext } from '../../languages-context';
 import { SwitcherUI } from './switcher-ui';
-import { useCurrentLanguage, useCuratedLanguages } from '@wpsyntex/polylang-react-library';
+import {
+	useCurrentLanguage,
+	useCuratedLanguages,
+} from '@wpsyntex/polylang-react-library';
 
 /**
  * Switcher container component.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,13 +84,9 @@ function configureWebpack( options ) {
 		],
 	} );
 
-	return [
-		...vanillaConfig,
-		...reactifiedConfig,
-	];
+	return [ ...vanillaConfig, ...reactifiedConfig ];
 }
 
 module.exports = ( env, options ) => {
 	return configureWebpack( options );
 };
-


### PR DESCRIPTION
Fix https://github.com/polylang/polylang-pro/issues/2999.

## What

Add ESLint on the Gutenberg blocks JS source code.

## Why

When the blocks were in Polylang Pro, ESLint was running on their source code. Since the migration to Polylang (#1811 ), this was no longer the case.

## How

- Add `.eslintrc` with rules matching those used in Polylang Pro, scoped to the blocks code
- Update the `static-analysis.yml` workflow to lint `js/src/blocks/` in addition to `tests/e2e/`
- Fix prettier issues raised by ESLint in `webpack.config.js`, `switcher-container.js`, and `navigation-language-switcher/components/navigation-switcher-container.js`