### PR TITLE
Fix fatal error in admin bar menu when a language filter is active.

### DIFF
--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -568,7 +568,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 				array(
 					'parent' => 'languages',
 					'id'     => $lang->slug,
-					'title'  => sprintf( '%s %s', $lang->get_admin_flag( 'aria-hidden' ), esc_html( $lang->name ) ),
+					'title'  => sprintf( '%s %s', 'all' === $lang->slug ? $lang->flag : $lang->get_admin_flag( 'aria-hidden' ), esc_html( $lang->name ) ),
 					'href'   => esc_url( add_query_arg( 'lang', $lang->slug, remove_query_arg( 'paged' ) ) ),
 					'meta'   => 'all' === $lang->slug ? array() : array( 'lang' => esc_attr( $lang->get_locale( 'display' ) ) ),
 				)

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -49,6 +49,32 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->assertEquals( '/wp-admin/edit.php?lang=fr', $fr->href );
 	}
 
+	public function test_admin_bar_menu_with_filtered_language() {
+		global $wp_admin_bar;
+		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
+
+		$this->go_to( home_url( '/wp-admin/edit.php' ) );
+		$links_model            = self::$model->get_links_model();
+		$pll_admin              = new PLL_Admin( $links_model );
+		$pll_admin->init();
+		$pll_admin->filter_lang = self::$model->get_language( 'fr' );
+		$pll_admin->pref_lang   = $pll_admin->filter_lang;
+
+		_wp_admin_bar_init();
+		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+
+		// 'fr' is selected, so it should not appear in the dropdown.
+		$fr = $wp_admin_bar->get_node( 'fr' );
+		$this->assertNull( $fr );
+
+		// 'all' and 'en' should appear as dropdown items.
+		$all = $wp_admin_bar->get_node( 'all' );
+		$this->assertSame( 'languages', $all->parent );
+
+		$en = $wp_admin_bar->get_node( 'en' );
+		$this->assertSame( 'languages', $en->parent );
+	}
+
 	public function test_admin_bar_menu_should_hide() {
 		global $wp_admin_bar;
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -54,8 +54,8 @@ class Admin_Test extends PLL_UnitTestCase {
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
 
 		$this->go_to( home_url( '/wp-admin/edit.php' ) );
-		$links_model            = self::$model->get_links_model();
-		$pll_admin              = new PLL_Admin( $links_model );
+		$links_model = self::$model->get_links_model();
+		$pll_admin   = new PLL_Admin( $links_model );
 		$pll_admin->init();
 		$pll_admin->filter_lang = self::$model->get_language( 'fr' );
 		$pll_admin->pref_lang   = $pll_admin->filter_lang;


### PR DESCRIPTION
## What

A fatal error occurs when selecting a specific language in the admin bar language filter.

## Why

[PR#1857](https://github.com/polylang/polylang/pull/1857/changes#diff-ca00bee05f2fda3fe19aedf691fb3a9358cfc5301e628be2533a6e0a27814a4cL572) introduced `get_admin_flag()` on `PLL_Language`, replacing direct access to `->flag`.

In `admin_bar_menu()`, the items list includes a `stdClass` pseudo item for "Show all languages". When a specific language is selected as filter, that item is no longer skipped by the `continue` and `get_admin_flag()` is called on it  which throws a fatal error since `stdClass` has no such method.

## Fix

Check `'all' === $lang->slug` before calling `get_admin_flag()`, falling back to `$lang->flag` for the pseudo item.

This is the same convention already used in the same loop for `get_locale()`.

Adds a test covering the missing case: `admin_bar_menu` with a language filter active.