### PR TITLE
Adapt our PHPCS config to VIP Coding Standards 3.1

### DIFF
--- a/js/src/block-editor.js
+++ b/js/src/block-editor.js
@@ -150,9 +150,9 @@ jQuery(
 					// Notice that window.location changing triggers automatically page reloading.
 					if ( -1 != location.search.indexOf( 'new_lang' ) ) {
 						// use regexp non capturing group to replace new_lang parameter no matter where it is and capture other parameters which can be behind it
-						window.location.search = window.location.search.replace( /(?:new_lang=[^&]*)(&)?(.*)/, 'new_lang=' + lang + '$1$2' ); // phpcs:ignore WordPressVIPMinimum.JS.Window.location, WordPressVIPMinimum.JS.Window.VarAssignment
+						window.location.search = window.location.search.replace( /(?:new_lang=[^&]*)(&)?(.*)/, 'new_lang=' + lang + '$1$2' );
 					} else {
-						window.location.search = window.location.search + ( ( -1 != window.location.search.indexOf( '?' ) ) ? '&' : '?' ) + 'new_lang=' + lang; // phpcs:ignore WordPressVIPMinimum.JS.Window.location, WordPressVIPMinimum.JS.Window.VarAssignment
+						window.location.search = window.location.search + ( ( -1 != window.location.search.indexOf( '?' ) ) ? '&' : '?' ) + 'new_lang=' + lang;
 					}
 				};
 

--- a/js/src/blocks/hooks/use-memoized-flag.js
+++ b/js/src/blocks/hooks/use-memoized-flag.js
@@ -43,7 +43,7 @@ export const useMemoizedFlag = (
 					'--pll-flag-width': flagWidth,
 				} }
 				/* eslint-disable-next-line prettier/prettier */
