### PR TITLE
Fix conflict between language code and sitemap URL

### DIFF
--- a/changelog/3017
+++ b/changelog/3017
@@ -1,0 +1,1 @@
+* Fix conflict between language code and sitemap URL #3017

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -961,12 +961,6 @@ parameters:
 			path: src/modules/site-health/admin-site-health.php
 
 		-
-			message: '#^Parameter \#1 \$name of method WP_Sitemaps_Provider\:\:get_sitemap_url\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/modules/sitemaps/multilingual-sitemaps-provider.php
-
-		-
 			message: '#^Offset ''file'' might not exist on array\{function\: string, line\?\: int, file\?\: string, class\?\: class\-string, type\?\: ''\-\>''\|''\:\:'', args\?\: list\<mixed\>, object\?\: object\}\.$#'
 			identifier: offsetAccess.notFound
 			count: 2

--- a/src/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/src/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -18,7 +18,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * Pattern to match a name with language.
 	 *  `.*` in `(?<SUBTYPE>.*)` because users don't have sub-types. See `get_sitemap_data()`.
 	 */
-	private const PATTERN = '#^(?<SUBTYPE>.*)---pll-sep---(?<LANG>.+)$#';
+	private const PATTERN = '#^(?<SUBTYPE>.*)' . self::SEPARATOR . '(?<LANG>.+)$#';
 
 	/**
 	 * The decorated sitemaps provider.

--- a/src/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/src/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -9,7 +9,7 @@
  * @since 2.8
  */
 class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
-	public const PLL_SEPARATOR = '---pll-sep---';
+	public const SEPARATOR = '---pll-sep---';
 
 	/**
 	 * The decorated sitemaps provider.
@@ -68,7 +68,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$this->links_model = &$links_model;
 		$this->model       = &$links_model->model;
 
-		self::$pattern = sprintf( '#^(?<SUBTYPE>.*)%s(?<LANG>.+)$#', self::PLL_SEPARATOR ); // `.*` because users don't have sub-types. See `get_sitemap_data()`.
+		self::$pattern = sprintf( '#^(?<SUBTYPE>.*)%s(?<LANG>.+)$#', self::SEPARATOR ); // `.*` because users don't have sub-types. See `get_sitemap_data()`.
 	}
 
 	/**
@@ -135,7 +135,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		self::$filter_lang = $lang;
 
 		$return = array(
-			'name'  => sprintf( "{$object_subtype_name}%s{$lang}", self::PLL_SEPARATOR ),
+			'name'  => sprintf( "{$object_subtype_name}%s{$lang}", self::SEPARATOR ),
 			'pages' => $this->get_max_num_pages( $object_subtype_name ),
 		);
 

--- a/src/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/src/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -48,6 +48,11 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	private static $filter_lang = '';
 
 	/**
+	 * @var string
+	 */
+	private static string $pattern;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 2.8
@@ -62,6 +67,8 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$this->provider    = $provider;
 		$this->links_model = &$links_model;
 		$this->model       = &$links_model->model;
