### PR TITLE
ci(static-analysis): skip PHPCS/PHPStan when no PHP files change

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,10 +17,20 @@ jobs:
     - name: Check out the source code
       uses: actions/checkout@v4
 
+    - name: Filter according to modified files
+      uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          php:
+            - '**/*.php'
+
     - name: Run PHPCS and PHPStan tests
       uses: polylang/actions/static-analysis@main
+      if: ${{ steps.filter.outputs.php == 'true' }}
 
     - name: Run PHPCompatibility for files that require php 5.6
+      if: ${{ steps.filter.outputs.php == 'true' }}
       run: vendor/bin/phpcs --standard=phpcs-phpcompatibility-56.xml.dist
       shell: bash
 


### PR DESCRIPTION
## What?
Gate PHPCS, PHPStan, and PHPCompatibility behind a `dorny/paths-filter` check for `**/*.php`.

## Why?
Avoid running PHP static analysis when a PR only changes non-PHP files (JS, docs, workflows, etc.).

## How?
Mirror the existing ESLint path-filter pattern: always check out and filter, then run PHP analysis only when at least one PHP file changed.