### PR TITLE
Bring back missing language names in Screen Options

### DIFF
--- a/src/admin/admin-filters-columns.php
+++ b/src/admin/admin-filters-columns.php
@@ -90,9 +90,13 @@ class PLL_Admin_Filters_Columns {
 			 * - `WP_Screen::render_list_table_columns_preferences()` applies `wp_strip_all_tags()` in the screen options:
 			 *   this will remove the flag, and reveal the language name (that looses its `<span>`).
 			 * - `WP_List_Table::print_column_headers()` doesn't apply any escaping function in the column headers:
-			 *   the flag will be displayed, and the language name will still be present but hidden.
+			 *   the flag will be displayed, and the language name will still be present but visually hidden.
 			 */
-			$columns[ 'language_' . $language->slug ] = sprintf( '%s<span class="hidden">%s</span>', $language->get_admin_flag(), esc_html( $language->name ) );
+			$columns[ "language_{$language->slug}" ] = sprintf(
+				'%s<span class="screen-reader-text">%s</span>',
+				$language->get_admin_flag( 'aria-hidden' ),
+				esc_html( $language->name )
+			);
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/src/admin/admin-filters-columns.php
+++ b/src/admin/admin-filters-columns.php
@@ -85,7 +85,14 @@ class PLL_Admin_Filters_Columns {
 		}
 
 		foreach ( $this->model->get_languages_list() as $language ) {
-			$columns[ 'language_' . $language->slug ] = $language->get_admin_flag();
+			/*
+			 * Hack:
+			 * - `WP_Screen::render_list_table_columns_preferences()` applies `wp_strip_all_tags()` in the screen options:
+			 *   this will remove the flag, and reveal the language name (that looses its `<span>`).
+			 * - `WP_List_Table::print_column_headers()` doesn't apply any escaping function in the column headers:
+			 *   the flag will be displayed, and the language name will still be present but hidden.
+			 */
+			$columns[ 'language_' . $language->slug ] = sprintf( '%s<span class="hidden">%s</span>', $language->get_admin_flag(), esc_html( $language->name ) );
 		}
 
 		return isset( $end ) ? array_merge( $columns, $end ) : $columns;

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -15,6 +15,17 @@ abstract class PLL_UnitTestCase extends WP_UnitTestCase {
 			}
 		);
 
+		Functions\when( 'get_column_headers' )->alias(
+			// Copies the WordPress function without its static variable.
+			function ( $screen ) {
+				if ( is_string( $screen ) ) {
+					$screen = convert_to_screen( $screen );
+				}
+
+				return apply_filters( "manage_{$screen->id}_columns", array() );
+			}
+		);
+
 		parent::set_up();
 
 		add_filter( 'wp_using_themes', '__return_true' ); // To pass the test in PLL_Choose_Lang::init() by default.

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -300,7 +300,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		// Make sure the columns contain an image, and a language name wrapped in a tag.
 		$this->assertArrayHasKey( 'language_en', $columns );
 		$this->assertStringContainsString( '<img ', $columns['language_en'] );
-		$this->assertStringContainsString( '<span class="hidden">English</span>', $columns['language_en'] );
+		$this->assertStringContainsString( '<span class="screen-reader-text">English</span>', $columns['language_en'] );
 
 		// Assert the position in the list.
 		$columns = array_keys( $columns );
@@ -334,7 +334,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		// Make sure the columns contain an image, and a language name wrapped in a tag.
 		$this->assertArrayHasKey( 'language_en', $columns );
 		$this->assertStringContainsString( '<img ', $columns['language_en'] );