+
+		self::$pattern = sprintf( '#^(?<SUBTYPE>.*)%s(?<LANG>.+)$#', self::PLL_SEPARATOR ); // `.*` because users don't have sub-types. See `get_sitemap_data()`.
 	}
 
 	/**
@@ -196,9 +203,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 */
 	public function get_sitemap_url( $name, $page ) {
 		// Check if a language was added in `$name`.
-		$pattern = sprintf( '#^(?<SUBTYPE>.*)%s(?<LANG>.+)$#', self::PLL_SEPARATOR ); // `.*` because users don't have sub-types. See `get_sitemap_data()`.
-
-		if ( preg_match( $pattern, $name, $matches ) ) {
+		if ( preg_match( self::$pattern, $name, $matches ) ) {
 			$lang = $this->model->get_language( $matches['LANG'] );
 
 			if ( ! empty( $lang ) ) {

--- a/src/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/src/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -9,7 +9,16 @@
  * @since 2.8
  */
 class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
+	/**
+	 * Separator between name and language slug.
+	 */
 	public const SEPARATOR = '---pll-sep---';
+
+	/**
+	 * Pattern to match a name with language.
+	 *  `.*` in `(?<SUBTYPE>.*)` because users don't have sub-types. See `get_sitemap_data()`.
+	 */
+	private const PATTERN = '#^(?<SUBTYPE>.*)---pll-sep---(?<LANG>.+)$#';
 
 	/**
 	 * The decorated sitemaps provider.
@@ -48,11 +57,6 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	private static $filter_lang = '';
 
 	/**
-	 * @var string
-	 */
-	private static string $pattern;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 2.8
@@ -67,8 +71,6 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		$this->provider    = $provider;
 		$this->links_model = &$links_model;
 		$this->model       = &$links_model->model;
-
-		self::$pattern = sprintf( '#^(?<SUBTYPE>.*)%s(?<LANG>.+)$#', self::SEPARATOR ); // `.*` because users don't have sub-types. See `get_sitemap_data()`.
 	}
 
 	/**
@@ -203,7 +205,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 */
 	public function get_sitemap_url( $name, $page ) {
 		// Check if a language was added in `$name`.
-		if ( preg_match( self::$pattern, $name, $matches ) ) {
+		if ( preg_match( self::PATTERN, $name, $matches ) ) {
 			$lang = $this->model->get_language( $matches['LANG'] );
 
 			if ( ! empty( $lang ) ) {

--- a/src/modules/sitemaps/multilingual-sitemaps-provider.php
+++ b/src/modules/sitemaps/multilingual-sitemaps-provider.php
@@ -9,6 +9,8 @@
  * @since 2.8
  */
 class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
+	public const PLL_SEPARATOR = '---pll-sep---';
+
 	/**
 	 * The decorated sitemaps provider.
 	 *
@@ -36,7 +38,6 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 */
 	protected $model;
 
-
 	/**
 	 * Language used to filter queries for the sitemap index.
 	 *
@@ -55,12 +56,12 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @param PLL_Links_Model      $links_model The PLL_Links_Model instance.
 	 */
 	public function __construct( $provider, &$links_model ) {
-		$this->name = $provider->name;
+		$this->name        = $provider->name;
 		$this->object_type = $provider->object_type;
 
-		$this->provider = $provider;
+		$this->provider    = $provider;
 		$this->links_model = &$links_model;
-		$this->model = &$links_model->model;
+		$this->model       = &$links_model->model;
 	}
 
 	/**
@@ -104,23 +105,30 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	}
 
 	/**
-	 * Gets data for a given sitemap type.
+	 * Returns data for a given sitemap sub-type.
+	 * Suffixes the given sub-type with a language slug, so `get_sitemap_url()` can receive it.
 	 *
 	 * @since 2.8
 	 *
-	 * @param string $object_subtype_name Object subtype name if any.
-	 * @param string $lang                Optional language name.
+	 * @param string $object_subtype_name Object sub-type name if any.
+	 * @param string $lang                Optional language slug.
 	 * @return array
 	 */
 	protected function get_sitemap_data( $object_subtype_name, $lang = '' ) {
 		$object_subtype_name = (string) $object_subtype_name;
 
-		if ( ! empty( $lang ) ) {
-			self::$filter_lang = $lang;
+		if ( empty( $lang ) ) {
+			return array(
+				'name'  => $object_subtype_name,
+				'pages' => $this->get_max_num_pages( $object_subtype_name ),
+			);
 		}
 
+		// Allow `page---pll-sep---fr` (page is a "posts sub-type") and `---pll-sep---fr` (the "users" type doesn't have sub-types).
+		self::$filter_lang = $lang;
+
 		$return = array(
-			'name'  => implode( '-', array_filter( array( $object_subtype_name, $lang ) ) ),
+			'name'  => sprintf( "{$object_subtype_name}%s{$lang}", self::PLL_SEPARATOR ),
 			'pages' => $this->get_max_num_pages( $object_subtype_name ),
 		);
 
@@ -129,7 +137,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	}
 
 	/**
-	 * Gets data about each sitemap type.
+	 * Returns data about each sitemap type.
 	 *
 	 * @since 2.8
 	 *
@@ -142,10 +150,12 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		add_filter( 'wp_sitemaps_taxonomies_query_args', array( self::class, 'query_args' ) );
 
 		$object_subtypes = $this->get_object_subtypes();
+		$language_slugs  = $this->model->languages->get_list( array( 'fields' => 'slug' ) );
 
 		if ( empty( $object_subtypes ) ) {
-			foreach ( $this->model->get_languages_list( array( 'fields' => 'slug' ) ) as $language ) {
-				$sitemap_data[] = $this->get_sitemap_data( '', $language );
+			// No sub-types. Ex: users.
+			foreach ( $language_slugs as $language_slug ) {
+				$sitemap_data[] = $this->get_sitemap_data( '', $language_slug );
 			}
 		}
 
@@ -161,12 +171,14 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 		}
 
 		foreach ( array_keys( $object_subtypes ) as $object_subtype_name ) {
-			if ( call_user_func( $func, $object_subtype_name ) ) {
-				foreach ( $this->model->get_languages_list( array( 'fields' => 'slug' ) ) as $language ) {
-					$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name, $language );
-				}
-			} else {
+			if ( ! call_user_func( $func, $object_subtype_name ) ) {
+				// Not a translated sub-type.
 				$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name );
+				continue;
+			}
+
+			foreach ( $language_slugs as $language_slug ) {
+				$sitemap_data[] = $this->get_sitemap_data( $object_subtype_name, $language_slug );
 			}
 		}
 
@@ -174,7 +186,7 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	}
 
 	/**
-	 * Gets the URL of a sitemap entry.
+	 * Returns the URL of a sitemap entry.
 	 *
 	 * @since 2.8
 	 *
@@ -183,22 +195,24 @@ class PLL_Multilingual_Sitemaps_Provider extends WP_Sitemaps_Provider {
 	 * @return string The composed URL for a sitemap entry.
 	 */
 	public function get_sitemap_url( $name, $page ) {
-		// Check if a language was added in $name.
-		$pattern = '#(' . implode( '|', $this->model->get_languages_list( array( 'fields' => 'slug' ) ) ) . ')$#';
+		// Check if a language was added in `$name`.
+		$pattern = sprintf( '#^(?<SUBTYPE>.*)%s(?<LANG>.+)$#', self::PLL_SEPARATOR ); // `.*` because users don't have sub-types. See `get_sitemap_data()`.
+
 		if ( preg_match( $pattern, $name, $matches ) ) {
-			$lang = $this->model->get_language( $matches[1] );
+			$lang = $this->model->get_language( $matches['LANG'] );
 
 			if ( ! empty( $lang ) ) {
-				$name = preg_replace( '#(-?' . $lang->slug . ')$#', '', $name );
-				$url = $this->provider->get_sitemap_url( $name, $page );
+				$url = $this->provider->get_sitemap_url( $matches['SUBTYPE'], $page );
 				return $this->links_model->add_language_to_link( $url, $lang );
 			}
+			// Should not happen but we don't want our separator to stay in the final URL.
+			$name = $matches['SUBTYPE'];
 		}
 
-		// If no language is present in $name, we may attempt to get the current sitemap url (e.g. in redirect_canonical() ).
+		// If no language is present in `$name`, we may attempt to get the current sitemap URL (e.g. in `redirect_canonical()` ).
 		if ( get_query_var( 'lang' ) ) {
 			$lang = $this->model->get_language( get_query_var( 'lang' ) );
-			$url = $this->provider->get_sitemap_url( $name, $page );
+			$url  = $this->provider->get_sitemap_url( $name, $page );
 			return $this->links_model->add_language_to_link( $url, $lang );
 		}
 

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -80,7 +80,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 			'http://example.org/en/wp-sitemap-posts-page-1.xml',
 			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
 
 	public function test_sitemaps_posts() {
@@ -100,19 +100,19 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 			'http://example.org/en/wp-sitemap-posts-page-1.xml',
 			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/en/wp-sitemap-users-1.xml',
 			'http://example.org/fr/wp-sitemap-users-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['users']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['users']->get_sitemap_entries(), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/en/wp-sitemap-taxonomies-category-1.xml',
 			'http://example.org/fr/wp-sitemap-taxonomies-category-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
 	}
 
 	public function test_sitemaps_untranslated_cpt_and_tax() {
@@ -129,12 +129,12 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 			'http://example.org/en/wp-sitemap-posts-page-1.xml',
 			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/wp-sitemap-taxonomies-taxen-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
 	}
 
 	public function test_home_urls() {
@@ -151,13 +151,13 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$expected = array(
 			'http://example.org/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
 
 		$this->pll_env->curlang = self::$model->get_language( 'fr' );
 		$expected = array(
 			'http://example.org/fr/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
 
 		unset( $GLOBALS['wp_actions']['template_redirect'] );
 	}
@@ -189,34 +189,34 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$expected = array(
 			'http://example.org/test/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'post' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'post' ), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/author/admin/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['users']->get_url_list( 1 ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['users']->get_url_list( 1 ), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/tag/tag-en/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
 
 		$this->pll_env->curlang = self::$model->get_language( 'fr' );
 
 		$expected = array(
 			'http://example.org/fr/essai/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'post' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'post' ), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/fr/author/admin/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['users']->get_url_list( 1 ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['users']->get_url_list( 1 ), 'loc' ) );
 
 		$expected = array(
 			'http://example.org/fr/tag/tag-fr/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
 	}
 
 	public function test_subdomains() {
@@ -231,7 +231,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$expected = array(
 			'http://fr.example.org/wp-sitemap-posts-page-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
 
 	public function test_subdomains_home_url() {
@@ -251,7 +251,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$expected = array(
 			'http://fr.example.org/',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
 
 		unset( $GLOBALS['wp_actions']['template_redirect'] );
 	}
@@ -272,7 +272,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$expected = array(
 			'http://example.fr/wp-sitemap-posts-page-1.xml',
 		);
-		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
 
 	public function test_users() {

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -23,8 +23,9 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
 		create_initial_taxonomies();
-		register_post_type( 'cpt', array( 'public' => true ) ); // *Untranslated* custom post type.
-		register_taxonomy( 'tax', 'cpt' ); // *Untranslated* custom tax.
+		// Use a custom post type and a taxonomy whose slug ends with a language slug. See https://github.com/polylang/polylang-pro/issues/3017.
+		register_post_type( 'cpten', array( 'public' => true ) ); // *Untranslated* custom post type.
+		register_taxonomy( 'taxen', 'cpten' ); // *Untranslated* custom tax.
 
 		$links_model = self::$model->get_links_model();
 		if ( method_exists( $links_model, 'init' ) ) {
@@ -54,8 +55,8 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		_unregister_post_type( 'cpt' );
-		_unregister_taxonomy( 'tax' );
+		_unregister_post_type( 'cpten' );
+		_unregister_taxonomy( 'taxen' );
 	}
 
 	public function test_sitemap_providers() {
@@ -117,21 +118,21 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	public function test_sitemaps_untranslated_cpt_and_tax() {
 		$this->init();
 
-		self::factory()->term->create( array( 'taxonomy' => 'tax', 'name' => 'test' ) );
-		$post_id = self::factory()->post->create( array( 'post_type' => 'cpt' ) );
-		wp_set_post_terms( $post_id, 'test', 'tax' );
+		self::factory()->term->create( array( 'taxonomy' => 'taxen', 'name' => 'test' ) );
+		$post_id = self::factory()->post->create( array( 'post_type' => 'cpten' ) );
+		wp_set_post_terms( $post_id, 'test', 'taxen' );
 
 		$providers = wp_get_sitemap_providers();
 
 		$expected = array(
-			'http://example.org/wp-sitemap-posts-cpt-1.xml',
+			'http://example.org/wp-sitemap-posts-cpten-1.xml',
 			'http://example.org/en/wp-sitemap-posts-page-1.xml',
 			'http://example.org/fr/wp-sitemap-posts-page-1.xml',
 		);
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 
 		$expected = array(
-			'http://example.org/wp-sitemap-taxonomies-tax-1.xml',
+			'http://example.org/wp-sitemap-taxonomies-taxen-1.xml',
 		);
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
 	}

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -1,18 +1,16 @@
 <?php
 
 class Sitemaps_Test extends PLL_UnitTestCase {
-	/**
-	 * @param WP_UnitTest_Factory $factory
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		parent::wpSetUpBeforeClass( $factory );
-
-		self::create_language( 'en_US' );
-		self::create_language( 'fr_FR' );
+	public static function pllSetUpBeforeClass( PLL_UnitTest_Factory $factory ) {
+		$factory->language->create_many( 2 );
 	}
 
-	protected function init( $sitemap_class = 'PLL_Sitemaps' ) {
+	protected function init( $sitemap_class = 'PLL_Sitemaps', array $options = array() ): void {
 		global $wp_rewrite, $wp_sitemaps;
+
+		// To avoid a redirect due to the 'hide_default' option during the context setup.
+		add_filter( 'pll_redirect_home', '__return_false' );
+		add_filter( 'pll_check_canonical_url', '__return_false' );
 
 		// Initialize sitemaps.
 		$wp_sitemaps = null;
@@ -27,20 +25,25 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		register_post_type( 'cpten', array( 'public' => true ) ); // *Untranslated* custom post type.
 		register_taxonomy( 'taxen', 'cpten' ); // *Untranslated* custom tax.
 
-		$links_model = self::$model->get_links_model();
-		if ( method_exists( $links_model, 'init' ) ) {
-			$links_model->init();
-		}
+		$options = array_merge(
+			array(
+				'default_lang' => 'en',
+				'hide_default' => false,
+				'force_lang'   => 1,
+			),
+			$options
+		);
+		$this->pll_env = ( new PLL_Context_Frontend( array( 'options' => $options ) ) )->get();
+		$this->pll_env->links_model->init();
 
-		$this->pll_env = new PLL_Frontend( $links_model );
 		$this->pll_env->sitemaps = new $sitemap_class( $this->pll_env );
 		$this->pll_env->sitemaps->init();
 
 		wp_sitemaps_get_server(); // Allows to register sitemaps rewrite rules.
 
 		// Refresh languages.
-		self::$model->clean_languages_cache();
-		self::$model->get_languages_list();
+		$this->pll_env->model->clean_languages_cache();
+		$this->pll_env->model->get_languages_list();
 
 		// Flush rules.
 		$wp_rewrite->flush_rules();
@@ -140,8 +143,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_home_urls() {
-		self::$model->options['hide_default'] = 1;
-		$this->init();
+		$this->init( 'PLL_Sitemaps', array( 'hide_default' => true ) );
 
 		// For the home_url filter.
 		$this->pll_env->links = new PLL_Frontend_Links( $this->pll_env );
@@ -149,13 +151,13 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 
 		$providers = wp_get_sitemap_providers();
 
-		$this->pll_env->curlang = self::$model->get_language( 'en' );
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'en' );
 		$expected = array(
 			'http://example.org/',
 		);
 		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_url_list( 1, 'page' ), 'loc' ) );
 
-		$this->pll_env->curlang = self::$model->get_language( 'fr' );
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'fr' );
 		$expected = array(
 			'http://example.org/fr/',
 		);
@@ -165,8 +167,8 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_url_list_posts() {
-		self::$model->options['hide_default'] = 1;
-		$this->init();
+		$this->init( 'PLL_Sitemaps', array( 'hide_default' => true ) );
+
 		$this->pll_env->terms = new PLL_CRUD_Terms( $this->pll_env );
 
 		$tag_en = self::factory()->tag->create( array( 'name' => 'tag-en', 'lang' => 'en' ) );
@@ -180,7 +182,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 
 		$providers = wp_get_sitemap_providers();
 
-		$this->pll_env->curlang = self::$model->get_language( 'en' );
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'en' );
 
 		$expected = array(
 			'http://example.org/test/',
@@ -197,7 +199,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		);
 		$this->assertSameSets( $expected, wp_list_pluck( $providers['taxonomies']->get_url_list( 1, 'post_tag' ), 'loc' ) );
 
-		$this->pll_env->curlang = self::$model->get_language( 'fr' );
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'fr' );
 
 		$expected = array(
 			'http://example.org/fr/essai/',
@@ -216,8 +218,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_subdomains() {
-		self::$model->options['force_lang'] = 2;
-		$this->init( 'PLL_Sitemaps_Domain' );
+		$this->init( 'PLL_Sitemaps_Domain', array( 'force_lang' => 2 ) );
 
 		$_SERVER['HTTP_HOST'] = 'fr.example.org';
 		$_SERVER['REQUEST_URI'] = '/wp-sitemap.xml';
@@ -231,8 +232,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_subdomains_home_url() {
-		self::$model->options['force_lang'] = 2;
-		$this->init( 'PLL_Sitemaps_Domain' );
+		$this->init( 'PLL_Sitemaps_Domain', array( 'force_lang' => 2 ) );
 
 		$_SERVER['HTTP_HOST'] = 'fr.example.org';
 		$_SERVER['REQUEST_URI'] = '/wp-sitemap-posts-page-1.xml';
@@ -243,7 +243,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 
 		$providers = wp_get_sitemap_providers();
 
-		$this->pll_env->curlang = self::$model->get_language( 'fr' );
+		$this->pll_env->curlang = $this->pll_env->model->get_language( 'fr' );
 		$expected = array(
 			'http://fr.example.org/',
 		);
@@ -253,15 +253,19 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_domains() {
-		self::$model->options['force_lang'] = 3;
-		self::$model->options['domains'] = array(
-			'en' => 'http://example.org',
-			'fr' => 'http://example.fr',
-		);
-		$this->init( 'PLL_Sitemaps_Domain' );
-
 		$_SERVER['HTTP_HOST'] = 'example.fr';
 		$_SERVER['REQUEST_URI'] = '/wp-sitemap.xml';
+
+		$this->init(
+			'PLL_Sitemaps_Domain',
+			array(
+				'force_lang' => 3,
+				'domains'    => array(
+					'en' => 'http://example.org',
+					'fr' => 'http://example.fr',
+				),
+			)
+		);
 
 		$providers = wp_get_sitemap_providers();
 
@@ -272,9 +276,6 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_users() {
-		self::$model->options['hide_default'] = 0;
-		self::$model->options['force_lang']   = 1;
-
 		$this->init();
 
 		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'en' ) );

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -34,16 +34,11 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 			$options
 		);
 		$this->pll_env = ( new PLL_Context_Frontend( array( 'options' => $options ) ) )->get();
-		$this->pll_env->links_model->init();
 
 		$this->pll_env->sitemaps = new $sitemap_class( $this->pll_env );
 		$this->pll_env->sitemaps->init();
 
 		wp_sitemaps_get_server(); // Allows to register sitemaps rewrite rules.
-
-		// Refresh languages.
-		$this->pll_env->model->clean_languages_cache();
-		$this->pll_env->model->get_languages_list();
 
 		// Flush rules.
 		$wp_rewrite->flush_rules();

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -86,8 +86,13 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	public function test_sitemaps_posts() {
 		$this->init();
 
-		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'en' ) );
-		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'fr' ) );
+		$post_en = self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'en' ) );
+		$cat_en  = self::factory()->category->create( array( 'lang' => 'en' ) );
+		wp_set_post_terms( $post_en, array( $cat_en ), 'category' );
+
+		$post_fr = self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'fr' ) );
+		$cat_fr  = self::factory()->category->create( array( 'lang' => 'fr' ) );
+		wp_set_post_terms( $post_fr, array( $cat_fr ), 'category' );
 
 		$providers = wp_get_sitemap_providers();
 

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -274,4 +274,25 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		);
 		$this->assertEqualSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 	}
+
+	public function test_users() {
+		self::$model->options['hide_default'] = 0;
+		self::$model->options['force_lang']   = 1;
+
+		$this->init();
+
+		$en = self::factory()->post->create( array( 'post_author' => 1 ) );
+		self::$model->post->set_language( $en, 'en' );
+
+		$fr = self::factory()->post->create( array( 'post_author' => 1 ) );
+		self::$model->post->set_language( $fr, 'fr' );
+
+		$providers = wp_get_sitemap_providers();
+
+		$expected = array(
+			'http://example.org/en/wp-sitemap-users-1.xml',
+			'http://example.org/fr/wp-sitemap-users-1.xml',
+		);
+		$this->assertSameSets( $expected, wp_list_pluck( $providers['users']->get_sitemap_entries(), 'loc' ) );
+	}
 }

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -86,11 +86,8 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	public function test_sitemaps_posts() {
 		$this->init();
 
-		$en = self::factory()->post->create( array( 'post_author' => 1 ) );
-		self::$model->post->set_language( $en, 'en' );
-
-		$fr = self::factory()->post->create( array( 'post_author' => 1 ) );
-		self::$model->post->set_language( $fr, 'fr' );
+		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'en' ) );
+		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'fr' ) );
 
 		$providers = wp_get_sitemap_providers();
 
@@ -167,19 +164,13 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->init();
 		$this->pll_env->terms = new PLL_CRUD_Terms( $this->pll_env );
 
-		$tag_en = self::factory()->tag->create( array( 'name' => 'tag-en' ) );
-		self::$model->term->set_language( $tag_en, 'en' );
+		$tag_en = self::factory()->tag->create( array( 'name' => 'tag-en', 'lang' => 'en' ) );
+		$tag_fr = self::factory()->tag->create( array( 'name' => 'tag-fr', 'lang' => 'fr' ) );
 
-		$tag_fr = self::factory()->tag->create( array( 'name' => 'tag-fr' ) );
-		self::$model->term->set_language( $tag_fr, 'fr' );
-
-		$en = self::factory()->post->create( array( 'post_title' => 'test', 'post_author' => 1 ) );
-		self::$model->post->set_language( $en, 'en' );
+		$en = self::factory()->post->create( array( 'post_title' => 'test', 'post_author' => 1, 'lang' => 'en' ) );
 		wp_set_post_terms( $en, array( $tag_en ), 'post_tag' );
 
-
-		$fr = self::factory()->post->create( array( 'post_title' => 'essai', 'post_author' => 1 ) );
-		self::$model->post->set_language( $fr, 'fr' );
+		$fr = self::factory()->post->create( array( 'post_title' => 'essai', 'post_author' => 1, 'lang' => 'fr' ) );
 		wp_set_post_terms( $fr, array( $tag_fr ), 'post_tag' );
 
 		$providers = wp_get_sitemap_providers();
@@ -281,11 +272,8 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 
 		$this->init();
 
-		$en = self::factory()->post->create( array( 'post_author' => 1 ) );
-		self::$model->post->set_language( $en, 'en' );
-
-		$fr = self::factory()->post->create( array( 'post_author' => 1 ) );
-		self::$model->post->set_language( $fr, 'fr' );
+		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'en' ) );
+		self::factory()->post->create( array( 'post_author' => 1, 'lang' => 'fr' ) );
 
 		$providers = wp_get_sitemap_providers();
 

--- a/tests/phpunit/tests/test-sitemaps.php
+++ b/tests/phpunit/tests/test-sitemaps.php
@@ -23,7 +23,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		create_initial_taxonomies();
 		// Use a custom post type and a taxonomy whose slug ends with a language slug. See https://github.com/polylang/polylang-pro/issues/3017.
 		register_post_type( 'cpten', array( 'public' => true ) ); // *Untranslated* custom post type.
-		register_taxonomy( 'taxen', 'cpten' ); // *Untranslated* custom tax.
+		register_taxonomy( 'tax-en', 'cpten' ); // *Untranslated* custom tax.
 
 		$options = array_merge(
 			array(
@@ -59,7 +59,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		parent::tear_down();
 
 		_unregister_post_type( 'cpten' );
-		_unregister_taxonomy( 'taxen' );
+		_unregister_taxonomy( 'tax-en' );
 	}
 
 	public function test_sitemap_providers() {
@@ -123,9 +123,9 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 	public function test_sitemaps_untranslated_cpt_and_tax() {
 		$this->init();
 
-		self::factory()->term->create( array( 'taxonomy' => 'taxen', 'name' => 'test' ) );
+		self::factory()->term->create( array( 'taxonomy' => 'tax-en', 'name' => 'test' ) );
 		$post_id = self::factory()->post->create( array( 'post_type' => 'cpten' ) );
-		wp_set_post_terms( $post_id, 'test', 'taxen' );
+		wp_set_post_terms( $post_id, 'test', 'tax-en' );
 
 		$providers = wp_get_sitemap_providers();
 
@@ -137,7 +137,7 @@ class Sitemaps_Test extends PLL_UnitTestCase {
 		$this->assertSameSets( $expected, wp_list_pluck( $providers['posts']->get_sitemap_entries(), 'loc' ) );
 
 		$expected = array(
-			'http://example.org/wp-sitemap-taxonomies-taxen-1.xml',
+			'http://example.org/wp-sitemap-taxonomies-tax-en-1.xml',
 		);
 		$this->assertSameSets( $expected, wp_list_pluck( $providers['taxonomies']->get_sitemap_entries(), 'loc' ) );
 	}


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/3017.

## What

Polylang makes the sitemap multilingual by duplicating URLs for each language. However, when a post type or term name ends with a language code (ex: `broken` ends with `en`), this language code is stripped off the post type name, leading to an incorrect URL.

## Why

Each URL is created by `WP_Sitemaps_Provider::get_sitemap_url()`, and it accepts only 2 parameters: `$name` (a post type name, a taxonomy name) and `$page` (an integer), while Polylang needs a language to be able to add it to the URL. The solution in use is to suffix `$name` with a language code, like `page-en`: this is done by `get_sitemap_data()` in `get_sitemap_type_data()`. Then [`get_sitemap_url()` can retrieve the language code from `$name`](https://github.com/polylang/polylang/commit/596fef929b6ef487e92f33110fafa41ff21f8df2#diff-9a35433bdf5e91acdddfbd216e76b49ea291fcc552da29c16a7ba51a491b6412R206). The issue is easy to guess: create a custom post type named `foobar-fr` and tell Polylang not to translate it (otherwize Polylang will add another language code to it): when receiving `foobar-fr` in `get_sitemap_url()`, Polylang will believe it's the post type `foobar` in `fr`. Worse, the regex patterns allows `foobarfr` to match.

## How

1. Instead of using `{post_type}-{lang_code}`, use a more unique separator: `---pll-sep---`.
2. Make the regex pattern more robust.

Notes:
1. Use 1 `preg_match()` to match everything instead of: 1 `preg_match()` to match the language code, and 1 `preg_replace()` to replace it.
2. The new pattern allows `SUBTYPE` to be empty (`(?<SUBTYPE>.*)`) for the same reason that the previous patterns allowed to match without the `-` character:
  - `post`, `page`, and any CPT are post types, they are some sort of "sub-types".
  - `category`, `post_tag`, etc are taxonomies, they are also "sub-types".
  - But what about users? They don't have sub-types, that's why the sub-type is allowed to be empty. That's also why `get_sitemap_type_data()` loops through the languages to fill the output when `$object_subtypes` is empty.