### PR TITLE
Fix e2e tests with WP 7.0

### DIFF
--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -57,50 +57,57 @@ test.describe.serial(
 		test( 'Block should be displayed in the editor', async ( {
 			admin,
 			page,
+			editor,
 		} ) => {
-			// Go to the Navigation Editor.
-			await admin.visitSiteEditor();
-			await page.getByRole( 'button', { name: 'Navigation' } ).click();
-			await page.getByRole( 'button', { name: 'Actions' } ).click();
-			await page.getByRole( 'menuitem', { name: 'Edit' } ).click();
+			await navigateToNavigationEditor( admin, page, navigation );
 
-			// Check the editor opens.
-			await expect(
-				page.getByRole( 'heading', { name: 'Navigation' } )
-			).toBeVisible();
+			// Navigation editor: Add page (WP 7) or Add block appender (WP 6.9) → Link UI → Browse all.
+			const navigationBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Navigation',
+			} );
+			await navigationBlock.click();
 
-			// Add the Navigation Language Switcher block.
-			await page.locator( '.editor-visual-editor' ).click();
+			const navInserter = navigationBlock
+				.getByRole( 'button', { name: 'Add page' } )
+				.or(
+					navigationBlock.getByRole( 'button', { name: 'Add block' } )
+				);
+			await expect( navInserter ).toBeVisible();
+			await navInserter.click();
+
 			await page
-				.locator( 'iframe[name="editor-canvas"]' )
-				.contentFrame()
-				.locator( 'html' )
-				.click();
-			await page
-				.locator( 'iframe[name="editor-canvas"]' )
-				.contentFrame()
 				.getByRole( 'button', { name: 'Add block' } )
+				.filter( { hasText: 'Add block' } )
+				.first()
 				.click();
-			await page.getByText( 'Add block' ).click();
-			await page
-				.getByRole( 'button', { name: 'Browse all. This will open' } )
+
+			// QuickInserter only lists a few blocks; Polylang's block is not among them.
+			const addBlockDialog = page.getByRole( 'dialog', {
+				name: 'Add block',
+			} );
+			await expect( addBlockDialog ).toBeVisible();
+
+			await addBlockDialog
+				.getByRole( 'button', {
+					name: 'Browse all. This will open the main inserter panel in the editor toolbar.',
+				} )
 				.click();
-			await page.getByRole( 'searchbox', { name: 'Search' } ).click();
-			await page
+
+			const blockLibrary = page.getByRole( 'region', {
+				name: 'Block Library',
+			} );
+			await blockLibrary
 				.getByRole( 'searchbox', { name: 'Search' } )
 				.fill( 'language' );
-			await page
+			await blockLibrary
 				.getByRole( 'option', { name: 'Navigation Language Switcher' } )
 				.click();
 
 			// Check the Navigation Language Switcher block is displayed in the canvas.
 			await expect(
-				page
-					.locator( 'iframe[name="editor-canvas"]' )
-					.contentFrame()
-					.getByRole( 'document', {
-						name: 'Block: Navigation Language',
-					} )
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Navigation Language',
+				} )
 			).toBeVisible();
 
 			// Save the changes for next tests.
