### PR TITLE
[Language switcher rework] Add tests for base classes

### DIFF
--- a/tests/phpunit/tests/Switcher/TestCase.php
+++ b/tests/phpunit/tests/Switcher/TestCase.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Switcher;
+
+use DOMXpath;
+use PLL_Model;
+use DOMDocument;
+use PLL_Frontend;
+use PLL_UnitTestCase;
+use PLL_UnitTest_Factory;
+use WP_Syntex\Polylang\Switcher\Switcher;
+use WP_Syntex\Polylang\Switcher\Settings\Settings;
+
+abstract class TestCase extends PLL_UnitTestCase {
+	protected static $posts;
+	protected $pll_options;
+
+	/**
+	 * @param PLL_UnitTest_Factory $factory
+	 * @return void
+	 */
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		parent::pllSetUpBeforeClass( $factory );
+
+		$factory->language->create_many( 3 );
+
+		// Create posts to not trigger 'hide_if_empty'.
+		self::$posts = self::factory()->post->create_translated(
+			array( 'lang' => 'en' ),
+			array( 'lang' => 'fr' )
+		);
+
+		self::require_api();
+	}
+
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		parent::wpTearDownAfterClass();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->pll_options = $this->create_options(
+			array(
+				'default_lang' => 'en',
+			)
+		);
+	}
+
+	protected function init_frontend(): PLL_Frontend {
+		$this->pll_model     = new PLL_Model( $this->pll_options );
+		$links_model         = $this->pll_model->get_links_model();
+		$GLOBALS['polylang'] = new PLL_Frontend( $links_model );
+		$GLOBALS['polylang']->init();
+		return $GLOBALS['polylang'];
+	}
+
+	/**
+	 * Returns a new instance of the switcher.
+	 *
+	 * @param PLL_Frontend $pll_env      Polylang's instance.
+	 * @param array        $settings_arr Optional settings.
+	 * @return Switcher
+	 */
+	protected function get_new_switcher( PLL_Frontend $pll_env, array $settings_arr = array() ): Switcher {
+		return new Switcher( new Settings( $settings_arr ), $pll_env->links );
+	}
+
+	/**
+	 * Inits Polylang and returns a new instance of the switcher.
+	 *
+	 * @param array $settings_arr Optional settings.
+	 * @return Switcher
+	 */
+	protected function get_switcher( array $settings_arr = array() ): Switcher {
+		return $this->get_new_switcher( $this->init_frontend(), $settings_arr );
+	}
+
+	/**
+	 * Returns an instance of `DOMXpath`.
+	 *
+	 * @param string $html HTML as a string.
+	 * @return DOMXpath
+	 */
+	protected function get_domxpath( string $html ): DOMXpath {
+		$doc = new DOMDocument();
+		$doc->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_NOERROR );
+		return new DOMXpath( $doc );
+	}
+}

