### PR TITLE
Update version range for e2e-test-utils-playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@playwright/test": "^1.58.2",
     "@wordpress/babel-preset-default": "^8.41.0",
     "@wordpress/base-styles": "^6.17.0",
-    "@wordpress/e2e-test-utils-playwright": "^1.41.0",
+    "@wordpress/e2e-test-utils-playwright": "^1.41.0 <=1.44.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
     "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@playwright/test": "^1.58.2",
     "@wordpress/babel-preset-default": "^8.41.0",
     "@wordpress/base-styles": "^6.17.0",
-    "@wordpress/e2e-test-utils-playwright": "^1.41.0 <=1.44.0",
+    "@wordpress/e2e-test-utils-playwright": "^1.41.0 <=1.47.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
     "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@playwright/test": "^1.58.2",
     "@wordpress/babel-preset-default": "^8.41.0",
     "@wordpress/base-styles": "^6.17.0",
-    "@wordpress/e2e-test-utils-playwright": "^1.41.0 <=1.47.0",
+    "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
     "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils",


### PR DESCRIPTION
JS source was removed from that package, our "new" NodeJS version complains:

> Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently unsupported for files under node_modules

https://github.com/polylang/polylang/actions/runs/27137321471/job/80092943837