### PR TITLE
Use a WP_Query for `get_untranslated()`

### DIFF
--- a/src/crud-posts.php
+++ b/src/crud-posts.php
@@ -538,7 +538,7 @@ class PLL_CRUD_Posts {
 			return $clauses;
 		}
 
-		$untranslated_in = PLL()->model->languages->get( $query->query['untranslated_in'] );
+		$untranslated_in = $this->model->languages->get( $query->query['untranslated_in'] );
 
 		if ( empty( $untranslated_in ) ) {
 			return $clauses;

--- a/src/translated-post.php
+++ b/src/translated-post.php
@@ -429,7 +429,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 		$args = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
 
 		/** @var WP_Post[] */
-		$posts = new WP_Query()->query( $args );
+		$posts = ( new WP_Query() )->query( $args );
 
 		foreach ( $posts as $i => $post ) {
 			if ( ! $this->current_user_can_read( $post->ID, 'edit' ) ) {

--- a/src/translated-post.php
+++ b/src/translated-post.php
@@ -402,59 +402,40 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 	 * @return WP_Post[] Array of posts.
 	 */
 	public function get_untranslated( $type, PLL_Language $untranslated_in, PLL_Language $lang, $search = '' ) {
-		global $wpdb;
+		$args = array(
+			's'                => $search,
+			'suppress_filters' => false, // To make the post_fields filter work.
+			'lang'             => '', // Avoid admin language filter.
+			'untranslated_in'  => $untranslated_in,
+			'numberposts'      => 20, // Limit to 20 posts by default.
+			'post_status'      => 'any',
+			'post_type'        => $type,
+			'tax_query'        => array(
+				array(
+					'taxonomy' => $this->tax_language,
+					'field'    => 'term_taxonomy_id', // WP 3.5+.
+					'terms'    => $lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
+				),
+			),
+		);
 
-		$args = array( 'numberposts' => 20 ); // Limit to 20 posts by default.
 		/**
 		 * Filters the query args when auto suggesting untranslated posts in the Languages metabox.
 		 *
 		 * @since 1.7
-		 * @since 3.4 Handled arguments restricted to `numberposts` to limit queried posts.
-		 *            No `WP_Query` is made anymore, a custom one is used instead.
 		 *
-		 * @param array $args WP_Query arguments
+		 * @param array $args WP_Query arguments.
 		 */
 		$args = apply_filters( 'pll_ajax_posts_not_translated_args', $args );
 
-		$limit             = $args['numberposts'];
-		$search_like       = '%' . $wpdb->esc_like( $search ) . '%';
-		$untranslated_like = '%' . $wpdb->esc_like( $untranslated_in->slug ) . '%';
-		$posts             = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM {$wpdb->posts}
-				INNER JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)
-				AND tr1.term_taxonomy_id IN (%d)
-				AND (({$wpdb->posts}.post_title LIKE %s)
-					OR ({$wpdb->posts}.post_excerpt LIKE %s)
-					OR ({$wpdb->posts}.post_content LIKE %s)
-				)
-				AND {$wpdb->posts}.post_type = %s
-				AND {$wpdb->posts}.post_status NOT IN ('trash', 'auto-draft')
-				WHERE {$wpdb->posts}.ID NOT IN (
-					SELECT {$wpdb->posts}.ID FROM {$wpdb->posts}
-						LEFT JOIN {$wpdb->term_relationships} AS tr2 ON ({$wpdb->posts}.ID = tr2.object_id)
-						INNER JOIN {$wpdb->term_taxonomy} AS tt ON (tt.term_taxonomy_id = tr2.term_taxonomy_id)
-							AND (tt.taxonomy = 'post_translations')
-							AND tt.description LIKE %s
-				)
-				LIMIT 0, %d",
-				$lang->get_tax_prop( $this->tax_language, 'term_taxonomy_id' ),
-				$search_like,
-				$search_like,
-				$search_like,
-				$type,
-				$untranslated_like,
-				$limit
-			)
-		);
+		/** @var WP_Post[] */
+		$posts = new WP_Query()->query( $args );
 
 		foreach ( $posts as $i => $post ) {
 			if ( ! $this->current_user_can_read( $post->ID, 'edit' ) ) {
 				unset( $posts[ $i ] );
 				continue;
 			}
-
-			$posts[ $i ] = new WP_Post( $post );
 		}
 
 		return $posts;

--- a/src/translated-post.php
+++ b/src/translated-post.php
@@ -410,6 +410,7 @@ class PLL_Translated_Post extends PLL_Translated_Object implements PLL_Translata
 			'numberposts'      => 20, // Limit to 20 posts by default.
 			'post_status'      => 'any',
 			'post_type'        => $type,
+			'no_found_rows'    => true,
 			'tax_query'        => array(
 				array(
 					'taxonomy' => $this->tax_language,

--- a/tests/phpunit/tests/test-ajax-filters-post.php
+++ b/tests/phpunit/tests/test-ajax-filters-post.php
@@ -24,6 +24,7 @@ class Ajax_Filters_Post_Test extends PLL_Ajax_UnitTestCase {
 		$links_model = self::$model->get_links_model();
 		$this->pll_admin = new PLL_Admin( $links_model );
 
+		$this->pll_admin->post = new PLL_CRUD_Posts( $this->pll_admin );
 		$this->pll_admin->filters_post = new PLL_Admin_Filters_Post( $this->pll_admin );
 		$this->pll_admin->classic_editor = new PLL_Admin_Classic_Editor( $this->pll_admin );
 		$this->pll_admin->links = new PLL_Admin_Links( $this->pll_admin );


### PR DESCRIPTION
This PR is a follow-up of #1892 

In #1187, we switched from a `WP_Query` to a custom DB query for `PLL_Translated_Post;;get_untranslated()`.
in #1892, we introduced a `WP_Query` filter to get untranslated posts. Thus it's now better to re-use the `WP_Query` and use this filter (via the query var `untranslated_in`) to avoid to repeat ourselves. Moreover the query used in #1892 is more robust than the previous custom query in `get_untranslated()` (See https://github.com/polylang/polylang/pull/1892#discussion_r3311844063).

NB: This method is already covered by tests.