### PR TITLE
Drop support of WP < 6.8

### DIFF
--- a/js/src/post.js
+++ b/js/src/post.js
@@ -64,13 +64,8 @@ jQuery(
 											$.each(
 												terms,
 												function ( i ) {
-													// Backward compatibility with WordPress < 6.7.
-													// Support both old (WP < 6.7) and new (WP >= 6.7) ID formats.
-													// Old format: category-123 (WordPress < 6.7).
-													// New format: in-category-123-1 (WordPress >= 6.7).
 													const termId = pll_term_languages[ lg ][ tax ][ i ];
-													const selector = `#${tax}-${termId}, [id^="in-${tax}-${termId}-"]`;
-													$( selector ).toggle( lang === lg );
+													$( `[id^="in-${tax}-${termId}-"]` ).toggle( lang === lg );
 												}
 											);
 										}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<file>.</file>
 
 	<config name="testVersion" value="7.4-"/><!-- PHPCompatibilityWP -->
-	<config name="minimum_supported_wp_version" value="6.5"/>
+	<config name="minimum_supported_wp_version" value="6.8"/>
 
 	<rule ref="PHPCompatibilityWP"/>
 

--- a/polylang.php
+++ b/polylang.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://polylang.pro
  * Description:       Adds multilingual capability to WordPress
  * Version:           3.9-dev
- * Requires at least: 6.5
+ * Requires at least: 6.8
  * Requires PHP:      7.4
  * Author:            WP SYNTEX
  * Author URI:        https://polylang.pro
