### PR TITLE
chore(build): exclude eslint.config.cjs from dist

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,6 +15,7 @@ phpunit.xml
 readme.md
 rector.php
 webpack.config.js
+eslint.config.cjs
 
 # Folders
 


### PR DESCRIPTION
## What?
Add `eslint.config.cjs` to `.distignore` so it is not shipped in the distribution package.
Traced by `polylang/distribute` https://github.com/polylang/distribute/actions/runs/30796363908/job/91630737470
Regression introduced in https://github.com/polylang/polylang/pull/1933

## Why?
ESLint config is a development-only file and should not be included in the plugin zip distributed to users.

## How?
List `eslint.config.cjs` alongside the other build/dev config files already ignored in `.distignore`.

## Test plan
- [ ] Build/pack the plugin and verify `eslint.config.cjs` is absent from the resulting zip