### PR TITLE
Allow to filter untranslated posts in the posts list table

### DIFF
--- a/changelog/1892
+++ b/changelog/1892
@@ -1,0 +1,1 @@
+* Allow to filter untranslated posts in the posts list table #1892

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -46,6 +46,9 @@ class PLL_Admin_Filters_Post {
 
 		// Sets the language in Tiny MCE
 		add_filter( 'tiny_mce_before_init', array( $this, 'tiny_mce_before_init' ) );
+
+		// Filter untranslated items in the posts list table.
+		add_action( 'restrict_manage_posts', array( $this, 'untranslated_dropdown' ) );
 	}
 
 	/**
@@ -262,5 +265,50 @@ class PLL_Admin_Filters_Post {
 			$mce_init['directionality'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
 		}
 		return $mce_init;
+	}
+
+	/**
+	 * Displays a dropdown for filtering unstranslated items in the posts list table.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string $post_type The post type.
+	 * @return void
+	 */
+	public function untranslated_dropdown( $post_type ) {
+		if ( ! $this->model->is_translated_post_type( $post_type ) ) {
+			return;
+		}
+
+		$languages = $this->model->get_languages_list();
+
+		foreach ( $languages as $k => $language ) {
+			$languages[ $k ] = $language->to_std_class(); // Important not to modify the language name everywhere.
+			/* translators: %s is a native language name */
+			$languages[ $k ]->name = sprintf( __( 'Untranslated in %s', 'polylang' ), $language->name );
+		}
+
+		$dropdown = new PLL_Walker_Dropdown();
+
+		$dropdown_html = $dropdown->walk(
+			array_merge(
+				array( (object) array( 'slug' => 0, 'name' => __( 'All translations statuses', 'polylang' ) ) ),
+				$languages
+			),
+			-1,
+			array(
+				'id'       => 'pll_untranslated_in',
+				'name'     => 'untranslated_in',
+				'class'    => 'postform',
+				'selected' => isset( $_GET['untranslated_in'] ) ? sanitize_key( $_GET['untranslated_in'] ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			)
+		);
+
+		printf(
+			'<label class="screen-reader-text" for="pll_untranslated_in">%s</label>',
+			esc_html__( 'Filter untranslated items', 'polylang' )
+		);
+
+		echo $dropdown_html; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }

--- a/src/crud-posts.php
+++ b/src/crud-posts.php
@@ -73,6 +73,11 @@ class PLL_CRUD_Posts {
 			add_action( 'delete_attachment', array( $this, 'delete_post' ) );
 			add_filter( 'wp_delete_file', array( $this, 'wp_delete_file' ) );
 		}
+
+		// Filter query.
+		add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
+		add_action( 'parse_query', array( $this, 'parse_query' ) );
+		add_filter( 'posts_clauses', array( $this, 'posts_clauses' ), 10, 2 );
 	}
 
 	/**
@@ -441,5 +446,76 @@ class PLL_CRUD_Posts {
 		$this->model->term->save_translations( $term->term_id, $trs );
 
 		return $tr_term_id;
+	}
+
+	/**
+	 * Add public query vars. Currently only 'untranslated in'.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string[] $qvars The array of allowed query variable names.
+	 * @return string[]
+	 */
+	public function add_query_vars( $qvars ) {
+		$qvars[] = 'untranslated_in';
+		return $qvars;
+	}
+
+	/**
+	 * Ensures filters are not suppressed when querying untranslated posts.
+	 *
+	 * @since 3.9
+	 *
+	 * @param WP_Query $query The WP_Query instance (passed by reference).
+	 * @return void
+	 */
+	public function parse_query( $query ) {
+		if ( ! empty( $query->query['untranslated_in'] ) ) {
+			unset( $query->query['suppress_filters'] );
+			unset( $query->query_vars['suppress_filters'] );
+		}
+	}
+
+	/**
+	 * Filters the WP_Query SQL clauses to remove posts:
+	 * - translated in the language queried by `unstranslated_in`.
+	 * - in the language queried by `unstranslated_in`.
+	 *
+	 * This second condition is necessary as a post not translated in any language
+	 * has no translation group.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string[] $clauses The clauses for the query.
+	 * @param WP_Query $query   The WP_Query instance (passed by reference).
+	 * @return string[]
+	 */
+	public function posts_clauses( $clauses, $query ) {
+		global $wpdb;
+
+		if ( empty( $query->query['untranslated_in'] ) ) {
+			return $clauses;
+		}
+
+		$untranslated_in = PLL()->model->languages->get( $query->query['untranslated_in'] );
+
+		if ( empty( $untranslated_in ) ) {
+			return $clauses;
+		}
+
+		$clauses['where'] .= $wpdb->prepare(
+			" AND {$wpdb->posts}.ID NOT IN (
+				SELECT {$wpdb->posts}.ID FROM {$wpdb->posts}
+					LEFT JOIN {$wpdb->term_relationships} AS pllutr ON {$wpdb->posts}.ID = pllutr.object_id
+					INNER JOIN {$wpdb->term_taxonomy} AS pllutt ON pllutt.term_taxonomy_id = pllutr.term_taxonomy_id
+					WHERE ( pllutr.term_taxonomy_id IN (%d) )
+					OR ( pllutt.taxonomy = 'post_translations' AND pllutt.description LIKE %s )
+			)",
+			$untranslated_in->term_id,
+			'%' . $wpdb->esc_like( $untranslated_in->slug ) . '%'
+		);
+
+
+		return $clauses;
 	}
 }

