### PR TITLE
Fix namespace for metas tests

### DIFF
--- a/tests/phpunit/tests/Meta/TestCase.php
+++ b/tests/phpunit/tests/Meta/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 use PLL_Sync;
 use PLL_Model;

--- a/tests/phpunit/tests/Meta/TestCase.php
+++ b/tests/phpunit/tests/Meta/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 use PLL_Sync;
 use PLL_Model;

--- a/tests/phpunit/tests/Meta/test-Post.php
+++ b/tests/phpunit/tests/Meta/test-Post.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 use PLL_UnitTest_Factory;
 

--- a/tests/phpunit/tests/Meta/test-Post.php
+++ b/tests/phpunit/tests/Meta/test-Post.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 use PLL_UnitTest_Factory;
 

--- a/tests/phpunit/tests/Meta/test-Term.php
+++ b/tests/phpunit/tests/Meta/test-Term.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 use PLL_UnitTest_Factory;
 

--- a/tests/phpunit/tests/Meta/test-Term.php
+++ b/tests/phpunit/tests/Meta/test-Term.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 use PLL_UnitTest_Factory;
 

--- a/tests/phpunit/tests/Meta/trait-Add.php
+++ b/tests/phpunit/tests/Meta/trait-Add.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 trait Add {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Add.php
+++ b/tests/phpunit/tests/Meta/trait-Add.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 trait Add {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Copy.php
+++ b/tests/phpunit/tests/Meta/trait-Copy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 trait Copy {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Copy.php
+++ b/tests/phpunit/tests/Meta/trait-Copy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 trait Copy {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Delete.php
+++ b/tests/phpunit/tests/Meta/trait-Delete.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 trait Delete {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Delete.php
+++ b/tests/phpunit/tests/Meta/trait-Delete.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 trait Delete {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Update.php
+++ b/tests/phpunit/tests/Meta/trait-Update.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang_Pro\Tests\Integration\modules\Meta;
+namespace WP_Syntex\Polylang\Tests\Integration\Meta;
 
 trait Update {
 	/**

--- a/tests/phpunit/tests/Meta/trait-Update.php
+++ b/tests/phpunit/tests/Meta/trait-Update.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Syntex\Polylang\Tests\Integration\Meta;
+namespace WP_Syntex\Polylang\Tests\Meta;
 
 trait Update {
 	/**


### PR DESCRIPTION
The namespace wrongly refers to Polylang Pro. I also removed the unnecessary 'modules`.