@@ -62,7 +62,7 @@ if ( defined( 'POLYLANG_VERSION' ) ) {
 
 // Go on loading the plugin.
 define( 'POLYLANG_VERSION', '3.9-dev' );
-define( 'PLL_MIN_WP_VERSION', '6.5' );
+define( 'PLL_MIN_WP_VERSION', '6.8' );
 define( 'PLL_MIN_PHP_VERSION', '7.4' );
 
 define( 'POLYLANG_FILE', __FILE__ );

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ If you are not a developer, we recommend to [download Polylang](https://wordpres
 
 Before starting, make sure that you have the following software installed and working on your computer:
 
-1. A local [WordPress](https://wordpress.org/support/article/how-to-install-wordpress/) (6.5 or later) instance
+1. A local [WordPress](https://wordpress.org/support/article/how-to-install-wordpress/) (6.8 or later) instance
 2. [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) to clone the Polylang repository (or your fork of the Polylang repository).
 3. [Node.js](https://nodejs.org/en/download/) which provides [NPM](https://docs.npmjs.com/). They are both required by [Webpack](https://webpack.js.org/guides/getting-started/) that Polylang uses to build and minify CSS and javascript files. We recommend to install Node.js LTS version.
 4. [Composer](https://getcomposer.org/doc/00-intro.md) because Polylang uses its autoloader to work and it is required to install development tools such as PHP CodeSniffer that ensures your code follows coding standards.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Chouby, manooweb, raaaahman, marianne38, sebastienserre, greglone, hugod
 Donate link: https://polylang.pro
 Tags: multilingual, translate, translation, language, localization
-Requires at least: 6.5
+Requires at least: 6.8
 Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 3.8.6
@@ -71,7 +71,7 @@ Wherever third party code has been used, credit has been given in the code’s c
 
 == Installation ==
 
-1. Make sure you are using WordPress 6.5 or later and that your server is running PHP 7.4 or later (same requirement as WordPress itself).
+1. Make sure you are using WordPress 6.8 or later and that your server is running PHP 7.4 or later (same requirement as WordPress itself).
 1. If you tried other multilingual plugins, deactivate them before activating Polylang, otherwise, you may get unexpected results!
 1. Install and activate the plugin as usual from the 'Plugins' menu in WordPress.
 1. The [setup wizard](https://polylang.pro/documentation/support/getting-started/setup-wizard/) is automatically launched to help you get started more easily with Polylang by configuring the main features.

--- a/src/frontend/frontend-filters-search.php
+++ b/src/frontend/frontend-filters-search.php
@@ -95,14 +95,8 @@ class PLL_Frontend_Filters_Search {
 	 * @return void
 	 */
 	public function add_admin_bar_menus() {
-		// Backward compatibility with WP < 6.6. The priority was 4 before this version, 9999 since then.
-		$priority = has_action( 'admin_bar_menu', 'wp_admin_bar_search_menu' );
-		if ( ! is_int( $priority ) ) {
-			return;
-		}
-
-		remove_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', $priority );
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_search_menu' ), $priority );
+		remove_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', 9999 );
+		add_action( 'admin_bar_menu', array( $this, 'admin_bar_search_menu' ), 9999 );
 	}
 
 	/**

--- a/tests/phpunit/includes/testcase-preload-paths.php
+++ b/tests/phpunit/includes/testcase-preload-paths.php
@@ -76,12 +76,9 @@ abstract class PLL_Preload_Paths_TestCase extends PLL_UnitTestCase {
 	}
 
 	protected function get_context( $context_name, $post = null ) {
-		$context_settings = array();
-
-		if ( property_exists( WP_Block_Editor_Context::class, 'name' ) ) {
-			// Backward compatibility with WordPress < 6.0 where `WP_Block_Editor_Context::$name` didn't exist yet.
-			$context_settings['name'] = $context_name;
-		}
+		$context_settings = array(
+			'name' => $context_name,
+		);
 
 		if ( ! is_null( $post ) ) {
 			$context_settings['post'] = $post;

--- a/tests/phpunit/tests/Capabilities/UI/test-Media.php
+++ b/tests/phpunit/tests/Capabilities/UI/test-Media.php
@@ -158,25 +158,6 @@ class Test_Media extends PLL_UnitTestCase {
 	 * @param string   $html           The HTML string.
 	 */
 	protected function assert_languages_in_dropdown( array $expected_langs, string $html ): void {
-		// Backward compatibility with WP 6.6 and below.
-		if ( version_compare( get_bloginfo( 'version' ), '6.7', '<' ) ) {
-			$dom = new \DOMDocument();
-			$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-
-			$langs = array();
-			foreach ( $dom->getElementsByTagName( 'option' ) as $option ) {
-				$lang = $option->getAttribute( 'lang' );
-
-				if ( '' !== $lang ) {
-					$langs[] = $lang;
-				}
-			}
-
-			$this->assertSameSets( $expected_langs, $langs );
-
-			return;
-		}
-
 		$processor = \WP_HTML_Processor::create_fragment( $html );
 		$langs     = array();
 
@@ -198,26 +179,6 @@ class Test_Media extends PLL_UnitTestCase {
 	 * @param string $html          The HTML string.
 	 */
 	protected function assert_selected_language( string $expected_slug, string $html ): void {
-		// Backward compatibility with WP 6.6 and below.
-		if ( version_compare( get_bloginfo( 'version' ), '6.7', '<' ) ) {
-			$dom = new \DOMDocument();
-			$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-
-			foreach ( $dom->getElementsByTagName( 'option' ) as $option ) {
-				if ( ! $option->hasAttribute( 'selected' ) ) {
-					continue;
-				}
-
-				$this->assertSame( $expected_slug, $option->getAttribute( 'value' ) );
-
-				return;
-			}
-
-			$this->fail( 'A language should be selected.' );
-
-			return;
-		}
-
 		$processor = \WP_HTML_Processor::create_fragment( $html );
 		$found     = false;
 
@@ -241,20 +202,6 @@ class Test_Media extends PLL_UnitTestCase {
 	 * @return bool
 	 */
 	protected function is_dropdown_disabled( string $html ): bool {
-		// Backward compatibility with WP 6.6 and below.
-		if ( version_compare( get_bloginfo( 'version' ), '6.7', '<' ) ) {
-			$dom = new \DOMDocument();
-			$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-
-			$selects = $dom->getElementsByTagName( 'select' );
-
-			if ( 0 === $selects->length ) {
-				return false;
-			}
-
-			return $selects->item( 0 )->hasAttribute( 'disabled' );
-		}
-
 		$processor = \WP_HTML_Processor::create_fragment( $html );
 
 		if ( ! $processor->next_tag( 'SELECT' ) ) {
@@ -270,19 +217,6 @@ class Test_Media extends PLL_UnitTestCase {
 	 * @param string $html The HTML string.
 	 */
 	protected function assert_first_option_is_empty( string $html ): void {
-		// Backward compatibility with WP 6.6 and below.
-		if ( version_compare( get_bloginfo( 'version' ), '6.7', '<' ) ) {
-			$dom = new \DOMDocument();
-			$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-
-			$options = $dom->getElementsByTagName( 'option' );
-
-			$this->assertGreaterThan( 0, $options->length, 'The dropdown should have options.' );
-			$this->assertEmpty( $options->item( 0 )->getAttribute( 'value' ), 'The first option should have an empty value.' );
-
-			return;
-		}
-
 		$processor = \WP_HTML_Processor::create_fragment( $html );
 
 		$this->assertTrue( $processor->next_tag( 'OPTION' ), 'The dropdown should have options.' );

--- a/tests/phpunit/tests/Frontend/test-Discovery_Links.php
+++ b/tests/phpunit/tests/Frontend/test-Discovery_Links.php
@@ -44,11 +44,6 @@ class Test_Discovery_Links extends PLL_UnitTestCase {
 
 		$expected = '<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="http://example.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fexample.org%2Ffr%2Ftest%2F&#038;lang=fr" /><link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="http://example.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fexample.org%2Ffr%2Ftest%2F&#038;format=xml&#038;lang=fr" />';
 
-		if ( version_compare( $GLOBALS['wp_version'], '6.6.0', '<' ) ) {
-			// Title attribute added in 6.6.0, @see {https://core.trac.wordpress.org/ticket/59006/}.
-			$expected = '<link rel="alternate" type="application/json+oembed" href="http://example.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fexample.org%2Ffr%2Ftest%2F&#038;lang=fr" /><link rel="alternate" type="text/xml+oembed" href="http://example.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fexample.org%2Ffr%2Ftest%2F&#038;format=xml&#038;lang=fr" />';
-		}
-
 		$this->assertSame( $expected, str_replace( "\n", '', get_echo( 'wp_oembed_add_discovery_links' ) ) );
 	}
 }

--- a/tests/phpunit/tests/test-switcher-block-frontend.php
+++ b/tests/phpunit/tests/test-switcher-block-frontend.php
@@ -64,13 +64,6 @@ class Switcher_Block_Frontend_Test extends PLL_UnitTestCase {
 	 * @param string $expected The name of a file containing the expected result.
 	 */
 	public function test_render_polylang_navigation_switcher_block( $options, $context, $expected ) {
-		global $wp_version;
-
-		// Backward compatibility with WordPress < 6.8.
-		if ( version_compare( $wp_version, '6.8-alpha', '<' ) ) {
-			$this->markTestSkipped( 'Test on navigation language switcher block HTML rendering requires WP 6.8.' );
-		}
-
 		// We need to have some content in the defined languages
 		$en = self::factory()->post->create();
 		self::$model->post->set_language( $en, 'en' );


### PR DESCRIPTION
The PR raises the min WP version to 6.8 (released in April 2025) and thus removes some backward compatibility code. 