--- a/src/crud-posts.php
+++ b/src/crud-posts.php
@@ -503,18 +503,29 @@ class PLL_CRUD_Posts {
 			return $clauses;
 		}
 
+		$tt_id = $untranslated_in->get_tax_prop( 'language', 'term_taxonomy_id' );
+
 		$clauses['where'] .= $wpdb->prepare(
 			" AND {$wpdb->posts}.ID NOT IN (
-				SELECT {$wpdb->posts}.ID FROM {$wpdb->posts}
-					LEFT JOIN {$wpdb->term_relationships} AS pllutr ON {$wpdb->posts}.ID = pllutr.object_id
-					INNER JOIN {$wpdb->term_taxonomy} AS pllutt ON pllutt.term_taxonomy_id = pllutr.term_taxonomy_id
-					WHERE ( pllutr.term_taxonomy_id IN (%d) )
-					OR ( pllutt.taxonomy = 'post_translations' AND pllutt.description LIKE %s )
+				SELECT pllutr.object_id
+				FROM {$wpdb->term_relationships} AS pllutr
+				WHERE pllutr.term_taxonomy_id = %d
 			)",
-			$untranslated_in->term_id,
-			'%' . $wpdb->esc_like( $untranslated_in->slug ) . '%'
+			$tt_id
 		);
 
+		$clauses['where'] .= $wpdb->prepare(
+			" AND {$wpdb->posts}.ID NOT IN (
+				SELECT pllutr1.object_id
+				FROM {$wpdb->term_relationships} AS pllutr1
+				JOIN {$wpdb->term_taxonomy} AS pllutt ON pllutt.term_taxonomy_id = pllutr1.term_taxonomy_id
+				JOIN {$wpdb->term_relationships} AS pllutr2 ON pllutr2.term_taxonomy_id = pllutt.term_taxonomy_id
+				JOIN {$wpdb->term_relationships} AS pllutr3 ON pllutr3.object_id = pllutr2.object_id
+				WHERE pllutt.taxonomy = 'post_translations'
+				AND pllutr3.term_taxonomy_id = %d
+			)",
+			$tt_id
+		);
 
 		return $clauses;
 	}

--- a/tests/phpunit/tests/test-crud-posts.php
+++ b/tests/phpunit/tests/test-crud-posts.php
@@ -254,8 +254,6 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 	 * @see https://github.com/polylang/polylang-pro/issues/2249.
 	 */
 	public function test_save_post_when_no_default_category_set() {
-		$this->pll_admin->posts = new PLL_CRUD_Posts( $this->pll_admin );
-
 		// Create an english category.
 		$en_cat = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'English category' ) );
 		$this->pll_admin->model->term->set_language( $en_cat, 'en' );