-		$this->assertStringContainsString( '<span class="hidden">English</span>', $columns['language_en'] );
+		$this->assertStringContainsString( '<span class="screen-reader-text">English</span>', $columns['language_en'] );
 
 		// Assert the position in the list.
 		$columns = array_keys( $columns );

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -296,6 +296,13 @@ class Columns_Test extends PLL_UnitTestCase {
 		$columns = $list_table->get_column_info()[0];
 		$columns = array_intersect_key( $columns, array_flip( array( 'comments' ) ) ); // Keep only the Comments column.
 		$columns = apply_filters( 'manage_edit-post_columns', $columns );
+
+		// Make sure the columns contain an image, and a language name wrapped in a tag.
+		$this->assertArrayHasKey( 'language_en', $columns );
+		$this->assertStringContainsString( '<img ', $columns['language_en'] );
+		$this->assertStringContainsString( '<span class="hidden">English</span>', $columns['language_en'] );
+
+		// Assert the position in the list.
 		$columns = array_keys( $columns );
 		$en = array_search( 'language_en', $columns );
 
@@ -323,6 +330,13 @@ class Columns_Test extends PLL_UnitTestCase {
 		$columns = $list_table->get_column_info()[0];
 		$columns = array_intersect_key( $columns, array_flip( array( 'posts' ) ) ); // Keep only the Count column.
 		$columns = apply_filters( 'manage_edit-post_tag_columns', $columns );
+
+		// Make sure the columns contain an image, and a language name wrapped in a tag.
+		$this->assertArrayHasKey( 'language_en', $columns );
+		$this->assertStringContainsString( '<img ', $columns['language_en'] );
+		$this->assertStringContainsString( '<span class="hidden">English</span>', $columns['language_en'] );
+
+		// Assert the position in the list.
 		$columns = array_keys( $columns );
 		$en = array_search( 'language_en', $columns );
 

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -33,9 +33,6 @@ class Columns_Test extends PLL_UnitTestCase {
 		wp_set_current_user( self::$editor );
 	}
 
-	/**
-	 * This must be the first test due to the static variable in get_culumn_headers().
-	 */
 	public function test_no_screen_options_in_term_screen() {
 		new PLL_Context_Admin();
 		set_current_screen( 'term.php' );
@@ -43,10 +40,8 @@ class Columns_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * This test has also to deal with the static variable in get_culumn_headers().
-	 *
 	 * @testWith ["edit-post"]
-	 *           ["edit-category"]
+	 *           ["edit-tags"]
 	 *
 	 * @param string $screen
 	 * @return void

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -42,6 +42,32 @@ class Columns_Test extends PLL_UnitTestCase {
 		$this->assertEmpty( get_column_headers( get_current_screen() ) );
 	}
 
+	/**
+	 * This test has also to deal with the static variable in get_culumn_headers().
+	 *
+	 * @testWith ["edit-post"]
+	 *           ["edit-category"]
+	 *
+	 * @param string $screen
+	 * @return void
+	 */
+	public function test_screen_options_in_list_screens( $screen ) {
+		new PLL_Context_Admin();
+		set_current_screen( $screen );
+
+		ob_start();
+		get_current_screen()->render_list_table_columns_preferences();
+		$html = ob_get_clean();
+
+		$doc  = new DomDocument();
+		$doc->loadHTML( '<?xml encoding="UTF-8">' . $html );
+		$xpath = new DOMXpath( $doc );
+
+		$this->assertNotEmpty( $xpath->query( '//label[.="English"]' )->length );
+		$this->assertNotEmpty( $xpath->query( '//label[.="Français"]' )->length );
+	}
+
+
 	public function test_post_with_no_language() {
 		$post_id = self::factory()->post->create();
 

--- a/tests/phpunit/tests/test-columns.php
+++ b/tests/phpunit/tests/test-columns.php
@@ -59,7 +59,7 @@ class Columns_Test extends PLL_UnitTestCase {
 		get_current_screen()->render_list_table_columns_preferences();
 		$html = ob_get_clean();
 
-		$doc  = new DomDocument();
+		$doc = new DomDocument();
 		$doc->loadHTML( '<?xml encoding="UTF-8">' . $html );
 		$xpath = new DOMXpath( $doc );
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/3032.

Regression introduced by https://github.com/polylang/polylang/pull/1857/changes#diff-d6f3bf462714cc89a7ed43ae3abadb594e878c5900a7c3f25ef920f327e0b410L88.

## Why

`WP_Screen::render_list_table_columns_preferences()` applies `wp_strip_all_tags()` in the screen options, which removes our flags and leave an empty label.

## How

Add the language name next to the flag, but as a hidden text (wrapped in `<span class="screen-reader-text">`).

1. `WP_Screen::render_list_table_columns_preferences()` will remove the flag, and reveal the language name (that looses its `<span>`).
2. `WP_List_Table::print_column_headers()` doesn't apply any escaping function in the column headers: the flag will be displayed, and the language name will still be present but hidden.