### PR TITLE
Fix e2e tests for strings.

### DIFF
--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -66,9 +66,6 @@ test.describe.serial( 'Strings translations', () => {
 					.getByRole( 'button', { name: 'Save Changes' } )
 					.click();
 
-				await page
-					.getByRole( 'button', { name: 'Save Changes' } )
-					.click();
 				await expect(
 					page.getByRole( 'cell', {
 						name: 'polylang FR',


### PR DESCRIPTION
## What?
Playwright 1.61.0 seems to fail to execute a duplicated line introduced in https://github.com/polylang/polylang/pull/1861.

## How?
Remove the duplicated code in `tests/e2e/specs/strings-translations.spec.js`.