@@ -276,5 +274,21 @@ class CRUD_Posts_Test extends PLL_UnitTestCase {
 		edit_post();
 
 		$this->assertEmpty( wp_get_post_categories( $post->ID ) );
+	}
+
+	public function test_untranslated_in_query() {
+		$only_en    = self::factory()->post->create( array( 'lang' => 'en' ) );
+		$translated = self::factory()->post->create_translated( array( 'lang' => 'en' ), array( 'lang' => 'fr' ) );
+
+		self::factory()->post->create( array( 'lang' => 'fr' ) ); // Add a post only in French.
+
+		$post_ids = wp_list_pluck( get_posts( array( 'untranslated_in' => 'fr' ) ), 'ID' );
+		$this->assertSameSets( array( $only_en ), $post_ids );
+
+		$post_ids = wp_list_pluck( get_posts( array( 'lang' => 'en', 'untranslated_in' => 'de' ) ), 'ID' );
+		$this->assertSameSets( array( $only_en, $translated['en'] ), $post_ids );
+
+		$post_ids = wp_list_pluck( get_posts( array( 'lang' => 'en', 'untranslated_in' => 'en' ) ), 'ID' );
+		$this->assertEmpty( $post_ids );
 	}
 }

--- a/tests/phpunit/tests/test-posts-list.php
+++ b/tests/phpunit/tests/test-posts-list.php
@@ -1,0 +1,60 @@
+<?php
+
+class Posts_List_Test extends PLL_UnitTestCase {
+
+	protected static $en;
+	protected static $fr;
+	protected static $posts;
+
+	/**
+	 * @param PLL_UnitTest_Factory $factory
+	 * @return void
+	 */
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
+
+		$factory->language->create_many( 3 );
+
+		self::$en    = self::factory()->post->create( array( 'lang' => 'en' ) );
+		self::$fr    = self::factory()->post->create( array( 'lang' => 'fr' ) );
+		self::$posts = self::factory()->post->create_translated( array( 'lang' => 'en' ), array( 'lang' => 'fr' ) );
+	}
+
+	public function test_filtered_list_table() {
+		new PLL_Context_Admin();
+
+		$_GET['untranslated_in'] = 'fr';
+		$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit.php' ) );
+		$list_table->prepare_items();
+		$GLOBALS['post'] = $GLOBALS['wp_the_query']->post; // Needed by touch_time.
+
+		ob_start();
+		$list_table->display();
+		$html = ob_get_clean();
+		$doc  = new DomDocument();
+		$doc->loadHTML( $html );
+		$xpath = new DOMXpath( $doc );
+
+		// The dropdown.
+		$options = $xpath->query( './/select[@name="untranslated_in"]/option', $doc );
+		$this->assertSame( 4, $options->length, 'Expected the <select> tag to contain 4 <option> tags.' );
+		$this->assertSameSets(
+			array( '0', 'en', 'fr', 'de' ),
+			array(
+				$options->item( 0 )->getAttribute( 'value' ),
+				$options->item( 1 )->getAttribute( 'value' ),
+				$options->item( 2 )->getAttribute( 'value' ),
+				$options->item( 3 )->getAttribute( 'value' ),
+			)
+		);
+
+		// The selected item.
+		$selected = $xpath->query( './/select[@name="untranslated_in"]/option[@selected="selected"]', $doc );
+		$this->assertEquals( 'fr', $selected->item( 0 )->getAttribute( 'value' ) );
+
+		// The list of posts.
+		$rows = $xpath->query( '//tbody/tr', $doc );
+		$this->assertSame( 1, $rows->length, 'The list table must contain 1 post' );
+		$this->assertSame( 'post-' . self::$en, $rows->item( 0 )->getAttribute( 'id' ) );
+	}
+}


### PR DESCRIPTION
This PR adds a new filter on top of the posts list table allowing to filter the list for untranslated posts in a a given language.
In order to achieve that, a new query var `untranslated_in` is added to `WP_Query`. As we need a custom sql clause, this requires to remove the `suppress_filters` query var if present in the query (generally when using `get_posts()`).  