--- a/tests/phpunit/tests/Switcher/TestCase.php
+++ b/tests/phpunit/tests/Switcher/TestCase.php
@@ -71,7 +71,7 @@ abstract class TestCase extends PLL_UnitTestCase {
 	 * @param array $settings_arr Optional settings.
 	 * @return Switcher
 	 */
-	protected function get_switcher( array $settings_arr = array() ): Switcher {
+	protected function get_switcher_and_init_frontend( array $settings_arr = array() ): Switcher {
 		return $this->get_new_switcher( $this->init_frontend(), $settings_arr );
 	}
 

--- a/tests/phpunit/tests/Switcher/TestCase.php
+++ b/tests/phpunit/tests/Switcher/TestCase.php
@@ -82,8 +82,8 @@ abstract class TestCase extends PLL_UnitTestCase {
 	 * @return DOMXpath
 	 */
 	protected function get_domxpath( string $html ): DOMXpath {
-		// Inline SVG `xmlns` confuses libxml's HTML parser on some platforms (extra nodes).
-		$html = preg_replace( '/\sxmlns="http:\/\/www\.w3\.org\/2000\/svg"/', '', $html );
+		// Inline SVG makes libxml's HTML parser invent extra wrapper nodes on some platforms.
+		$html = preg_replace( '/<svg\b[^>]*>.*?<\/svg>/s', '', $html );
 
 		$doc = new DOMDocument();
 		$doc->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_NOERROR );

--- a/tests/phpunit/tests/Switcher/TestCase.php
+++ b/tests/phpunit/tests/Switcher/TestCase.php
@@ -82,6 +82,9 @@ abstract class TestCase extends PLL_UnitTestCase {
 	 * @return DOMXpath
 	 */
 	protected function get_domxpath( string $html ): DOMXpath {
+		// Inline SVG `xmlns` confuses libxml's HTML parser on some platforms (extra nodes).
+		$html = preg_replace( '/\sxmlns="http:\/\/www\.w3\.org\/2000\/svg"/', '', $html );
+
 		$doc = new DOMDocument();
 		$doc->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_NOERROR );
 		return new DOMXpath( $doc );

--- a/tests/phpunit/tests/Switcher/TestCase.php
+++ b/tests/phpunit/tests/Switcher/TestCase.php
@@ -13,7 +13,6 @@ use WP_Syntex\Polylang\Switcher\Settings\Settings;
 
 abstract class TestCase extends PLL_UnitTestCase {
 	protected static $posts;
-	protected $pll_options;
 
 	/**
 	 * @param PLL_UnitTest_Factory $factory
@@ -41,18 +40,14 @@ abstract class TestCase extends PLL_UnitTestCase {
 		parent::wpTearDownAfterClass();
 	}
 
-	public function set_up() {
-		parent::set_up();
-
-		$this->pll_options = $this->create_options(
-			array(
-				'default_lang' => 'en',
+	protected function init_frontend(): PLL_Frontend {
+		$this->pll_model     = new PLL_Model(
+			$this->create_options(
+				array(
+					'default_lang' => 'en',
+				)
 			)
 		);
-	}
-
-	protected function init_frontend(): PLL_Frontend {
-		$this->pll_model     = new PLL_Model( $this->pll_options );
 		$links_model         = $this->pll_model->get_links_model();
 		$GLOBALS['polylang'] = new PLL_Frontend( $links_model );
 		$GLOBALS['polylang']->init();

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Switcher;
+
+class Get_Test extends TestCase {
+	public function test_default_values(): void {
+		$html  = $this->get_switcher()->get();
+		$xpath = $this->get_domxpath( $html );
+
+		$wrappers = $xpath->query( '//div' );
+		$this->assertSame( 1, $wrappers->count() );
+		$wrapper = $wrappers->item( 0 );
+		$this->assertMatchesRegularExpression( '/^pll-switcher-\d+$/', $wrapper->getAttribute( 'id' ) );
+		$this->assertSame( 'Choose a language', $wrapper->getAttribute( 'aria-label' ) );
+		$this->assertSameSets(
+			array( 'pll-switcher', 'pll-layout-vertical', 'pll-alignment-left' ),
+			explode( ' ', $wrapper->getAttribute( 'class' ) )
+		);
+
+		$lis = $xpath->query( '//div/ul/li' );
+		$this->assertSame( 2, $lis->count() ); // The 3rd language is hadden because `hide_if_empty` is `true`.
+
+		// The first language is the default one (en).
+		$en_language = $this->pll_model->get_language( 'en' );
+		$this->assertSameSets(
+			array( 'lang-item', 'lang-item-' . $en_language->term_id, 'lang-item-en', 'current-lang', 'no-translation', 'lang-item-first' ),
+			explode( ' ', $lis->item( 0 )->getAttribute( 'class' ) )
+		);
+
+		// The remaining language is fr.
+		$fr_language = $this->pll_model->get_language( 'fr' );
+		$this->assertSameSets(
+			array( 'lang-item', 'lang-item-' . $fr_language->term_id, 'lang-item-fr', 'no-translation' ),
+			explode( ' ', $lis->item( 1 )->getAttribute( 'class' ) )
+		);
+
+		$links = $xpath->query( '//div/ul/li/a' );
+		$this->assertSame( 2, $links->count() );
+
+		$this->assertSame( 'en-US', $links->item( 0 )->getAttribute( 'lang' ) );
+		$this->assertSame( 'en-US', $links->item( 0 )->getAttribute( 'hreflang' ) );
+		$this->assertSame( 'true', $links->item( 0 )->getAttribute( 'aria-current' ) );
+		$this->assertSame( $en_language->get_home_url(), $links->item( 0 )->getAttribute( 'href' ) );
+		$this->assertSame( 'English', $links->item( 0 )->nodeValue );
+
+		$this->assertSame( 'fr-FR', $links->item( 1 )->getAttribute( 'lang' ) );
+		$this->assertSame( 'fr-FR', $links->item( 1 )->getAttribute( 'hreflang' ) );
+		$this->assertSame( '', $links->item( 1 )->getAttribute( 'aria-current' ) );
+		$this->assertSame( $fr_language->get_home_url(), $links->item( 1 )->getAttribute( 'href' ) );
+		$this->assertSame( 'Français', $links->item( 1 )->nodeValue );
+
+		$spans = $xpath->query( '//div/ul/li/a/span' );
+		$this->assertSame( 0, $spans->count() ); // No flags.
+	}
+
+	public function test_layout_unknown(): void {
+		$html = $this->get_switcher( array( 'layout' => 'unknown' ) )->get();
+
+		$wrappers = $this->get_domxpath( $html )->query( '//div' );
+		$this->assertSame( 1, $wrappers->count() );
+		$wrapper = $wrappers->item( 0 );
+		$classes = $wrapper->getAttribute( 'class' );
+		$this->assertStringContainsString( ' pll-layout-vertical ', " $classes " );
+	}
+
+	public function test_layout_select(): void {
+		$html  = $this->get_switcher( array( 'layout' => 'select' ) )->get();
+		$xpath = $this->get_domxpath( $html );
+
+		$wrappers = $xpath->query( '//div' );
+		$this->assertSame( 1, $wrappers->count() );
+		$wrapper = $wrappers->item( 0 );
+		$classes = $wrapper->getAttribute( 'class' );
+		$this->assertStringContainsString( ' pll-layout-select ', " $classes " );
+
+		$labels = $xpath->query( '//div/label' );
+		$this->assertSame( 1, $labels->count() );
+		$label = $labels->item( 0 );
+		$this->assertSame( 'screen-reader-text', $label->getAttribute( 'class' ) );
+		$label_for = $label->getAttribute( 'for' );
+		$this->assertMatchesRegularExpression( '/^pll-switcher-\d+$/', $label_for );
+		$this->assertSame( 'Choose a language', $label->nodeValue );
+
+		$selects = $xpath->query( '//div/select' );
+		$this->assertSame( 1, $selects->count() );
+		$select = $selects->item( 0 );
+		$this->assertSame( 'pll-switcher-select', $select->getAttribute( 'class' ) );
+		$this->assertSame( $label_for, $select->getAttribute( 'id' ) );
+
+		$options = $xpath->query( '//div/select/option' );
+		$this->assertSame( 2, $options->count() );
+
+		// The first language is the default one (en).
+		$en_language = $this->pll_model->get_language( 'en' );
+		$en_option   = $options->item( 0 );
+
+		$this->assertSame( 'en-US', $en_option->getAttribute( 'lang' ) );
+		$this->assertSame( $en_language->get_home_url(), $en_option->getAttribute( 'value' ) );
+		$this->assertSame( 'selected', $en_option->getAttribute( 'selected' ) );
+		$this->assertSameSets(
+			array( 'lang-item', 'lang-item-' . $en_language->term_id, 'lang-item-en', 'current-lang', 'no-translation', 'lang-item-first' ),
+			explode( ' ', $en_option->getAttribute( 'class' ) )
+		);
+		$this->assertSame( 'English', $en_option->nodeValue );
+
+		// The remaining language is fr.
+		$fr_language = $this->pll_model->get_language( 'fr' );
+		$fr_option   = $options->item( 1 );
+
+		$this->assertSame( 'fr-FR', $fr_option->getAttribute( 'lang' ) );
+		$this->assertSame( $fr_language->get_home_url(), $fr_option->getAttribute( 'value' ) );
+		$this->assertSame( '', $fr_option->getAttribute( 'selected' ) );
+		$this->assertSameSets(
+			array( 'lang-item', 'lang-item-' . $fr_language->term_id, 'lang-item-fr', 'no-translation' ),
+			explode( ' ', $fr_option->getAttribute( 'class' ) )
+		);
+		$this->assertSame( 'Français', $fr_option->nodeValue );
+	}
+
+	public function test_layout_dropdown(): void {
+		$html  = $this->get_switcher( array( 'layout' => 'dropdown' ) )->get();
+		$xpath = $this->get_domxpath( $html );
+
+		$wrappers = $xpath->query( '//div' );
+		$this->assertSame( 1, $wrappers->count() );
+		$wrapper = $wrappers->item( 0 );
+		$classes = $wrapper->getAttribute( 'class' );
+		$this->assertStringContainsString( ' pll-layout-dropdown ', " $classes " );
+
+		$top_level_links = $xpath->query( '//div/a' );
+		$this->assertSame( 1, $top_level_links->count() );
+		$this->assertSame(
+			$this->pll_model->get_language( 'en' )->get_home_url(),
+			$top_level_links->item( 0 )->getAttribute( 'href' )
+		);
+
+		$uls = $xpath->query( '//div/ul' );
+		$this->assertSame( 1, $uls->count() );
+	}
+
+	public function test_layouts_horizontal_vertical(): void {
+		$pll_env = $this->init_frontend();
+
+		foreach ( array( 'horizontal', 'vertical' ) as $layout ) {
+			$html    = $this->get_new_switcher( $pll_env, array( 'layout' => $layout ) )->get();
+			$xpath   = $this->get_domxpath( $html );
+
+		$wrappers = $xpath->query( '//div' );
+		$this->assertSame( 1, $wrappers->count() );
+		$wrapper = $wrappers->item( 0 );
+			$classes = $wrapper->getAttribute( 'class' );
+			$this->assertStringContainsString( " pll-layout-$layout ", " $classes " );
+
+			$uls = $xpath->query( '//div/ul' );
+			$this->assertSame( 1, $uls->count() );
+		}
+	}
+
+	public function test_nav_tag(): void {
+		add_theme_support( 'html5', array( 'navigation-widgets' ) );
+
+		$html  = $this->get_switcher()->get();
+		$xpath = $this->get_domxpath( $html );
+
+		$wrapper = $xpath->query( '//nav' );
+		$this->assertSame( 1, $wrapper->count() );
+	}
+}

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -49,7 +49,7 @@ class Get_Test extends TestCase {
 		$this->assertSame( $fr_language->get_home_url(), $links->item( 1 )->getAttribute( 'href' ) );
 		$this->assertSame( 'Français', $links->item( 1 )->nodeValue );
 
-		$spans = $xpath->query( '//div/ul/li/a/span' );
+		$spans = $xpath->query( '//div/ul/li/a/span[@class="pll-switcher-flag"]' );
 		$this->assertSame( 0, $spans->count() ); // No flags.
 	}
 

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -79,7 +79,7 @@ class Get_Test extends TestCase {
 		$this->assertSame( 'screen-reader-text', $label->getAttribute( 'class' ) );
 		$label_for = $label->getAttribute( 'for' );
 		$this->assertMatchesRegularExpression( '/^pll-switcher-\d+$/', $label_for );
-		$this->assertSame( 'Choose a language', $label->nodeValue );
+		$this->assertSame( 'Choose a language', $label->nodeValue ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		$selects = $xpath->query( '//div/select' );
 		$this->assertSame( 1, $selects->count() );
@@ -101,7 +101,7 @@ class Get_Test extends TestCase {
 			array( 'lang-item', 'lang-item-' . $en_language->term_id, 'lang-item-en', 'current-lang', 'no-translation', 'lang-item-first' ),
 			explode( ' ', $en_option->getAttribute( 'class' ) )
 		);
-		$this->assertSame( 'English', $en_option->nodeValue );
+		$this->assertSame( 'English', $en_option->nodeValue ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// The remaining language is fr.
 		$fr_language = $this->pll_model->get_language( 'fr' );
@@ -114,7 +114,7 @@ class Get_Test extends TestCase {
 			array( 'lang-item', 'lang-item-' . $fr_language->term_id, 'lang-item-fr', 'no-translation' ),
 			explode( ' ', $fr_option->getAttribute( 'class' ) )
 		);
-		$this->assertSame( 'Français', $fr_option->nodeValue );
+		$this->assertSame( 'Français', $fr_option->nodeValue ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	public function test_layout_dropdown(): void {
@@ -142,12 +142,12 @@ class Get_Test extends TestCase {
 		$pll_env = $this->init_frontend();
 
 		foreach ( array( 'horizontal', 'vertical' ) as $layout ) {
-			$html    = $this->get_new_switcher( $pll_env, array( 'layout' => $layout ) )->get();
-			$xpath   = $this->get_domxpath( $html );
+			$html  = $this->get_new_switcher( $pll_env, array( 'layout' => $layout ) )->get();
+			$xpath = $this->get_domxpath( $html );
 
-		$wrappers = $xpath->query( '//div' );
-		$this->assertSame( 1, $wrappers->count() );
-		$wrapper = $wrappers->item( 0 );
+			$wrappers = $xpath->query( '//div' );
+			$this->assertSame( 1, $wrappers->count() );
+			$wrapper = $wrappers->item( 0 );
 			$classes = $wrapper->getAttribute( 'class' );
 			$this->assertStringContainsString( " pll-layout-$layout ", " $classes " );
 

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -18,7 +18,7 @@ class Get_Test extends TestCase {
 		);
 
 		$lis = $xpath->query( '//div/ul/li' );
-		$this->assertSame( 2, $lis->count() ); // The 3rd language is hadden because `hide_if_empty` is `true`.
+		$this->assertSame( 2, $lis->count() ); // The 3rd language is hidden because `hide_if_empty` is `true`.
 
 		// The first language is the default one (en).
 		$en_language = $this->pll_model->get_language( 'en' );

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -138,22 +138,24 @@ class Get_Test extends TestCase {
 		$this->assertSame( 1, $uls->count() );
 	}
 
-	public function test_layouts_horizontal_vertical(): void {
-		$pll_env = $this->init_frontend();
+	/**
+	 * @testWith ["horizontal"]
+	 *           ["vertical"]
+	 *
+	 * @param string $layout Layout slug.
+	 */
+	public function test_layouts_horizontal_vertical( string $layout ): void {
+		$html  = $this->get_switcher( array( 'layout' => $layout ) )->get();
+		$xpath = $this->get_domxpath( $html );
 
-		foreach ( array( 'horizontal', 'vertical' ) as $layout ) {
-			$html  = $this->get_new_switcher( $pll_env, array( 'layout' => $layout ) )->get();
-			$xpath = $this->get_domxpath( $html );
+		$wrappers = $xpath->query( '//div' );
+		$this->assertSame( 1, $wrappers->count() );
+		$wrapper = $wrappers->item( 0 );
+		$classes = $wrapper->getAttribute( 'class' );
+		$this->assertStringContainsString( " pll-layout-$layout ", " $classes " );
 
-			$wrappers = $xpath->query( '//div' );
-			$this->assertSame( 1, $wrappers->count() );
-			$wrapper = $wrappers->item( 0 );
-			$classes = $wrapper->getAttribute( 'class' );
-			$this->assertStringContainsString( " pll-layout-$layout ", " $classes " );
-
-			$uls = $xpath->query( '//div/ul' );
-			$this->assertSame( 1, $uls->count() );
-		}
+		$uls = $xpath->query( '//div/ul' );
+		$this->assertSame( 1, $uls->count() );
 	}
 
 	public function test_nav_tag(): void {

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -121,20 +121,20 @@ class Get_Test extends TestCase {
 		$html  = $this->get_switcher_and_init_frontend( array( 'layout' => 'dropdown' ) )->get();
 		$xpath = $this->get_domxpath( $html );
 
-		$wrappers = $xpath->query( '//div' );
+		$wrappers = $xpath->query( '//div[contains(concat( " ", normalize-space( @class ), " " ), " pll-switcher ")]' );
 		$this->assertSame( 1, $wrappers->count() );
 		$wrapper = $wrappers->item( 0 );
 		$classes = $wrapper->getAttribute( 'class' );
 		$this->assertStringContainsString( ' pll-layout-dropdown ', " $classes " );
 
-		$top_level_links = $xpath->query( '//div/a' );
+		$top_level_links = $xpath->query( './a', $wrapper );
 		$this->assertSame( 1, $top_level_links->count() );
 		$this->assertSame(
 			$this->pll_model->get_language( 'en' )->get_home_url(),
 			$top_level_links->item( 0 )->getAttribute( 'href' )
 		);
 
-		$uls = $xpath->query( '//div/ul' );
+		$uls = $xpath->query( './ul', $wrapper );
 		$this->assertSame( 1, $uls->count() );
 	}
 

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -121,21 +121,22 @@ class Get_Test extends TestCase {
 		$html  = $this->get_switcher_and_init_frontend( array( 'layout' => 'dropdown' ) )->get();
 		$xpath = $this->get_domxpath( $html );
 
-		$wrappers = $xpath->query( '//div[contains(concat( " ", normalize-space( @class ), " " ), " pll-switcher ")]' );
-		$this->assertSame( 1, $wrappers->count() );
+		$wrappers = $xpath->query( '//*[contains(concat( " ", normalize-space( @class ), " " ), " pll-switcher ")]' );
+		$this->assertSame( 1, $wrappers->count(), $html );
 		$wrapper = $wrappers->item( 0 );
 		$classes = $wrapper->getAttribute( 'class' );
 		$this->assertStringContainsString( ' pll-layout-dropdown ', " $classes " );
 
-		$top_level_links = $xpath->query( './a', $wrapper );
-		$this->assertSame( 1, $top_level_links->count() );
+		// Top-level current language link (outside the submenu list).
+		$top_level_links = $xpath->query( './/a[not(ancestor::li)]', $wrapper );
+		$this->assertSame( 1, $top_level_links->count(), $html );
 		$this->assertSame(
 			$this->pll_model->get_language( 'en' )->get_home_url(),
 			$top_level_links->item( 0 )->getAttribute( 'href' )
 		);
 
-		$uls = $xpath->query( './ul', $wrapper );
-		$this->assertSame( 1, $uls->count() );
+		$uls = $xpath->query( './/ul', $wrapper );
+		$this->assertSame( 1, $uls->count(), $html );
 	}
 
 	/**

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -4,7 +4,7 @@ namespace WP_Syntex\Polylang\Tests\Switcher;
 
 class Get_Test extends TestCase {
 	public function test_default_values(): void {
-		$html  = $this->get_switcher()->get();
+		$html  = $this->get_switcher_and_init_frontend()->get();
 		$xpath = $this->get_domxpath( $html );
 
 		$wrappers = $xpath->query( '//div' );
@@ -54,7 +54,7 @@ class Get_Test extends TestCase {
 	}
 
 	public function test_layout_unknown(): void {
-		$html = $this->get_switcher( array( 'layout' => 'unknown' ) )->get();
+		$html = $this->get_switcher_and_init_frontend( array( 'layout' => 'unknown' ) )->get();
 
 		$wrappers = $this->get_domxpath( $html )->query( '//div' );
 		$this->assertSame( 1, $wrappers->count() );
@@ -64,7 +64,7 @@ class Get_Test extends TestCase {
 	}
 
 	public function test_layout_select(): void {
-		$html  = $this->get_switcher( array( 'layout' => 'select' ) )->get();
+		$html  = $this->get_switcher_and_init_frontend( array( 'layout' => 'select' ) )->get();
 		$xpath = $this->get_domxpath( $html );
 
 		$wrappers = $xpath->query( '//div' );
@@ -118,7 +118,7 @@ class Get_Test extends TestCase {
 	}
 
 	public function test_layout_dropdown(): void {
-		$html  = $this->get_switcher( array( 'layout' => 'dropdown' ) )->get();
+		$html  = $this->get_switcher_and_init_frontend( array( 'layout' => 'dropdown' ) )->get();
 		$xpath = $this->get_domxpath( $html );
 
 		$wrappers = $xpath->query( '//div' );
@@ -145,7 +145,7 @@ class Get_Test extends TestCase {
 	 * @param string $layout Layout slug.
 	 */
 	public function test_layouts_horizontal_vertical( string $layout ): void {
-		$html  = $this->get_switcher( array( 'layout' => $layout ) )->get();
+		$html  = $this->get_switcher_and_init_frontend( array( 'layout' => $layout ) )->get();
 		$xpath = $this->get_domxpath( $html );
 
 		$wrappers = $xpath->query( '//div' );
@@ -161,7 +161,7 @@ class Get_Test extends TestCase {
 	public function test_nav_tag(): void {
 		add_theme_support( 'html5', array( 'navigation-widgets' ) );
 
-		$html  = $this->get_switcher()->get();
+		$html  = $this->get_switcher_and_init_frontend()->get();
 		$xpath = $this->get_domxpath( $html );
 
 		$wrapper = $xpath->query( '//nav' );

--- a/tests/phpunit/tests/Switcher/test-Get.php
+++ b/tests/phpunit/tests/Switcher/test-Get.php
@@ -40,13 +40,13 @@ class Get_Test extends TestCase {
 		$this->assertSame( 'en-US', $links->item( 0 )->getAttribute( 'lang' ) );
 		$this->assertSame( 'en-US', $links->item( 0 )->getAttribute( 'hreflang' ) );
 		$this->assertSame( 'true', $links->item( 0 )->getAttribute( 'aria-current' ) );
-		$this->assertSame( $en_language->get_home_url(), $links->item( 0 )->getAttribute( 'href' ) );
+		$this->assertSame( 'http://example.org/', $links->item( 0 )->getAttribute( 'href' ) );
 		$this->assertSame( 'English', $links->item( 0 )->nodeValue );
 
 		$this->assertSame( 'fr-FR', $links->item( 1 )->getAttribute( 'lang' ) );
 		$this->assertSame( 'fr-FR', $links->item( 1 )->getAttribute( 'hreflang' ) );
 		$this->assertSame( '', $links->item( 1 )->getAttribute( 'aria-current' ) );
-		$this->assertSame( $fr_language->get_home_url(), $links->item( 1 )->getAttribute( 'href' ) );
+		$this->assertSame( 'http://example.org/?lang=fr', $links->item( 1 )->getAttribute( 'href' ) );
 		$this->assertSame( 'Français', $links->item( 1 )->nodeValue );
 
 		$spans = $xpath->query( '//div/ul/li/a/span[@class="pll-switcher-flag"]' );

--- a/tests/phpunit/tests/Switcher/test-GetElements.php
+++ b/tests/phpunit/tests/Switcher/test-GetElements.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Switcher;
+
+use WP_Syntex\Polylang\Switcher\Element;
+
+class GetElements_Test extends TestCase {
+	public function test_default_values(): void {
+		$elements = $this->get_switcher()->get_elements();
+
+		$this->assertCount( 2, $elements );
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertArrayHasKey( 'fr', $elements );
+		$this->assertSame( 'en', array_key_first( $elements ) );
+
+		$language_en = $this->pll_model->get_language( 'en' );
+		$expected_en = array(
+			'id'               => $language_en->term_id,
+			'slug'             => 'en',
+			'locale'           => 'en-US',
+			'url'              => $language_en->get_home_url(),
+			'label'            => 'English',
+			'flag'             => '',
+			'direction'        => 'ltr',
+			'order'            => 0,
+			'has_translations' => false,
+			'is_empty'         => false,
+			'is_current'       => true,
+			'item_classes'     => array(
+				'lang-item',
+				'lang-item-' . $language_en->term_id,
+				'lang-item-en',
+				'current-lang',
+				'no-translation',
+				'lang-item-first',
+			),
+			'link_classes'     => array(),
+		);
+
+		$this->assertSameSetsWithIndex( $expected_en, get_object_vars( $elements['en'] ) );
+
+		$language_fr = $this->pll_model->get_language( 'fr' );
+		$expected_fr = array(
+			'id'               => $language_fr->term_id,
+			'slug'             => 'fr',
+			'locale'           => 'fr-FR',
+			'url'              => $language_fr->get_home_url(),
+			'label'            => 'Français',
+			'flag'             => '',
+			'direction'        => 'ltr',
+			'order'            => 0,
+			'has_translations' => false,
+			'is_empty'         => false,
+			'is_current'       => false,
+			'item_classes'     => array(
+				'lang-item',
+				'lang-item-' . $language_fr->term_id,
+				'lang-item-fr',
+				'no-translation',
+			),
+			'link_classes'     => array(),
+		);
+
+		$this->assertSameSetsWithIndex( $expected_fr, get_object_vars( $elements['fr'] ) );
+	}
+
+	public function test_non_default_values(): void {
+		// `$post_id` and `$hide_if_no_translation` have dedicated tests.
+		// `$preserve_spacing`, `$show_wrapper`, `$wrapper_classes`, and `$unique_id` have no effects on elements.
+		$elements = $this->get_switcher(
+			array(
+				'layout'            => 'horizontal',
+				'alignment'         => 'stretched',
+				'show_flags'        => true,
+				'flag_aspect_ratio' => '1:1',
+				'show_labels'       => 'codes',
+				'hide_current'      => true,  // Hide EN.
+				'hide_if_empty'     => false, // Display DE.
+				'force_home'        => true,
+				'item_classes'      => array( 'foobar_item_1', 'foobar_item_2' ),
+				'link_classes'      => array( 'barbaz_link_1', 'barbaz_link_2' ),
+			)
+		)->get_elements();
+
+		$this->assertCount( 2, $elements );
+		$this->assertArrayHasKey( 'fr', $elements );
+		$this->assertArrayHasKey( 'de', $elements );
+
+		$language_fr = $this->pll_model->get_language( 'fr' );
+		$expected_fr = array(
+			'id'               => $language_fr->term_id,
+			'slug'             => 'fr',
+			'locale'           => 'fr-FR',
+			'url'              => $language_fr->get_home_url(),
+			'label'            => 'FR',
+			'flag'             => $language_fr->get_display_flag( 'no-alt' ),
+			'direction'        => 'ltr',
+			'order'            => 0,
+			'has_translations' => false,
+			'is_empty'         => false,
+			'is_current'       => false,
+			'item_classes'     => array(
+				'lang-item',
+				'lang-item-' . $language_fr->term_id,
+				'lang-item-fr',
+				'foobar_item_1',
+				'foobar_item_2',
+				'no-translation',
+				'lang-item-first',
+			),
+			'link_classes'     => array(
+				'barbaz_link_1',
+				'barbaz_link_2',
+			),
+		);
+
+		$this->assertSameSetsWithIndex( $expected_fr, get_object_vars( $elements['fr'] ) );
+
+		$language_de = $this->pll_model->get_language( 'de' );
+		$expected_de = array(
+			'id'               => $language_de->term_id,
+			'slug'             => 'de',
+			'locale'           => 'de-DE',
+			'url'              => $language_de->get_home_url(),
+			'label'            => 'DE',
+			'flag'             => $language_de->get_display_flag( 'no-alt' ),
+			'direction'        => 'ltr',
+			'order'            => 0,
+			'has_translations' => false,
+			'is_empty'         => true,
+			'is_current'       => false,
+			'item_classes'     => array(
+				'lang-item',
+				'lang-item-' . $language_de->term_id,
+				'lang-item-de',
+				'foobar_item_1',
+				'foobar_item_2',
+				'no-translation',
+			),
+			'link_classes'     => array(
+				'barbaz_link_1',
+				'barbaz_link_2',
+			),
+		);
+
+		$this->assertSameSetsWithIndex( $expected_de, get_object_vars( $elements['de'] ) );
+	}
+
+	public function test_current_element(): void {
+		$pll_env = $this->init_frontend();
+		$pll_env->curlang = $pll_env->model->languages->get( 'fr' );
+
+		$elements = $this->get_new_switcher( $pll_env )->get_elements();
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertArrayHasKey( 'fr', $elements );
+
+		$this->assertFalse( $elements['en']->is_current );
+		$this->assertTrue( $elements['fr']->is_current );
+	}
+
+	public function test_post_id(): void {
+		$switcher = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) );
+		$elements = $switcher->get_elements();
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertArrayHasKey( 'fr', $elements );
+
+		$this->assertSame( get_permalink( self::$posts['en'] ), $elements['en']->url );
+		$this->assertSame( get_permalink( self::$posts['fr'] ), $elements['fr']->url );
+		$this->assertTrue( $elements['en']->has_translations );
+		$this->assertTrue( $elements['fr']->has_translations );
+		$this->assertNotContains( 'no-translation', $elements['en']->item_classes );
+		$this->assertNotContains( 'no-translation', $elements['fr']->item_classes );
+	}
+
+	public function test_hide_if_no_translation(): void {
+		$pll_env = $this->init_frontend();
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'post_id'                => self::$posts['en'],
+				'hide_if_empty'          => false, // For DE.
+				'hide_if_no_translation' => true,
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertCount( 2, $elements ); // EN + FR.
+		$this->assertArrayNotHasKey( 'de', $elements );
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'post_id'                => self::$posts['en'],
+				'hide_if_empty'          => false, // For DE.
+				'hide_if_no_translation' => false,
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertCount( 3, $elements ); // EN + FR + DE.
+		$this->assertArrayHasKey( 'de', $elements );
+		$this->assertFalse( $elements['de']->has_translations );
+		$this->assertSame( $pll_env->model->languages->get( 'de' )->get_home_url(), $elements['de']->url );
+	}
+
+	public function test_label(): void {
+		$pll_env = $this->init_frontend();
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'show_flags' => true,
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertArrayHasKey( 'en', $elements );
+		$label = $elements['en']->get_label();
+
+		$this->assertMatchesRegularExpression(
+			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span>English<\/span>$/', // Empty alt.
+			$label
+		);
+		$this->assertStringNotContainsString( ' style="', $label );
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'show_flags'  => true,
+				'show_labels' => 'codes',
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertMatchesRegularExpression(
+			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span>EN<\/span>$/', // Empty alt.
+			$elements['en']->get_label()
+		);
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'show_flags' => true,
+				'show_labels' => '',
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertMatchesRegularExpression(
+			'/^<img[^>]* alt="[^"]+"[^>]*>$/', // Non empty alt.
+			$elements['en']->get_label()
+		);
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'show_flags' => false,
+				'show_labels' => '',
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertSame( 'English', $elements['en']->get_label() );
+
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'layout'     => 'select',
+				'show_flags' => true,
+				'show_labels' => '',
+			)
+		);
+		$elements = $switcher->get_elements();
+		$this->assertSame( 'English', $elements['en']->get_label() );
+	}
+
+	public function test_home_url(): void {
+		$pll_env  = $this->init_frontend();
+		$home_url = $pll_env->model->languages->get( 'en' )->get_home_url();
+		$post_url = get_permalink( self::$posts['en'] );
+
+		// Not home URL.
+		$switcher = $this->get_new_switcher( $pll_env, array( 'post_id' => self::$posts['en'] ) );
+		$elements = $switcher->get_elements();
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertSame( $post_url, $elements['en']->url );
+
+		// The filter returns an empty string.
+		$cb = function ( $url, $slug ) use ( $post_url ) {
+			if ( 'en' !== $slug ) {
+				return $url;
+			}
+			$this->assertSame( $post_url, $url );
+			return '';
+		};
+		add_filter( 'pll_the_language_link', $cb, 10, 2 );
+		$switcher = $this->get_new_switcher( $pll_env, array( 'post_id' => self::$posts['en'] ) );
+		$elements = $switcher->get_elements();
+		remove_filter( 'pll_the_language_link', $cb );
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertSame( $home_url, $elements['en']->url );
+
+		// The filter returns a non-string value.
+		$cb = function ( $url, $slug ) use ( $post_url ) {
+			if ( 'en' !== $slug ) {
+				return $url;
+			}
+			$this->assertSame( $post_url, $url );
+			return array();
+		};
+		add_filter( 'pll_the_language_link', $cb, 10, 2 );
+		$switcher = $this->get_new_switcher( $pll_env, array( 'post_id' => self::$posts['en'] ) );
+		$elements = $switcher->get_elements();
+		remove_filter( 'pll_the_language_link', $cb );
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertSame( $home_url, $elements['en']->url );
+
+		// `force_home` is set to `true`.
+		$cb = function ( $url, $slug ) use ( $post_url ) {
+			if ( 'en' === $slug ) {
+				$this->assertSame( $post_url, $url );
+			}
+			return $url;
+		};
+		add_filter( 'pll_the_language_link', $cb, 10, 2 );
+		$switcher = $this->get_new_switcher(
+			$pll_env,
+			array(
+				'post_id'    => self::$posts['en'],
+				'force_home' => true,
+			)
+		);
+		$elements = $switcher->get_elements();
+		remove_filter( 'pll_the_language_link', $cb );
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertSame( $home_url, $elements['en']->url );
+	}
+
+	public function test_type_of_elements(): void {
+		$pll_env = $this->init_frontend();
+
+		foreach ( array( 'horizontal', 'vertical', 'dropdown', 'unknown' ) as $layout ) {
+			$switcher = $this->get_new_switcher( $pll_env, array( 'layout' => $layout ) );
+			$elements = $switcher->get_elements();
+
+			$this->assertArrayHasKey( 'en', $elements );
+			$this->assertInstanceOf( Element\Nav::class, $elements['en'] );
+		}
+
+		$switcher = $this->get_new_switcher( $pll_env, array( 'layout' => 'select' ) );
+		$elements = $switcher->get_elements();
+
+		$this->assertArrayHasKey( 'en', $elements );
+		$this->assertInstanceOf( Element\Select::class, $elements['en'] );
+	}
+}

--- a/tests/phpunit/tests/Switcher/test-GetElements.php
+++ b/tests/phpunit/tests/Switcher/test-GetElements.php
@@ -93,7 +93,7 @@ class GetElements_Test extends TestCase {
 			'locale'           => 'fr-FR',
 			'url'              => $language_fr->get_home_url(),
 			'label'            => 'FR',
-			'flag'             => $language_fr->get_display_flag( 'no-alt' ),
+			'flag'             => $this->remove_style_attributes( $language_fr->get_display_flag( 'no-alt' ) ),
 			'direction'        => 'ltr',
 			'order'            => 0,
 			'has_translations' => false,
@@ -123,7 +123,7 @@ class GetElements_Test extends TestCase {
 			'locale'           => 'de-DE',
 			'url'              => $language_de->get_home_url(),
 			'label'            => 'DE',
-			'flag'             => $language_de->get_display_flag( 'no-alt' ),
+			'flag'             => $this->remove_style_attributes( $language_de->get_display_flag( 'no-alt' ) ),
 			'direction'        => 'ltr',
 			'order'            => 0,
 			'has_translations' => false,
@@ -218,7 +218,7 @@ class GetElements_Test extends TestCase {
 		$label = $elements['en']->get_label();
 
 		$this->assertMatchesRegularExpression(
-			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span>English<\/span>$/', // Empty alt.
+			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span class="pll-switcher-label">English<\/span>$/', // Empty alt.
 			$label
 		);
 		$this->assertStringNotContainsString( ' style="', $label );
@@ -232,7 +232,7 @@ class GetElements_Test extends TestCase {
 		);
 		$elements = $switcher->get_elements();
 		$this->assertMatchesRegularExpression(
-			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span>EN<\/span>$/', // Empty alt.
+			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span class="pll-switcher-label">EN<\/span>$/', // Empty alt.
 			$elements['en']->get_label()
 		);
 
@@ -245,7 +245,7 @@ class GetElements_Test extends TestCase {
 		);
 		$elements = $switcher->get_elements();
 		$this->assertMatchesRegularExpression(
-			'/^<img[^>]* alt="[^"]+"[^>]*>$/', // Non empty alt.
+			'/^<span class="pll-switcher-flag"><img[^>]* alt="[^"]+"[^>]*><\/span>$/', // Non empty alt.
 			$elements['en']->get_label()
 		);
 
@@ -257,7 +257,7 @@ class GetElements_Test extends TestCase {
 			)
 		);
 		$elements = $switcher->get_elements();
-		$this->assertSame( 'English', $elements['en']->get_label() );
+		$this->assertSame( '<span class="pll-switcher-label">English</span>', $elements['en']->get_label() );
 
 		$switcher = $this->get_new_switcher(
 			$pll_env,
@@ -353,5 +353,15 @@ class GetElements_Test extends TestCase {
 
 		$this->assertArrayHasKey( 'en', $elements );
 		$this->assertInstanceOf( Element\Select::class, $elements['en'] );
+	}
+
+	/**
+	 * Removes `style` attributes from the given markup.
+	 *
+	 * @param string $string Markup.
+	 * @return string
+	 */
+	private function remove_style_attributes( string $string ): string {
+		return preg_replace( '/style=(["\']).*\1/', '', $string );
 	}
 }

--- a/tests/phpunit/tests/Switcher/test-GetElements.php
+++ b/tests/phpunit/tests/Switcher/test-GetElements.php
@@ -2,8 +2,6 @@
 
 namespace WP_Syntex\Polylang\Tests\Switcher;
 
-use WP_Syntex\Polylang\Switcher\Element;
-
 class GetElements_Test extends TestCase {
 	public function test_default_values(): void {
 		$elements = $this->get_switcher()->get_elements();
@@ -331,24 +329,6 @@ class GetElements_Test extends TestCase {
 
 		$this->assertArrayHasKey( 'en', $elements );
 		$this->assertSame( $this->pll_model->get_language( 'en' )->get_home_url(), $elements['en']->url );
-	}
-
-	public function test_type_of_elements(): void {
-		$pll_env = $this->init_frontend();
-
-		foreach ( array( 'horizontal', 'vertical', 'dropdown', 'unknown' ) as $layout ) {
-			$switcher = $this->get_new_switcher( $pll_env, array( 'layout' => $layout ) );
-			$elements = $switcher->get_elements();
-
-			$this->assertArrayHasKey( 'en', $elements );
-			$this->assertInstanceOf( Element\Nav::class, $elements['en'] );
-		}
-
-		$switcher = $this->get_new_switcher( $pll_env, array( 'layout' => 'select' ) );
-		$elements = $switcher->get_elements();
-
-		$this->assertArrayHasKey( 'en', $elements );
-		$this->assertInstanceOf( Element\Select::class, $elements['en'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/Switcher/test-GetElements.php
+++ b/tests/phpunit/tests/Switcher/test-GetElements.php
@@ -270,20 +270,17 @@ class GetElements_Test extends TestCase {
 		$this->assertSame( 'English', $elements['en']->get_label() );
 	}
 
-	public function test_home_url(): void {
-		$pll_env  = $this->init_frontend();
-		$home_url = $pll_env->model->languages->get( 'en' )->get_home_url();
+	public function test_home_url_uses_permalink_for_post(): void {
 		$post_url = get_permalink( self::$posts['en'] );
-
-		// Not home URL.
-		$switcher = $this->get_new_switcher( $pll_env, array( 'post_id' => self::$posts['en'] ) );
-		$elements = $switcher->get_elements();
+		$elements = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) )->get_elements();
 
 		$this->assertArrayHasKey( 'en', $elements );
 		$this->assertSame( $post_url, $elements['en']->url );
+	}
 
-		// The filter returns an empty string.
-		$cb = function ( $url, $slug ) use ( $post_url ) {
+	public function test_home_url_fallback_when_filter_returns_empty_string(): void {
+		$post_url = get_permalink( self::$posts['en'] );
+		$cb       = function ( $url, $slug ) use ( $post_url ) {
 			if ( 'en' !== $slug ) {
 				return $url;
 			}
@@ -291,15 +288,16 @@ class GetElements_Test extends TestCase {
 			return '';
 		};
 		add_filter( 'pll_the_language_link', $cb, 10, 2 );
-		$switcher = $this->get_new_switcher( $pll_env, array( 'post_id' => self::$posts['en'] ) );
-		$elements = $switcher->get_elements();
+		$elements = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) )->get_elements();
 		remove_filter( 'pll_the_language_link', $cb );
 
 		$this->assertArrayHasKey( 'en', $elements );
-		$this->assertSame( $home_url, $elements['en']->url );
+		$this->assertSame( $this->pll_model->get_language( 'en' )->get_home_url(), $elements['en']->url );
+	}
 
-		// The filter returns a non-string value.
-		$cb = function ( $url, $slug ) use ( $post_url ) {
+	public function test_home_url_fallback_when_filter_returns_non_string(): void {
+		$post_url = get_permalink( self::$posts['en'] );
+		$cb       = function ( $url, $slug ) use ( $post_url ) {
 			if ( 'en' !== $slug ) {
 				return $url;
 			}
@@ -307,33 +305,32 @@ class GetElements_Test extends TestCase {
 			return array();
 		};
 		add_filter( 'pll_the_language_link', $cb, 10, 2 );
-		$switcher = $this->get_new_switcher( $pll_env, array( 'post_id' => self::$posts['en'] ) );
-		$elements = $switcher->get_elements();
+		$elements = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) )->get_elements();
 		remove_filter( 'pll_the_language_link', $cb );
 
 		$this->assertArrayHasKey( 'en', $elements );
-		$this->assertSame( $home_url, $elements['en']->url );
+		$this->assertSame( $this->pll_model->get_language( 'en' )->get_home_url(), $elements['en']->url );
+	}
 
-		// `force_home` is set to `true`.
-		$cb = function ( $url, $slug ) use ( $post_url ) {
+	public function test_home_url_when_force_home_is_true(): void {
+		$post_url = get_permalink( self::$posts['en'] );
+		$cb       = function ( $url, $slug ) use ( $post_url ) {
 			if ( 'en' === $slug ) {
 				$this->assertSame( $post_url, $url );
 			}
 			return $url;
 		};
 		add_filter( 'pll_the_language_link', $cb, 10, 2 );
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+		$elements = $this->get_switcher(
 			array(
 				'post_id'    => self::$posts['en'],
 				'force_home' => true,
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
 		remove_filter( 'pll_the_language_link', $cb );
 
 		$this->assertArrayHasKey( 'en', $elements );
-		$this->assertSame( $home_url, $elements['en']->url );
+		$this->assertSame( $this->pll_model->get_language( 'en' )->get_home_url(), $elements['en']->url );
 	}
 
 	public function test_type_of_elements(): void {

--- a/tests/phpunit/tests/Switcher/test-GetElements.php
+++ b/tests/phpunit/tests/Switcher/test-GetElements.php
@@ -175,45 +175,40 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_hide_if_no_translation(): void {
-		$pll_env = $this->init_frontend();
-
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+		$elements = $this->get_switcher(
 			array(
 				'post_id'                => self::$posts['en'],
 				'hide_if_empty'          => false, // For DE.
 				'hide_if_no_translation' => true,
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertCount( 2, $elements ); // EN + FR.
 		$this->assertArrayNotHasKey( 'de', $elements );
+	}
 
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+	public function test_show_if_no_translation(): void {
+		$elements = $this->get_switcher(
 			array(
 				'post_id'                => self::$posts['en'],
 				'hide_if_empty'          => false, // For DE.
 				'hide_if_no_translation' => false,
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertCount( 3, $elements ); // EN + FR + DE.
 		$this->assertArrayHasKey( 'de', $elements );
 		$this->assertFalse( $elements['de']->has_translations );
-		$this->assertSame( $pll_env->model->languages->get( 'de' )->get_home_url(), $elements['de']->url );
+		$this->assertSame( $this->pll_model->get_language( 'de' )->get_home_url(), $elements['de']->url );
 	}
 
-	public function test_label(): void {
-		$pll_env = $this->init_frontend();
-
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+	public function test_label_with_flags_and_names(): void {
+		$elements = $this->get_switcher(
 			array(
 				'show_flags' => true,
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertArrayHasKey( 'en', $elements );
 		$label = $elements['en']->get_label();
 
@@ -222,52 +217,56 @@ class GetElements_Test extends TestCase {
 			$label
 		);
 		$this->assertStringNotContainsString( ' style="', $label );
+	}
 
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+	public function test_label_with_flags_and_codes(): void {
+		$elements = $this->get_switcher(
 			array(
 				'show_flags'  => true,
 				'show_labels' => 'codes',
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertMatchesRegularExpression(
 			'/^<span class="pll-switcher-flag"><img[^>]* alt=""[^>]*><\/span><span class="pll-switcher-label">EN<\/span>$/', // Empty alt.
 			$elements['en']->get_label()
 		);
+	}
 
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+	public function test_label_with_flags_only(): void {
+		$elements = $this->get_switcher(
 			array(
-				'show_flags' => true,
+				'show_flags'  => true,
 				'show_labels' => '',
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertMatchesRegularExpression(
 			'/^<span class="pll-switcher-flag"><img[^>]* alt="[^"]+"[^>]*><\/span>$/', // Non empty alt.
 			$elements['en']->get_label()
 		);
+	}
 
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+	public function test_label_falls_back_to_names_when_empty(): void {
+		$elements = $this->get_switcher(
 			array(
-				'show_flags' => false,
+				'show_flags'  => false,
 				'show_labels' => '',
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertSame( '<span class="pll-switcher-label">English</span>', $elements['en']->get_label() );
+	}
 
-		$switcher = $this->get_new_switcher(
-			$pll_env,
+	public function test_label_for_select_layout(): void {
+		$elements = $this->get_switcher(
 			array(
-				'layout'     => 'select',
-				'show_flags' => true,
+				'layout'      => 'select',
+				'show_flags'  => true,
 				'show_labels' => '',
 			)
-		);
-		$elements = $switcher->get_elements();
+		)->get_elements();
+
 		$this->assertSame( 'English', $elements['en']->get_label() );
 	}
 

--- a/tests/phpunit/tests/Switcher/test-GetElements.php
+++ b/tests/phpunit/tests/Switcher/test-GetElements.php
@@ -4,7 +4,7 @@ namespace WP_Syntex\Polylang\Tests\Switcher;
 
 class GetElements_Test extends TestCase {
 	public function test_default_values(): void {
-		$elements = $this->get_switcher()->get_elements();
+		$elements = $this->get_switcher_and_init_frontend()->get_elements();
 
 		$this->assertCount( 2, $elements );
 		$this->assertArrayHasKey( 'en', $elements );
@@ -65,7 +65,7 @@ class GetElements_Test extends TestCase {
 	public function test_non_default_values(): void {
 		// `$post_id` and `$hide_if_no_translation` have dedicated tests.
 		// `$preserve_spacing`, `$show_wrapper`, `$wrapper_classes`, and `$unique_id` have no effects on elements.
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'layout'            => 'horizontal',
 				'alignment'         => 'stretched',
@@ -158,7 +158,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_post_id(): void {
-		$switcher = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) );
+		$switcher = $this->get_switcher_and_init_frontend( array( 'post_id' => self::$posts['en'] ) );
 		$elements = $switcher->get_elements();
 
 		$this->assertArrayHasKey( 'en', $elements );
@@ -173,7 +173,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_hide_if_no_translation(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'post_id'                => self::$posts['en'],
 				'hide_if_empty'          => false, // For DE.
@@ -186,7 +186,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_show_if_no_translation(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'post_id'                => self::$posts['en'],
 				'hide_if_empty'          => false, // For DE.
@@ -201,7 +201,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_label_with_flags_and_names(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'show_flags' => true,
 			)
@@ -218,7 +218,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_label_with_flags_and_codes(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'show_flags'  => true,
 				'show_labels' => 'codes',
@@ -232,7 +232,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_label_with_flags_only(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'show_flags'  => true,
 				'show_labels' => '',
@@ -246,7 +246,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_label_falls_back_to_names_when_empty(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'show_flags'  => false,
 				'show_labels' => '',
@@ -257,7 +257,7 @@ class GetElements_Test extends TestCase {
 	}
 
 	public function test_label_for_select_layout(): void {
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'layout'      => 'select',
 				'show_flags'  => true,
@@ -270,7 +270,7 @@ class GetElements_Test extends TestCase {
 
 	public function test_home_url_uses_permalink_for_post(): void {
 		$post_url = get_permalink( self::$posts['en'] );
-		$elements = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) )->get_elements();
+		$elements = $this->get_switcher_and_init_frontend( array( 'post_id' => self::$posts['en'] ) )->get_elements();
 
 		$this->assertArrayHasKey( 'en', $elements );
 		$this->assertSame( $post_url, $elements['en']->url );
@@ -286,7 +286,7 @@ class GetElements_Test extends TestCase {
 			return '';
 		};
 		add_filter( 'pll_the_language_link', $cb, 10, 2 );
-		$elements = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) )->get_elements();
+		$elements = $this->get_switcher_and_init_frontend( array( 'post_id' => self::$posts['en'] ) )->get_elements();
 		remove_filter( 'pll_the_language_link', $cb );
 
 		$this->assertArrayHasKey( 'en', $elements );
@@ -303,7 +303,7 @@ class GetElements_Test extends TestCase {
 			return array();
 		};
 		add_filter( 'pll_the_language_link', $cb, 10, 2 );
-		$elements = $this->get_switcher( array( 'post_id' => self::$posts['en'] ) )->get_elements();
+		$elements = $this->get_switcher_and_init_frontend( array( 'post_id' => self::$posts['en'] ) )->get_elements();
 		remove_filter( 'pll_the_language_link', $cb );
 
 		$this->assertArrayHasKey( 'en', $elements );
@@ -319,7 +319,7 @@ class GetElements_Test extends TestCase {
 			return $url;
 		};
 		add_filter( 'pll_the_language_link', $cb, 10, 2 );
-		$elements = $this->get_switcher(
+		$elements = $this->get_switcher_and_init_frontend(
 			array(
 				'post_id'    => self::$posts['en'],
 				'force_home' => true,

--- a/tests/phpunit/tests/Switcher/test-Print.php
+++ b/tests/phpunit/tests/Switcher/test-Print.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Switcher;
+
+class Print_Test extends TestCase {
+	public function test_print(): void {
+		$switcher = $this->get_switcher();
+		$html_get = $switcher->get();
+
+		ob_start();
+		$switcher->print();
+		$html_print = ob_get_clean();
+
+		$this->assertSame( $html_get, $html_print );
+	}
+}

--- a/tests/phpunit/tests/Switcher/test-Print.php
+++ b/tests/phpunit/tests/Switcher/test-Print.php
@@ -4,7 +4,7 @@ namespace WP_Syntex\Polylang\Tests\Switcher;
 
 class Print_Test extends TestCase {
 	public function test_print(): void {
-		$switcher = $this->get_switcher();
+		$switcher = $this->get_switcher_and_init_frontend();
 		$html_get = $switcher->get();
 
 		ob_start();


### PR DESCRIPTION
This adds tests for the class `Switcher` mainly, but internally the class `Settings`, the elements, and the layouts are also tested.