@@ -119,8 +126,8 @@ test.describe.serial(
 		 *     - Edit the Navigation Language Switcher block settings to dropdown.
 		 *     - Ensure the dropdown is displayed in the editor.
 		 */
-		test( 'Block in dropdown mode', async ( { page } ) => {
-			await navigateToNavigationEditor( page, navigation );
+		test( 'Block in dropdown mode', async ( { admin, page } ) => {
+			await navigateToNavigationEditor( admin, page, navigation );
 
 			// Edit the Navigation Language Switcher block settings to dropdown and add language names and flags.
 			await page
@@ -202,8 +209,8 @@ test.describe.serial(
 		 *     - Edit the Navigation Language Switcher block settings to list.
 		 *     - Ensure the list is displayed in the editor.
 		 */
-		test( 'Block in list mode', async ( { page } ) => {
-			await navigateToNavigationEditor( page, navigation );
+		test( 'Block in list mode', async ( { admin, page } ) => {
+			await navigateToNavigationEditor( admin, page, navigation );
 
 			// Edit the Navigation Language Switcher block settings to dropdown and add language names and flags.
 			await selectNavigationLanguageSwitcherBlock( page );
@@ -286,8 +293,11 @@ test.describe.serial(
 		 *     - Ensure the hides languages with no translation setting is displayed correctly.
 		 *     - Ensure settings (forces link to front page, hides the current language, hides languages with no translation) are dispal correctly.
 		 */
-		test( 'Block advanced settings can be edited', async ( { page } ) => {
-			await navigateToNavigationEditor( page, navigation );
+		test( 'Block advanced settings can be edited', async ( {
+			admin,
+			page,
+		} ) => {
+			await navigateToNavigationEditor( admin, page, navigation );
 
 			// Edit the Navigation Language Switcher block settings to forces link to front page.
 			await selectNavigationLanguageSwitcherBlock( page );
@@ -359,15 +369,22 @@ const getNavigationLanguageSwitcherBlockLocator = async ( page ) => {
 };
 
 /**
- * Navigates to the Navigation editor page.
+ * Navigates to the Navigation editor page and waits for the canvas to be ready.
  *
+ * @param {Object} admin      The admin object.
  * @param {Page}   page       The page object.
- * @param {Object} navigation The navigation object with id property.
+ * @param {Object} navigation The navigation object with id and title properties.
  */
-const navigateToNavigationEditor = async ( page, navigation ) => {
-	await page.goto(
-		`wp-admin/site-editor.php?p=/wp_navigation/${ navigation.id }&canvas=edit`
-	);
+const navigateToNavigationEditor = async ( admin, page, navigation ) => {
+	await admin.visitSiteEditor( {
+		postId: navigation.id,
+		postType: 'wp_navigation',
+		canvas: 'edit',
+	} );
+
+	await expect(
+		page.locator( 'iframe[name="editor-canvas"]' )
+	).toBeVisible();
 };
 
 /**

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -77,7 +77,6 @@ test.describe.serial(
 
 			await page
 				.getByRole( 'button', { name: 'Add block' } )
-				.filter( { hasText: 'Add block' } )
 				.first()
 				.click();
 

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -70,7 +70,7 @@ test.describe.serial(
 			const navInserter = navigationBlock
 				.getByRole( 'button', { name: 'Add page' } )
 				.or(
-					navigationBlock.getByRole( 'button', { name: 'Add block' } )
+					navigationBlock.getByRole( 'button', { name: 'Add block' } ) // Fallback for WP 6.9
 				);
 			await expect( navInserter ).toBeVisible();
 			await navInserter.click();

--- a/tests/e2e/specs/widgets/language-switcher-widget.spec.js
+++ b/tests/e2e/specs/widgets/language-switcher-widget.spec.js
@@ -43,6 +43,14 @@ test.describe(
 			await resetAllSettings( requestUtils );
 		} );
 
+		test.beforeEach( async ( { admin, editor } ) => {
+			await admin.visitAdminPage( 'widgets.php' );
+
+			await editor.setPreferences( 'core/edit-widgets', {
+				welcomeGuide: false,
+			} );
+		} );
+
 		/**
 		 * Ensures the language switcher block can be added in the widget editor without crashing and displays the languages.
 		 *
@@ -57,25 +65,22 @@ test.describe(
 		 *     - Verify the block preview lists English and French.
 		 */
 		test( 'Block can be added in a widget area and displays languages', async ( {
-			admin,
 			page,
 		} ) => {
-			// Navigate to widget editor.
-			await admin.visitAdminPage( 'widgets.php' );
-
-			// Wait for the block editor to load.
-			await page.waitForSelector( '.edit-widgets-header' );
-
-			// Open Block Inserter.
 			await page
-				.getByRole( 'button', { name: 'Block Inserter' } )
+				.getByRole( 'toolbar', { name: 'Document tools' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 
-			// Search for the Language Switcher block.
-			await page
+			const blockLibrary = page.getByRole( 'region', {
+				name: 'Block Library',
+			} );
+			await expect( blockLibrary ).toBeVisible();
+
+			await blockLibrary
 				.getByRole( 'searchbox', { name: 'Search' } )
 				.fill( 'Language Switcher' );
-			await page
+			await blockLibrary
 				.getByRole( 'option', {
 					name: 'Language Switcher',
 					exact: true,

--- a/tests/e2e/specs/widgets/language-switcher-widget.spec.js
+++ b/tests/e2e/specs/widgets/language-switcher-widget.spec.js
@@ -43,12 +43,8 @@ test.describe(
 			await resetAllSettings( requestUtils );
 		} );
 
-		test.beforeEach( async ( { admin, editor } ) => {
+		test.beforeEach( async ( { admin } ) => {
 			await admin.visitAdminPage( 'widgets.php' );
-
-			await editor.setPreferences( 'core/edit-widgets', {
-				welcomeGuide: false,
-			} );
 		} );
 
 		/**


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang/actions/runs/26281607744/job/77358916925

## How?
Rework user workflows and avoid hardcoded selectors.

> [!WARNING]
> Requires https://github.com/polylang/e2e-test-utils/pull/9