### PR TITLE
Fix test for languages table in WP 7.1

### DIFF
--- a/tests/phpunit/tests/test-settings-list-tables.php
+++ b/tests/phpunit/tests/test-settings-list-tables.php
@@ -61,8 +61,8 @@ class Settings_List_Tables_Test extends PLL_UnitTestCase {
 		// The rows ( 1 per language ).
 		$this->assertSame( 2, $xpath->query( '//tbody/tr' )->length );
 
-		// Just check 1 language name.
-		$td = $xpath->query( '//tbody/tr/td/a' );
+		// Just check 1 language name. Use * because td is replaced by th in WP 7.1.
+		$td = $xpath->query( '//tbody/tr/*[@class="name column-name has-row-actions column-primary"]/a' );
 		$this->assertSame( 'English', $td->item( 0 )->nodeValue );
 	}
 


### PR DESCRIPTION
The items in the primary column now use a `<th>` instead of a `<`td>`
See https://core.trac.wordpress.org/ticket/32892
and more specifically https://github.com/WordPress/wordpress-develop/commit/0029901b39ca9389114f1c59240504e99598daa7#diff-cb86bbc65c5b0b668d8a1b1a8b46cbe90f86c22cad5cdaea26bb77a4f34e484fR1832

This PR fixes a test which was targeting the `<td>`.
See https://github.com/polylang/polylang/actions/runs/30251749602/job/89931108936?pr=1926