### PR TITLE
Introduce `assertSameTranslations()`

### DIFF
--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -278,4 +278,22 @@ trait PLL_UnitTestCase_Trait {
 			self::markTestSkipped( $message );
 		}
 	}
+
+	/**
+	 * Asserts that translations are identical. Backward compatibility with PLL < 3.9.
+	 *
+	 * Since PLL 3.9, translations is an object, not an array anymore.
+	 *
+	 * @param array        $expected     Expected value.
+	 * @param array|object $translations The value under test.
+	 * @return void
+	 */
+	protected function assertSameTranslations( array $expected, $translations ): void {
+		if ( version_compare( (string) preg_replace( '/-.*$/', '', POLYLANG_VERSION ), '3.9' ) >= 0 ) { // Strip -dev suffix out.
+			$this->assertInstanceOf( \stdClass::class, $translations );
+			$translations = (array) $translations;
+		}
+
+		$this->assertSameSetsWithIndex( $expected, $translations );
+	}
 }


### PR DESCRIPTION
Since https://github.com/polylang/polylang-pro/pull/2995, translations are objects instead of arrays.

This PR introduces a method that helps us assert that translations are what we expect, whichever version of PLL Pro we're dealing with.