### PR TITLE
fix(phpdoc): qualify class names in Languages model docs

### DIFF
--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -115,7 +115,7 @@ class Languages {
 	 *                     this is to prevent confusion between `term_id` and `term_taxonomy_id`.
 	 * @return \PLL_Language|false Language object, false if no language found.
 	 *
-	 * @phpstan-param PLL_Language|WP_Term|int|string $value
+	 * @phpstan-param \PLL_Language|\WP_Term|int|string $value
 	 */
 	public function get( $value ) {
 		if ( $value instanceof PLL_Language ) {
@@ -143,7 +143,7 @@ class Languages {
 			$this->cache->set( 'language:' . $lang->w3c, $lang );
 		}
 
-		/** @var PLL_Language|false */
+		/** @var \PLL_Language|false */
 		return $this->cache->get( 'language:' . $value );
 	}
 
@@ -663,7 +663,7 @@ class Languages {
 			 * @since 3.4 Deprecated. If you used this hook to filter URLs, you may hook `'site_url'` instead.
 			 * @deprecated
 			 *
-			 * @param PLL_Language[] $languages The list of language objects.
+			 * @param \PLL_Language[] $languages The list of language objects.
 			 */
 			$languages = apply_filters_deprecated( 'pll_after_languages_cache', array( $languages ), '3.4' );
 
@@ -1025,7 +1025,7 @@ class Languages {
 		// Don't allow to overwrite `$locale`, `$rtl`, and `$flag_code`.
 		$new_data = array_merge( $old_data, $add_data, $new_data );
 
-		/** @var non-empty-string $serialized maybe_serialize() cannot return anything else than a string when fed by an array. */
+		/** @phpstan-var non-empty-string $serialized maybe_serialize() cannot return anything else than a string when fed by an array. */
 		$serialized = maybe_serialize( $new_data );
 		return $serialized;
 	}
@@ -1136,7 +1136,7 @@ class Languages {
 				 * }
 				 * @param string           $old_slug The old language slug.
 				 * @param string           $new_slug The new language slug.
-				 * @param WP_Term          $term     The term containing the post or term translation group.
+				 * @param \WP_Term         $term     The term containing the post or term translation group.
 				 */
 				$tr = apply_filters( 'update_translation_group', $tr, $old_slug, $new_slug, $term );
 
@@ -1304,7 +1304,7 @@ class Languages {
 	 *
 	 * @return \PLL_Language[] An array of `PLL_Language` objects, array keys are the type.
 	 *
-	 * @phpstan-return list<PLL_Language>
+	 * @phpstan-return list<\PLL_Language>
 	 */
 	protected function get_from_taxonomies(): array {
 		$terms_by_slug = array();
@@ -1316,11 +1316,11 @@ class Languages {
 		}
 
 		/**
-		 * @var (
+		 * @phpstan-var (
 		 *     array{
 		 *         string: array{
-		 *             language: WP_Term,
-		 *         }&array<non-empty-string, WP_Term>
+		 *             language: \WP_Term,
+		 *         }&array<non-empty-string, \WP_Term>
 		 *     }
 		 * ) $terms_by_slug
 		 */
@@ -1339,14 +1339,14 @@ class Languages {
 		 * @since 3.4 Deprecated.
 		 * @deprecated
 		 *
-		 * @param PLL_Language[]       $languages The list of language objects.
-		 * @param Languages $model     `Language` object.
+		 * @param \PLL_Language[] $languages The list of language objects.
+		 * @param \Languages      $model     `Languages` object.
 		 */
 		$languages = apply_filters_deprecated( 'pll_languages_list', array( $languages, $this ), '3.4', 'pll_additional_language_data' );
 
 		if ( ! $this->are_ready() ) {
 			// Do not cache an incomplete list.
-			/** @var list<PLL_Language> $languages */
+			/** @phpstan-var list<\PLL_Language> $languages */
 			return $languages;
 		}
 
@@ -1365,7 +1365,7 @@ class Languages {
 
 		set_transient( self::TRANSIENT_NAME, $languages_data );
 
-		/** @var list<PLL_Language> $languages */
+		/** @phpstan-var list<\PLL_Language> $languages */
 		return $languages;
 	}
 

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -33,23 +33,23 @@ class Languages {
 	/**
 	 * Polylang's options.
 	 *
-	 * @var Options
+	 * @var \WP_Syntex\Polylang\Options\Options
 	 */
 	private Options $options;
 
 	/**
 	 * Translatable objects registry.
 	 *
-	 * @var PLL_Translatable_Objects
+	 * @var \PLL_Translatable_Objects
 	 */
 	private PLL_Translatable_Objects $translatable_objects;
 
 	/**
 	 * Internal non persistent cache object.
 	 *
-	 * @var PLL_Cache
+	 * @var \PLL_Cache
 	 *
-	 * @phpstan-var PLL_Cache<mixed>
+	 * @phpstan-var \PLL_Cache<mixed>
 	 */
 	private PLL_Cache $cache;
 
@@ -90,11 +90,11 @@ class Languages {
 	 *
 	 * @since 3.7
 	 *
-	 * @param Options                  $options              Polylang's options.
-	 * @param PLL_Translatable_Objects $translatable_objects Translatable objects registry.
-	 * @param PLL_Cache                $cache                Internal non persistent cache object.
+	 * @param \WP_Syntex\Polylang\Options\Options $options              Polylang's options.
+	 * @param \PLL_Translatable_Objects           $translatable_objects Translatable objects registry.
+	 * @param \PLL_Cache                          $cache                Internal non persistent cache object.
 	 *
-	 * @phpstan-param PLL_Cache<mixed> $cache
+	 * @phpstan-param \PLL_Cache<mixed> $cache
 	 */
 	public function __construct( Options $options, PLL_Translatable_Objects $translatable_objects, PLL_Cache $cache ) {
 		$this->options              = $options;
@@ -750,7 +750,7 @@ class Languages {
 	 *            Returns a `WP_Error` object.
 	 *
 	 * @param string $slug New language slug.
-	 * @return WP_Error A `WP_Error` object containing possible errors during slug validation/sanitization.
+	 * @return \WP_Error A `WP_Error` object containing possible errors during slug validation/sanitization.
 	 */
 	public function update_default( string $slug ): WP_Error {
 		$prev_default_lang = $this->options->get( 'default_lang' );
@@ -1036,9 +1036,9 @@ class Languages {
 	 * @since 0.4
 	 * @since 3.7 Moved from `PLL_Admin_Model::validate_lang()` to `WP_Syntex\Polylang\Model\Languages::validate_lang()`.
 	 *
-	 * @param array             $args Parameters of {@see WP_Syntex\Polylang\Model\Languages::add() or @see WP_Syntex\Polylang\Model\Languages::update()}.
-	 * @param PLL_Language|null $lang Optional the language currently updated, the language is created if not set.
-	 * @return WP_Error
+	 * @param array              $args Parameters of {@see WP_Syntex\Polylang\Model\Languages::add() or @see WP_Syntex\Polylang\Model\Languages::update()}.
+	 * @param \PLL_Language|null $lang Optional the language currently updated, the language is created if not set.
+	 * @return \WP_Error
 	 *
 	 * @phpstan-param array{
 	 *     locale?: string,
@@ -1100,7 +1100,7 @@ class Languages {
 	 *
 	 * @param string $old_slug The old language slug.
 	 * @param string $new_slug Optional, the new language slug, if not set it means that the language has been deleted.
-	 * @return WP_Error
+	 * @return \WP_Error
 	 *
 	 * @phpstan-param non-empty-string $old_slug
 	 */
@@ -1238,12 +1238,12 @@ class Languages {
 	 * @since 3.4
 	 * @since 3.7 Moved from `PLL_Model::update_secondary_language_terms()` to `WP_Syntex\Polylang\Model\Languages::update_secondary_language_terms()`.
 	 *
-	 * @param string            $slug       Language term slug (with or without the `pll_` prefix).
-	 * @param string            $name       Language name (label).
-	 * @param PLL_Language|null $language   Optional. A language object. Required to update the existing terms.
-	 * @param string[]          $taxonomies Optional. List of language taxonomies to deal with. An empty value means
-	 *                                      all of them. Defaults to all taxonomies.
-	 * @return WP_Error
+	 * @param string             $slug       Language term slug (with or without the `pll_` prefix).
+	 * @param string             $name       Language name (label).
+	 * @param \PLL_Language|null $language   Optional. A language object. Required to update the existing terms.
+	 * @param string[]           $taxonomies Optional. List of language taxonomies to deal with. An empty value means
+	 *                                       all of them. Defaults to all taxonomies.
+	 * @return \WP_Error
 	 *
 	 * @phpstan-param non-empty-string $slug
 	 * @phpstan-param non-empty-string $name

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -5,12 +5,12 @@
 
 namespace WP_Syntex\Polylang\Model;
 
+use WP_Term;
+use WP_Error;
 use PLL_Cache;
 use PLL_Language;
 use PLL_Language_Factory;
 use PLL_Translatable_Objects;
-use WP_Error;
-use WP_Term;
 use WP_Syntex\Polylang\Options\Options;
 
 defined( 'ABSPATH' ) || exit;

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -182,7 +182,7 @@ class Languages {
 	 *     no_default_cat?: bool
 	 * } $args
 	 */
-	public function add( array $args ) {
+	public function add( $args ) {
 		$args['rtl']        = $args['rtl'] ?? $args['is_rtl'] ?? null;
 		$args['flag']       = $args['flag'] ?? $args['flag_code'] ?? null;
 		$args['term_group'] = $args['term_group'] ?? 0;
@@ -313,7 +313,7 @@ class Languages {
 	 *     flag_code?: string
 	 * } $args
 	 */
-	public function update( array $args ) {
+	public function update( $args ) {
 		$id   = (int) $args['lang_id'];
 		$lang = $this->get( $id );
 
@@ -471,8 +471,8 @@ class Languages {
 	 * @param int $lang_id Language term_id.
 	 * @return bool
 	 */
-	public function delete( int $lang_id ): bool {
-		$lang = $this->get( $lang_id );
+	public function delete( $lang_id ): bool {
+		$lang = $this->get( (int) $lang_id );
 
 		if ( empty( $lang ) ) {
 			return false;
@@ -586,7 +586,7 @@ class Languages {
 	 * }
 	 * @return array List of PLL_Language objects or PLL_Language object properties.
 	 */
-	public function get_list( array $args = array() ): array {
+	public function get_list( $args = array() ): array {
 		if ( ! $this->are_ready() ) {
 			_doing_it_wrong(
 				__METHOD__ . '()',
@@ -752,7 +752,7 @@ class Languages {
 	 * @param string $slug New language slug.
 	 * @return WP_Error A `WP_Error` object containing possible errors during slug validation/sanitization.
 	 */
-	public function update_default( string $slug ): WP_Error {
+	public function update_default( $slug ): WP_Error {
 		$prev_default_lang = $this->options->get( 'default_lang' );
 
 		if ( $prev_default_lang === $slug ) {
@@ -1047,7 +1047,7 @@ class Languages {
 	 *     flag?: string
 	 * } $args
 	 */
-	protected function validate_lang( array $args, ?PLL_Language $lang = null ): WP_Error {
+	protected function validate_lang( $args, ?PLL_Language $lang = null ): WP_Error {
 		$errors = new WP_Error();
 
 		// Validate locale with the same pattern as WP 4.3. See #28303.
@@ -1104,7 +1104,7 @@ class Languages {
 	 *
 	 * @phpstan-param non-empty-string $old_slug
 	 */
-	protected function update_translations( string $old_slug, string $new_slug = '' ): WP_Error {
+	protected function update_translations( $old_slug, $new_slug = '' ): WP_Error {
 		global $wpdb;
 
 		$term_ids = array();
@@ -1249,7 +1249,7 @@ class Languages {
 	 * @phpstan-param non-empty-string $name
 	 * @phpstan-param array<non-empty-string> $taxonomies
 	 */
-	protected function update_secondary_language_terms( string $slug, string $name, ?PLL_Language $language = null, array $taxonomies = array() ): WP_Error {
+	protected function update_secondary_language_terms( $slug, $name, ?PLL_Language $language = null, array $taxonomies = array() ): WP_Error {
 		$slug = 0 === strpos( $slug, 'pll_' ) ? $slug : "pll_$slug";
 		$errors = new WP_Error();
 

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -35,35 +35,37 @@ class Languages {
 	 *
 	 * @var Options
 	 */
-	private $options;
+	private Options $options;
 
 	/**
 	 * Translatable objects registry.
 	 *
 	 * @var PLL_Translatable_Objects
 	 */
-	private $translatable_objects;
+	private PLL_Translatable_Objects $translatable_objects;
 
 	/**
 	 * Internal non persistent cache object.
 	 *
-	 * @var PLL_Cache<mixed>
+	 * @var PLL_Cache
+	 *
+	 * @phpstan-var PLL_Cache<mixed>
 	 */
-	private $cache;
+	private PLL_Cache $cache;
 
 	/**
 	 * Flag set to true during the language objects creation.
 	 *
 	 * @var bool
 	 */
-	private $is_creating_list = false;
+	private bool $is_creating_list = false;
 
 	/**
 	 * Tells if {@see WP_Syntex\Polylang\Model\Languages::get_list()} can be used.
 	 *
 	 * @var bool
 	 */
-	private $languages_ready = false;
+	private bool $languages_ready = false;
 
 	/**
 	 * List of automatic language proxies.
@@ -72,7 +74,7 @@ class Languages {
 	 *
 	 * @phpstan-var array<non-falsy-string, Languages_Proxy_Interface>
 	 */
-	private $automatic_proxies = array();
+	private array $automatic_proxies = array();
 
 	/**
 	 * List of language proxies.
@@ -81,7 +83,7 @@ class Languages {
 	 *
 	 * @phpstan-var array<non-falsy-string, Languages_Proxy_Interface>
 	 */
-	private $proxies = array();
+	private array $proxies = array();
 
 	/**
 	 * Constructor.

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -182,7 +182,7 @@ class Languages {
 	 *     no_default_cat?: bool
 	 * } $args
 	 */
-	public function add( $args ) {
+	public function add( array $args ) {
 		$args['rtl']        = $args['rtl'] ?? $args['is_rtl'] ?? null;
 		$args['flag']       = $args['flag'] ?? $args['flag_code'] ?? null;
 		$args['term_group'] = $args['term_group'] ?? 0;
@@ -313,7 +313,7 @@ class Languages {
 	 *     flag_code?: string
 	 * } $args
 	 */
-	public function update( $args ) {
+	public function update( array $args ) {
 		$id   = (int) $args['lang_id'];
 		$lang = $this->get( $id );
 
@@ -471,8 +471,8 @@ class Languages {
 	 * @param int $lang_id Language term_id.
 	 * @return bool
 	 */
-	public function delete( $lang_id ): bool {
-		$lang = $this->get( (int) $lang_id );
+	public function delete( int $lang_id ): bool {
+		$lang = $this->get( $lang_id );
 
 		if ( empty( $lang ) ) {
 			return false;
@@ -586,7 +586,7 @@ class Languages {
 	 * }
 	 * @return array List of PLL_Language objects or PLL_Language object properties.
 	 */
-	public function get_list( $args = array() ): array {
+	public function get_list( array $args = array() ): array {
 		if ( ! $this->are_ready() ) {
 			_doing_it_wrong(
 				__METHOD__ . '()',
@@ -752,7 +752,7 @@ class Languages {
 	 * @param string $slug New language slug.
 	 * @return WP_Error A `WP_Error` object containing possible errors during slug validation/sanitization.
 	 */
-	public function update_default( $slug ): WP_Error {
+	public function update_default( string $slug ): WP_Error {
 		$prev_default_lang = $this->options->get( 'default_lang' );
 
 		if ( $prev_default_lang === $slug ) {
@@ -1047,7 +1047,7 @@ class Languages {
 	 *     flag?: string
 	 * } $args
 	 */
-	protected function validate_lang( $args, ?PLL_Language $lang = null ): WP_Error {
+	protected function validate_lang( array $args, ?PLL_Language $lang = null ): WP_Error {
 		$errors = new WP_Error();
 
 		// Validate locale with the same pattern as WP 4.3. See #28303.
@@ -1104,7 +1104,7 @@ class Languages {
 	 *
 	 * @phpstan-param non-empty-string $old_slug
 	 */
-	protected function update_translations( $old_slug, $new_slug = '' ): WP_Error {
+	protected function update_translations( string $old_slug, string $new_slug = '' ): WP_Error {
 		global $wpdb;
 
 		$term_ids = array();
@@ -1249,7 +1249,7 @@ class Languages {
 	 * @phpstan-param non-empty-string $name
 	 * @phpstan-param array<non-empty-string> $taxonomies
 	 */
-	protected function update_secondary_language_terms( $slug, $name, ?PLL_Language $language = null, array $taxonomies = array() ): WP_Error {
+	protected function update_secondary_language_terms( string $slug, string $name, ?PLL_Language $language = null, array $taxonomies = array() ): WP_Error {
 		$slug = 0 === strpos( $slug, 'pll_' ) ? $slug : "pll_$slug";
 		$errors = new WP_Error();
 

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -111,7 +111,7 @@ class Languages {
 	 *                     `term_id` and `term_taxonomy_id` can be fetched for any language taxonomy.
 	 *                     /!\ For the `term_taxonomy_id`, prefix the ID by `tt:` (ex: `"tt:{$tt_id}"`),
 	 *                     this is to prevent confusion between `term_id` and `term_taxonomy_id`.
-	 * @return PLL_Language|false Language object, false if no language found.
+	 * @return \PLL_Language|false Language object, false if no language found.
 	 *
 	 * @phpstan-param PLL_Language|WP_Term|int|string $value
 	 */
@@ -166,7 +166,7 @@ class Languages {
 	 *   @type string $flag_code      Optional. Country code, {@see src/settings/flags.php}. Will be converted to flag.
 	 *   @type bool   $no_default_cat Optional. If set, no default category will be created for this language. Default is false.
 	 * }
-	 * @return PLL_Language|WP_Error The object language on success, a `WP_Error` otherwise.
+	 * @return \PLL_Language|\WP_Error The object language on success, a `WP_Error` otherwise.
 	 *
 	 * @phpstan-param array{
 	 *     name?: string,
@@ -297,7 +297,7 @@ class Languages {
 	 *   @type string $flag       Optional, country code, {@see src/settings/flags.php}.
 	 *   @type string $flag_code  Optional. Country code, {@see src/settings/flags.php}. Will be converted to flag.
 	 * }
-	 * @return PLL_Language|WP_Error The updated object language on success, a `WP_Error` otherwise.
+	 * @return \PLL_Language|\WP_Error The updated object language on success, a `WP_Error` otherwise.
 	 *
 	 * @phpstan-param array{
 	 *     lang_id: int|numeric-string,
@@ -453,7 +453,7 @@ class Languages {
 		 *   @type string $no_default_cat Optional, if set, no default category has been created for this language.
 		 *   @type string $flag           Optional, country code, @see src/settings/flags.php.
 		 * }
-		 * @param PLL_Language $lang Previous value of the language being edited.
+		 * @param \PLL_Language $lang Previous value of the language being edited.
 		 */
 		do_action( 'pll_update_language', $args, $lang );
 
@@ -720,7 +720,7 @@ class Languages {
 	 * @since 3.4
 	 * @since 3.7 Moved from `PLL_Model::get_default_language()` to `WP_Syntex\Polylang\Model\Languages::get_default()`.
 	 *
-	 * @return PLL_Language|false Default language object, `false` if no language found.
+	 * @return \PLL_Language|false Default language object, `false` if no language found.
 	 */
 	public function get_default() {
 		if ( ! empty( $this->options['default_lang'] ) ) {
@@ -880,8 +880,8 @@ class Languages {
 	 *
 	 * @since 3.8
 	 *
-	 * @param PLL_Language[] $languages The list of language objects.
-	 * @param array          $args {
+	 * @param \PLL_Language[] $languages The list of language objects.
+	 * @param array           $args {
 	 *   @type string $fields Optional. Returns only that field if set; {@see PLL_Language} for a list of fields.
 	 * }
 	 * @return array List of `PLL_Language` objects or `PLL_Language` object properties.
@@ -1300,7 +1300,7 @@ class Languages {
 	 * @since 3.4
 	 * @since 3.7 Moved from `PLL_Model::get_languages_from_taxonomies()` to `WP_Syntex\Polylang\Model\Languages::get_from_taxonomies()`.
 	 *
-	 * @return PLL_Language[] An array of `PLL_Language` objects, array keys are the type.
+	 * @return \PLL_Language[] An array of `PLL_Language` objects, array keys are the type.
 	 *
 	 * @phpstan-return list<PLL_Language>
 	 */
@@ -1338,7 +1338,7 @@ class Languages {
 		 * @deprecated
 		 *
 		 * @param PLL_Language[]       $languages The list of language objects.
-		 * @param Language $model     `Language` object.
+		 * @param Languages $model     `Language` object.
 		 */
 		$languages = apply_filters_deprecated( 'pll_languages_list', array( $languages, $this ), '3.4', 'pll_additional_language_data' );
 
@@ -1375,7 +1375,7 @@ class Languages {
 	 * @since 3.2.3
 	 * @since 3.7 Moved from `PLL_Model::get_language_terms()` to `WP_Syntex\Polylang\Model\Languages::get_terms()`.
 	 *
-	 * @return WP_Term[]
+	 * @return \WP_Term[]
 	 */
 	protected function get_terms(): array {
 		$terms = get_terms(

--- a/src/Model/Languages.php
+++ b/src/Model/Languages.php
@@ -33,23 +33,23 @@ class Languages {
 	/**
 	 * Polylang's options.
 	 *
-	 * @var \WP_Syntex\Polylang\Options\Options
+	 * @var Options
 	 */
 	private Options $options;
 
 	/**
 	 * Translatable objects registry.
 	 *
-	 * @var \PLL_Translatable_Objects
+	 * @var PLL_Translatable_Objects
 	 */
 	private PLL_Translatable_Objects $translatable_objects;
 
 	/**
 	 * Internal non persistent cache object.
 	 *
-	 * @var \PLL_Cache
+	 * @var PLL_Cache
 	 *
-	 * @phpstan-var \PLL_Cache<mixed>
+	 * @phpstan-var PLL_Cache<mixed>
 	 */
 	private PLL_Cache $cache;
 
@@ -90,11 +90,11 @@ class Languages {
 	 *
 	 * @since 3.7
 	 *
-	 * @param \WP_Syntex\Polylang\Options\Options $options              Polylang's options.
-	 * @param \PLL_Translatable_Objects           $translatable_objects Translatable objects registry.
-	 * @param \PLL_Cache                          $cache                Internal non persistent cache object.
+	 * @param Options                  $options              Polylang's options.
+	 * @param PLL_Translatable_Objects $translatable_objects Translatable objects registry.
+	 * @param PLL_Cache                $cache                Internal non persistent cache object.
 	 *
-	 * @phpstan-param \PLL_Cache<mixed> $cache
+	 * @phpstan-param PLL_Cache<mixed> $cache
 	 */
 	public function __construct( Options $options, PLL_Translatable_Objects $translatable_objects, PLL_Cache $cache ) {
 		$this->options              = $options;
@@ -750,7 +750,7 @@ class Languages {
 	 *            Returns a `WP_Error` object.
 	 *
 	 * @param string $slug New language slug.
-	 * @return \WP_Error A `WP_Error` object containing possible errors during slug validation/sanitization.
+	 * @return WP_Error A `WP_Error` object containing possible errors during slug validation/sanitization.
 	 */
 	public function update_default( string $slug ): WP_Error {
 		$prev_default_lang = $this->options->get( 'default_lang' );
@@ -1036,9 +1036,9 @@ class Languages {
 	 * @since 0.4
 	 * @since 3.7 Moved from `PLL_Admin_Model::validate_lang()` to `WP_Syntex\Polylang\Model\Languages::validate_lang()`.
 	 *
-	 * @param array              $args Parameters of {@see WP_Syntex\Polylang\Model\Languages::add() or @see WP_Syntex\Polylang\Model\Languages::update()}.
-	 * @param \PLL_Language|null $lang Optional the language currently updated, the language is created if not set.
-	 * @return \WP_Error
+	 * @param array             $args Parameters of {@see WP_Syntex\Polylang\Model\Languages::add() or @see WP_Syntex\Polylang\Model\Languages::update()}.
+	 * @param PLL_Language|null $lang Optional the language currently updated, the language is created if not set.
+	 * @return WP_Error
 	 *
 	 * @phpstan-param array{
 	 *     locale?: string,
@@ -1100,7 +1100,7 @@ class Languages {
 	 *
 	 * @param string $old_slug The old language slug.
 	 * @param string $new_slug Optional, the new language slug, if not set it means that the language has been deleted.
-	 * @return \WP_Error
+	 * @return WP_Error
 	 *
 	 * @phpstan-param non-empty-string $old_slug
 	 */
@@ -1238,12 +1238,12 @@ class Languages {
 	 * @since 3.4
 	 * @since 3.7 Moved from `PLL_Model::update_secondary_language_terms()` to `WP_Syntex\Polylang\Model\Languages::update_secondary_language_terms()`.
 	 *
-	 * @param string             $slug       Language term slug (with or without the `pll_` prefix).
-	 * @param string             $name       Language name (label).
-	 * @param \PLL_Language|null $language   Optional. A language object. Required to update the existing terms.
-	 * @param string[]           $taxonomies Optional. List of language taxonomies to deal with. An empty value means
-	 *                                       all of them. Defaults to all taxonomies.
-	 * @return \WP_Error
+	 * @param string            $slug       Language term slug (with or without the `pll_` prefix).
+	 * @param string            $name       Language name (label).
+	 * @param PLL_Language|null $language   Optional. A language object. Required to update the existing terms.
+	 * @param string[]          $taxonomies Optional. List of language taxonomies to deal with. An empty value means
+	 *                                      all of them. Defaults to all taxonomies.
+	 * @return WP_Error
 	 *
 	 * @phpstan-param non-empty-string $slug
 	 * @phpstan-param non-empty-string $name


### PR DESCRIPTION
## What?
Qualify class names in PHPDoc `@param` / `@return` tags in `WP_Syntex\Polylang\Model\Languages` (e.g. `PLL_Language` → `\PLL_Language`, `WP_Error` → `\WP_Error`, `WP_Term` → `\WP_Term`). Also correct a wrong `@param Language` type to `Languages` on a deprecated filter.

## Why?
This class lives in a namespaced context. Unqualified PHPDoc types do not resolve correctly for third parties using Polylang auto-generated stubs when there is no native type hint on the argument or return.

## How?
Prefix global / root classes with `\` in PHPDoc where stubs rely on documentation rather than PHP type hints.

## Test plan
- [ ] Confirm stub generators (or IDE inspection of stubs) resolve `\PLL_Language`, `\WP_Error`, and `\WP_Term` correctly for methods without native type hints