### PR TITLE
Allow the `select` layout to hide the current language

### DIFF
--- a/js/src/blocks/language-switcher/components/switcher-controls.js
+++ b/js/src/blocks/language-switcher/components/switcher-controls.js
@@ -269,15 +269,13 @@ export const SwitcherControls = ( { attributes, setAttributes } ) => {
 							setAttributes( { force_home: value } )
 						}
 					/>
-					{ 'select' !== layout && (
-						<ToggleControl
-							label={ __( 'Hide current', 'polylang' ) }
-							checked={ hide_current }
-							onChange={ ( value ) =>
-								setAttributes( { hide_current: value } )
-							}
-						/>
-					) }
+					<ToggleControl
+						label={ __( 'Hide current', 'polylang' ) }
+						checked={ hide_current }
+						onChange={ ( value ) =>
+							setAttributes( { hide_current: value } )
+						}
+					/>
 					<ToggleControl
 						label={ __( 'Hide if no translation', 'polylang' ) }
 						checked={ hide_if_no_translation }

--- a/js/src/blocks/language-switcher/components/switcher-controls.js
+++ b/js/src/blocks/language-switcher/components/switcher-controls.js
@@ -269,13 +269,15 @@ export const SwitcherControls = ( { attributes, setAttributes } ) => {
 							setAttributes( { force_home: value } )
 						}
 					/>
-					<ToggleControl
-						label={ __( 'Hide current', 'polylang' ) }
-						checked={ hide_current }
-						onChange={ ( value ) =>
-							setAttributes( { hide_current: value } )
-						}
-					/>
+					{ 'select' !== layout && (
+						<ToggleControl
+							label={ __( 'Hide current', 'polylang' ) }
+							checked={ hide_current }
+							onChange={ ( value ) =>
+								setAttributes( { hide_current: value } )
+							}
+						/>
+					) }
 					<ToggleControl
 						label={ __( 'Hide if no translation', 'polylang' ) }
 						checked={ hide_if_no_translation }

--- a/src/Switcher/Fields/Widget.php
+++ b/src/Switcher/Fields/Widget.php
@@ -76,10 +76,7 @@ class Widget extends Abstract_Fields {
 				'label' => __( 'Force link to front page', 'polylang' ),
 			),
 			'hide_current'           => array(
-				'label'   => __( 'Hide the current language', 'polylang' ),
-				'hide_if' => array(
-					'layout' => 'select',
-				),
+				'label' => __( 'Hide the current language', 'polylang' ),
 			),
 			'hide_if_no_translation' => array(
 				'label' => __( 'Hide languages with no translation', 'polylang' ),

--- a/src/Switcher/Settings/Settings.php
+++ b/src/Switcher/Settings/Settings.php
@@ -250,9 +250,8 @@ class Settings extends Abstract_Settings_Legacy {
 
 		// Mandatory settings for the `select` layout.
 		if ( 'select' === $validated['layout'] ) {
-			$validated['show_flags']   = false;
-			$validated['show_labels']  = 'names';
-			$validated['hide_current'] = false;
+			$validated['show_flags']  = false;
+			$validated['show_labels'] = 'names';
 		}
 
 		// Make sure something is displayed.


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2958.

All is in the title.