### PR TITLE
[Language switcher rework] Classic menu

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
 		"camelcase": [
 			2,
 			{
-				"allow": [ "pll_block_editor_blocks_settings", "show_flags", "show_names" ],
+				"allow": [ "pll_block_editor_blocks_settings", "show_flags", "show_names", "pll_data" ],
 				"properties": "never",
 				"ignoreDestructuring": true
 			}
@@ -28,6 +28,7 @@
 	},
 	"globals": {
 		"pll_block_editor_blocks_settings": true,
+		"pll_data": true,
 		"pllDefaultLanguage": true
 	},
 	"env": {

--- a/css/src/frontend-switcher.css
+++ b/css/src/frontend-switcher.css
@@ -132,11 +132,10 @@
 	text-align: right;
 }
 .pll-switcher-flag,
-.pll-switcher-flag + span {
+.pll-switcher-label {
 	display: inline-block;
-	vertical-align: middle;
 }
-.pll-switcher-flag + span {
+.pll-switcher-flag + .pll-switcher-label {
 	margin-inline-start: .3em;
 	writing-mode: horizontal-tb;
 }
@@ -144,7 +143,7 @@
 /* Flags */
 .pll-switcher-flag img {
 	width: 18px;
-	vertical-align: middle;
+	vertical-align: baseline;
 	object-fit: cover;
 	object-position: center;
 }

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -52,7 +52,7 @@ const pllNavMenu = {
 
 			const metabox = event.target
 				.closest( '.menu-item' )
-				.querySelector( '.menu-item-settings' );
+				?.querySelector( '.menu-item-settings' );
 
 			if ( ! metabox?.id ) {
 				// Should not happen.
@@ -292,6 +292,10 @@ const pllNavMenu = {
 			// Hide rows.
 			const key = event.target.getAttribute( 'data-key' );
 
+			if ( ! key ) {
+				return;
+			}
+
 			wrapper
 				.querySelectorAll(
 					`[class*="pll-hidden-if-${ key }-"]:not(.pll-hidden-if-${ key }-${ value })` // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword, Generic.ControlStructures.InlineControlStructure.NotAllowed
@@ -311,7 +315,7 @@ const pllNavMenu = {
 					'[data-key="show_flags"]'
 				);
 
-				if ( true !== otherInput.checked ) {
+				if ( otherInput && true !== otherInput.checked ) {
 					otherInput.checked = true;
 					otherInput.dispatchEvent(
 						new Event( 'change', { bubbles: true } )
@@ -322,7 +326,7 @@ const pllNavMenu = {
 					'[data-key="show_labels"]'
 				);
 
-				if ( '' === otherInput.value ) {
+				if ( otherInput && '' === otherInput.value ) {
 					otherInput.value = 'names';
 					otherInput.dispatchEvent(
 						new Event( 'change', { bubbles: true } )

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -1,7 +1,5 @@
 /**
  * Handles the options in the language switcher nav menu metabox.
- *
- * @package Polylang
  */
 
 const pllNavMenu = {
@@ -34,8 +32,10 @@ const pllNavMenu = {
 		}
 
 		pllNavMenu.wrapper.addEventListener( 'click', pllNavMenu.printMetabox );
-		pllNavMenu.wrapper.addEventListener( 'change', pllNavMenu.ensureContent );
-		pllNavMenu.wrapper.addEventListener( 'change', pllNavMenu.showHideRows );
+		pllNavMenu.wrapper.addEventListener(
+			'change',
+			pllNavMenu.manageRowsAndValues
+		);
 	},
 
 	printMetabox: {
@@ -50,71 +50,118 @@ const pllNavMenu = {
 				return;
 			}
 
-			const metabox = event.target.closest( '.menu-item' ).querySelector( '.menu-item-settings' );
+			const metabox = event.target
+				.closest( '.menu-item' )
+				.querySelector( '.menu-item-settings' );
 
 			if ( ! metabox?.id ) {
 				// Should not happen.
 				return;
 			}
 
-			if ( ! metabox.querySelectorAll( 'input[value="#pll_switcher"][type=text]' ).length ) {
+			if (
+				! metabox.querySelectorAll(
+					'input[value="#pll_switcher"][type=text]'
+				).length
+			) {
 				// Not our metabox, or already replaced.
 				return;
 			}
 
 			// Remove default fields we don't need.
 			[ ...metabox.children ].forEach( ( el ) => {
-				if ( 'P' === el.nodeName && ! el.classList.contains( 'field-move' ) ) {
+				if (
+					'P' === el.nodeName &&
+					! el.classList.contains( 'field-move' )
+				) {
 					el.remove();
 				}
 			} );
 
-			const t      = pllNavMenu.printMetabox;
-			const itemId = Number( metabox.id.replace( 'menu-item-settings-', '' ) );
+			const t = pllNavMenu.printMetabox;
+			const itemId = Number(
+				metabox.id.replace( 'menu-item-settings-', '' )
+			);
 
-			metabox.append( t.createHiddenInput( 'title', itemId, pll_data.title ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-			metabox.append( t.createHiddenInput( 'url', itemId, '#pll_switcher' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			// phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			metabox.append(
+				t.createHiddenInput( 'title', itemId, pll_data.title )
+			);
+			// phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			metabox.append(
+				t.createHiddenInput( 'url', itemId, '#pll_switcher' )
+			);
 			metabox.append( t.createHiddenInput( 'pll-detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
-			const ids          = Array( 'hide_if_no_translation', 'hide_current', 'force_home', 'show_flags', 'show_names', 'dropdown' ); // Reverse order.
-			const isValDefined = typeof( pll_data.val[ itemId ] ) !== 'undefined';
+			const menuValues =
+				typeof pll_data.val[ itemId ] !== 'undefined'
+					? pll_data.val[ itemId ]
+					: {};
 
-			ids.forEach( ( optionName ) => {
-				// Create the checkbox's wrapper.
-				const inputWrapper = t.createElement( 'p', { class: 'description' } );
+			Object.keys( pll_data.data )
+				.reverse()
+				.forEach( ( optionName ) => {
+					const optionData = pll_data.data[ optionName ];
+					const optionValue =
+						typeof menuValues[ optionName ] !== 'undefined'
+							? menuValues[ optionName ]
+							: optionData.default;
+					// Create the wrapper.
+					const wrapperAtts = { class: 'description' };
 
-				if ( 'hide_current' === optionName && isValDefined && 1 === pll_data.val[ itemId ].dropdown ) {
-					// Hide the `hide_current` checkbox if `dropdown` is checked.
-					inputWrapper.classList.add( 'hidden' );
-				}
+					if ( optionData.hide_if ) {
+						Object.keys( optionData.hide_if ).forEach(
+							( conditionName ) => {
+								const conditionValue =
+									optionData.hide_if[ conditionName ];
+								wrapperAtts.class += ` pll-hidden-if-${ conditionName }-${ conditionValue }`; // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace
 
-				metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+								if (
+									typeof menuValues[ conditionName ] !==
+										'undefined' &&
+									conditionValue ===
+										menuValues[ conditionName ]
+								) {
+									wrapperAtts.class += ` pll-hidden-by-${ conditionName }`;
+								}
+							}
+						);
+					}
 
-				// Create the checkbox's label.
-				const inputId = `edit-menu-item-${ optionName }-${ itemId }`;
-				const label   = t.createElement( 'label', { 'for': inputId } );
-				label.innerText = ` ${ pll_data.strings[ optionName ] }`;
+					const inputWrapper = t.createElement( 'p', wrapperAtts );
 
-				inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+					metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 
-				// Create the checkbox.
-				const cb = t.createElement( 'input', {
-					type:  'checkbox',
-					id:    inputId,
-					name:  `menu-item-${ optionName }[${ itemId }]`,
-					value: 1,
+					// Create the label.
+					const label = t.createElement( 'label', {
+						for: `edit-menu-item-${ optionName }-${ itemId }`, // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword
+					} );
+					label.innerText = ` ${ optionData.label } `;
+
+					inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+
+					// Create the input.
+					if ( optionData.choices ) {
+						const input = t.createSelectInput(
+							optionName,
+							itemId,
+							optionValue,
+							optionData.choices
+						);
+						label.append( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+					} else {
+						const input = t.createCheckboxInput(
+							optionName,
+							itemId,
+							optionValue
+						);
+						label.prepend( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+					}
 				} );
-
-				if ( ( isValDefined && 1 === pll_data.val[ itemId ][ optionName ] ) || ( ! isValDefined && 'show_names' === optionName ) ) { // `show_names` as default value.
-					cb.checked = true;
-				}
-
-				label.prepend( cb ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
-			} );
 		},
 
 		/**
-		 * Creates and returns a `<input type=hidden"/>` element.
+		 * Creates and returns a `<input type="hidden"/>` element.
 		 *
 		 * @param {string}        id     An identifier for this input. It will be part of the final `id` attribute.
 		 * @param {number}        itemId The ID of the menu element (post ID).
@@ -122,11 +169,81 @@ const pllNavMenu = {
 		 * @return {HTMLElement} The input element.
 		 */
 		createHiddenInput: ( id, itemId, value ) => {
+			return pllNavMenu.printMetabox.createInput(
+				id,
+				itemId,
+				value,
+				'hidden'
+			);
+		},
+
+		/**
+		 * Creates and returns a `<input type="checkbox"/>` element.
+		 *
+		 * @param {string}         id     An identifier for this input. It will be part of the final `id` attribute.
+		 * @param {number}         itemId The ID of the menu element (post ID).
+		 * @param {boolean|number} value  The option value.
+		 * @return {HTMLElement} The input element.
+		 */
+		createCheckboxInput: ( id, itemId, value ) => {
+			const input = pllNavMenu.printMetabox.createInput(
+				id,
+				itemId,
+				1,
+				'checkbox'
+			);
+			input.setAttribute( 'data-key', id );
+			if ( value ) {
+				input.checked = true;
+			}
+			return input;
+		},
+
+		/**
+		 * Creates and returns a `<select/>` element.
+		 *
+		 * @param {string}        id      An identifier for this input. It will be part of the final `id` attribute.
+		 * @param {number}        itemId  The ID of the menu element (post ID).
+		 * @param {string|number} value   The option value.
+		 * @param {Object}        choices Choices.
+		 * @return {HTMLElement} The input element.
+		 */
+		createSelectInput: ( id, itemId, value, choices ) => {
+			const input = pllNavMenu.printMetabox.createElement( 'select', {
+				id: `edit-menu-item-${ id }-${ itemId }`,
+				name: `menu-item-${ id }[${ itemId }]`,
+				'data-key': id,
+			} );
+			Object.keys( choices ).forEach( ( optionValue ) => {
+				const atts = { value: optionValue };
+				if ( value === optionValue ) {
+					atts.selected = 'selected';
+				}
+				const option = pllNavMenu.printMetabox.createElement(
+					'option',
+					atts
+				);
+				option.innerText = choices[ optionValue ];
+				input.append( option ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			} );
+			return input;
+		},
+
+		/**
+		 * Creates and returns a `<input/>` element.
+		 *
+		 * @param {string}        id     An identifier for this input. It will be part of the final `id` attribute.
+		 * @param {number}        itemId The ID of the menu element (post ID).
+		 * @param {string|number} value  The input's value.
+		 * @param {string}        type   The type of input.
+		 * @return {HTMLElement} The input element.
+		 */
+		createInput: ( id, itemId, value, type ) => {
 			return pllNavMenu.printMetabox.createElement( 'input', {
-				type:  'hidden',
-				id:    `edit-menu-item-${ id }-${ itemId }`,
-				name:  `menu-item-${ id }[${ itemId }]`,
-				value: value,
+				type,
+				id: `edit-menu-item-${ id }-${ itemId }`,
+				name: `menu-item-${ id }[${ itemId }]`,
+				value,
 			} );
 		},
 
@@ -146,71 +263,71 @@ const pllNavMenu = {
 		},
 	},
 
-	ensureContent: {
-		regExpr: new RegExp( /^edit-menu-item-show_(names|flags)-(\d+)$/ ),
-
+	manageRowsAndValues: {
 		/**
-		 * Event callback that disallows unchecking both `show_names` and `show_flags`.
+		 * Event callback that hides rows and forbids disabling both flag and name/code.
 		 *
 		 * @param {Event} event The event.
 		 */
 		handleEvent: ( event ) => {
-			if ( ! event.target.id || event.target.checked ) {
-				// Now checked, nothing to do.
+			let value = '';
+
+			if ( 'SELECT' === event.target.nodeName ) {
+				value = event.target.value;
+			} else if (
+				'INPUT' === event.target.nodeName &&
+				'checkbox' === event.target.type
+			) {
+				value = event.target.checked;
+			} else {
 				return;
 			}
 
-			const matches = event.target.id.match( pllNavMenu.ensureContent.regExpr );
+			const wrapper = event.target.closest( '.menu-item-settings' );
 
-			if ( ! matches ) {
-				// Not the checkbox we want.
+			if ( ! wrapper ) {
 				return;
 			}
 
-			// Check the other checkbox.
-			const [ , type, id ] = matches;
-			const otherType = 'names' === type ? 'flags' : 'names';
-			document.getElementById( `edit-menu-item-show_${ otherType }-${ id }` ).checked = true;
-		},
-	},
+			// Hide rows.
+			const key = event.target.getAttribute( 'data-key' );
 
-	showHideRows: {
-		regExpr: new RegExp( /^edit-menu-item-dropdown-(\d+)$/ ),
+			wrapper
+				.querySelectorAll(
+					`[class*="pll-hidden-if-${ key }-"]:not(.pll-hidden-if-${ key }-${ value })` // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword, Generic.ControlStructures.InlineControlStructure.NotAllowed
+				)
+				.forEach( ( input ) => {
+					input.classList.remove( `pll-hidden-by-${ key }` );
+				} );
+			wrapper
+				.querySelectorAll( `.pll-hidden-if-${ key }-${ value }` ) // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword, Generic.ControlStructures.InlineControlStructure.NotAllowed
+				.forEach( ( input ) => {
+					input.classList.add( `pll-hidden-by-${ key }` );
+				} );
 
-		/**
-		 * Event callback that shows or hides the `hide_current` checkbox when `dropdown` is checked.
-		 *
-		 * @param {Event} event The event.
-		 */
-		handleEvent: ( event ) => {
-			if ( ! event.target.id ) {
-				// Not the checkbox we want.
-				return;
-			}
+			// Forbid disabling both flag and name/code.
+			if ( 'show_labels' === key && '' === value ) {
+				const otherInput = wrapper.querySelector(
+					'[data-key="show_flags"]'
+				);
 
-			const matches = event.target.id.match( pllNavMenu.showHideRows.regExpr );
+				if ( true !== otherInput.checked ) {
+					otherInput.checked = true;
+					otherInput.dispatchEvent(
+						new Event( 'change', { bubbles: true } )
+					);
+				}
+			} else if ( 'show_flags' === key && false === value ) {
+				const otherInput = wrapper.querySelector(
+					'[data-key="show_labels"]'
+				);
 
-			if ( ! matches ) {
-				// Not the checkbox we want.
-				return;
-			}
-
-			const hideCb = document.getElementById( `edit-menu-item-hide_current-${ matches[1] }` );
-
-			if ( ! hideCb ) {
-				// Should not happen.
-				return;
-			}
-
-			const description = hideCb.closest( '.description' );
-
-			// Hide or show.
-			description.classList.toggle( 'hidden', event.target.checked );
-
-			if ( event.target.checked ) {
-				// Uncheck after hiding.
-				hideCb.checked = false;
-				hideCb.dispatchEvent( new Event( 'change' ) );
+				if ( '' === otherInput.value ) {
+					otherInput.value = 'names';
+					otherInput.dispatchEvent(
+						new Event( 'change', { bubbles: true } )
+					);
+				}
 			}
 		},
 	},

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -98,66 +98,64 @@ const pllNavMenu = {
 					? pll_data.val[ itemId ]
 					: {};
 
-			Object.keys( pll_data.data )
-				.reverse()
-				.forEach( ( optionName ) => {
-					const optionData = pll_data.data[ optionName ];
-					const optionValue =
-						typeof menuValues[ optionName ] !== 'undefined'
-							? menuValues[ optionName ]
-							: optionData.default;
-					// Create the wrapper.
-					const wrapperAtts = { class: 'description' };
+			for ( const [ optionName, optionData ] of Object.entries(
+				pll_data.data
+			).reverse() ) {
+				const optionValue =
+					typeof menuValues[ optionName ] !== 'undefined'
+						? menuValues[ optionName ]
+						: optionData.default;
+				// Create the wrapper.
+				const wrapperAtts = { class: 'description' };
 
-					if ( optionData.hide_if ) {
-						Object.keys( optionData.hide_if ).forEach(
-							( conditionName ) => {
-								const conditionValue =
-									optionData.hide_if[ conditionName ];
-								wrapperAtts.class += ` pll-hidden-if-${ conditionName }-${ conditionValue }`; // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace
+				if ( optionData.hide_if ) {
+					Object.keys( optionData.hide_if ).forEach(
+						( conditionName ) => {
+							const conditionValue =
+								optionData.hide_if[ conditionName ];
+							wrapperAtts.class += ` pll-hidden-if-${ conditionName }-${ conditionValue }`; // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace
 
-								if (
-									typeof menuValues[ conditionName ] !==
-										'undefined' &&
-									conditionValue ===
-										menuValues[ conditionName ]
-								) {
-									wrapperAtts.class += ` pll-hidden-by-${ conditionName }`;
-								}
+							if (
+								typeof menuValues[ conditionName ] !==
+									'undefined' &&
+								conditionValue === menuValues[ conditionName ]
+							) {
+								wrapperAtts.class += ` pll-hidden-by-${ conditionName }`;
 							}
-						);
-					}
+						}
+					);
+				}
 
-					const inputWrapper = t.createElement( 'p', wrapperAtts );
+				const inputWrapper = t.createElement( 'p', wrapperAtts );
 
-					metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+				metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
 
-					// Create the label.
-					const label = t.createElement( 'label', {
-						for: `edit-menu-item-${ optionName }-${ itemId }`, // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword
-					} );
-					label.innerText = ` ${ optionData.label } `;
-
-					inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-
-					// Create the input.
-					if ( optionData.choices ) {
-						const input = t.createSelectInput(
-							optionName,
-							itemId,
-							optionValue,
-							optionData.choices
-						);
-						label.append( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
-					} else {
-						const input = t.createCheckboxInput(
-							optionName,
-							itemId,
-							optionValue
-						);
-						label.prepend( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
-					}
+				// Create the label.
+				const label = t.createElement( 'label', {
+					for: `edit-menu-item-${ optionName }-${ itemId }`, // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword
 				} );
+				label.innerText = ` ${ optionData.label } `;
+
+				inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+
+				// Create the input.
+				if ( optionData.choices ) {
+					const input = t.createSelectInput(
+						optionName,
+						itemId,
+						optionValue,
+						optionData.choices
+					);
+					label.append( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+				} else {
+					const input = t.createCheckboxInput(
+						optionName,
+						itemId,
+						optionValue
+					);
+					label.prepend( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+				}
+			}
 		},
 
 		/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -637,12 +637,6 @@ parameters:
 			path: src/frontend/frontend-nav-menu.php
 
 		-
-			message: '#^Parameter \#1 \$links of method PLL_Switcher\:\:the_languages\(\) expects PLL_Links, PLL_Admin_Links\|PLL_Frontend_Links\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/frontend/frontend-nav-menu.php
-
-		-
 			message: '#^Parameter \#1 \$post_id of function get_post_meta expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Switcher/Element/Abstract_Element.php
+++ b/src/Switcher/Element/Abstract_Element.php
@@ -10,6 +10,7 @@ use PLL_Links;
 use PLL_Language;
 use PLL_Frontend_Links;
 use PLL_Translated_Post;
+use WP_HTML_Tag_Processor;
 use WP_Syntex\Polylang\Switcher\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -172,10 +173,8 @@ abstract class Abstract_Element {
 		if ( $this->settings->show_labels ) {
 			$this->label = 'codes' === $this->settings->show_labels ? strtoupper( $this->language->slug ) : $this->language->name;
 		}
-		if ( $this->settings->show_flags ) {
-			$this->flag = $this->language->get_display_flag( $this->settings->show_labels ? 'no-alt' : 'alt' );
-		}
 
+		$this->set_flag();
 		$this->set_url();
 	}
 
@@ -215,7 +214,38 @@ abstract class Abstract_Element {
 	}
 
 	/**
-	 * Sets the URL of the given element.
+	 * Sets the flag of the element.
+	 *
+	 * @since 3.9
+	 *
+	 * @return void
+	 */
+	private function set_flag(): void {
+		if ( ! $this->settings->show_flags ) {
+			return;
+		}
+
+		$this->flag = $this->language->get_display_flag( $this->settings->show_labels ? 'no-alt' : 'alt' );
+
+		if ( empty( $this->flag ) ) {
+			return;
+		}
+
+		$flag = new WP_HTML_Tag_Processor( $this->flag );
+
+		if ( ! $flag->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			return;
+		}
+
+		if ( ! $flag->remove_attribute( 'style' ) ) {
+			return;
+		}
+
+		$this->flag = $flag->get_updated_html();
+	}
+
+	/**
+	 * Sets the URL of the element.
 	 *
 	 * @since 3.9
 	 *

--- a/src/Switcher/Element/Nav.php
+++ b/src/Switcher/Element/Nav.php
@@ -73,8 +73,7 @@ class Nav extends Abstract_Element {
 		$label = '';
 
 		if ( ! empty( $this->flag ) ) {
-			$flag   = (string) preg_replace( '/ style="[^"]*"/', '', $this->flag );
-			$label .= sprintf( '<span class="pll-switcher-flag">%s</span>', $flag );
+			$label .= sprintf( '<span class="pll-switcher-flag">%s</span>', $this->flag );
 		}
 
 		if ( ! empty( $this->label ) ) {

--- a/src/Switcher/Element/Nav.php
+++ b/src/Switcher/Element/Nav.php
@@ -71,7 +71,13 @@ class Nav extends Abstract_Element {
 	 */
 	public function get_label(): string {
 		if ( empty( $this->flag ) ) {
-			return esc_html( $this->label );
+			if ( ! $this->settings->show_flags ) {
+				return esc_html( $this->label );
+			}
+			// The element should display a flag but the language doesn't have one: add a `<span>` to maintain
+			// a quite-similar markup than the items that display a flag. It also provides an addistional way to the user
+			// to customize with CSS.
+			return sprintf( '<span class="pll-switcher-label">%s</span>', esc_html( $this->label ) );
 		}
 
 		if ( empty( $this->label ) ) {
@@ -79,7 +85,7 @@ class Nav extends Abstract_Element {
 		}
 
 		return sprintf(
-			'<span class="pll-switcher-flag">%s</span><span>%s</span>',
+			'<span class="pll-switcher-flag">%s</span><span class="pll-switcher-label">%s</span>',
 			(string) preg_replace( '/ style="[^"]*"/', '', $this->flag ),
 			esc_html( $this->label )
 		);

--- a/src/Switcher/Element/Nav.php
+++ b/src/Switcher/Element/Nav.php
@@ -70,24 +70,17 @@ class Nav extends Abstract_Element {
 	 * @return string
 	 */
 	public function get_label(): string {
-		if ( empty( $this->flag ) ) {
-			if ( ! $this->settings->show_flags ) {
-				return esc_html( $this->label );
-			}
-			// The element should display a flag but the language doesn't have one: add a `<span>` to maintain
-			// a quite-similar markup than the items that display a flag. It also provides an addistional way to the user
-			// to customize with CSS.
-			return sprintf( '<span class="pll-switcher-label">%s</span>', esc_html( $this->label ) );
+		$label = '';
+
+		if ( ! empty( $this->label ) ) {
+			$label .= sprintf( '<span class="pll-switcher-label">%s</span>', esc_html( $this->label ) );
 		}
 
-		if ( empty( $this->label ) ) {
-			return (string) preg_replace( '/ style="[^"]*"/', '', $this->flag );
+		if ( ! empty( $this->flag ) ) {
+			$flag   = (string) preg_replace( '/ style="[^"]*"/', '', $this->flag );
+			$label .= sprintf( '<span class="pll-switcher-flag">%s</span>', $flag );
 		}
 
-		return sprintf(
-			'<span class="pll-switcher-flag">%s</span><span class="pll-switcher-label">%s</span>',
-			(string) preg_replace( '/ style="[^"]*"/', '', $this->flag ),
-			esc_html( $this->label )
-		);
+		return $label;
 	}
 }

--- a/src/Switcher/Element/Nav.php
+++ b/src/Switcher/Element/Nav.php
@@ -72,13 +72,13 @@ class Nav extends Abstract_Element {
 	public function get_label(): string {
 		$label = '';
 
-		if ( ! empty( $this->label ) ) {
-			$label .= sprintf( '<span class="pll-switcher-label">%s</span>', esc_html( $this->label ) );
-		}
-
 		if ( ! empty( $this->flag ) ) {
 			$flag   = (string) preg_replace( '/ style="[^"]*"/', '', $this->flag );
 			$label .= sprintf( '<span class="pll-switcher-flag">%s</span>', $flag );
+		}
+
+		if ( ! empty( $this->label ) ) {
+			$label .= sprintf( '<span class="pll-switcher-label">%s</span>', esc_html( $this->label ) );
 		}
 
 		return $label;

--- a/src/Switcher/Fields/Menu.php
+++ b/src/Switcher/Fields/Menu.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher\Fields;
+
+use WP_Syntex\Polylang\Switcher\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that holds the setting field data when in a menu.
+ *
+ * @since 3.9
+ *
+ * @phpstan-import-type FieldsData from Abstract_Fields
+ */
+class Menu extends Abstract_Fields {
+	/**
+	 * Returns setting field data available for the language switcher.
+	 *
+	 * @since 3.9
+	 *
+	 * @return array[]
+	 *
+	 * @phpstan-return FieldsData
+	 */
+	public static function get(): array {
+		return array(
+			'layout'                 => array(
+				'label'   => __( 'Layout:', 'polylang' ),
+				'choices' => array(
+					'horizontal' => __( 'Inline', 'polylang' ),
+					'dropdown'   => __( 'Dropdown', 'polylang' ),
+				),
+			),
+			'show_flags'             => array(
+				'label' => __( 'Display flags', 'polylang' ),
+			),
+			'flag_aspect_ratio'      => array(
+				'label'   => __( 'Flags aspect:', 'polylang' ),
+				'choices' => array(
+					'3:2' => __( 'Landscape', 'polylang' ),
+					'1:1' => __( 'Square', 'polylang' ),
+				),
+				'hide_if' => array(
+					'show_flags' => false,
+				),
+			),
+			'show_labels'            => array(
+				'label'   => __( 'Display labels:', 'polylang' ),
+				'choices' => array(
+					''      => __( 'No', 'polylang' ),
+					'names' => __( 'Language names', 'polylang' ),
+					'codes' => __( 'Language codes', 'polylang' ),
+				),
+			),
+			'force_home'             => array(
+				'label' => __( 'Force link to front page', 'polylang' ),
+			),
+			'hide_current'           => array(
+				'label' => __( 'Hide the current language', 'polylang' ),
+			),
+			'hide_if_no_translation' => array(
+				'label' => __( 'Hide languages with no translation', 'polylang' ),
+			),
+		);
+	}
+
+	/**
+	 * Adds some legacy keys that we want to keep in the database alongside the new ones in case of plugin rollback.
+	 * Must not be called before `Abstract_Fields::filter()`.
+	 *
+	 * This would be useful in case a user rollbacks to a version < 3.9.
+	 * Backward compatibility with Polylang < 3.9.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $settings Switcher settings.
+	 * @return array
+	 */
+	public static function add_legacy_settings( array $settings ): array {
+		$settings['dropdown']   = isset( $settings['layout'] ) && 'dropdown' === $settings['layout'] ? 1 : 0;
+		$settings['show_names'] = ! empty( $settings['show_labels'] ) ? 1 : 0;
+		return $settings;
+	}
+}

--- a/src/Switcher/Settings/Menu.php
+++ b/src/Switcher/Settings/Menu.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package Polylang
+ */
+
+namespace WP_Syntex\Polylang\Switcher\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that holds the language switcher's settings for a menu.
+ *
+ * @since 3.9
+ */
+class Menu extends Settings {
+	/**
+	 * @var string
+	 *
+	 * @phpstan-var 'horizontal'|'dropdown'
+	 */
+	public string $layout = 'horizontal';
+
+	/**
+	 * Validates the settings (value and type).
+	 * This removes additional keys.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $settings Switcher settings.
+	 * @return array
+	 */
+	protected function validate( array $settings ): array {
+		if ( isset( $settings['layout'] ) ) {
+			if ( 'select' === $settings['layout'] ) {
+				$settings['layout'] = 'dropdown';
+			} elseif ( 'vertical' === $settings['layout'] ) {
+				$settings['layout'] = 'horizontal';
+			}
+		}
+		return parent::validate( $settings );
+	}
+
+	/**
+	 * Converts the legacy structure to the new one.
+	 * This preserves the legacy structure's keys.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $settings The settings.
+	 * @return array
+	 */
+	protected function convert_from_legacy( array $settings ): array {
+		$settings = parent::convert_from_legacy( $settings );
+
+		$settings['layout'] = ! empty( $settings['dropdown'] ) ? 'dropdown' : 'horizontal';
+
+		return $settings;
+	}
+
+	/**
+	 * Converts the new structure to the legacy one.
+	 * This preserves the new structure's keys.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $settings Settings in new structure.
+	 * @return array
+	 */
+	protected function convert_to_legacy( array $settings ): array {
+		$args = parent::convert_to_legacy( $settings );
+
+		if ( isset( $settings['layout'] ) && 'dropdown' === $settings['layout'] ) {
+			$args['dropdown'] = 1;
+		} else {
+			$args['dropdown'] = 0;
+		}
+
+		return $args;
+	}
+}

--- a/src/Switcher/Settings/Menu.php
+++ b/src/Switcher/Settings/Menu.php
@@ -30,13 +30,16 @@ class Menu extends Settings {
 	 * @return array
 	 */
 	protected function validate( array $settings ): array {
-		if ( isset( $settings['layout'] ) ) {
-			if ( 'select' === $settings['layout'] ) {
-				$settings['layout'] = 'dropdown';
-			} elseif ( 'vertical' === $settings['layout'] ) {
-				$settings['layout'] = 'horizontal';
-			}
+		if ( ! isset( $settings['layout'] ) || in_array( $settings['layout'], array( 'horizontal', 'dropdown' ), true ) ) {
+			return parent::validate( $settings );
 		}
+
+		if ( 'select' === $settings['layout'] ) {
+			$settings['layout'] = 'dropdown';
+		} else {
+			$settings['layout'] = 'horizontal';
+		}
+
 		return parent::validate( $settings );
 	}
 

--- a/src/admin/admin-nav-menu.php
+++ b/src/admin/admin-nav-menu.php
@@ -3,6 +3,9 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Switcher\Settings\Settings;
+use WP_Syntex\Polylang\Switcher\Fields\Menu as Fields;
+
 /**
  * Manages custom menus translations as well as the language switcher menu item on admin side
  *
@@ -111,10 +114,17 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 		wp_enqueue_script( 'pll_nav_menu', plugins_url( "/js/build/nav-menu{$suffix}.js", POLYLANG_ROOT_FILE ), array(), POLYLANG_VERSION );
 
+		$fields   = Fields::get();
+		$defaults = new Settings( array() );
+
+		foreach ( $fields as $key => $field ) {
+			$fields[ $key ]['default'] = $defaults->$key;
+		}
+
 		$data = array(
-			'strings' => PLL_Switcher::get_switcher_options( 'menu', 'string' ), // The strings for the options
-			'title'   => __( 'Languages', 'polylang' ), // The title
-			'val'     => array(),
+			'data'  => $fields,
+			'title' => __( 'Languages', 'polylang' ),
+			'val'   => array(),
 		);
 
 		// Get all language switcher menu items
@@ -130,7 +140,13 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 
 		// The options values for the language switcher
 		foreach ( $items as $item ) {
-			$data['val'][ $item ] = get_post_meta( $item, '_pll_menu_item', true );
+			$meta = get_post_meta( $item, '_pll_menu_item', true );
+
+			if ( ! is_array( $meta ) ) {
+				continue;
+			}
+
+			$data['val'][ $item ] = Fields::filter( new Settings( Fields::remove_legacy_settings( $meta ) ) );
 		}
 
 		// Send all these data to javascript
@@ -159,19 +175,23 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 			return;
 		}
 
-		$options = array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 0, 'show_names' => 1, 'dropdown' => 0 ); // Default values.
-
-		// Our jQuery form has not been displayed.
+		// Our JS form has not been displayed.
 		if ( empty( $_POST['menu-item-pll-detect'][ $menu_item_db_id ] ) ) {
 			if ( ! get_post_meta( $menu_item_db_id, '_pll_menu_item', true ) ) { // Our options were never saved.
-				update_post_meta( $menu_item_db_id, '_pll_menu_item', $options );
+				$this->update_menu_meta( $menu_item_db_id, array() );
 			}
-		} else {
-			foreach ( array_keys( $options ) as $opt ) {
-				$options[ $opt ] = empty( $_POST[ 'menu-item-' . $opt ][ $menu_item_db_id ] ) ? 0 : 1;
-			}
-			update_post_meta( $menu_item_db_id, '_pll_menu_item', $options ); // Allow us to easily identify our nav menu item.
+			return;
 		}
+
+		$meta = array();
+
+		foreach ( Fields::get() as $name => $field ) {
+			if ( isset( $_POST[ "menu-item-{$name}" ][ $menu_item_db_id ] ) ) {
+				$meta[ $name ] = $_POST[ "menu-item-{$name}" ][ $menu_item_db_id ]; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			}
+		}
+
+		$this->update_menu_meta( $menu_item_db_id, $meta );
 	}
 
 	/**
@@ -311,5 +331,20 @@ class PLL_Admin_Nav_Menu extends PLL_Nav_Menu {
 		}
 
 		$this->options->set( 'nav_menus', $nav_menus );
+	}
+
+	/**
+	 * Stores the menu data into the database.
+	 *
+	 * @since 3.9
+	 *
+	 * @param int   $menu_id Menu ID.
+	 * @param array $data    Data to store.
+	 * @return void
+	 */
+	private function update_menu_meta( int $menu_id, array $data ): void {
+		$validated = Fields::filter( new Settings( $data ) );
+		$validated = Fields::add_legacy_settings( $validated );
+		update_post_meta( $menu_id, '_pll_menu_item', $validated );
 	}
 }

--- a/src/frontend/frontend-nav-menu.php
+++ b/src/frontend/frontend-nav-menu.php
@@ -3,6 +3,11 @@
  * @package Polylang
  */
 
+use WP_Syntex\Polylang\Switcher\Switcher;
+use WP_Syntex\Polylang\Switcher\Element\Nav;
+use WP_Syntex\Polylang\Switcher\Fields\Menu as Fields;
+use WP_Syntex\Polylang\Switcher\Settings\Menu as Settings;
+
 /**
  * Manages custom menus translations as well as the language switcher menu item on frontend
  *
@@ -17,6 +22,11 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	public $curlang;
 
 	/**
+	 * @var PLL_Links|null
+	 */
+	private ?PLL_Links $links;
+
+	/**
 	 * Constructor
 	 *
 	 * @since 1.2
@@ -27,6 +37,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 		parent::__construct( $polylang );
 
 		$this->curlang = &$polylang->curlang;
+		$this->links   = &$polylang->links;
 
 		// Split the language switcher menu item in several language menu items
 		add_filter( 'wp_get_nav_menu_items', array( $this, 'wp_get_nav_menu_items' ), 20 ); // after the customizer menus
@@ -58,29 +69,6 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	}
 
 	/**
-	 * Format a language switcher menu item title based on options
-	 *
-	 * @since 2.2.6
-	 *
-	 * @param string $flag    Formatted flag
-	 * @param string $name    Language name
-	 * @param array  $options Language switcher options
-	 * @return string Formatted menu item title
-	 */
-	protected function get_item_title( $flag, $name, $options ) {
-		if ( $options['show_flags'] ) {
-			if ( $options['show_names'] ) {
-				$title = sprintf( '%1$s<span style="margin-%2$s:0.3em;">%3$s</span>', $flag, is_rtl() ? 'right' : 'left', esc_html( $name ) );
-			} else {
-				$title = $flag;
-			}
-		} else {
-			$title = esc_html( $name );
-		}
-		return $title;
-	}
-
-	/**
 	 * Splits the one language switcher menu item of backend in several menu items on frontend.
 	 * Takes care to menu_order as it is used later in wp_nav_menu().
 	 *
@@ -90,7 +78,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 	 * @return stdClass[] Modified menu items.
 	 */
 	public function wp_get_nav_menu_items( $items ) {
-		if ( empty( $this->curlang ) ) {
+		if ( empty( $this->curlang ) || empty( $this->links ) ) {
 			return $items;
 		}
 
@@ -102,57 +90,67 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 		usort( $items, array( $this, 'usort_menu_items' ) );
 
 		$new_items = array();
-
-		$offset = 0;
+		$offset    = 0;
 
 		foreach ( $items as $item ) {
-			if ( $options = get_post_meta( $item->ID, '_pll_menu_item', true ) ) {
-				/** This filter is documented in src/switcher.php */
-				$options = apply_filters( 'pll_the_languages_args', $options ); // Honor the filter here for 'show_flags', 'show_names' and 'dropdown'.
+			$options = get_post_meta( $item->ID, '_pll_menu_item', true );
 
-				$switcher = new PLL_Switcher();
-				$args = array_merge( array( 'raw' => 1 ), $options );
-
-				/** @var array */
-				$the_languages = $switcher->the_languages( PLL()->links, $args );
-
-				// parent item for dropdown
-				if ( ! empty( $options['dropdown'] ) ) {
-					$name = isset( $options['display_names_as'] ) && 'slug' === $options['display_names_as'] ? $this->curlang->slug : $this->curlang->name;
-					$item->title = $this->get_item_title( $this->curlang->get_display_flag( empty( $options['show_names'] ) ? 'alt' : 'no-alt' ), $name, $options );
-					$item->attr_title = '';
-					$item->classes = array( 'pll-parent-menu-item' );
-					$item->menu_order += $offset;
-					$new_items[] = $item;
-					++$offset;
-				}
-
-				$i = 0; // for incrementation of menu order only in case of dropdown
-				foreach ( $the_languages as $lang ) {
-					++$i;
-					$lang_item = clone $item;
-					$lang_item->ID = $lang_item->ID . '-' . $lang['slug']; // A unique ID
-					$lang_item->title = $this->get_item_title( $lang['flag'], $lang['name'], $options );
-					$lang_item->attr_title = '';
-					$lang_item->url = $lang['url'];
-					$lang_item->lang = $lang['locale']; // Save this for use in nav_menu_link_attributes
-					$lang_item->classes = $lang['classes'];
-					if ( ! empty( $options['dropdown'] ) ) {
-						$lang_item->menu_order = $item->menu_order + $i;
-						$lang_item->menu_item_parent = $item->db_id;
-						$lang_item->db_id = 0; // to avoid recursion
-					} else {
-						$lang_item->menu_order += $offset;
-					}
-					$new_items[] = $lang_item;
-					++$offset;
-				}
-				--$offset;
-			} else {
+			if ( empty( $options ) || ! is_array( $options ) ) {
 				$item->menu_order += $offset;
-				$new_items[] = $item;
+				$new_items[]       = $item;
+				continue;
 			}
+
+			$settings = new Settings( Fields::remove_legacy_settings( $options ) );
+			$elements = ( new Switcher( $settings, $this->links ) )->get_elements();
+
+			if ( 'dropdown' === $settings->layout ) {
+				// Parent item for dropdown.
+				$element = new Nav( $this->curlang, $settings, $this->links );
+
+				$item->title       = $element->get_label();
+				$item->attr_title  = '';
+				$item->url         = $element->url;
+				$item->classes     = array_merge( $element->item_classes, array( 'pll-parent-menu-item' ) );
+				$item->menu_order += $offset;
+
+				if ( $settings->show_flags ) {
+					// Since it is added to the parent `<li>`, no need to add it to the child elements too.
+					$item->classes[] = 'pll-aspect-ratio-' . str_replace( ':', '', $settings->flag_aspect_ratio );
+				}
+
+				$new_items[] = $item;
+				++$offset;
+			}
+
+			$i = 0; // For incrementation of menu order only in case of dropdown.
+			foreach ( $elements as $element ) {
+				++$i;
+				$lang_item = clone $item;
+
+				$lang_item->ID         = "{$lang_item->ID}-{$element->slug}"; // A unique ID.
+				$lang_item->title      = $element->get_label();
+				$lang_item->attr_title = '';
+				$lang_item->url        = $element->url;
+				$lang_item->lang       = $element->locale; // Save this for use in nav_menu_link_attributes.
+				$lang_item->classes    = $element->item_classes;
+
+				if ( 'dropdown' === $settings->layout ) {
+					$lang_item->menu_order       = $item->menu_order + $i;
+					$lang_item->menu_item_parent = $item->db_id;
+					$lang_item->db_id            = 0; // To avoid recursion.
+				} else {
+					$lang_item->classes     = array_diff( $lang_item->classes, array( 'lang-item-first' ) ); // Doesn't mean anything here.
+					$lang_item->classes[]   = 'pll-aspect-ratio-' . str_replace( ':', '', $settings->flag_aspect_ratio );
+					$lang_item->menu_order += $offset;
+				}
+
+				$new_items[] = $lang_item;
+				++$offset;
+			}
+			--$offset;
 		}
+
 		return $new_items;
 	}
 

--- a/src/frontend/frontend-nav-menu.php
+++ b/src/frontend/frontend-nav-menu.php
@@ -104,6 +104,10 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 			$settings = new Settings( Fields::remove_legacy_settings( $options ) );
 			$elements = ( new Switcher( $settings, $this->links ) )->get_elements();
 
+			if ( empty ( $elements ) ) {
+				continue;
+			}
+
 			if ( 'dropdown' === $settings->layout ) {
 				// Parent item for dropdown.
 				$element = new Nav( $this->curlang, $settings, $this->links );

--- a/src/frontend/frontend-nav-menu.php
+++ b/src/frontend/frontend-nav-menu.php
@@ -104,7 +104,7 @@ class PLL_Frontend_Nav_Menu extends PLL_Nav_Menu {
 			$settings = new Settings( Fields::remove_legacy_settings( $options ) );
 			$elements = ( new Switcher( $settings, $this->links ) )->get_elements();
 
-			if ( empty ( $elements ) ) {
+			if ( empty( $elements ) ) {
 				continue;
 			}
 

--- a/tests/phpunit/tests/Switcher/Settings/test-Maybe_Filter_Legacy.php
+++ b/tests/phpunit/tests/Switcher/Settings/test-Maybe_Filter_Legacy.php
@@ -143,6 +143,10 @@ class Maybe_Filter_Legacy_Test extends PLL_UnitTestCase {
 				'layout'   => 'vertical',
 				'expected' => 'horizontal',
 			),
+			'unknown layout'  => array(
+				'layout'   => 'trucmuche',
+				'expected' => 'horizontal',
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/Switcher/Settings/test-Maybe_Filter_Legacy.php
+++ b/tests/phpunit/tests/Switcher/Settings/test-Maybe_Filter_Legacy.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace WP_Syntex\Polylang\Tests\Switcher\Settings;
+
+use Mockery;
+use PLL_UnitTestCase;
+use WP_Syntex\Polylang\Switcher\Settings\Menu as Menu_Settings;
+
+class Maybe_Filter_Legacy_Test extends PLL_UnitTestCase {
+	public function tear_down() {
+		Mockery::close();
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that the filter `pll_the_languages_args` receives the right legacy values, converted from non-legacy values (see `Switcher\Settings\Menu::convert_to_legacy()`).
+	 * Tests that the final values are converted back to their original values (see `Switcher\Settings\Menu::convert_from_legacy()`).
+	 *
+	 * @expectedDeprecated pll_the_languages_args
+	 */
+	public function test_filtered_menu_new_args(): void {
+		$fired = false;
+		$args  = array(
+			'layout'       => 'dropdown',
+			'hide_current' => true,
+		);
+		add_filter(
+			'pll_the_languages_args',
+			function ( $args ) use ( &$fired ) {
+				$this->assertIsArray( $args );
+				$this->assertArrayHasKey( 'dropdown', $args, 'The `dropdown` key should be present.' );
+				$this->assertSame( 1, $args['dropdown'], 'The layout `dropdown` should be converted into `dropdown = 1`.' );
+				$this->assertArrayHasKey( 'layout', $args, 'The `layout` key should be present.' );
+				$this->assertSame( 'dropdown', $args['layout'], 'The layout should be `dropdown`.' );
+				$this->assertArrayHasKey( 'hide_current', $args, 'The `hide_current` key should be present.' );
+				$this->assertSame( 1, $args['hide_current'], 'The value of the `hide_current` key should be converted into an integer.' );
+				$fired = true;
+				return $args;
+			}
+		);
+		$settings = new Menu_Settings( $args );
+		$this->assertTrue( $fired, 'The filter `pll_the_languages_args` should have been fired.' );
+		$this->assertSame( 'dropdown', $settings->layout, 'The layout should be back to `dropdown`.' );
+		$this->assertTrue( $settings->hide_current, 'The value of the `hide_current` key should be back to a boolean.' );
+	}
+
+	/**
+	 * Tests that the filter `pll_the_languages_args` receives the right legacy values, converted from non-legacy values.
+	 * Tests that the final values are converted into the right values after being changed in the filter.
+	 *
+	 * @expectedDeprecated pll_the_languages_args
+	 */
+	public function test_changed_menu_new_args(): void {
+		$fired = false;
+		$args  = array(
+			'layout' => 'dropdown',
+		);
+		add_filter(
+			'pll_the_languages_args',
+			function ( $args ) use ( &$fired ) {
+				$this->assertIsArray( $args );
+				$this->assertArrayHasKey( 'dropdown', $args, 'The `dropdown` key should be present.' );
+				$this->assertSame( 1, $args['dropdown'], 'The layout `dropdown` should be converted into `dropdown = 1`.' );
+				$args['dropdown'] = 0;
+				$fired = true;
+				return $args;
+			}
+		);
+		$settings = new Menu_Settings( $args );
+		$this->assertTrue( $fired, 'The filter `pll_the_languages_args` should have been fired.' );
+		$this->assertSame( 'horizontal', $settings->layout, 'The layout should have been changed to `horizontal`.' );
+	}
+
+	/**
+	 * Tests that the filter `pll_the_languages_args` receives the right legacy values.
+	 * Tests that the final values are converted to the right non-legacy values.
+	 *
+	 * @expectedDeprecated pll_the_languages_args
+	 */
+	public function test_filtered_menu_legacy_args(): void {
+		$fired = false;
+		$args  = array(
+			'dropdown'     => 1,
+			'hide_current' => 1,
+		);
+		add_filter(
+			'pll_the_languages_args',
+			function ( $args ) use ( &$fired ) {
+				$this->assertIsArray( $args );
+				$this->assertArrayHasKey( 'dropdown', $args, 'The `dropdown` key should be present.' );
+				$this->assertSame( 1, $args['dropdown'], 'The layout `dropdown` should be converted into `dropdown = 1`.' );
+				$this->assertArrayNotHasKey( 'layout', $args, 'The `layout` key should not be present.' );
+				$this->assertArrayHasKey( 'hide_current', $args, 'The `hide_current` key should be present.' );
+				$this->assertSame( 1, $args['hide_current'], 'The value of the `hide_current` key should be converted into an integer.' );
+				$fired = true;
+				return $args;
+			}
+		);
+		$settings = new Menu_Settings( $args );
+		$this->assertTrue( $fired, 'The filter `pll_the_languages_args` should have been fired.' );
+		$this->assertSame( 'dropdown', $settings->layout, 'The layout should be converted into `dropdown`.' );
+		$this->assertTrue( $settings->hide_current, 'The value of the `hide_current` key should be converted into a boolean.' );
+	}
+
+	/**
+	 * Tests that the filter `pll_the_languages_args` is not fired.
+	 * Tests that the method `convert_to_legacy()` is not called.
+	 */
+	public function test_conversion_to_legacy_does_not_run(): void {
+		$args = array(
+			'dropdown' => 1,
+		);
+		$mock = Mockery::mock( Menu_Settings::class, array( $args ) )->makePartial();
+		$mock->shouldAllowMockingProtectedMethods();
+		$mock->shouldNotReceive( 'convert_to_legacy' );
+
+		$settings = new $mock( $args );
+		$this->assertFalse( (bool) did_filter( 'pll_the_languages_args' ), 'The filter `pll_the_languages_args` should not have been fired.' );
+		$this->assertSame( 'dropdown', $settings->layout, 'The layout should be converted into `dropdown`.' );
+	}
+
+	/**
+	 * Tests that unsupported layouts are converted to supported ones (see `Switcher\Settings\Menu::validate()` ).
+	 *
+	 * @dataProvider menu_unsupported_layout_provider
+	 *
+	 * @param string $layout   Layout to use.
+	 * @param string $expected Expected layout.
+	 * @return void
+	 */
+	public function test_menu_unsupported_layout( string $layout, string $expected ): void {
+		$args = array(
+			'layout' => $layout,
+		);
+		$settings = new Menu_Settings( $args );
+		$this->assertSame( $expected, $settings->layout, "The layout should be converted into `$expected`." );
+	}
+
+	public function menu_unsupported_layout_provider(): array {
+		return array(
+			'select layout'   => array(
+				'layout'   => 'select',
+				'expected' => 'dropdown',
+			),
+			'vertical layout' => array(
+				'layout'   => 'vertical',
+				'expected' => 'horizontal',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/Switcher/Settings/test-Maybe_Filter_Legacy.php
+++ b/tests/phpunit/tests/Switcher/Settings/test-Maybe_Filter_Legacy.php
@@ -15,10 +15,9 @@ class Maybe_Filter_Legacy_Test extends PLL_UnitTestCase {
 	/**
 	 * Tests that the filter `pll_the_languages_args` receives the right legacy values, converted from non-legacy values (see `Switcher\Settings\Menu::convert_to_legacy()`).
 	 * Tests that the final values are converted back to their original values (see `Switcher\Settings\Menu::convert_from_legacy()`).
-	 *
-	 * @expectedDeprecated pll_the_languages_args
 	 */
 	public function test_filtered_menu_new_args(): void {
+		$this->setExpectedDeprecated( 'pll_the_languages_args' );
 		$fired = false;
 		$args  = array(
 			'layout'       => 'dropdown',
@@ -47,10 +46,9 @@ class Maybe_Filter_Legacy_Test extends PLL_UnitTestCase {
 	/**
 	 * Tests that the filter `pll_the_languages_args` receives the right legacy values, converted from non-legacy values.
 	 * Tests that the final values are converted into the right values after being changed in the filter.
-	 *
-	 * @expectedDeprecated pll_the_languages_args
 	 */
 	public function test_changed_menu_new_args(): void {
+		$this->setExpectedDeprecated( 'pll_the_languages_args' );
 		$fired = false;
 		$args  = array(
 			'layout' => 'dropdown',
@@ -74,10 +72,9 @@ class Maybe_Filter_Legacy_Test extends PLL_UnitTestCase {
 	/**
 	 * Tests that the filter `pll_the_languages_args` receives the right legacy values.
 	 * Tests that the final values are converted to the right non-legacy values.
-	 *
-	 * @expectedDeprecated pll_the_languages_args
 	 */
 	public function test_filtered_menu_legacy_args(): void {
+		$this->setExpectedDeprecated( 'pll_the_languages_args' );
 		$fired = false;
 		$args  = array(
 			'dropdown'     => 1,

--- a/tests/phpunit/tests/test-nav-menus.php
+++ b/tests/phpunit/tests/test-nav-menus.php
@@ -246,9 +246,16 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 				'menu-item-status' => 'publish',
 			)
 		);
-
-		$options['hide_if_empty'] = 0; // FIXME for some reason the languages counts are 0 even if I manually call clean_languages_cache()
 		update_post_meta( $item_id, '_pll_menu_item', $options );
+
+		// Force displaying empty languages (de).
+		add_filter(
+			'pll_language_switcher_settings',
+			static function ( $settings ) {
+				$settings['hide_if_empty'] = false;
+				return $settings;
+			}
+		);
 
 		// get the primary location of the current theme
 		$locations = array_keys( get_registered_nav_menus() );
@@ -396,8 +403,18 @@ class Nav_Menus_Test extends PLL_UnitTestCase {
 
 		wp_update_nav_menu_item( $menu_en, $item_id, $args );
 
-		$expected = array( 'hide_if_no_translation' => 0, 'hide_current' => 0, 'force_home' => 0, 'show_flags' => 1, 'show_names' => 1, 'dropdown' => 0 );
-		$this->assertEqualSets( $expected, get_post_meta( $item_id, '_pll_menu_item', true ) );
+		$expected = array(
+			'layout'                 => 'vertical',
+			'show_flags'             => true,
+			'flag_aspect_ratio'      => '3:2',
+			'show_labels'            => 'names',
+			'force_home'             => false,
+			'hide_current'           => false,
+			'hide_if_no_translation' => false,
+			'dropdown'               => 0, // Backward compatibility.
+			'show_names'             => 1, // Backward compatibility.
+		);
+		$this->assertSameSetsWithIndex( $expected, get_post_meta( $item_id, '_pll_menu_item', true ) );
 	}
 
 	public function test_language_switcher_metabox() {


### PR DESCRIPTION
This implements the new switcher classes for the classic menu.

Some details:

- Small tweaks to CSS: align flags to the baseline instead of middle. This allows to better align items with and without a flag.
- Small tweaks to the markup: when an is supposed to display a flag but the related language doesn't have one, still print the `<span>` around the label. It doesn't change anything to the display but it improves consistency with the other items that have this `<span>`, and it adds a possibility for our users to customize it with custom CSS.
- The admin JS file now passes ESLint.

<img width="464" height="497" alt="image" src="https://github.com/user-attachments/assets/a9176207-19b9-4a3f-ba6e-62d2f50545ba" />