### PR TITLE
Fix `get_pages()` post_type on hierarchical CPT screens

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -247,12 +247,6 @@ parameters:
 			path: src/admin/admin-filters-post.php
 
 		-
-			message: '#^Parameter \#1 \$posts of function update_post_caches expects array\<WP_Post\>, array\<WP_Post\>\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/admin/admin-filters-post.php
-
-		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -99,7 +99,7 @@ class PLL_Admin_Filters_Post {
 
 		// Hierarchical post types
 		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
-			$pages = get_pages( array( 'sort_column' => 'menu_order, post_title' ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
+			$pages = get_pages( array( 'post_type' => $screen->post_type, array( 'sort_column' => 'menu_order, post_title' ) ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
 
 			update_post_caches( $pages, $screen->post_type, true, false );
 

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -99,7 +99,12 @@ class PLL_Admin_Filters_Post {
 
 		// Hierarchical post types
 		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
-			$pages = get_pages( array( 'post_type' => $screen->post_type, array( 'sort_column' => 'menu_order, post_title' ) ) ); // Same arguments as the parent pages dropdown to avoid an extra query.
+			$pages = get_pages(
+				array(
+					'sort_column' => 'menu_order, post_title',
+					'post_type' => $screen->post_type,
+				)
+			); // Same arguments as the parent pages dropdown to avoid an extra query.
 
 			update_post_caches( $pages, $screen->post_type, true, false );
 

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -102,7 +102,7 @@ class PLL_Admin_Filters_Post {
 			$pages = get_pages(
 				array(
 					'sort_column' => 'menu_order, post_title',
-					'post_type' => $screen->post_type,
+					'post_type'   => $screen->post_type,
 				)
 			); // Same arguments as the parent pages dropdown to avoid an extra query.
 

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -98,7 +98,7 @@ class PLL_Admin_Filters_Post {
 		}
 
 		// Hierarchical post types
-		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) ) {
+		if ( 'edit' == $screen->base && is_post_type_hierarchical( $screen->post_type ) && post_type_supports( $screen->post_type, 'page-attributes' ) ) {
 			$pages = get_pages(
 				array(
 					'sort_column' => 'menu_order, post_title',

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -106,6 +106,10 @@ class PLL_Admin_Filters_Post {
 				)
 			); // Same arguments as the parent pages dropdown to avoid an extra query.
 
+			if ( ! is_array( $pages ) ) {
+				return;
+			}
+
 			update_object_term_cache( wp_list_pluck( $pages, 'ID' ), $screen->post_type );
 
 			$page_languages = array();

--- a/src/admin/admin-filters-post.php
+++ b/src/admin/admin-filters-post.php
@@ -106,7 +106,7 @@ class PLL_Admin_Filters_Post {
 				)
 			); // Same arguments as the parent pages dropdown to avoid an extra query.
 
-			update_post_caches( $pages, $screen->post_type, true, false );
+			update_object_term_cache( wp_list_pluck( $pages, 'ID' ), $screen->post_type );
 
 			$page_languages = array();
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -503,7 +503,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	}
 
 	private function register_post_type_for_dropdown_test( array $args ): void {
-		if ( in_array( 'translated', $args ) ) {
+		if ( in_array( 'translated', $args, true ) ) {
 			add_filter(
 				'pll_get_post_types',
 				function ( $post_types ) {
@@ -516,8 +516,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 			'doc',
 			array(
 				'public'       => true,
-				'hierarchical' => in_array( 'hierarchical', $args ),
-				'supports'     => in_array( 'page-attributes', $args ) ? array( 'page-attributes' ) : array(),
+				'hierarchical' => in_array( 'hierarchical', $args, true ),
+				'supports'     => in_array( 'page-attributes', $args, true ) ? array( 'page-attributes' ) : array(),
 			)
 		);
 	}

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -502,19 +502,28 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		);
 	}
 
-	private function register_translated_post_type( string $post_type, bool $hierarchical ): void {
-		add_filter(
-			'pll_get_post_types',
-			function ( $post_types ) use ( $post_type ) {
-				$post_types[] = $post_type;
-				return $post_types;
-			}
+	private function register_post_type_for_dropdown_test( string $post_type, bool $hierarchical, bool $page_attributes = true, bool $translated = true ): void {
+		if ( $translated ) {
+			add_filter(
+				'pll_get_post_types',
+				function ( $post_types ) use ( $post_type ) {
+					$post_types[] = $post_type;
+					return $post_types;
+				}
+			);
+		}
+		register_post_type(
+			$post_type,
+			array(
+				'public'       => true,
+				'hierarchical' => $hierarchical,
+				'supports'     => $page_attributes ? array( 'page-attributes' ) : array(),
+			)
 		);
-		register_post_type( $post_type, array( 'public' => true, 'hierarchical' => $hierarchical, 'supports' => array( 'page-attributes' ) ) );
 	}
 
 	public function test_inline_script_for_hierarchical_cpt() {
-		$this->register_translated_post_type( 'doc', true );
+		$this->register_post_type_for_dropdown_test( 'doc', true );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
@@ -528,30 +537,38 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertStringContainsString( wp_json_encode( $result ), $footer );
 	}
 
-	public function test_inline_script_for_non_hierarchical_cpt() {
-		$this->register_translated_post_type( 'doc', false );
+	/**
+	 * @testWith [true, true, true, true]
+	 *           [false, true, true, false]
+	 *           [true, false, true, false]
+	 *           [true, true, false, false]
+	 *
+	 * @param bool $hierarchical    Whether the post type is hierarchical.
+	 * @param bool $page_attributes Whether the post type supports 'page-attributes'.
+	 * @param bool $translated      Whether the post type is registered as translated by Polylang.
+	 * @param bool $expects_output  Whether pll_page_languages is expected in the footer.
+	 *
+	 * @return void
+	 */
+	public function test_inline_script_conditions_for_dropdown( bool $hierarchical, bool $page_attributes, bool $translated, bool $expects_output ): void {
+		$this->register_post_type_for_dropdown_test( 'doc', $hierarchical, $page_attributes, $translated );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 
 		$this->set_current_edit_screen( 'doc' );
 		$footer = $this->get_admin_footer_scripts();
 
-		$this->assertStringNotContainsString( 'pll_page_languages', $footer );
-	}
-
-	public function test_inline_script_for_hierarchical_untranslated_cpt() {
-		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true, 'supports' => array( 'page-attributes' ) ) );
-
-		$this->set_current_edit_screen( 'doc' );
-		$footer = $this->get_admin_footer_scripts();
-
-		$this->assertStringNotContainsString( 'pll_page_languages', $footer );
+		if ( $expects_output ) {
+			$this->assertStringContainsString( 'pll_page_languages', $footer );
+		} else {
+			$this->assertStringNotContainsString( 'pll_page_languages', $footer );
+		}
 	}
 
 	public function test_get_pages_query_is_cached_for_dropdown() {
 		global $post;
 
-		$this->register_translated_post_type( 'doc', true );
+		$this->register_post_type_for_dropdown_test( 'doc', true );
 
 		// touch_time() (called internally by inline_edit() further) reads the global $post
 		// via get_post() with no argument — not set outside The Loop, so we set it up manually here.

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -502,28 +502,28 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		);
 	}
 
-	private function register_post_type_for_dropdown_test( string $post_type, bool $hierarchical, bool $page_attributes = true, bool $translated = true ): void {
-		if ( $translated ) {
+	private function register_post_type_for_dropdown_test( array $args ): void {
+		if ( in_array( 'translated', $args ) ) {
 			add_filter(
 				'pll_get_post_types',
-				function ( $post_types ) use ( $post_type ) {
-					$post_types[] = $post_type;
+				function ( $post_types ) {
+					$post_types[] = 'doc';
 					return $post_types;
 				}
 			);
 		}
 		register_post_type(
-			$post_type,
+			'doc',
 			array(
 				'public'       => true,
-				'hierarchical' => $hierarchical,
-				'supports'     => $page_attributes ? array( 'page-attributes' ) : array(),
+				'hierarchical' => in_array( 'hierarchical', $args ),
+				'supports'     => in_array( 'page-attributes', $args ) ? array( 'page-attributes' ) : array(),
 			)
 		);
 	}
 
 	public function test_inline_script_for_hierarchical_cpt() {
-		$this->register_post_type_for_dropdown_test( 'doc', true );
+		$this->register_post_type_for_dropdown_test( array( 'hierarchical', 'page-attributes', 'translated' ) );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
@@ -538,50 +538,47 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @testWith [true, true, true, true]
-	 *           [false, true, true, false]
-	 *           [true, false, true, false]
-	 *           [true, true, false, false]
+	 * @testWith [["hierarchical", "page-attributes", "translated"], true]
+	 *           [["page-attributes", "translated"], false]
+	 *           [["hierarchical", "translated"], false]
+	 *           [["hierarchical", "page-attributes"], false]
 	 *
-	 * @param bool $hierarchical    Whether the post type is hierarchical.
-	 * @param bool $page_attributes Whether the post type supports 'page-attributes'.
-	 * @param bool $translated      Whether the post type is registered as translated by Polylang.
-	 * @param bool $expects_output  Whether pll_page_languages is expected in the footer.
+	 * @param array<string> $conditions     Which conditions are met: 'hierarchical', 'page-attributes', 'translated'.
+	 * @param bool          $expects_output Whether pll_page_languages is expected in the footer.
 	 *
 	 * @return void
 	 */
-	public function test_inline_script_conditions_for_dropdown( bool $hierarchical, bool $page_attributes, bool $translated, bool $expects_output ): void {
-		$this->register_post_type_for_dropdown_test( 'doc', $hierarchical, $page_attributes, $translated );
+	public function test_inline_script_conditions_for_dropdown( array $conditions, bool $expects_output ): void {
+		$this->register_post_type_for_dropdown_test( $conditions );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 
 		$this->set_current_edit_screen( 'doc' );
 		$footer = $this->get_admin_footer_scripts();
 
-		if ( $expects_output ) {
-			$this->assertStringContainsString( 'pll_page_languages', $footer );
-		} else {
-			$this->assertStringNotContainsString( 'pll_page_languages', $footer );
-		}
+		$this->assertSame( $expects_output, str_contains( $footer, 'pll_page_languages' ) );
 	}
 
 	public function test_get_pages_query_is_cached_for_dropdown() {
-		global $post;
+		global $wpdb, $post;
 
-		$this->register_post_type_for_dropdown_test( 'doc', true );
+		$this->register_post_type_for_dropdown_test( array( 'hierarchical', 'page-attributes', 'translated' ) );
 
-		// touch_time() (called internally by inline_edit() further) reads the global $post
-		// via get_post() with no argument — not set outside The Loop, so we set it up manually here.
+		/*
+		* touch_time() (called internally by inline_edit() further) reads the global $post
+		* via get_post() with no argument — not set outside The Loop, so we set it up manually here.
+		*/
 		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $post->ID, 'en' );
 
 		$this->set_current_edit_screen( 'doc' );
 
-		global $wpdb;
-
 		do_action( 'admin_enqueue_scripts' );
-		// Instantiating WP_Posts_List_Table automatically runs a query,
-		// so we call it before starting the count.
+
+		/*
+		* Instantiating WP_Posts_List_Table automatically runs a query,
+		* so we call it before starting the count.
+		*/
 		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );
 		$after_pll = $wpdb->num_queries;
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -565,9 +565,9 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->register_post_type_for_dropdown_test( array( 'hierarchical', 'page-attributes', 'translated' ) );
 
 		/*
-		* touch_time() (called internally by inline_edit() further) reads the global $post
-		* via get_post() with no argument — not set outside The Loop, so we set it up manually here.
-		*/
+		 * touch_time() (called internally by inline_edit() further) reads the global $post
+		 * via get_post() with no argument — not set outside The Loop, so we set it up manually here.
+		 */
 		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $post->ID, 'en' );
 
@@ -576,9 +576,9 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		do_action( 'admin_enqueue_scripts' );
 
 		/*
-		* Instantiating WP_Posts_List_Table automatically runs a query,
-		* so we call it before starting the count.
-		*/
+		 * Instantiating WP_Posts_List_Table automatically runs a query,
+		 * so we call it before starting the count.
+		 */
 		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );
 		$after_pll = $wpdb->num_queries;
 

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -42,8 +42,6 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public function tear_down() {
 		parent::tear_down();
 		_unregister_post_type( 'doc' );
-		_unregister_post_type( 'article' );
-		_unregister_post_type( 'doc_not_translated' );
 	}
 
 	public function test_default_language() {
@@ -479,14 +477,14 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		wp_default_scripts( $GLOBALS['wp_scripts'] );
 	}
 
-	private function get_admin_footer(): string {
+	private function get_admin_footer_scripts(): string {
 		do_action( 'admin_enqueue_scripts' );
 		ob_start();
 		do_action( 'admin_print_footer_scripts' );
 		return (string) ob_get_clean();
 	}
 
-	public function test_parent_pages_script_data_in_footer() {
+	public function test_inline_script_for_pages() {
 		$en = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
 
@@ -494,7 +492,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		self::$model->post->set_language( $fr, 'fr' );
 
 		$this->set_current_edit_screen( 'page' );
-		$footer = $this->get_admin_footer();
+		$footer = $this->get_admin_footer_scripts();
 
 		$pages = array( 'en' => array( $en ), 'fr' => array( $fr ) );
 
@@ -504,57 +502,56 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		);
 	}
 
-	public function test_hierarchical_cpt_script_data_in_footer() {
+	private function register_translated_post_type( string $post_type, bool $hierarchical ): void {
 		add_filter(
 			'pll_get_post_types',
-			function ( $post_types ) {
-				$post_types[] = 'doc';
+			function ( $post_types ) use ( $post_type ) {
+				$post_types[] = $post_type;
 				return $post_types;
 			}
 		);
-		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
+		register_post_type( $post_type, array( 'public' => true, 'hierarchical' => $hierarchical ) );
+	}
+
+	public function test_inline_script_for_hierarchical_cpt() {
+		$this->register_translated_post_type( 'doc', true );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $page, 'fr' );
 
 		$this->set_current_edit_screen( 'doc' );
-		$footer = $this->get_admin_footer();
+		$footer = $this->get_admin_footer_scripts();
 
 		$result = array( 'en' => array( $en ) );
 
 		$this->assertStringContainsString( wp_json_encode( $result ), $footer );
 	}
 
-	public function test_non_hierarchical_cpt_script_data_in_footer() {
-		register_post_type( 'article', array( 'public' => true, 'hierarchical' => false ) );
-		$en = self::factory()->post->create( array( 'post_type' => 'article' ) );
+	public function test_inline_script_for_non_hierarchical_cpt() {
+		$this->register_translated_post_type( 'doc', false );
+		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 
-		$this->set_current_edit_screen( 'article' );
-		$footer = $this->get_admin_footer();
+		$this->set_current_edit_screen( 'doc' );
+		$footer = $this->get_admin_footer_scripts();
 
 		$this->assertStringNotContainsString( 'pll_page_languages', $footer );
 	}
 
-	public function test_hierarchical_untranslated_cpt_script_data_in_footer() {
-		register_post_type( 'doc_not_translated', array( 'public' => true, 'hierarchical' => true ) );
+	public function test_inline_script_for_hierarchical_untranslated_cpt() {
+		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
 
-		$this->set_current_edit_screen( 'doc_not_translated' );
-		$footer = $this->get_admin_footer();
+		$this->set_current_edit_screen( 'doc' );
+		$footer = $this->get_admin_footer_scripts();
 
 		$this->assertStringNotContainsString( 'pll_page_languages', $footer );
 	}
 
 	public function test_get_pages_query_is_cached_for_dropdown() {
-		add_filter(
-			'pll_get_post_types',
-			function ( $post_types ) {
-				$post_types[] = 'doc';
-				return $post_types;
-			}
-		);
-		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
+		global $post;
+
+		$this->register_translated_post_type( 'doc', true );
 
 		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $post->ID, 'en' );
@@ -570,12 +567,6 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$after_pll = $wpdb->num_queries;
 
 		// touch_time() (called internally by inline_edit() further) reads the global $post
-		// via get_post() with no argument — not set outside The Loop, so we set it up manually here.
-		$post_id = $post->ID;
-		global $post;
-		$post = get_post( $post_id );
-		setup_postdata( $post );
-		// Now we trigger the dropdown build to check if it reuses the cached query.
 		ob_start();
 		$wp_list_table->inline_edit();
 		ob_end_clean();

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -39,6 +39,15 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$GLOBALS['polylang']             = $this->pll_admin;
 	}
 
+	public function tear_down() {
+		parent::tear_down();
+
+		remove_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
+		_unregister_post_type( 'doc' );
+		unset( $GLOBALS['current_screen'] );
+		unset( $GLOBALS['hook_suffix'], $_REQUEST['post_type'] );
+	}
+
 	public function test_default_language() {
 		// User preferred language
 		$this->pll_admin->pref_lang = self::$model->get_language( 'fr' );
@@ -492,13 +501,11 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		return $post_types;
 	}
 
-	public function test_get_page_return_correct_datas_from_query() {
-		// _unregister_post_type( 'doc' );
+	public function test_hierarchical_cpt_script_data_in_footer() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
 		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
 		$cpt = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $cpt, 'en' );
-
 		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $page, 'fr' );
 
@@ -507,6 +514,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		set_current_screen();
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		wp_default_scripts( $GLOBALS['wp_scripts'] );
+
 		do_action( 'admin_enqueue_scripts' );
 
 		ob_start();

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -42,7 +42,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		remove_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
+		remove_filter( 'pll_get_post_types', array( $this, 'add_doc_to_translated_post_types' ) );
 		_unregister_post_type( 'doc' );
 		_unregister_post_type( 'article' );
 		_unregister_post_type( 'doc_not_translated' );
@@ -475,6 +475,21 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$this->assertEquals( $term_id, $matches[1] );
 	}
 
+	private function set_current_edit_screen( string $post_type ): void {
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type']  = $post_type;
+		set_current_screen();
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+	}
+
+	private function get_admin_footer(): string {
+		do_action( 'admin_enqueue_scripts' );
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		return (string) ob_get_clean();
+	}
+
 	public function test_parent_pages_script_data_in_footer() {
 		$en = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -482,46 +497,29 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$fr = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $fr, 'fr' );
 
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type']  = 'page';
-		set_current_screen();
-		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		wp_default_scripts( $GLOBALS['wp_scripts'] );
-		do_action( 'admin_enqueue_scripts' );
-
-		ob_start();
-		do_action( 'admin_print_footer_scripts' );
-		$footer = ob_get_clean();
+		$this->set_current_edit_screen( 'page' );
+		$footer = $this->get_admin_footer();
 
 		$pages = array( 'en' => array( $en ), 'fr' => array( $fr ) );
 
 		$this->assertNotFalse( strpos( $footer, 'var pll_page_languages = ' . wp_json_encode( $pages ) ) );
 	}
 
-	public function filter_translated_post_type_in_settings( $post_types ) {
+	public function add_doc_to_translated_post_types( $post_types ) {
 		$post_types[] = 'doc';
 		return $post_types;
 	}
 
 	public function test_hierarchical_cpt_script_data_in_footer() {
-		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
+		add_filter( 'pll_get_post_types', array( $this, 'add_doc_to_translated_post_types' ) );
 		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
 		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $page, 'fr' );
 
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type']  = 'doc';
-		set_current_screen();
-		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		wp_default_scripts( $GLOBALS['wp_scripts'] );
-
-		do_action( 'admin_enqueue_scripts' );
-
-		ob_start();
-		do_action( 'admin_print_footer_scripts' );
-		$footer = ob_get_clean();
+		$this->set_current_edit_screen( 'doc' );
+		$footer = $this->get_admin_footer();
 
 		$result = array( 'en' => array( $en ) );
 
@@ -531,17 +529,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public function test_non_hierarchical_cpt_script_data_in_footer() {
 		register_post_type( 'article', array( 'public' => true, 'hierarchical' => false ) );
 
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type']  = 'article';
-		set_current_screen();
-		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		wp_default_scripts( $GLOBALS['wp_scripts'] );
-
-		do_action( 'admin_enqueue_scripts' );
-
-		ob_start();
-		do_action( 'admin_print_footer_scripts' );
-		$footer = ob_get_clean();
+		$this->set_current_edit_screen( 'article' );
+		$footer = $this->get_admin_footer();
 
 		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
 	}
@@ -551,37 +540,23 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$en = self::factory()->post->create( array( 'post_type' => 'doc_not_translated' ) );
 		self::$model->post->set_language( $en, 'en' );
 
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type']  = 'doc_not_translated';
-		set_current_screen();
-		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		wp_default_scripts( $GLOBALS['wp_scripts'] );
-
-		do_action( 'admin_enqueue_scripts' );
-
-		ob_start();
-		do_action( 'admin_print_footer_scripts' );
-		$footer = ob_get_clean();
+		$this->set_current_edit_screen( 'doc_not_translated' );
+		$footer = $this->get_admin_footer();
 
 		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
 	}
 
 	public function test_get_pages_query_is_cached_for_dropdown() {
-		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
+		add_filter( 'pll_get_post_types', array( $this, 'add_doc_to_translated_post_types' ) );
 		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
 
 		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $post->ID, 'en' );
 
-		$GLOBALS['hook_suffix'] = 'edit.php';
-		$_REQUEST['post_type']  = 'doc';
-		set_current_screen();
-		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		wp_default_scripts( $GLOBALS['wp_scripts'] );
+		$this->set_current_edit_screen( 'doc' );
 
 		global $wpdb;
 
-		$before = $wpdb->num_queries;
 		do_action( 'admin_enqueue_scripts' );
 		$after_pll = $wpdb->num_queries;
 
@@ -598,6 +573,5 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$after_dropdown = $wpdb->num_queries;
 
 		$this->assertSame( $after_pll, $after_dropdown );
-		$this->assertSame( 1, $after_pll - $before );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -45,6 +45,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		remove_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
 		_unregister_post_type( 'doc' );
 		_unregister_post_type( 'article' );
+		_unregister_post_type( 'doc_not_translated' );
 		unset( $GLOBALS['current_screen'] );
 		unset( $GLOBALS['hook_suffix'], $_REQUEST['post_type'] );
 	}

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -565,4 +565,39 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
 	}
+
+	public function test_get_pages_query_is_cached_for_dropdown() {
+		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
+		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
+
+		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
+		self::$model->post->set_language( $post->ID, 'en' );
+
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type']  = 'doc';
+		set_current_screen();
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+
+		global $wpdb;
+
+		$before = $wpdb->num_queries;
+		do_action( 'admin_enqueue_scripts' );
+		$after_pll = $wpdb->num_queries;
+
+		// Same arguments as the real 'parent page' dropdown built by wp_dropdown_pages() in WordPress core.
+		wp_dropdown_pages(
+			array(
+				'post_type'    => $post->post_type,
+				'exclude_tree' => $post->ID,
+				'selected'     => $post->post_parent,
+				'sort_column'  => 'menu_order, post_title',
+				'echo'         => 0,
+			)
+		);
+		$after_dropdown = $wpdb->num_queries;
+
+		$this->assertSame( $after_pll, $after_dropdown );
+		$this->assertSame( 1, $after_pll - $before );
+	}
 }

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -41,13 +41,9 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 	public function tear_down() {
 		parent::tear_down();
-
-		remove_filter( 'pll_get_post_types', array( $this, 'add_doc_to_translated_post_types' ) );
 		_unregister_post_type( 'doc' );
 		_unregister_post_type( 'article' );
 		_unregister_post_type( 'doc_not_translated' );
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['hook_suffix'], $_REQUEST['post_type'] );
 	}
 
 	public function test_default_language() {
@@ -234,16 +230,16 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		page_attributes_meta_box( $page );
 		$out = ob_get_clean();
 
-		$this->assertFalse( strpos( $out, 'test' ) );
-		$this->assertNotFalse( strpos( $out, 'essai' ) );
+		$this->assertStringNotContainsString( 'test', $out );
+		$this->assertStringContainsString( 'essai', $out );
 
 		$_POST['lang'] = 'en'; // Prevails on the post language (ajax response to language change)
 		ob_start();
 		page_attributes_meta_box( $page );
 		$out = ob_get_clean();
 
-		$this->assertNotFalse( strpos( $out, 'test' ) );
-		$this->assertFalse( strpos( $out, 'essai' ) );
+		$this->assertStringContainsString( 'test', $out );
+		$this->assertStringNotContainsString( 'essai', $out );
 	}
 
 	public function test_languages_meta_box_for_new_post() {
@@ -370,13 +366,13 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		// Link to English post
 		$input = $xpath->query( '//input[@name="media_tr_lang[en]"]' );
 		$this->assertEquals( $en, $input->item( 0 )->getAttribute( 'value' ) );
-		$this->assertNotFalse( strpos( $form, 'Edit the translation in English' ) );
+		$this->assertStringContainsString( 'Edit the translation in English', $form );
 
 		// No self link
 		$this->assertEmpty( $xpath->query( '//input[@name="media_tr_lang[fr]"]' )->length );
 
 		// Link to empty German post
-		$this->assertNotFalse( strpos( $form, 'Add a translation in Deutsch' ) );
+		$this->assertStringContainsString( 'Add a translation in Deutsch', $form );
 	}
 
 	public function test_get_posts_language_filter() {
@@ -502,16 +498,20 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$pages = array( 'en' => array( $en ), 'fr' => array( $fr ) );
 
-		$this->assertNotFalse( strpos( $footer, 'var pll_page_languages = ' . wp_json_encode( $pages ) ) );
-	}
-
-	public function add_doc_to_translated_post_types( $post_types ) {
-		$post_types[] = 'doc';
-		return $post_types;
+		$this->assertStringContainsString(
+			'var pll_page_languages = ' . wp_json_encode( $pages ),
+			$footer
+		);
 	}
 
 	public function test_hierarchical_cpt_script_data_in_footer() {
-		add_filter( 'pll_get_post_types', array( $this, 'add_doc_to_translated_post_types' ) );
+		add_filter(
+			'pll_get_post_types',
+			function ( $post_types ) {
+				$post_types[] = 'doc';
+				return $post_types;
+			}
+		);
 		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
 		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $en, 'en' );
@@ -523,31 +523,37 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$result = array( 'en' => array( $en ) );
 
-		$this->assertNotFalse( strpos( $footer, wp_json_encode( $result ) ) );
+		$this->assertStringContainsString( wp_json_encode( $result ), $footer );
 	}
 
 	public function test_non_hierarchical_cpt_script_data_in_footer() {
 		register_post_type( 'article', array( 'public' => true, 'hierarchical' => false ) );
+		$en = self::factory()->post->create( array( 'post_type' => 'article' ) );
+		self::$model->post->set_language( $en, 'en' );
 
 		$this->set_current_edit_screen( 'article' );
 		$footer = $this->get_admin_footer();
 
-		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
+		$this->assertStringNotContainsString( 'pll_page_languages', $footer );
 	}
 
 	public function test_hierarchical_untranslated_cpt_script_data_in_footer() {
 		register_post_type( 'doc_not_translated', array( 'public' => true, 'hierarchical' => true ) );
-		$en = self::factory()->post->create( array( 'post_type' => 'doc_not_translated' ) );
-		self::$model->post->set_language( $en, 'en' );
 
 		$this->set_current_edit_screen( 'doc_not_translated' );
 		$footer = $this->get_admin_footer();
 
-		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
+		$this->assertStringNotContainsString( 'pll_page_languages', $footer );
 	}
 
 	public function test_get_pages_query_is_cached_for_dropdown() {
-		add_filter( 'pll_get_post_types', array( $this, 'add_doc_to_translated_post_types' ) );
+		add_filter(
+			'pll_get_post_types',
+			function ( $post_types ) {
+				$post_types[] = 'doc';
+				return $post_types;
+			}
+		);
 		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
 
 		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
@@ -558,18 +564,21 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		global $wpdb;
 
 		do_action( 'admin_enqueue_scripts' );
+		// Instantiating WP_Posts_List_Table automatically runs a query,
+		// so we call it before starting the count.
+		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );
 		$after_pll = $wpdb->num_queries;
 
-		// Same arguments as the real 'parent page' dropdown built by wp_dropdown_pages() in WordPress core.
-		wp_dropdown_pages(
-			array(
-				'post_type'    => $post->post_type,
-				'exclude_tree' => $post->ID,
-				'selected'     => $post->post_parent,
-				'sort_column'  => 'menu_order, post_title',
-				'echo'         => 0,
-			)
-		);
+		// touch_time() (called internally by inline_edit() further) reads the global $post
+		// via get_post() with no argument — not set outside The Loop, so we set it up manually here.
+		$post_id = $post->ID;
+		global $post;
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+		// Now we trigger the dropdown build to check if it reuses the cached query.
+		ob_start();
+		$wp_list_table->inline_edit();
+		ob_end_clean();
 		$after_dropdown = $wpdb->num_queries;
 
 		$this->assertSame( $after_pll, $after_dropdown );

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -553,6 +553,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$this->register_translated_post_type( 'doc', true );
 
+		// touch_time() (called internally by inline_edit() further) reads the global $post
+		// via get_post() with no argument — not set outside The Loop, so we set it up manually here.
 		$post = self::factory()->post->create_and_get( array( 'post_type' => 'doc' ) );
 		self::$model->post->set_language( $post->ID, 'en' );
 
@@ -566,7 +568,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );
 		$after_pll = $wpdb->num_queries;
 
-		// touch_time() (called internally by inline_edit() further) reads the global $post
+		// Now we trigger the dropdown build to check if it reuses the cached query.
 		ob_start();
 		$wp_list_table->inline_edit();
 		ob_end_clean();

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -44,6 +44,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		remove_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
 		_unregister_post_type( 'doc' );
+		_unregister_post_type( 'article' );
 		unset( $GLOBALS['current_screen'] );
 		unset( $GLOBALS['hook_suffix'], $_REQUEST['post_type'] );
 	}
@@ -504,8 +505,8 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	public function test_hierarchical_cpt_script_data_in_footer() {
 		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
 		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
-		$cpt = self::factory()->post->create( array( 'post_type' => 'doc' ) );
-		self::$model->post->set_language( $cpt, 'en' );
+		$en = self::factory()->post->create( array( 'post_type' => 'doc' ) );
+		self::$model->post->set_language( $en, 'en' );
 		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		self::$model->post->set_language( $page, 'fr' );
 
@@ -521,8 +522,46 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 		do_action( 'admin_print_footer_scripts' );
 		$footer = ob_get_clean();
 
-		$result = array( 'en' => array( $cpt ) );
+		$result = array( 'en' => array( $en ) );
 
 		$this->assertNotFalse( strpos( $footer, wp_json_encode( $result ) ) );
+	}
+
+	public function test_non_hierarchical_cpt_script_data_in_footer() {
+		register_post_type( 'article', array( 'public' => true, 'hierarchical' => false ) );
+
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type']  = 'article';
+		set_current_screen();
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+
+		do_action( 'admin_enqueue_scripts' );
+
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		$footer = ob_get_clean();
+
+		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
+	}
+
+	public function test_hierarchical_untranslated_cpt_script_data_in_footer() {
+		register_post_type( 'doc_not_translated', array( 'public' => true, 'hierarchical' => true ) );
+		$en = self::factory()->post->create( array( 'post_type' => 'doc_not_translated' ) );
+		self::$model->post->set_language( $en, 'en' );
+
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type']  = 'doc_not_translated';
+		set_current_screen();
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+
+		do_action( 'admin_enqueue_scripts' );
+
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		$footer = ob_get_clean();
+
+		$this->assertFalse( strpos( $footer, 'pll_page_languages' ) );
 	}
 }

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -486,4 +486,35 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 
 		$this->assertNotFalse( strpos( $footer, 'var pll_page_languages = ' . wp_json_encode( $pages ) ) );
 	}
