### PR TITLE
Fix a typo in `pll_get_requested_url` doc

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -26,7 +26,7 @@ function pll_is_cache_active() {
 }
 
 /**
- * Get the the current requested url
+ * Get the current requested url.
  *
  * @since 2.6
  *


### PR DESCRIPTION
fix a typo in the doc description