### PR TITLE
Refresh static pages ids when the blog is switched

### DIFF
--- a/src/base.php
+++ b/src/base.php
@@ -172,6 +172,18 @@ abstract class PLL_Base {
 
 		if ( $this->is_active_on_current_site() ) {
 			$this->links_model = $this->model->get_links_model();
+
+			/*
+			 * Refresh the static pages ids, which are read once from the options
+			 * and would otherwise still belong to the previous blog. They are
+			 * cached per language by PLL_Static_Pages::set_static_pages(), hooked
+			 * to 'pll_additional_language_data' in every context, so a languages
+			 * cache built while the blog is switched would store the ids of the
+			 * previous blog.
+			 */
+			if ( ! empty( $this->static_pages ) ) {
+				$this->static_pages->init();
+			}
 		}
 	}
 

--- a/src/frontend/frontend.php
+++ b/src/frontend/frontend.php
@@ -287,10 +287,6 @@ class PLL_Frontend extends PLL_Base {
 			return;
 		}
 
-		if ( isset( $this->static_pages ) ) {
-			$this->static_pages->init();
-		}
-
 		// Send the slug instead of the locale here to avoid conflicts with same locales.
 		$this->load_strings_translations( $this->curlang->slug );
 	}


### PR DESCRIPTION
Fixes #1542, fixes #1534.

`PLL_Static_Pages` reads `page_on_front` and `page_for_posts` from the options once in `init()`, called from its constructor. `set_static_pages()` then caches them per language into the `pll_languages_list` transient, and it's hooked to `pll_additional_language_data` in the base class, so it runs in every context.

Only `PLL_Frontend::switch_blog()` re-ran `init()` after a blog switch (added in 3.6.1 for #1458). `PLL_Base::switch_blog()` — inherited by `PLL_Admin`, which is what WP-CLI loads, and by `PLL_REST_Request` — doesn't. So in admin, REST and CLI the ids keep belonging to the previous blog, and any cross-blog code that rebuilds the languages cache while switched writes those ids into the switched blog's transient. They're then served until the transient is flushed again.

Depending on whether the stale id exists on the switched blog you get either `page_on_front = 0`, so the language root renders the posts index (#1542), or another blog's page id, so the front page redirects to whatever that id happens to be locally — often an attachment (#1534).

This moves the call into `PLL_Base::switch_blog()` so every context is covered, and drops the now-duplicate frontend one. It's safe there because `translate_page_id()` already skips translating during the `switch_blog` action, so `init()` reads the raw option of the switched blog rather than the filtered value.

Note the frontend call also sat after an early return on `did_action( 'pll_language_defined' )`, so it was skipped in some frontend requests too.

### Steps to reproduce

Multisite, Polylang active on two blogs, both using a static front page with different page ids. Blog 2's front page id must not exist as a page on blog 2 — e.g. blog 1 uses id 105 and on blog 2 that id is an attachment.

```
wp --url=blog1.example eval '
  switch_to_blog( 2 );
  PLL()->model->clean_languages_cache();
  foreach ( PLL()->model->get_languages_list() as $l ) {
      echo "$l->slug page_on_front=$l->page_on_front\n";
  }
'
```

Before: prints blog 1's id, and that value is now in blog 2's `_transient_pll_languages_list`. Visiting blog 2's front page 301s to whatever that id resolves to.

After: prints blog 2's own id.

Any code doing `switch_to_blog()` plus a cache rebuild triggers it in the wild — a cron job, WP-CLI, or a plugin like Broadcast (#1542). Ours was a WP-CLI provisioning script; blog 2's homepage 301'd to a PDF attachment until the transient was flushed.

Verified against 3.8.6 on the affected site and on `master`.
