### PR TITLE
chore(deps): use npm @wpsyntex/polylang-react-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "serialize-javascript": "^7.0.4"
   },
   "dependencies": {
-    "@wpsyntex/polylang-react-library": "github:polylang/polylang-react-library"
+    "@wpsyntex/polylang-react-library": "^1.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",


### PR DESCRIPTION
## What?
Switch `@wpsyntex/polylang-react-library` from a GitHub dependency to the published npm package `^1.0.0`.

## Why?
The library is now published on npm; consumers should install the prebuilt package instead of cloning and building from GitHub.

## How?
One-line change in `package.json`: `github:polylang/polylang-react-library` → `^1.0.0`. No import or webpack changes.

## Test plan
- [x] `npm install` resolves `@wpsyntex/polylang-react-library@1.0.0` from the registry
- [x] Installed package contains `build/` and not `src/`
- [x] `npm run build` succeeds