### PR TITLE
Harden JS inline script

### DIFF
--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -331,7 +331,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 */
 	private function add_inline_scripts() {
 		if ( wp_script_is( 'pll_block-editor', 'enqueued' ) ) {
-			$default_lang_script = 'const pllDefaultLanguage = "' . $this->options['default_lang'] . '";';
+			$default_lang_script = sprintf( 'const pllDefaultLanguage = %s;', wp_json_encode( $this->options['default_lang'] ) );
 			wp_add_inline_script(
 				'pll_block-editor',
 				$default_lang_script,

--- a/src/language.php
+++ b/src/language.php
@@ -510,7 +510,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 		return sprintf(
 			'<img src="%s"%s%s%s%s />',
-			self::esc_flag_src( $flag['src'] ),
+			$flag['src'],
 			$alt_attr,
 			$width_attr,
 			$height_attr,
@@ -722,26 +722,6 @@ class PLL_Language extends PLL_Language_Deprecated {
 		}
 
 		return $this->$property ?? false;
-	}
-
-	/**
-	 * Escapes a flag image source URL for use in HTML.
-	 *
-	 * @since 3.9
-	 *
-	 * @param string $src Flag source URL.
-	 * @return string Escaped source URL, or empty string if invalid.
-	 */
-	protected static function esc_flag_src( string $src ): string {
-		if ( str_starts_with( $src, 'data:image/' ) ) {
-			if ( '' === esc_url_raw( $src, array( 'data' ) ) || false !== strpos( $src, '"' ) ) {
-				return '';
-			}
-
-			return $src;
-		}
-
-		return esc_url( $src );
 	}
 
 	/**

--- a/src/language.php
+++ b/src/language.php
@@ -510,7 +510,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 		return sprintf(
 			'<img src="%s"%s%s%s%s />',
-			esc_url( $flag['src'] ),
+			self::esc_flag_src( $flag['src'] ),
 			$alt_attr,
 			$width_attr,
 			$height_attr,
@@ -722,6 +722,26 @@ class PLL_Language extends PLL_Language_Deprecated {
 		}
 
 		return $this->$property ?? false;
+	}
+
+	/**
+	 * Escapes a flag image source URL for use in HTML.
+	 *
+	 * @since 3.9
+	 *
+	 * @param string $src Flag source URL.
+	 * @return string Escaped source URL, or empty string if invalid.
+	 */
+	protected static function esc_flag_src( string $src ): string {
+		if ( str_starts_with( $src, 'data:image/' ) ) {
+			if ( '' === esc_url_raw( $src, array( 'data' ) ) || false !== strpos( $src, '"' ) ) {
+				return '';
+			}
+
+			return $src;
+		}
+
+		return esc_url( $src );
 	}
 
 	/**

--- a/src/language.php
+++ b/src/language.php
@@ -510,7 +510,7 @@ class PLL_Language extends PLL_Language_Deprecated {
 
 		return sprintf(
 			'<img src="%s"%s%s%s%s />',
-			$flag['src'],
+			esc_url( $flag['src'] ),
 			$alt_attr,
 			$width_attr,
 			$height_attr,


### PR DESCRIPTION
## Summary
- Output `pllDefaultLanguage` with `wp_json_encode()` instead of string concatenation, matching the pattern used elsewhere (e.g. `pllDescriptionData`).

Fixes partially https://github.com/polylang/polylang-pro/issues/3028

## Test plan
- [ ] Open the block editor on a translated post type and confirm the default language is still applied correctly.