### PR TITLE
Add views for languages in posts list table

### DIFF
--- a/changelog/1899
+++ b/changelog/1899
@@ -1,0 +1,1 @@
+* Add views for languages in the posts list table #1899

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -297,6 +297,9 @@ class PLL_Admin_Filters_Post {
 				(int) $this->model->count_posts( $language, $q )
 			);
 		}
+
+		$views['all'] = str_replace( 'edit.php?', 'edit.php?lang=all&', $views['all'] );
+
 		return $views;
 	}
 }

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -46,6 +46,11 @@ class PLL_Admin_Filters_Post {
 
 		// Sets the language in Tiny MCE
 		add_filter( 'tiny_mce_before_init', array( $this, 'tiny_mce_before_init' ) );
+
+		// Languages views in post list tables.
+		foreach ( $this->model->get_translated_post_types() as $post_type ) {
+			add_filter( "views_edit-{$post_type}", array( $this, 'views_edit_post' ) );
+		}
 	}
 
 	/**
@@ -262,5 +267,36 @@ class PLL_Admin_Filters_Post {
 			$mce_init['directionality'] = $this->curlang->is_rtl ? 'rtl' : 'ltr';
 		}
 		return $mce_init;
+	}
+
+	/**
+	 * Add languages filter views to the list of views available for the post list table.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string[] $views Array of available list table views.
+	 */
+	public function views_edit_post( $views ) {
+		global $typenow;
+
+		if ( empty( $typenow ) ) {
+			return $views;
+		}
+
+		$q = array(
+			'post_type'   => $typenow,
+			'post_status' => 'any',
+		);
+
+		foreach ( $this->model->languages->get_list() as $language ) {
+			$views[ $language->slug ] = sprintf(
+				'<a href="%s" %s>%s <span class="count">(%d)</span></a>',
+				esc_url( add_query_arg( 'lang', $language->slug, remove_query_arg( 'paged' ) ) ),
+				! empty( $this->curlang ) && $this->curlang->slug === $language->slug ? 'class="current" aria-current="page"' : '',
+				esc_html( $language->name ),
+				(int) $this->model->count_posts( $language, $q )
+			);
+		}
+		return $views;
 	}
 }

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -275,6 +275,7 @@ class PLL_Admin_Filters_Post {
 	 * @since 3.9
 	 *
 	 * @param string[] $views Array of available list table views.
+	 * @return string[]
 	 */
 	public function views_edit_post( $views ) {
 		global $typenow;

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -348,11 +348,11 @@ class PLL_Admin_Filters_Post {
 
 		foreach ( $this->model->languages->get_list() as $language ) {
 			$views[ $language->slug ] = sprintf(
-				'<a href="%s" %s>%s <span class="count">(%d)</span></a>',
+				'<a href="%s" %s>%s <span class="count">(%s)</span></a>',
 				esc_url( add_query_arg( 'lang', $language->slug, remove_query_arg( 'paged' ) ) ),
 				! empty( $this->curlang ) && $this->curlang->slug === $language->slug ? 'class="current" aria-current="page"' : '',
 				esc_html( $language->name ),
-				(int) $this->model->count_posts( $language, $q )
+				number_format_i18n( (int) $this->model->count_posts( $language, $q ) )
 			);
 		}
 

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -332,6 +332,7 @@ class PLL_Admin_Filters_Post {
 	 * @since 3.9
 	 *
 	 * @param string[] $views Array of available list table views.
+	 * @return string[]
 	 */
 	public function views_edit_post( $views ) {
 		global $typenow;

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -354,6 +354,9 @@ class PLL_Admin_Filters_Post {
 				(int) $this->model->count_posts( $language, $q )
 			);
 		}
+
+		$views['all'] = str_replace( 'edit.php?', 'edit.php?lang=all&', $views['all'] );
+
 		return $views;
 	}
 }

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -49,6 +49,11 @@ class PLL_Admin_Filters_Post {
 
 		// Filter untranslated items in the posts list table.
 		add_action( 'restrict_manage_posts', array( $this, 'untranslated_dropdown' ) );
+
+		// Languages views in post list tables.
+		foreach ( $this->model->get_translated_post_types() as $post_type ) {
+			add_filter( "views_edit-{$post_type}", array( $this, 'views_edit_post' ) );
+		}
 	}
 
 	/**
@@ -319,5 +324,36 @@ class PLL_Admin_Filters_Post {
 		);
 
 		echo $dropdown_html; // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+
+	/**
+	 * Add languages filter views to the list of views available for the post list table.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string[] $views Array of available list table views.
+	 */
+	public function views_edit_post( $views ) {
+		global $typenow;
+
+		if ( empty( $typenow ) ) {
+			return $views;
+		}
+
+		$q = array(
+			'post_type'   => $typenow,
+			'post_status' => 'any',
+		);
+
+		foreach ( $this->model->languages->get_list() as $language ) {
+			$views[ $language->slug ] = sprintf(
+				'<a href="%s" %s>%s <span class="count">(%d)</span></a>',
+				esc_url( add_query_arg( 'lang', $language->slug, remove_query_arg( 'paged' ) ) ),
+				! empty( $this->curlang ) && $this->curlang->slug === $language->slug ? 'class="current" aria-current="page"' : '',
+				esc_html( $language->name ),
+				(int) $this->model->count_posts( $language, $q )
+			);
+		}
+		return $views;
 	}
 }

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -52,7 +52,7 @@ class PLL_Admin_Filters_Post {
 
 		// Languages views in post list tables.
 		foreach ( $this->model->get_translated_post_types() as $post_type ) {
-			add_filter( "views_edit-{$post_type}", array( $this, 'views_edit_post' ) );
+			add_filter( "views_edit-{$post_type}", array( $this, 'add_per_language_edit_views' ) );
 		}
 	}
 
@@ -334,7 +334,7 @@ class PLL_Admin_Filters_Post {
 	 * @param string[] $views Array of available list table views.
 	 * @return string[]
 	 */
-	public function views_edit_post( $views ) {
+	public function add_per_language_edit_views( $views ) {
 		global $typenow;
 
 		if ( empty( $typenow ) ) {

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -356,7 +356,9 @@ class PLL_Admin_Filters_Post {
 			);
 		}
 
-		$views['all'] = str_replace( 'edit.php?', 'edit.php?lang=all&', $views['all'] );
+		if ( isset( $views['all'] ) ) { // In case a filter removes this key.
+			$views['all'] = str_replace( 'edit.php?', 'edit.php?lang=all&', $views['all'] );
+		}
 
 		return $views;
 	}

--- a/src/model.php
+++ b/src/model.php
@@ -373,6 +373,7 @@ class PLL_Model {
 			$join    = $this->post->join_clause();
 			$where   = sprintf( " WHERE {$wpdb->posts}.post_type IN ( '%s' )", implode( "', '", esc_sql( $q['post_type'] ) ) );
 			$where  .= $this->post->where_clause( $this->languages->get_list() );
+			$where  .= " AND post_status != 'auto-draft'";
 			$groupby = ' GROUP BY pll_tr.term_taxonomy_id, post_status';
 
 			if ( ! empty( $q['m'] ) ) {
@@ -433,7 +434,7 @@ class PLL_Model {
 		$term_taxonomy_id = $lang->get_tax_prop( 'language', 'term_taxonomy_id' );
 
 		if ( 'any' === $q['post_status'] ) {
-			return (int) array_sum( $counts[ $term_taxonomy_id ] );
+			return isset( $counts[ $term_taxonomy_id ] ) ? (int) array_sum( $counts[ $term_taxonomy_id ] ) : 0;
 		}
 
 		return $counts[ $term_taxonomy_id ][ $q['post_status'] ] ?? 0;

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -503,6 +503,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	}
 
 	private function register_post_type_for_dropdown_test( array $args ): void {
+		self::$model->cache->clean();
+
 		if ( in_array( 'translated', $args, true ) ) {
 			add_filter(
 				'pll_get_post_types',


### PR DESCRIPTION
Closes #1057

This PR adds views for languages with post count above the posts list table. This counts all posts whatever the status.
The language views can be combined with the status views already available.
The WordPress 'All' view resets the languages views.

This feature somewhat duplicates the admin language filter available in the admin bar for the posts lists screens with the additional information of the posts count. This means that unlike WordPress status views, the language views are persistent (stored in DB).

This may help users on wp.com who don't have access to the admin bar.

Here is how it looks like:
<img width="664" height="277" alt="image" src="https://github.com/user-attachments/assets/fc6ff07f-3936-47b7-a98f-a09780c8a6af" />