-				dangerouslySetInnerHTML={ { // phpcs:ignore WordPressVIPMinimum.JS.DangerouslySetInnerHTML.Found
+				dangerouslySetInnerHTML={ {
 					__html: stripFlagDimensions( language.flag ),
 				} }
 			/>

--- a/js/src/classic-editor.js
+++ b/js/src/classic-editor.js
@@ -49,7 +49,7 @@ jQuery(
 
 					// @see code from WordPress core https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/js/tags-box.js#L291
 					// @see wp_generate_tag_cloud function which generate the escaped HTML https://github.com/WordPress/WordPress/blob/a02b5cc2a8eecb8e076fbb7cf4de7bd2ec8a8eb1/wp-includes/category-template.php#L966-L975
-					r = $( '<div />' ).addClass( 'the-tagcloud' ).attr( 'id', 'tagcloud-' + tax ).html( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+					r = $( '<div />' ).addClass( 'the-tagcloud' ).attr( 'id', 'tagcloud-' + tax ).html( r );
 					$( 'a', r ).on(
 						'click',
 						function () {
@@ -63,12 +63,12 @@ jQuery(
 					var v = tagCloud.css( 'display' );
 					if ( v ) {
 						// See the comment above when r variable is created.
-						$( '#tagcloud-' + tax ).replaceWith( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+						$( '#tagcloud-' + tax ).replaceWith( r );
 						$( '#tagcloud-' + tax ).css( 'display', v );
 					}
 					else {
 						// See the comment above when r variable is created.
-						$( '#' + id ).after( r ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
+						$( '#' + id ).after( r );
 					}
 				}
 			);
@@ -92,7 +92,7 @@ jQuery(
 				// add our hidden field in the new category form - for each hierarchical taxonomy
 				// to set the language when creating a new category
 				// html code inserted come from html code itself.
-				$( '#' + taxonomy + '-add-submit' ).before( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.before
+				$( '#' + taxonomy + '-add-submit' ).before(
 					$( '<input />' ).attr( 'type', 'hidden' )
 						.attr( 'id', taxonomy + '-lang' )
 						.attr( 'name', 'term_lang_choice' )
@@ -144,35 +144,35 @@ jQuery(
 										switch ( this.what ) {
 											case 'translations': // translations fields
 												// Data is built and come from server side and is well escaped when necessary
-												$( '.translations' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												$( '.translations' ).html( this.data );
 												initMetaboxAutoComplete();
 											break;
 											case 'taxonomy': // categories metabox for posts
 												var tax = this.data;
 												// @see wp_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L175
 												// @see https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/class-walker-category-checklist.php#L89-L111
-												$( '#' + tax + 'checklist' ).html( this.supplemental.all ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												$( '#' + tax + 'checklist' ).html( this.supplemental.all );
 												// @see wp_popular_terms_checklist https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/template.php#L236
-												$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												$( '#' + tax + 'checklist-pop' ).html( this.supplemental.populars );
 												// @see wp_dropdown_categories https://github.com/WordPress/WordPress/blob/5.5.1/wp-includes/category-template.php#L336
 												// which is called by PLL_Admin_Classic_Editor::post_lang_choice to generate supplemental.dropdown
-												$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+												$( '#new' + tax + '_parent' ).replaceWith( this.supplemental.dropdown );
 												$( '#' + tax + '-lang' ).val( $( '.post_lang_choice' ).val() ); // hidden field
 											break;
 											case 'pages': // parent dropdown list for pages
 												// @see wp_dropdown_pages https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/post-template.php#L1186-L1208
 												// @see https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/class-walker-page-dropdown.php#L88
-												$( '#parent_id' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												$( '#parent_id' ).html( this.data );
 											break;
 											case 'flag': // flag in front of the select dropdown
 												// Data is built and come from server side and is well escaped when necessary
-												$( '.pll-select-flag' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+												$( '.pll-select-flag' ).html( this.data );
 											break;
 											case 'permalink': // Sample permalink
 												var div = $( '#edit-slug-box' );
 												if ( '-1' != this.data && div.children().length ) {
 													// @see get_sample_permalink_html https://github.com/WordPress/WordPress/blob/5.2.2/wp-admin/includes/post.php#L1425-L1454
-													div.html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+													div.html( this.data );
 												}
 											break;
 										}

--- a/js/src/frontend-switcher.js
+++ b/js/src/frontend-switcher.js
@@ -35,7 +35,7 @@ const pllSwitcher = {
 		for ( const select of selects ) {
 			select.addEventListener( 'change', ( event ) => {
 				if ( event.currentTarget.value ) {
-					window.location.href = event.currentTarget.value; // PHPCS:ignore WordPressVIPMinimum.JS.Window.location, Already escaped in `WP_Syntex\Polylang\Switcher\Element\Select::get()`.
+					window.location.href = event.currentTarget.value; // Already escaped in `WP_Syntex\Polylang\Switcher\Element\Select::get()`.
 				}
 			} );
 		}

--- a/js/src/lib/confirmation-modal.js
+++ b/js/src/lib/confirmation-modal.js
@@ -19,7 +19,7 @@ export const initializeConfirmationModal = () => {
 
 	// Put it after languages list dropdown.
 	// PHPCS ignore dialogContainer is a new safe HTML code generated above.
-	languagesList.after( dialogContainer ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
+	languagesList.after( dialogContainer );
 
 	const dialogResult = new Promise(
 		( confirm, cancel ) => {

--- a/js/src/lib/metabox-autocomplete.js
+++ b/js/src/lib/metabox-autocomplete.js
@@ -20,7 +20,7 @@ export function initMetaboxAutoComplete() {
 					select: function (event, ui) {
 						jQuery('#htr_lang_' + tr_lang).val(ui.item.id);
 						// ui.item.link is built and come from server side and is well escaped when necessary
-						td.html(ui.item.link); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+						td.html(ui.item.link);
 					},
 				}
 			);
@@ -32,7 +32,7 @@ export function initMetaboxAutoComplete() {
 					if ( ! jQuery(this).val()  ) {
 						jQuery('#htr_lang_' + tr_lang).val(0);
 						// Value is retrieved from HTML already generated server side
-						td.html(td.siblings('.hidden').children().clone()); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+						td.html(td.siblings('.hidden').children().clone());
 					}
 				}
 			);

--- a/js/src/nav-menu.js
+++ b/js/src/nav-menu.js
@@ -83,15 +83,15 @@ const pllNavMenu = {
 				metabox.id.replace( 'menu-item-settings-', '' )
 			);
 
-			// phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+
 			metabox.append(
 				t.createHiddenInput( 'title', itemId, pll_data.title )
 			);
-			// phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+
 			metabox.append(
 				t.createHiddenInput( 'url', itemId, '#pll_switcher' )
 			);
-			metabox.append( t.createHiddenInput( 'pll-detect', itemId, 1 ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			metabox.append( t.createHiddenInput( 'pll-detect', itemId, 1 ) );
 
 			const menuValues =
 				typeof pll_data.val[ itemId ] !== 'undefined'
@@ -128,7 +128,7 @@ const pllNavMenu = {
 
 				const inputWrapper = t.createElement( 'p', wrapperAtts );
 
-				metabox.prepend( inputWrapper ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+				metabox.prepend( inputWrapper );
 
 				// Create the label.
 				const label = t.createElement( 'label', {
@@ -136,7 +136,7 @@ const pllNavMenu = {
 				} );
 				label.innerText = ` ${ optionData.label } `;
 
-				inputWrapper.append( label ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+				inputWrapper.append( label );
 
 				// Create the input.
 				if ( optionData.choices ) {
@@ -146,14 +146,14 @@ const pllNavMenu = {
 						optionValue,
 						optionData.choices
 					);
-					label.append( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+					label.append( input );
 				} else {
 					const input = t.createCheckboxInput(
 						optionName,
 						itemId,
 						optionValue
 					);
-					label.prepend( input ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+					label.prepend( input );
 				}
 			}
 		},
@@ -222,7 +222,7 @@ const pllNavMenu = {
 					atts
 				);
 				option.innerText = choices[ optionValue ];
-				input.append( option ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+				input.append( option );
 			} );
 			return input;
 		},

--- a/js/src/post.js
+++ b/js/src/post.js
@@ -156,7 +156,7 @@ jQuery(
 											// data is built with a call to WP_Posts_List_Table::single_row method
 											// which uses internally other WordPress methods which escape correctly values.
 											// For Polylang language columns the HTML code is correctly escaped in PLL_Admin_Filters_Columns::post_column method.
-											$( "#post-" + this.supplemental.post_id ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+											$( "#post-" + this.supplemental.post_id ).replaceWith( this.data );
 										}
 									}
 								);

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -59,11 +59,11 @@ jQuery(
 
 			// Add the flag from the data attribute in the selected element.
 			// `item.element` is the original `<option>` element, the data to prepend comes from a `data-html-flag` HTML attribute, filled by a method from `PLL_Language`.
-			wrapper.prepend( $( item.element ).data( 'flag-html' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+			wrapper.prepend( $( item.element ).data( 'flag-html' ) );
 			wrapper.children( 'img' ).addClass( 'ui-icon' );
 
 			// `wrapper` and `ul` are safe, see above.
-			return li.append( wrapper ).appendTo( ul ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append, WordPressVIPMinimum.JS.HTMLExecutingFunctions.appendTo
+			return li.append( wrapper ).appendTo( ul );
 		};
 		// Override selected item since jQuery UI 1.12 which introduces extension point method _renderButtonItem.
 		// @see https://api.jqueryui.com/1.12/selectmenu/#method-_renderButtonItem _renderButtonItem documentation.
@@ -74,7 +74,7 @@ jQuery(
 
 			// Add the flag from the data attribute in the selected element.
 			// The data to prepend comes from a `data-html-flag` HTML attribute, filled by a method from `PLL_Language`.
-			buttonItem.prepend( $( selectElement.element ).data( 'flag-html' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+			buttonItem.prepend( $( selectElement.element ).data( 'flag-html' ) );
 			buttonItem.children( 'img' ).addClass( 'ui-icon' );
 
 			return buttonItem;
@@ -275,14 +275,14 @@ jQuery(
 								switch ( this.what ) {
 									case 'license-update':
 										// Data comes from `PLL_License::get_form_field()`, where everything is escaped.
-										$( '#pll-license-' + this.data ).replaceWith( this.supplemental.html ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+										$( '#pll-license-' + this.data ).replaceWith( this.supplemental.html );
 									break;
 									case 'success':
 										tr.hide().prev().show(); // close only if there is no error
 									case 'error':
 										$( '.settings-error' ).remove(); // remove previous messages if any
 										// The data comes from `pll_add_notice()`, where message are passed through `wp_kses()`.
-										$( 'h1' ).after( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.after
+										$( 'h1' ).after( this.data );
 
 										// Make notices dismissible
 										// copy paste of common.js from WP 4.2.2
@@ -296,7 +296,7 @@ jQuery(
 												$button.find( '.screen-reader-text' ).text( btnText );
 
 												// Whitelist because of how the button is built. See above
-												$this.append( $button ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+												$this.append( $button );
 
 												$button.on(
 													'click.wp-dismiss-notice',
@@ -376,7 +376,7 @@ jQuery(
 					data,
 					function ( response ) {
 						// Data comes from `PLL_License::get_form_field()`, where everything is escaped.
-						$( '#pll-license-' + response.id ).replaceWith( response.html ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+						$( '#pll-license-' + response.id ).replaceWith( response.html );
 					}
 				);
 			}

--- a/js/src/term.js
+++ b/js/src/term.js
@@ -83,7 +83,7 @@ jQuery(
 											// data is built with a call to WP_Terms_List_Table::single_row method
 											// which uses internally other WordPress methods which escape correctly values.
 											// For Polylang language columns the HTML code is correctly escaped in PLL_Admin_Filters_Columns::term_column method.
-											$( "#tag-" + this.supplemental.term_id ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+											$( "#tag-" + this.supplemental.term_id ).replaceWith( this.data );
 										}
 									}
 								);
@@ -150,7 +150,7 @@ jQuery(
 							select: function ( event, ui ) {
 								$( '#htr_lang_' + tr_lang ).val( ui.item.id );
 								// ui.item.link is built and come from server side and is well escaped when necessary
-								td.html( ui.item.link ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+								td.html( ui.item.link );
 							},
 						}
 					);
@@ -162,7 +162,7 @@ jQuery(
 							if ( ! $( this ).val() ) {
 								$( '#htr_lang_' + tr_lang ).val( 0 );
 								// Value is retrieved from HTML already generated server side
-								td.html( td.siblings( '.hidden' ).children().clone() ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+								td.html( td.siblings( '.hidden' ).children().clone() );
 							}
 						}
 					);
@@ -202,20 +202,20 @@ jQuery(
 								switch ( this.what ) {
 									case 'translations': // translations fields
 										// Data is built and come from server side and is well escaped when necessary
-										$( "#term-translations" ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+										$( "#term-translations" ).html( this.data );
 										init_translations();
 									break;
 									case 'parent': // parent dropdown list for hierarchical taxonomies
 										// data correctly escaped in PLL_Admin_Filters_Term::term_lang_choice method which uses wp_dropdown_categories function.
-										$( '#parent' ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+										$( '#parent' ).replaceWith( this.data );
 									break;
 									case 'tag_cloud': // popular items
 										// data correctly escaped in PLL_Admin_Filters_Term::term_lang_choice method which uses wp_tag_cloud and wp_generate_tag_cloud functions.
-										$( '.tagcloud' ).replaceWith( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+										$( '.tagcloud' ).replaceWith( this.data );
 									break;
 									case 'flag': // flag in front of the select dropdown
 										// Data is built and come from server side and is well escaped when necessary
-										$( '.pll-select-flag' ).html( this.data ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+										$( '.pll-select-flag' ).html( this.data );
 									break;
 								}
 							}

--- a/js/src/user.js
+++ b/js/src/user.js
@@ -51,7 +51,7 @@ const pllDescription = {
 					img.setAttribute( 'height', data.flag.height );
 				}
 				label.textContent = ` ${ data.name }`;
-				label.prepend( img ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+				label.prepend( img );
 			} else {
 				label.textContent = data.name;
 			}
@@ -60,13 +60,13 @@ const pllDescription = {
 			textarea.setAttribute( 'id', `description_${ data.slug }` );
 			textarea.setAttribute( 'name', `description_${ data.slug }` );
 			textarea.setAttribute( 'dir', data.direction );
-			textarea.innerHTML = data.description; // phpcs:ignore WordPressVIPMinimum.JS.InnerHTML.Found
+			textarea.innerHTML = data.description;
 
-			wrapper.append( label, document.createElement( 'br' ), textarea ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			wrapper.append( label, document.createElement( 'br' ), textarea );
 			rows.push( wrapper );
 		} );
 
-		originTextarea.replaceWith( ...rows ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.replaceWith
+		originTextarea.replaceWith( ...rows );
 	},
 };
 

--- a/js/src/widgets.js
+++ b/js/src/widgets.js
@@ -201,12 +201,12 @@ const pllWidget = {
 
 			if ( icon ) {
 				if ( currentFlag ) {
-					currentFlag.innerHTML = `${ icon } &nbsp; `; // phpcs:ignore WordPressVIPMinimum.JS.InnerHTML.Found, `icon` comes from `PLL_Admin_Base::add_inline_scripts()`.
+					currentFlag.innerHTML = `${ icon } &nbsp; `; // `icon` comes from `PLL_Admin_Base::add_inline_scripts()`.
 				} else {
 					const newFlag = document.createElement( 'span' );
 					newFlag.classList.add( 'pll-lang' );
-					newFlag.innerHTML = `${ icon } &nbsp; `; // phpcs:ignore WordPressVIPMinimum.JS.InnerHTML.Found, `icon` comes from `PLL_Admin_Base::add_inline_scripts()`.
-					title.prepend( newFlag ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend, `newFlag` is a new element we just created with safe data.
+					newFlag.innerHTML = `${ icon } &nbsp; `; // `icon` comes from `PLL_Admin_Base::add_inline_scripts()`.
+					title.prepend( newFlag );, `newFlag` is a new element we just created with safe data.
 				}
 			} else if ( currentFlag ) {
 				currentFlag.remove();

--- a/js/src/widgets.js
+++ b/js/src/widgets.js
@@ -206,7 +206,7 @@ const pllWidget = {
 					const newFlag = document.createElement( 'span' );
 					newFlag.classList.add( 'pll-lang' );
 					newFlag.innerHTML = `${ icon } &nbsp; `; // `icon` comes from `PLL_Admin_Base::add_inline_scripts()`.
-					title.prepend( newFlag );, `newFlag` is a new element we just created with safe data.
+					title.prepend( newFlag ); // `newFlag` is a new element we just created with safe data.
 				}
 			} else if ( currentFlag ) {
 				currentFlag.remove();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="Polylang">
 	<description>Coding standards for Polylang</description>
 
-	<arg name="extensions" value="php,js" />
+	<arg name="extensions" value="php" />
 	<arg name="colors"/>
 	<arg value="ps"/>
 	<arg name="parallel" value="20"/>
@@ -51,6 +51,8 @@
 		<exclude name="WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts"/>
 		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown"/>
 		<exclude name="WordPressVIPMinimum.Performance.NoPaging.nopaging_nopaging"/>
+		<exclude name="WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts"/>
+		<exclude name="WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page"/>
 		<exclude name="WordPressVIPMinimum.Performance.TaxonomyMetaInOptions.PossibleTermMetaInOptions"/>
 		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE"/>
 	</rule>
@@ -154,46 +156,17 @@
 
 	<!--
 	#############################################################################
-	Global exclusions for js files.
-	#############################################################################
-	-->
-
-	<rule ref="PEAR.Functions.FunctionCallSignature">
-		<exclude-pattern>*/*.js</exclude-pattern>
-	</rule>
-
-	<rule ref="Generic.WhiteSpace.ScopeIndent">
-		<exclude-pattern>*/*.js</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.WhiteSpace.OperatorSpacing">
-		<exclude-pattern>*/*.js</exclude-pattern>
-	</rule>
-
-	<rule ref="Generic.Formatting.MultipleStatementAlignment">
-		<exclude-pattern>*/*.js</exclude-pattern>
-	</rule>
-
-	<!--
-	#############################################################################
 	Excluded files.
 	#############################################################################
 	-->
 
 	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
 		<exclude-pattern>*-build.php</exclude-pattern>
-		<exclude-pattern>*.js</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FileComment.SpacingAfterComment">
-		<exclude-pattern>*.js</exclude-pattern>
 	</rule>
 
-	<exclude-pattern>js/*.min.js</exclude-pattern>
-	<exclude-pattern>js/build</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>tmp/*</exclude-pattern>
-	<exclude-pattern>webpack.config.js</exclude-pattern>
 	<exclude-pattern>rector.php</exclude-pattern>
 	<exclude-pattern>coverage/*</exclude-pattern>
 	<exclude-pattern>playwright-report/*</exclude-pattern>

--- a/src/modules/wizard/js/languages-step.js
+++ b/src/modules/wizard/js/languages-step.js
@@ -23,20 +23,20 @@ jQuery(
 		function addLanguage( language ) {
 			// language properties come from the select dropdown which is built server side and well escaped.
 			// see template view-wizard-step-languages.php.
-			var languageValueHtml = $( '<td />' ).text( language.text ).prepend( language.flagUrl ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+			var languageValueHtml = $( '<td />' ).text( language.text ).prepend( language.flagUrl );
 			var languageTrashIconHtml = $( '<td />' )
-			.append( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			.append(
 				$( '<span />' )
 				.addClass( 'dashicons dashicons-trash' )
 				.attr( 'data-language', language.locale )
-				.append( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+				.append(
 					$( '<span />' )
 					.addClass( 'screen-reader-text' )
 					.text( pll_wizard_params.i18n_remove_language_icon )
 				)
 			);
 			// see the comment and the hardcoded code above. languageTrashIconHtml and languageValueHtml are safe.
-			var languageLineHtml = $( '<tr />' ).prepend( languageTrashIconHtml ).prepend( languageValueHtml ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+			var languageLineHtml = $( '<tr />' ).prepend( languageTrashIconHtml ).prepend( languageValueHtml );
 			var languageFieldHtml = $( '<input />' ).attr(
 				{
 					type: 'hidden',
@@ -50,7 +50,7 @@ jQuery(
 			languagesMap.set( language.locale, language );
 
 			// see above how languageLineHtml is built.
-			languagesListTable.append( languageLineHtml ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			languagesListTable.append( languageLineHtml );
 			// Bind click event on trash icon.
 			languagesListTable.on(
 				'click',
@@ -73,7 +73,7 @@ jQuery(
 			);
 			// see above how languageFieldHtml is built.
 			// Add hidden input field for posting the form.
-			languageFields.append( languageFieldHtml ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			languageFields.append( languageFieldHtml );
 
 		}
 
@@ -86,7 +86,7 @@ jQuery(
 			messagesContainer.empty();
 			// html is hardcoded and use of jQuery text method which is safe to add message value.
 			// In addition message is i18n value which is initialized server side in PLL_Wizard::add_step_languages and correctly escaped.
-			messagesContainer.prepend( $( '<p/>' ).addClass( 'error' ).text( message ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+			messagesContainer.prepend( $( '<p/>' ).addClass( 'error' ).text( message ) );
 		}
 
 		/**
@@ -123,7 +123,7 @@ jQuery(
 		function disableButton( button ){
 			button.prop( 'disabled', true );
 			// Because the button is disabled we need to add the value of the button to ensure it will pass in the request.
-			addLanguageForm.append( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
+			addLanguageForm.append(
 				$( '<input />' ).prop(
 					{
 						type: 'hidden',
@@ -274,7 +274,7 @@ jQuery(
 					$( this ).find( '#dialog-language' ).text( $( '#lang_list' ).children( ':selected' ).first().text() );
 					// language properties come from the select dropdown #lang_list which is built server side and well escaped.
 					// see template view-wizard-step-languages.php.
-					$( this ).find( '#dialog-language-flag' ).empty().prepend( $( '#lang_list' ).children( ':selected' ).data( 'flag-html' ) ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.prepend
+					$( this ).find( '#dialog-language-flag' ).empty().prepend( $( '#lang_list' ).children( ':selected' ).data( 'flag-html' ) );
 				},
 				buttons: [
 				{

--- a/tests/phpunit/includes/handle-wp-redirect-trait.php
+++ b/tests/phpunit/includes/handle-wp-redirect-trait.php
@@ -42,7 +42,7 @@ trait PLL_Handle_WP_Redirect_Trait {
 
 		add_filter(
 			'wp_redirect',
-			function ( $location, $status ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
+			function ( $location, $status ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.TerminatingInsteadOfReturn
 				$this->has_redirect      = true;
 				$this->redirect_location = $location;
 				$this->redirect_status   = $status;


### PR DESCRIPTION
See https://github.com/Automattic/VIP-Coding-Standards/blob/develop/CHANGELOG.md#310---2026-07-27

- The sniff of JS files is removed from the standard so I removed them too as well as the exclusions we had.
- I added exclusions related to new sniffs. We'll see later if we need to review these issues.
- I replaced the ignore `WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement` by `WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.TerminatingInsteadOfReturn` in `assert_redirect()`.