### PR TITLE
Fix nav block test failing with nightly

### DIFF
--- a/tests/phpunit/tests/test-switcher-block-frontend.php
+++ b/tests/phpunit/tests/test-switcher-block-frontend.php
@@ -214,10 +214,10 @@ class Switcher_Block_Frontend_Test extends PLL_UnitTestCase {
 					 * from WP_Style_Engine_CSS_Declarations::filter_declaration().
 					 * Also add some evil JavaScript (all JS evil anyway).
 					 */
-					'customOverlayBackgroundColor' => '#00ff00; word-spacing: 30px;" onclick="alert(\'toto\')"/><script>alert(\'toto\');<script/><ul style="',
+					'customOverlayBackgroundColor' => '#00ff00;" onclick="alert(\'toto\')"/><script>alert(\'toto\');<script/><ul style="',
 					'style'                        => array(
 						'typography' => array(
-							'fontSize' => '0.9rem; word-spacing: 30px;" onclick="alert(\'toto\')"/><script>alert(\'toto\');<script/><ul style="',
+							'fontSize' => '0.9rem;" onclick="alert(\'toto\')"/><script>alert(\'toto\');<script/><ul style="',
 						),
 					),
 				),


### PR DESCRIPTION
Fixes [this test](https://github.com/polylang/polylang/actions/runs/27906820113/job/82576836586) failing.

## What

Unexpected `word-spacing: 30px` appear for each `<li>` for the `Displayed as dropdown with unauthorized CSS` case of the test `test_render_polylang_navigation_switcher_block`.

## Why

[Changes to `safecss_filter_attr()`](https://github.com/WordPress/wordpress-develop/commit/e904e28cdd953271df416d2fb93e00af77e04eba#diff-13e853d5729978a0e7936543d65ad1a3e120b994702c9559bf99c3ad857f5066R2789) allow `word-spacing` to appear here.

## How

The aim of the test is to make sure that dangerous code is removed (the `onclick` attribute). `word-spacing` however, should it appear here or not, is not dangerous, so I chose to remove it from the test.