### PR TITLE
Switch `@wpsyntex/e2e-test-utils` from GitHub to NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@wordpress/e2e-test-utils-playwright": "^1.41.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
-    "@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils",
+    "@wpsyntex/e2e-test-utils": "^0.1.0",
     "@wpsyntex/polylang-build-scripts": "^2.1.0",
     "babel-loader": "^8.4.1",
     "clean-webpack-plugin": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@playwright/test": "^1.58.2",
     "@wordpress/babel-preset-default": "^8.41.0",
     "@wordpress/base-styles": "^6.17.0",
-    "@wordpress/e2e-test-utils-playwright": "^1.41.0",
+    "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
     "@wpsyntex/e2e-test-utils": "^0.1.0",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -21,7 +21,7 @@
 	"type": "module",
 	"dependencies": {
 		"@playwright/test": "^1.58.2",
-		"@wordpress/e2e-test-utils-playwright": "^1.41.0",
+		"@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
 		"@wpsyntex/e2e-test-utils": "^0.1.0"
 	}
 }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -22,6 +22,6 @@
 	"dependencies": {
 		"@playwright/test": "^1.58.2",
 		"@wordpress/e2e-test-utils-playwright": "^1.41.0",
-		"@wpsyntex/e2e-test-utils": "github:polylang/e2e-test-utils"
+		"@wpsyntex/e2e-test-utils": "^0.1.0"
 	}
 }


### PR DESCRIPTION
# What?
Now that `@wpsyntex/e2e-test-utils` is published on NPM, use the published package with a ^0.1.0 constraint instead of installing directly from the GitHub repository.

Cap @wordpress/e2e-test-utils-playwright below 1.47.0.
Versions 1.47.0 and above export TypeScript source instead of compiled JavaScript, which breaks e2e tests on Node.js 22.

> [!NOTE]
> Remove the upper bound once Gutenberg republishes compiled artifacts. See https://github.com/polylang/polylang-pro/issues/3021.