### PR TITLE
Alway define `pllEditorCurrentLanguageSlug` on server side.

### DIFF
--- a/src/modules/Blocks/Language_Switcher/Abstract_Block.php
+++ b/src/modules/Blocks/Language_Switcher/Abstract_Block.php
@@ -161,11 +161,6 @@ abstract class Abstract_Block {
 		// Translated strings used in JS code
 		wp_set_script_translations( $script_handle, 'polylang' );
 
-		// No need to render the JS variable if Polylang Pro is installed, the editor will use `lang` REST field instead.
-		if ( class_exists( 'WP_Syntex\Polylang_Pro\REST\Translated\Post' ) ) {
-			return;
-		}
-
 		// Fallback to default language if current language is not set, usually happens in Site Editor.
 		$current_language = $this->current_language;
 


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/polylang-pro/issues/3025

## How?
Alway define `pllEditorCurrentLanguageSlug` on server side, even when Polylang Pro is loaded. Otherwise the widget editor has not fallback for language [here](https://github.com/polylang/polylang-react-library/blob/0189e1c21a64c6f389822d657d2e53817a53f88c/src/hooks/use-current-language.js#L25) when Polylang Pro is activated.

## Tests plan:
- [ ] Ensure `polylang/language-switcher` block works as usual with Polylang Free (this PR).
- [ ] Ensure `polylang/language-switcher` block works with Polylang Pro (the other [PR](https://github.com/polylang/polylang-pro/pull/3026)). => Main issue