### PR TITLE
Fix fatal error when `$_REQUEST['lang']` is a locale in AJAX context.

### DIFF
--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -936,8 +936,8 @@ class Languages {
 	 * @param string $value The value to check.
 	 * @return bool
 	 */
-	public static function is_locale( string $value ): bool {
-		return (bool) preg_match( '#' . self::LOCALE_PATTERN . '#', $value );
+	public static function is_locale( $value ): bool {
+		return is_string( $value ) && (bool) preg_match( '#' . self::LOCALE_PATTERN . '#', $value );
 	}
 
 	/**

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -929,6 +929,18 @@ class Languages {
 	}
 
 	/**
+	 * Checks if a given value matches the locale format.
+	 *
+	 * @since 3.8.5
+	 *
+	 * @param string $value The value to check.
+	 * @return bool
+	 */
+	public static function is_locale( string $value ): bool {
+		return (bool) preg_match( '#' . self::LOCALE_PATTERN . '#', $value );
+	}
+
+	/**
 	 * Builds the language metas into an array and serializes it, to be stored in the term description.
 	 *
 	 * @since 3.4
@@ -1037,7 +1049,7 @@ class Languages {
 		$errors = new WP_Error();
 
 		// Validate locale with the same pattern as WP 4.3. See #28303.
-		if ( empty( $args['locale'] ) || ! preg_match( '#' . self::LOCALE_PATTERN . '#', $args['locale'], $matches ) ) {
+		if ( empty( $args['locale'] ) || ! self::is_locale( $args['locale'] ) ) {
 			$errors->add( 'pll_invalid_locale', __( 'Enter a valid WordPress locale', 'polylang' ) );
 		}
 

--- a/src/frontend/choose-lang-content.php
+++ b/src/frontend/choose-lang-content.php
@@ -51,7 +51,6 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	protected function get_current_language() {
 		global $wp_query;
 		if ( ! isset( $wp_query ) ) {
-			// `$wp_query` is not yet initialized before the query runs (e.g. during `plugins_loaded` in AJAX context).
 			return false;
 		}
 

--- a/src/frontend/choose-lang-content.php
+++ b/src/frontend/choose-lang-content.php
@@ -49,6 +49,12 @@ class PLL_Choose_Lang_Content extends PLL_Choose_Lang {
 	 * @return PLL_Language|false
 	 */
 	protected function get_current_language() {
+		global $wp_query;
+		if ( ! isset( $wp_query ) ) {
+			// `$wp_query` is not yet initialized before the query runs (e.g. during `plugins_loaded` in AJAX context).
+			return false;
+		}
+
 		// No language set for 404.
 		if ( is_404() || ( is_attachment() && ! $this->options['media_support'] ) ) {
 			return false;

--- a/src/frontend/choose-lang.php
+++ b/src/frontend/choose-lang.php
@@ -3,6 +3,8 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Model\Languages;
+
 /**
  * Base class to choose the language
  *
@@ -62,11 +64,11 @@ abstract class PLL_Choose_Lang {
 	public function init() {
 		if ( Polylang::is_ajax_on_front() || ! wp_using_themes() ) {
 			$lang = isset( $_REQUEST['lang'] ) && is_string( $_REQUEST['lang'] ) ? $_REQUEST['lang'] : ''; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			// Use `sanitize_locale_name` for locale-format values (e.g. `en_GB`) to preserve case, `sanitize_key` otherwise.
+			// Use Languages locale pattern for locale-format values (e.g. `en_GB`), `sanitize_key` otherwise.
 			$this->set_language(
 				empty( $lang )
 					? $this->get_preferred_language()
-					: $this->model->get_language( str_contains( $lang, '_' ) ? sanitize_locale_name( $lang ) : sanitize_key( $lang ) )
+					: $this->model->get_language( Languages::is_locale( $lang ) ? $lang : sanitize_key( $lang ) )
 			);
 		}
 

--- a/src/frontend/choose-lang.php
+++ b/src/frontend/choose-lang.php
@@ -61,7 +61,13 @@ abstract class PLL_Choose_Lang {
 	 */
 	public function init() {
 		if ( Polylang::is_ajax_on_front() || ! wp_using_themes() ) {
-			$this->set_language( empty( $_REQUEST['lang'] ) ? $this->get_preferred_language() : $this->model->get_language( sanitize_key( $_REQUEST['lang'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			$lang = isset( $_REQUEST['lang'] ) && is_string( $_REQUEST['lang'] ) ? $_REQUEST['lang'] : ''; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			// Use `sanitize_locale_name` for locale-format values (e.g. `en_GB`) to preserve case, `sanitize_key` otherwise.
+			$this->set_language(
+				empty( $lang )
+					? $this->get_preferred_language()
+					: $this->model->get_language( str_contains( $lang, '_' ) ? sanitize_locale_name( $lang ) : sanitize_key( $lang ) )
+			);
 		}
 
 		add_action( 'pre_comment_on_post', array( $this, 'pre_comment_on_post' ) ); // sets the language of comment

--- a/src/frontend/choose-lang.php
+++ b/src/frontend/choose-lang.php
@@ -62,19 +62,20 @@ abstract class PLL_Choose_Lang {
 	 * @return void
 	 */
 	public function init() {
-		if ( Polylang::is_ajax_on_front() || ! wp_using_themes() ) {
-			$lang = isset( $_REQUEST['lang'] ) && is_string( $_REQUEST['lang'] ) ? $_REQUEST['lang'] : ''; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			// Use Languages locale pattern for locale-format values (e.g. `en_GB`), `sanitize_key` otherwise.
-			$this->set_language(
-				empty( $lang )
-					? $this->get_preferred_language()
-					: $this->model->get_language( Languages::is_locale( $lang ) ? $lang : sanitize_key( $lang ) )
-			);
+		add_action( 'pre_comment_on_post', array( $this, 'pre_comment_on_post' ) ); // sets the language of comment.
+		add_action( 'parse_query', array( $this, 'parse_main_query' ), 2 ); // sets the language in special cases.
+		add_action( 'wp', array( $this, 'maybe_setcookie' ), 7 );
+
+		if ( ! Polylang::is_ajax_on_front() && wp_using_themes() ) {
+			return;
 		}
 
-		add_action( 'pre_comment_on_post', array( $this, 'pre_comment_on_post' ) ); // sets the language of comment
-		add_action( 'parse_query', array( $this, 'parse_main_query' ), 2 ); // sets the language in special cases
-		add_action( 'wp', array( $this, 'maybe_setcookie' ), 7 );
+		if ( isset( $_REQUEST['lang'] ) && is_string( $_REQUEST['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// Let's accept either WordPress locales or language codes.
+			$lang = $this->model->languages->get( Languages::is_locale( $_REQUEST['lang'] ) ? $_REQUEST['lang'] : sanitize_key( $_REQUEST['lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+
+		$this->set_language( empty( $lang ) ? $this->get_preferred_language() : $lang );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-copied-functions.php
+++ b/tests/phpunit/tests/test-copied-functions.php
@@ -15,10 +15,6 @@ class Copied_Functions_Test extends PHPUnit_Framework_TestCase {
 		$this->check_method( 'cc6308276c4e0553f75da06592f881cb', '6.2', 'wp_admin_bar_search_menu' );
 	}
 
-	public function test_sanitize_locale_name() {
-		$this->check_method( 'c095fac87bb4632618334ab540b9e87d', '6.2.1', 'sanitize_locale_name' );
-	}
-
 	/**
 	 * Monitors PLL_Term_Slug::maybe_get_parent_suffix()
 	 */


### PR DESCRIPTION
See https://secure.helpscout.net/conversation/3321243736/40542#thread-10167215994.

## What

Fix a fatal error triggered when an AJAX front request includes a locale-format `lang` parameter (e.g. `en_GB` instead of slug `en`).

## Why

`sanitize_key()` lowercases the value, turning `en_GB` into `en_gb`. `get_language('en_gb')` returns `false`, causing `set_language(false)` to fall through to `get_current_language()`, which calls `get_query_var()` on a `$wp_query` not yet initialized at `plugins_loaded` in AJAX context.

Observed with the Goldish theme, whose live search JS sends `lang=get_locale()` in its AJAX requests.

## Fix

* `Languages`: add an `is_locale()` static method and use it in `validate_lang()` to replace the inline `preg_match` call.
* `PLL_Choose_Lang::init()`: use `Languages::is_locale()` to detect locale-format values and safely preserve their case (handles `en_GB`), otherwise fallback to `sanitize_key()` as before. Also adds an `isset()` and `is_string()` guard to satisfy PHPStan.
* `PLL_Choose_Lang_Content::get_current_language()`: add a guard on `$wp_query` following the same pattern as WP core conditional tags (`is_404()` etc.), as a safety net for any code path calling this method before the query runs.
* `test-copied-functions.php`: remove `test_sanitize_locale_name()`. `sanitize_locale_name` is native since WP 6.2.1 and we require WP 6.5, so there is no need to monitor it anymore.