### PR TITLE
chore(deps): bump polylang-build-scripts to 2.2.0

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -26,6 +26,7 @@ js/src/
 node_modules/
 tests/
 tmp/
+dist/
 
 # Playwright
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ js/build/
 node_modules/
 tmp
 vendor/
+dist/
 
 # Files
 src/integrations/integration-build.php

--- a/package.json
+++ b/package.json
@@ -36,13 +36,15 @@
     "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/scripts": "^31.6.0",
+    "@wpsyntex/distribute": "^0.1.0",
     "@wpsyntex/e2e-test-utils": "^0.1.0",
-    "@wpsyntex/polylang-build-scripts": "^2.1.0",
+    "@wpsyntex/polylang-build-scripts": "^2.2.0",
     "babel-loader": "^8.4.1",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.1.4",
-    "css-minimizer-webpack-plugin": "^6.0.0",
+    "css-minimizer-webpack-plugin": "^8.0.0",
+    "glob": "^11.0.0",
     "mini-css-extract-plugin": "^2.10.1",
     "postcss": "^8.5.8",
     "rimraf": "^6.1.3",
@@ -69,6 +71,7 @@
     "test:php:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 vendor/bin/phpunit'",
     "test:php:coverage": "npm run env:composer coverage",
     "test:php:coverage:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 composer coverage'",
-    "lint:js": "wp-scripts lint-js"
+    "lint:js": "wp-scripts lint-js",
+    "dist": "distribute"
   }
 }


### PR DESCRIPTION
## What?

- Bump `@wpsyntex/polylang-build-scripts` from `^2.1.0` to `^2.2.0`.
- Add `@wpsyntex/distribute` (`^0.1.0`) as a dev dependency.
- Wire the `dist` npm script to run `distribute`.
- Align transitive build tooling with build-scripts 2.2.0 (`css-minimizer-webpack-plugin` `^8.0.0`, `glob` `^11.0.0`).
- Ignore `dist/` in `.gitignore` and `.distignore` so release zip artifacts are not tracked or packaged.

## Why?

`@wpsyntex/polylang-build-scripts` 2.2.0 introduces new peer dependency constraints. And the shared `@wpsyntex/distribute` package for release packaging is now live. This repo should use the same version and expose `npm run dist` for consistent zip builds across WPSyntex plugins.

## How?

Update `package.json` devDependencies and scripts; add `dist/` to ignore files. No application PHP/JS source changes.

## Test plan

- [x] `npm install` completes without errors
- [x] `npm run build` succeeds
- [x] `npm run dist` produces the expected release artifact
- [x] CI passes on this PR