+
+	public function filter_translated_post_type_in_settings( $post_types ) {
+		$post_types[] = 'doc';
+		return $post_types;
+	}
+
+	public function test_get_page_return_correct_datas_from_query() {
+		// _unregister_post_type( 'doc' );
+		add_filter( 'pll_get_post_types', array( $this, 'filter_translated_post_type_in_settings' ) );
+		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
+		$cpt = self::factory()->post->create( array( 'post_type' => 'doc' ) );
+		self::$model->post->set_language( $cpt, 'en' );
+
+		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		self::$model->post->set_language( $page, 'fr' );
+
+		$GLOBALS['hook_suffix'] = 'edit.php';
+		$_REQUEST['post_type']  = 'doc';
+		set_current_screen();
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+		wp_default_scripts( $GLOBALS['wp_scripts'] );
+		do_action( 'admin_enqueue_scripts' );
+
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		$footer = ob_get_clean();
+
+		$result = array( 'en' => array( $cpt ) );
+
+		$this->assertNotFalse( strpos( $footer, wp_json_encode( $result ) ) );
+	}
 }

--- a/tests/phpunit/tests/test-admin-filters-post.php
+++ b/tests/phpunit/tests/test-admin-filters-post.php
@@ -510,7 +510,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 				return $post_types;
 			}
 		);
-		register_post_type( $post_type, array( 'public' => true, 'hierarchical' => $hierarchical ) );
+		register_post_type( $post_type, array( 'public' => true, 'hierarchical' => $hierarchical, 'supports' => array( 'page-attributes' ) ) );
 	}
 
 	public function test_inline_script_for_hierarchical_cpt() {
@@ -540,7 +540,7 @@ class Admin_Filters_Post_Test extends PLL_UnitTestCase {
 	}
 
 	public function test_inline_script_for_hierarchical_untranslated_cpt() {
-		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true ) );
+		register_post_type( 'doc', array( 'public' => true, 'hierarchical' => true, 'supports' => array( 'page-attributes' ) ) );
 
 		$this->set_current_edit_screen( 'doc' );
 		$footer = $this->get_admin_footer_scripts();


### PR DESCRIPTION
Fixes [#3052](https://github.com/polylang/polylang-pro/issues/3052)

## Why
In `admin_enqueue_scripts()`, hierarchical post types were using `get_pages()` with default values (post type = page).
So with a CPT, the wrong pages were sent to the JS.
As a consequence, `update_post_caches()` was also priming the cache with the wrong content because of the mismatched arguments.
On top of that, `wp_dropdown_pages()` ended up being called twice: even though the code intended to avoid this ("Same arguments as the parent pages dropdown to avoid an extra query"), the arguments actually differed, so two separate queries were run.
On top of that, `is_post_type_hierarchical()` alone doesn't guarantee the "Parent" dropdown is actually displayed on screen: WordPress only renders it when the post type also supports `page-attributes` (see `WP_Posts_List_Table::inline_edit()`).

## What
Added the current post_type to the `get_pages()` arguments to fix this.
Same for the dropdown: the arguments are now identical, so only one query is run.

Replaced `update_post_caches()` by `update_object_term_cache()`: only the term cache is actually needed here (post ID and language), so priming the full post cache was unnecessary. `get_pages()` can return `false`, so a guard was added before iterating over the result.

Added a `post_type_supports( $screen->post_type, 'page-attributes' )` check alongside `is_post_type_hierarchical()`, to avoid building `pll_page_languages` when the dropdown will never be shown.

## Tests
Added to `tests/phpunit/tests/test-admin-filters-post.php`:
- `test_inline_script_for_pages`: base case on the `page` post type, checks `pll_page_languages` for two languages.
- `test_inline_script_for_hierarchical_cpt`: a translated hierarchical CPT screen only returns that CPT's items, not `page` posts (the actual regression this PR fixes).
- `test_inline_script_conditions_for_dropdown`: parameterized test (`@testWith`) covering the hierarchical / page-attributes / translated combinations, replacing `test_inline_script_for_non_hierarchical_cpt` and `test_inline_script_for_hierarchical_untranslated_cpt`, and adding coverage for the new `page-attributes` condition above.
- `test_get_pages_query_is_cached_for_dropdown`: checks that Polylang and the dropdown share the same cached query, resulting in a single SQL query.

Also merged the two post-type registration helpers into a single one, reused across these tests.