### PR TITLE
chore(eslint): switch to @automattic/eslint-plugin-wpvip

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require( '@automattic/eslint-plugin-wpvip/prettierrc' );

--- a/.typos.toml
+++ b/.typos.toml
@@ -23,6 +23,7 @@ extend-ignore-re = [
     "Etiquette exemple",
     "non-classe",
     "\\bicl_lso_",
+    "Automattic",
 ]
 
 [default.extend-identifiers]

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -39,6 +39,22 @@ module.exports = [
 			],
 		},
 		rules: {
+			// Same as the WPVIP config, but tolerates the blank lines introduced by
+			// the WordPress `/** … dependencies */` import blocks.
+			'import/order': [
+				'error',
+				{
+					'newlines-between': 'always-and-inside-groups',
+					alphabetize: {
+						order: 'asc',
+					},
+					groups: [
+						[ 'builtin', 'external' ],
+						[ 'index', 'internal', 'object', 'parent', 'sibling' ],
+						[ 'type' ],
+					],
+				},
+			],
 			camelcase: [
 				2,
 				{

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const wpPlugin = require( '@wordpress/eslint-plugin' );
+const AutomatticPlugin = require( '@automattic/eslint-plugin-wpvip' );
 const globals = require( 'globals' );
 
 module.exports = [
@@ -20,7 +20,11 @@ module.exports = [
 			'**/*.map',
 		],
 	},
-	...wpPlugin.configs.recommended,
+	// Compose explicitly: `recommended` only auto-loads React when `react` is a
+	// declared dependency; we get it transitively via `@wordpress/element`.
+	...AutomatticPlugin.configs.javascript,
+	...AutomatticPlugin.configs.formatting,
+	...AutomatticPlugin.configs.react,
 	{
 		settings: {
 			'import/core-modules': [
@@ -35,12 +39,6 @@ module.exports = [
 			],
 		},
 		rules: {
-			'jsdoc/no-undefined-types': [
-				1,
-				{
-					definedTypes: [ 'React', 'ReactElement', 'APIFetchOptions' ],
-				},
-			],
 			camelcase: [
 				2,
 				{

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -90,4 +90,6 @@ module.exports = [
 			},
 		},
 	},
+	// Last: Prettier turns off conflicting stylistic ESLint rules.
+	...AutomatticPlugin.configs.prettier,
 ];

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const AutomatticPlugin = require( '@automattic/eslint-plugin-wpvip' );
+const wpPlugin = require( '@wordpress/eslint-plugin' );
 const globals = require( 'globals' );
 
 module.exports = [
@@ -25,6 +26,9 @@ module.exports = [
 	...AutomatticPlugin.configs.javascript,
 	...AutomatticPlugin.configs.formatting,
 	...AutomatticPlugin.configs.react,
+	// WordPress-specific rules only (not the full WP recommended stack).
+	...wpPlugin.configs.custom,
+	...wpPlugin.configs.i18n,
 	{
 		settings: {
 			'import/core-modules': [

--- a/js/src/blocks/components/switcher-controls.js
+++ b/js/src/blocks/components/switcher-controls.js
@@ -11,6 +11,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 	ToolbarDropdownMenu,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';

--- a/js/src/blocks/components/switcher-controls.js
+++ b/js/src/blocks/components/switcher-controls.js
@@ -91,13 +91,13 @@ export const SwitcherControls = ( {
 
 	const { createWarningNotice } = useDispatch( noticesStore );
 
-	const layoutSelectOptions = ALL_LAYOUT_OPTIONS.filter( ( option ) =>
-		layoutOptions.includes( option.value ),
+	const layoutSelectOptions = ALL_LAYOUT_OPTIONS.filter( option =>
+		layoutOptions.includes( option.value )
 	);
 
-	const layoutToolbarControls = ALL_LAYOUT_TOOLBAR_CONTROLS.filter(
-		( control ) => layoutOptions.includes( control.layout ),
-	).map( ( control ) => ( {
+	const layoutToolbarControls = ALL_LAYOUT_TOOLBAR_CONTROLS.filter( control =>
+		layoutOptions.includes( control.layout )
+	).map( control => ( {
 		title: control.title,
 		onClick: () => setAttributes( { layout: control.layout } ),
 	} ) );
@@ -137,10 +137,7 @@ export const SwitcherControls = ( {
 			onClick: () => {
 				if ( ! show_flags ) {
 					createWarningNotice(
-						__(
-							'Labels cannot be hidden if flags are not shown.',
-							'polylang',
-						),
+						__( 'Labels cannot be hidden if flags are not shown.', 'polylang' )
 					);
 
 					return;
@@ -162,7 +159,7 @@ export const SwitcherControls = ( {
 						label={ __( 'Layout', 'polylang' ) }
 						value={ layout }
 						options={ layoutSelectOptions }
-						onChange={ ( value ) => {
+						onChange={ value => {
 							setAttributes( { layout: value } );
 
 							if ( 'select' === value ) {
@@ -180,14 +177,11 @@ export const SwitcherControls = ( {
 							label={ __( 'Labels', 'polylang' ) }
 							value={ show_labels }
 							options={ labelOptions }
-							onChange={ ( value ) => {
+							onChange={ value => {
 								if ( '' === value ) {
 									if ( ! show_flags ) {
 										createWarningNotice(
-											__(
-												'Labels cannot be hidden if flags are not shown.',
-												'polylang',
-											),
+											__( 'Labels cannot be hidden if flags are not shown.', 'polylang' )
 										);
 
 										return;
@@ -195,8 +189,7 @@ export const SwitcherControls = ( {
 
 									setAttributes( {
 										show_labels: value,
-										flag_label_spacing:
-											LABEL_SPACING_DEFAULT_VALUE,
+										flag_label_spacing: LABEL_SPACING_DEFAULT_VALUE,
 									} );
 
 									return;
@@ -211,13 +204,10 @@ export const SwitcherControls = ( {
 						<ToggleControl
 							label={ __( 'Display flags', 'polylang' ) }
 							checked={ show_flags }
-							onChange={ ( value ) => {
+							onChange={ value => {
 								if ( '' === show_labels && ! value ) {
 									createWarningNotice(
-										__(
-											'Flags cannot be hidden if labels are not displayed.',
-											'polylang',
-										),
+										__( 'Flags cannot be hidden if labels are not displayed.', 'polylang' )
 									);
 
 									return;
@@ -234,10 +224,7 @@ export const SwitcherControls = ( {
 								selected={ flag_aspect_ratio }
 								options={ [
 									{
-										label: __(
-											'Landscape (3:2)',
-											'polylang',
-										),
+										label: __( 'Landscape (3:2)', 'polylang' ),
 										value: '3:2',
 									},
 									{
@@ -245,7 +232,7 @@ export const SwitcherControls = ( {
 										value: '1:1',
 									},
 								] }
-								onChange={ ( value ) =>
+								onChange={ value =>
 									setAttributes( {
 										flag_aspect_ratio: value,
 									} )
@@ -260,7 +247,7 @@ export const SwitcherControls = ( {
 								step={ 1 }
 								allowReset={ true }
 								resetFallbackValue={ 0 }
-								onChange={ ( value ) =>
+								onChange={ value =>
 									setAttributes( {
 										flag_border_radius: value,
 									} )
@@ -272,7 +259,7 @@ export const SwitcherControls = ( {
 								label={ __( 'Size', 'polylang' ) }
 								value={ flag_width }
 								units={ CSS_LENGTH_UNITS }
-								onChange={ ( value ) =>
+								onChange={ value =>
 									setAttributes( {
 										flag_width: value,
 									} )
@@ -284,7 +271,7 @@ export const SwitcherControls = ( {
 									label={ __( 'Label spacing', 'polylang' ) }
 									value={ flag_label_spacing }
 									units={ CSS_LENGTH_UNITS }
-									onChange={ ( value ) =>
+									onChange={ value =>
 										setAttributes( {
 											flag_label_spacing: value,
 										} )
@@ -298,26 +285,17 @@ export const SwitcherControls = ( {
 					<ToggleControl
 						label={ __( 'Force link to front page', 'polylang' ) }
 						checked={ force_home }
-						onChange={ ( value ) =>
-							setAttributes( { force_home: value } )
-						}
+						onChange={ value => setAttributes( { force_home: value } ) }
 					/>
 					<ToggleControl
 						label={ __( 'Hide the current language', 'polylang' ) }
 						checked={ hide_current }
-						onChange={ ( value ) =>
-							setAttributes( { hide_current: value } )
-						}
+						onChange={ value => setAttributes( { hide_current: value } ) }
 					/>
 					<ToggleControl
-						label={ __(
-							'Hide languages with no translation',
-							'polylang',
-						) }
+						label={ __( 'Hide languages with no translation', 'polylang' ) }
 						checked={ hide_if_no_translation }
-						onChange={ ( value ) =>
-							setAttributes( { hide_if_no_translation: value } )
-						}
+						onChange={ value => setAttributes( { hide_if_no_translation: value } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>
@@ -329,21 +307,14 @@ export const SwitcherControls = ( {
 					/>
 					{ 'select' !== layout && (
 						<ToolbarButton
-							icon={
-								<span className="dashicons dashicons-flag"></span>
-							}
+							icon={ <span className="dashicons dashicons-flag"></span> }
 							label={
-								show_flags
-									? __( 'Hide flags', 'polylang' )
-									: __( 'Display flags', 'polylang' )
+								show_flags ? __( 'Hide flags', 'polylang' ) : __( 'Display flags', 'polylang' )
 							}
 							onClick={ () => {
 								if ( show_flags && '' === show_labels ) {
 									createWarningNotice(
-										__(
-											'Flags cannot be hidden if labels are not displayed.',
-											'polylang',
-										),
+										__( 'Flags cannot be hidden if labels are not displayed.', 'polylang' )
 									);
 
 									return;
@@ -357,9 +328,7 @@ export const SwitcherControls = ( {
 					) }
 					{ 'select' !== layout && (
 						<ToolbarDropdownMenu
-							icon={
-								<span className="dashicons dashicons-editor-textcolor"></span>
-							}
+							icon={ <span className="dashicons dashicons-editor-textcolor"></span> }
 							label={ __( 'Labels', 'polylang' ) }
 							controls={ toolbarLabelControls }
 						/>

--- a/js/src/blocks/components/switcher-controls.js
+++ b/js/src/blocks/components/switcher-controls.js
@@ -11,7 +11,6 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 	ToolbarDropdownMenu,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';

--- a/js/src/blocks/components/switcher-controls.js
+++ b/js/src/blocks/components/switcher-controls.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -15,8 +14,9 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
-import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 const CSS_LENGTH_UNITS = [
 	{ value: 'px', label: 'px' },
@@ -92,11 +92,11 @@ export const SwitcherControls = ( {
 	const { createWarningNotice } = useDispatch( noticesStore );
 
 	const layoutSelectOptions = ALL_LAYOUT_OPTIONS.filter( ( option ) =>
-		layoutOptions.includes( option.value )
+		layoutOptions.includes( option.value ),
 	);
 
 	const layoutToolbarControls = ALL_LAYOUT_TOOLBAR_CONTROLS.filter(
-		( control ) => layoutOptions.includes( control.layout )
+		( control ) => layoutOptions.includes( control.layout ),
 	).map( ( control ) => ( {
 		title: control.title,
 		onClick: () => setAttributes( { layout: control.layout } ),
@@ -139,8 +139,8 @@ export const SwitcherControls = ( {
 					createWarningNotice(
 						__(
 							'Labels cannot be hidden if flags are not shown.',
-							'polylang'
-						)
+							'polylang',
+						),
 					);
 
 					return;
@@ -186,8 +186,8 @@ export const SwitcherControls = ( {
 										createWarningNotice(
 											__(
 												'Labels cannot be hidden if flags are not shown.',
-												'polylang'
-											)
+												'polylang',
+											),
 										);
 
 										return;
@@ -216,8 +216,8 @@ export const SwitcherControls = ( {
 									createWarningNotice(
 										__(
 											'Flags cannot be hidden if labels are not displayed.',
-											'polylang'
-										)
+											'polylang',
+										),
 									);
 
 									return;
@@ -236,7 +236,7 @@ export const SwitcherControls = ( {
 									{
 										label: __(
 											'Landscape (3:2)',
-											'polylang'
+											'polylang',
 										),
 										value: '3:2',
 									},
@@ -312,7 +312,7 @@ export const SwitcherControls = ( {
 					<ToggleControl
 						label={ __(
 							'Hide languages with no translation',
-							'polylang'
+							'polylang',
 						) }
 						checked={ hide_if_no_translation }
 						onChange={ ( value ) =>
@@ -342,8 +342,8 @@ export const SwitcherControls = ( {
 									createWarningNotice(
 										__(
 											'Flags cannot be hidden if labels are not displayed.',
-											'polylang'
-										)
+											'polylang',
+										),
 									);
 
 									return;

--- a/js/src/blocks/components/switcher-language-link.js
+++ b/js/src/blocks/components/switcher-language-link.js
@@ -25,12 +25,7 @@ export const SwitcherLanguageLink = ( {
 	flagWidth,
 	labelSpacing,
 } ) => {
-	const flag = useMemoizedFlag(
-		language,
-		showFlags,
-		flagBorderRadius,
-		flagWidth,
-	);
+	const flag = useMemoizedFlag( language, showFlags, flagBorderRadius, flagWidth );
 
 	return (
 		<SwitcherLinkElement

--- a/js/src/blocks/components/switcher-language-link.js
+++ b/js/src/blocks/components/switcher-language-link.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import { useMemoizedFlag } from '../hooks/use-memoized-flag';
 import { SwitcherLinkElement } from './switcher-link-element';
 import { getLabel } from './switcher-utils';
+import { useMemoizedFlag } from '../hooks/use-memoized-flag';
 
 /**
  * Renders a language link for the switcher preview.
@@ -29,7 +29,7 @@ export const SwitcherLanguageLink = ( {
 		language,
 		showFlags,
 		flagBorderRadius,
-		flagWidth
+		flagWidth,
 	);
 
 	return (

--- a/js/src/blocks/components/switcher-link-element.js
+++ b/js/src/blocks/components/switcher-link-element.js
@@ -10,9 +10,7 @@
 export const SwitcherLinkElement = ( { flag, label, labelSpacing } ) => {
 	const hasLabel = '' !== label;
 	const labelStyle =
-		hasLabel && labelSpacing
-			? { '--pll-flag-label-spacing': labelSpacing }
-			: undefined;
+		hasLabel && labelSpacing ? { '--pll-flag-label-spacing': labelSpacing } : undefined;
 
 	return (
 		// eslint-disable-next-line jsx-a11y/anchor-is-valid

--- a/js/src/blocks/components/switcher-utils.js
+++ b/js/src/blocks/components/switcher-utils.js
@@ -7,12 +7,7 @@
  * @param {string}  [alignment]     The items alignment. Omitted when unset.
  * @return {string} The switcher class names.
  */
-export const getSwitcherClassName = (
-	layout,
-	showFlags,
-	flagAspectRatio,
-	alignment,
-) => {
+export const getSwitcherClassName = ( layout, showFlags, flagAspectRatio, alignment ) => {
 	const classes = [ 'pll-switcher', `pll-layout-${ layout }` ];
 
 	if ( alignment ) {
@@ -20,9 +15,7 @@ export const getSwitcherClassName = (
 	}
 
 	if ( showFlags ) {
-		classes.push(
-			`pll-aspect-ratio-${ flagAspectRatio.replace( ':', '' ) }`,
-		);
+		classes.push( `pll-aspect-ratio-${ flagAspectRatio.replace( ':', '' ) }` );
 	}
 
 	return classes.join( ' ' );

--- a/js/src/blocks/components/switcher-utils.js
+++ b/js/src/blocks/components/switcher-utils.js
@@ -11,7 +11,7 @@ export const getSwitcherClassName = (
 	layout,
 	showFlags,
 	flagAspectRatio,
-	alignment
+	alignment,
 ) => {
 	const classes = [ 'pll-switcher', `pll-layout-${ layout }` ];
 
@@ -21,7 +21,7 @@ export const getSwitcherClassName = (
 
 	if ( showFlags ) {
 		classes.push(
-			`pll-aspect-ratio-${ flagAspectRatio.replace( ':', '' ) }`
+			`pll-aspect-ratio-${ flagAspectRatio.replace( ':', '' ) }`,
 		);
 	}
 

--- a/js/src/blocks/hooks/use-current-language-with-editor-context.js
+++ b/js/src/blocks/hooks/use-current-language-with-editor-context.js
@@ -15,7 +15,7 @@ const findLanguageBySlug = ( languages, slug ) => {
 		return null;
 	}
 
-	const currentLanguage = languages.find( ( language ) => {
+	const currentLanguage = languages.find( language => {
 		return language.slug === slug;
 	} );
 
@@ -32,9 +32,9 @@ const findLanguageBySlug = ( languages, slug ) => {
  * @param {Array} languages The languages list.
  * @return {Object|null} The current language, `null` if not found.
  */
-export const useCurrentLanguageWithEditorContext = ( languages ) => {
+export const useCurrentLanguageWithEditorContext = languages => {
 	return useSelect(
-		( select ) => {
+		select => {
 			if ( ! languages ) {
 				return null;
 			}
@@ -54,8 +54,7 @@ export const useCurrentLanguageWithEditorContext = ( languages ) => {
 				return null;
 			}
 
-			const currentLanguageSlug =
-				currentPost.lang ?? pllEditorCurrentLanguageSlug; // eslint-disable-line no-undef
+			const currentLanguageSlug = currentPost.lang ?? pllEditorCurrentLanguageSlug; // eslint-disable-line no-undef
 
 			return findLanguageBySlug( languages, currentLanguageSlug );
 		},

--- a/js/src/blocks/hooks/use-memoized-flag.js
+++ b/js/src/blocks/hooks/use-memoized-flag.js
@@ -28,7 +28,7 @@ export const useMemoizedFlag = (
 	language,
 	showFlags,
 	flagBorderRadius,
-	flagWidth
+	flagWidth,
 ) => {
 	return useMemo( () => {
 		if ( ! showFlags || ! language?.flag ) {

--- a/js/src/blocks/hooks/use-memoized-flag.js
+++ b/js/src/blocks/hooks/use-memoized-flag.js
@@ -9,7 +9,7 @@ import { useMemo } from '@wordpress/element';
  * @param {string} html The flag HTML markup.
  * @return {string} The flag HTML without fixed dimensions.
  */
-const stripFlagDimensions = ( html ) => {
+const stripFlagDimensions = html => {
 	return html
 		.replace( /\s(?:width|height)=["'][^"']*["']/gi, '' )
 		.replace( /\sstyle=["'][^"']*["']/gi, '' );
@@ -24,12 +24,7 @@ const stripFlagDimensions = ( html ) => {
  * @param {string}  flagWidth        The width of the flags as a CSS length.
  * @return {ReactElement|null} The flag for the language.
  */
-export const useMemoizedFlag = (
-	language,
-	showFlags,
-	flagBorderRadius,
-	flagWidth,
-) => {
+export const useMemoizedFlag = ( language, showFlags, flagBorderRadius, flagWidth ) => {
 	return useMemo( () => {
 		if ( ! showFlags || ! language?.flag ) {
 			return null;

--- a/js/src/blocks/language-switcher/deprecated.js
+++ b/js/src/blocks/language-switcher/deprecated.js
@@ -48,8 +48,7 @@ const v1 = {
 		},
 	},
 
-	isEligible: ( attributes ) =>
-		'dropdown' in attributes || 'show_names' in attributes,
+	isEligible: attributes => 'dropdown' in attributes || 'show_names' in attributes,
 
 	migrate( attributes ) {
 		const {

--- a/js/src/blocks/language-switcher/edit.js
+++ b/js/src/blocks/language-switcher/edit.js
@@ -30,10 +30,7 @@ export const Edit = ( { attributes, setAttributes } ) => {
 
 	return (
 		<div { ...useBlockProps() }>
-			<SwitcherControls
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-			/>
+			<SwitcherControls attributes={ attributes } setAttributes={ setAttributes } />
 			<Disabled>
 				<LanguagesContext.Provider value={ { languages } }>
 					<RenderedSwitcher attributes={ attributes } />

--- a/js/src/blocks/language-switcher/edit.js
+++ b/js/src/blocks/language-switcher/edit.js
@@ -11,10 +11,11 @@ import { Disabled } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { RenderedSwitcher } from './rendered-switcher';
-import { LanguagesContext } from '../languages-context';
 import { useLanguagesList } from '@wpsyntex/polylang-react-library';
+
+import { RenderedSwitcher } from './rendered-switcher';
 import { SwitcherControls } from '../components/switcher-controls';
+import { LanguagesContext } from '../languages-context';
 
 /**
  * Edit callback for language switcher block.

--- a/js/src/blocks/language-switcher/index.js
+++ b/js/src/blocks/language-switcher/index.js
@@ -11,9 +11,10 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { translation as translationIcon } from '@wpsyntex/polylang-react-library';
+
+import deprecated from './deprecated';
 import { Edit } from './edit';
 import metadata from '../../../../src/modules/Blocks/Language_Switcher/Standard/block.json';
-import deprecated from './deprecated';
 
 registerBlockType( metadata.name, {
 	icon: translationIcon,

--- a/js/src/blocks/language-switcher/rendered-switcher.js
+++ b/js/src/blocks/language-switcher/rendered-switcher.js
@@ -14,14 +14,14 @@ import {
 /**
  * Internal dependencies
  */
-import { useCurrentLanguageWithEditorContext } from '../hooks/use-current-language-with-editor-context';
-import { LanguagesContext } from '../languages-context';
 import { SwitcherLanguageLink } from '../components/switcher-language-link';
 import {
 	getLabel,
 	getLabelSpacing,
 	getSwitcherClassName,
 } from '../components/switcher-utils';
+import { useCurrentLanguageWithEditorContext } from '../hooks/use-current-language-with-editor-context';
+import { LanguagesContext } from '../languages-context';
 
 /**
  * Rendered switcher component.
@@ -46,14 +46,14 @@ export const RenderedSwitcher = ( { attributes } ) => {
 	const curatedLanguages = useCuratedLanguages(
 		languages,
 		currentLanguage,
-		false
+		false,
 	);
 	const alignment = style?.typography?.textAlign;
 	const switcherClassName = getSwitcherClassName(
 		layout,
 		show_flags,
 		flag_aspect_ratio,
-		alignment
+		alignment,
 	);
 	const labelSpacing = getLabelSpacing( show_labels, flag_label_spacing );
 	const linkProps = {

--- a/js/src/blocks/language-switcher/rendered-switcher.js
+++ b/js/src/blocks/language-switcher/rendered-switcher.js
@@ -15,11 +15,7 @@ import {
  * Internal dependencies
  */
 import { SwitcherLanguageLink } from '../components/switcher-language-link';
-import {
-	getLabel,
-	getLabelSpacing,
-	getSwitcherClassName,
-} from '../components/switcher-utils';
+import { getLabel, getLabelSpacing, getSwitcherClassName } from '../components/switcher-utils';
 import { useCurrentLanguageWithEditorContext } from '../hooks/use-current-language-with-editor-context';
 import { LanguagesContext } from '../languages-context';
 
@@ -43,17 +39,13 @@ export const RenderedSwitcher = ( { attributes } ) => {
 	} = attributes;
 	const { languages } = useContext( LanguagesContext );
 	const currentLanguage = useCurrentLanguageWithEditorContext( languages );
-	const curatedLanguages = useCuratedLanguages(
-		languages,
-		currentLanguage,
-		false,
-	);
+	const curatedLanguages = useCuratedLanguages( languages, currentLanguage, false );
 	const alignment = style?.typography?.textAlign;
 	const switcherClassName = getSwitcherClassName(
 		layout,
 		show_flags,
 		flag_aspect_ratio,
-		alignment,
+		alignment
 	);
 	const labelSpacing = getLabelSpacing( show_labels, flag_label_spacing );
 	const linkProps = {
@@ -71,10 +63,7 @@ export const RenderedSwitcher = ( { attributes } ) => {
 			<nav className={ switcherClassName }>
 				<div className="pll-switcher-inner">
 					{ currentLanguageItem && (
-						<SwitcherLanguageLink
-							language={ currentLanguageItem }
-							{ ...linkProps }
-						/>
+						<SwitcherLanguageLink language={ currentLanguageItem } { ...linkProps } />
 					) }
 					<button className="pll-submenu-toggle">
 						<SubmenuIcon />
@@ -88,12 +77,9 @@ export const RenderedSwitcher = ( { attributes } ) => {
 		return (
 			<div className={ switcherClassName }>
 				<select className="pll-switcher-select">
-					{ curatedLanguages.map( ( language ) => {
+					{ curatedLanguages.map( language => {
 						return (
-							<option
-								key={ language.slug }
-								value={ language.slug }
-							>
+							<option key={ language.slug } value={ language.slug }>
 								{ getLabel( language, show_labels ) }
 							</option>
 						);
@@ -106,13 +92,10 @@ export const RenderedSwitcher = ( { attributes } ) => {
 	return (
 		<nav className={ switcherClassName }>
 			<ul>
-				{ curatedLanguages.map( ( language ) => {
+				{ curatedLanguages.map( language => {
 					return (
 						<li key={ language.slug }>
-							<SwitcherLanguageLink
-								language={ language }
-								{ ...linkProps }
-							/>
+							<SwitcherLanguageLink language={ language } { ...linkProps } />
 						</li>
 					);
 				} ) }

--- a/js/src/blocks/language-switcher/rendered-switcher.js
+++ b/js/src/blocks/language-switcher/rendered-switcher.js
@@ -6,10 +6,7 @@ import { useContext } from '@wordpress/element';
 /**
  * External dependencies
  */
-import {
-	SubmenuIcon,
-	useCuratedLanguages,
-} from '@wpsyntex/polylang-react-library';
+import { SubmenuIcon, useCuratedLanguages } from '@wpsyntex/polylang-react-library';
 
 /**
  * Internal dependencies

--- a/js/src/blocks/navigation-language-switcher/deprecated.js
+++ b/js/src/blocks/navigation-language-switcher/deprecated.js
@@ -48,8 +48,7 @@ const v1 = {
 		},
 	},
 
-	isEligible: ( attributes ) =>
-		'dropdown' in attributes || 'show_names' in attributes,
+	isEligible: attributes => 'dropdown' in attributes || 'show_names' in attributes,
 
 	migrate( attributes ) {
 		const {

--- a/js/src/blocks/navigation-language-switcher/edit.js
+++ b/js/src/blocks/navigation-language-switcher/edit.js
@@ -47,10 +47,7 @@ export const Edit = ( { attributes, context, setAttributes } ) => {
 			/>
 			<Disabled>
 				<LanguagesContext.Provider value={ { languages } }>
-					<RenderedSwitcher
-						attributes={ attributes }
-						context={ context }
-					/>
+					<RenderedSwitcher attributes={ attributes } context={ context } />
 				</LanguagesContext.Provider>
 			</Disabled>
 		</div>

--- a/js/src/blocks/navigation-language-switcher/edit.js
+++ b/js/src/blocks/navigation-language-switcher/edit.js
@@ -11,10 +11,11 @@ import { Disabled } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import { useLanguagesList } from '@wpsyntex/polylang-react-library';
+
 import { SwitcherControls } from '../components/switcher-controls';
 import { LanguagesContext } from '../languages-context';
 import { RenderedSwitcher } from './rendered-switcher';
-import { useLanguagesList } from '@wpsyntex/polylang-react-library';
 
 /**
  * Edit callback for navigation language switcher block.

--- a/js/src/blocks/navigation-language-switcher/index.js
+++ b/js/src/blocks/navigation-language-switcher/index.js
@@ -12,9 +12,10 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { translation as translationIcon } from '@wpsyntex/polylang-react-library';
+
+import deprecated from './deprecated';
 import { Edit } from './edit';
 import { menuItemsToBlocksFilter } from './menu-items-converter';
-import deprecated from './deprecated';
 import metadata from '../../../../src/modules/Blocks/Language_Switcher/Navigation/block.json';
 
 registerBlockType( metadata.name, {
@@ -39,5 +40,5 @@ registerBlockType( metadata.name, {
 addFilter(
 	'blocks.navigation.__unstableMenuItemsToBlocks',
 	'polylang/include-language-switcher',
-	menuItemsToBlocksFilter
+	menuItemsToBlocksFilter,
 );

--- a/js/src/blocks/navigation-language-switcher/index.js
+++ b/js/src/blocks/navigation-language-switcher/index.js
@@ -40,5 +40,5 @@ registerBlockType( metadata.name, {
 addFilter(
 	'blocks.navigation.__unstableMenuItemsToBlocks',
 	'polylang/include-language-switcher',
-	menuItemsToBlocksFilter,
+	menuItemsToBlocksFilter
 );

--- a/js/src/blocks/navigation-language-switcher/menu-items-converter.js
+++ b/js/src/blocks/navigation-language-switcher/menu-items-converter.js
@@ -34,7 +34,7 @@ function mapBlockTree( blocks, menuItems, blocksMapping, mapper ) {
 			block.innerBlocks,
 			menuItems,
 			blocksMapping,
-			mapper
+			mapper,
 		),
 	} );
 
@@ -57,7 +57,7 @@ const blocksFilter = ( block, menuItems, blocksMapping ) => {
 		block.attributes?.url === '#pll_switcher'
 	) {
 		const menuItem = menuItems.find(
-			( item ) => item.url === '#pll_switcher'
+			( item ) => item.url === '#pll_switcher',
 		); // Get the corresponding menu item.
 		const attributes = menuItem.meta._pll_menu_item; // Get its options.
 		const newBlock = createBlock( metadata.name, attributes );
@@ -80,6 +80,6 @@ export const menuItemsToBlocksFilter = ( blocks, menuItems ) => ( {
 		blocks.innerBlocks,
 		menuItems,
 		blocks.mapping,
-		blocksFilter
+		blocksFilter,
 	),
 } );

--- a/js/src/blocks/navigation-language-switcher/menu-items-converter.js
+++ b/js/src/blocks/navigation-language-switcher/menu-items-converter.js
@@ -28,14 +28,9 @@ function mapBlockTree( blocks, menuItems, blocksMapping, mapper ) {
 	 * @param {Object} block The block to replace or not.
 	 * @return {Object} The new block potentially replaced by the `mapper`.
 	 */
-	const convertBlock = ( block ) => ( {
+	const convertBlock = block => ( {
 		...mapper( block, menuItems, blocksMapping ),
-		innerBlocks: mapBlockTree(
-			block.innerBlocks,
-			menuItems,
-			blocksMapping,
-			mapper,
-		),
+		innerBlocks: mapBlockTree( block.innerBlocks, menuItems, blocksMapping, mapper ),
 	} );
 
 	return blocks.map( convertBlock );
@@ -52,13 +47,8 @@ function mapBlockTree( blocks, menuItems, blocksMapping, mapper ) {
  * @return {Object} The block correctly converted.
  */
 const blocksFilter = ( block, menuItems, blocksMapping ) => {
-	if (
-		block.name === 'core/navigation-link' &&
-		block.attributes?.url === '#pll_switcher'
-	) {
-		const menuItem = menuItems.find(
-			( item ) => item.url === '#pll_switcher',
-		); // Get the corresponding menu item.
+	if ( block.name === 'core/navigation-link' && block.attributes?.url === '#pll_switcher' ) {
+		const menuItem = menuItems.find( item => item.url === '#pll_switcher' ); // Get the corresponding menu item.
 		const attributes = menuItem.meta._pll_menu_item; // Get its options.
 		const newBlock = createBlock( metadata.name, attributes );
 		blocksMapping[ menuItem.id ] = newBlock.clientId; // Update the blocks mapping.
@@ -76,10 +66,5 @@ const blocksFilter = ( block, menuItems, blocksMapping ) => {
  */
 export const menuItemsToBlocksFilter = ( blocks, menuItems ) => ( {
 	...blocks,
-	innerBlocks: mapBlockTree(
-		blocks.innerBlocks,
-		menuItems,
-		blocks.mapping,
-		blocksFilter,
-	),
+	innerBlocks: mapBlockTree( blocks.innerBlocks, menuItems, blocks.mapping, blocksFilter ),
 } );

--- a/js/src/blocks/navigation-language-switcher/rendered-switcher.js
+++ b/js/src/blocks/navigation-language-switcher/rendered-switcher.js
@@ -28,26 +28,15 @@ import { LanguagesContext } from '../languages-context';
  * @return {ReactElement} The rendered switcher.
  */
 export const RenderedSwitcher = ( { attributes, context } ) => {
-	const {
-		layout,
-		show_labels,
-		show_flags,
-		flag_border_radius,
-		flag_width,
-		flag_label_spacing,
-	} = attributes;
+	const { layout, show_labels, show_flags, flag_border_radius, flag_width, flag_label_spacing } =
+		attributes;
 	const { showSubmenuIcon, openSubmenusOnClick } = context;
 	const { languages } = useContext( LanguagesContext );
 	const currentLanguage = useCurrentLanguage( languages );
 	const isDropdown = layout === 'dropdown';
-	const languagesToRender = useCuratedLanguages(
-		languages,
-		currentLanguage,
-		isDropdown,
-	);
+	const languagesToRender = useCuratedLanguages( languages, currentLanguage, isDropdown );
 	const labelSpacing = getLabelSpacing( show_labels, flag_label_spacing );
-	const withSubmenuIcon =
-		isDropdown && ( showSubmenuIcon || openSubmenusOnClick );
+	const withSubmenuIcon = isDropdown && ( showSubmenuIcon || openSubmenusOnClick );
 	const linkProps = {
 		showLabels: show_labels,
 		showFlags: show_flags,
@@ -58,13 +47,10 @@ export const RenderedSwitcher = ( { attributes, context } ) => {
 
 	return (
 		<>
-			{ languagesToRender.map( ( language ) => {
+			{ languagesToRender.map( language => {
 				return (
 					<Fragment key={ language.slug }>
-						<SwitcherLanguageLink
-							language={ language }
-							{ ...linkProps }
-						/>
+						<SwitcherLanguageLink language={ language } { ...linkProps } />
 						{ withSubmenuIcon && (
 							<span className="wp-block-navigation__submenu-icon">
 								<SubmenuIcon />

--- a/js/src/blocks/navigation-language-switcher/rendered-switcher.js
+++ b/js/src/blocks/navigation-language-switcher/rendered-switcher.js
@@ -15,9 +15,9 @@ import {
 /**
  * Internal dependencies
  */
-import { LanguagesContext } from '../languages-context';
 import { SwitcherLanguageLink } from '../components/switcher-language-link';
 import { getLabelSpacing } from '../components/switcher-utils';
+import { LanguagesContext } from '../languages-context';
 
 /**
  * Rendered switcher component.
@@ -43,7 +43,7 @@ export const RenderedSwitcher = ( { attributes, context } ) => {
 	const languagesToRender = useCuratedLanguages(
 		languages,
 		currentLanguage,
-		isDropdown
+		isDropdown,
 	);
 	const labelSpacing = getLabelSpacing( show_labels, flag_label_spacing );
 	const withSubmenuIcon =

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@wordpress/base-styles": "^6.17.0",
         "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
         "@wordpress/env": "^10.39.0",
+        "@wordpress/eslint-plugin": "^25.8.0",
         "@wordpress/scripts": "^32.6.0",
         "@wpsyntex/distribute": "^0.1.0",
         "@wpsyntex/e2e-test-utils": "^0.1.0",
@@ -7472,6 +7473,8 @@
     },
     "node_modules/@wordpress/eslint-plugin": {
       "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.8.0.tgz",
+      "integrity": "sha512-QqYfiAVUYFLUhiLlVwB1MoGHcyNElwAPFeXnfZhYUPvFYOmQucsn4dxEGpl67PfcM2XWimni5z+mUquv4y1Mow==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "glob": "^11.0.0",
         "mini-css-extract-plugin": "^2.10.1",
         "postcss": "^8.5.8",
+        "prettier": "npm:wp-prettier@3.0.3",
         "rimraf": "^6.1.3",
         "sass": "^1.98.0",
         "sass-loader": "^16.0.7",
@@ -19818,6 +19819,8 @@
     "node_modules/prettier": {
       "name": "wp-prettier",
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+      "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@wpsyntex/polylang-react-library": "^1.0.0"
       },
       "devDependencies": {
+        "@automattic/eslint-plugin-wpvip": "^1.3.0",
         "@playwright/test": "^1.58.2",
         "@wordpress/babel-preset-default": "^8.41.0",
         "@wordpress/base-styles": "^6.17.0",
@@ -26,6 +27,7 @@
         "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^7.1.4",
         "css-minimizer-webpack-plugin": "^8.0.0",
+        "eslint": "^9.39.5",
         "glob": "^11.0.0",
         "mini-css-extract-plugin": "^2.10.1",
         "postcss": "^8.5.8",
@@ -53,6 +55,175 @@
       "version": "10.4.3",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-1.3.0.tgz",
+      "integrity": "sha512-3lkGzFtMK6r1A6GTom5jx4/PQ4DPVJYb3i513uZGUo+uFtbmCmQfvv0d0L+8QCI1N1sSOoAGAvQX06/lQcESeg==",
+      "dev": true,
+      "license": "GPL-2.0+",
+      "dependencies": {
+        "@babel/eslint-parser": "^7.28.5",
+        "@typescript-eslint/parser": "^8.54.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jest": "^29.12.2",
+        "eslint-plugin-jsdoc": "^63.0.0",
+        "eslint-plugin-json": "^4.0.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-promise": "^7.2.1",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-security": "^4.0.0",
+        "eslint-plugin-unused-imports": "^4.3.0",
+        "find-package-json": "^1.2.0",
+        "globals": "^16.0.0 || ^17.0.0",
+        "typescript-eslint": "^8.48.1"
+      },
+      "peerDependencies": {
+        "eslint": "^9.7.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "prettier": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "typescript": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/@es-joy/jsdoccomment": {
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.65.0",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~8.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/eslint-plugin-jsdoc": {
+      "version": "63.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
+      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.91.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^5.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/jsdoc-type-pratt-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@automattic/eslint-plugin-wpvip/node_modules/spdx-expression-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2058,6 +2229,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
       "version": "4.7.2",
       "dev": true,
@@ -2132,27 +2313,44 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.7.0",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
@@ -2166,24 +2364,155 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -5247,6 +5576,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "dev": true,
@@ -5696,6 +6038,8 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7440,6 +7784,58 @@
         }
       }
     },
+    "node_modules/@wordpress/scripts/node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@wordpress/scripts/node_modules/@webpack-cli/configtest": {
       "version": "2.1.1",
       "dev": true,
@@ -7499,6 +7895,23 @@
       "peerDependencies": {
         "@playwright/test": ">=1",
         "@types/node": "^20.17.10"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/array-union": {
@@ -7606,6 +8019,203 @@
         }
       }
     },
+    "node_modules/@wordpress/scripts/node_modules/eslint": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@wordpress/scripts/node_modules/find-cache-dir": {
       "version": "4.0.0",
       "dev": true,
@@ -7673,6 +8283,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wordpress/scripts/node_modules/kind-of": {
       "version": "6.0.3",
@@ -11930,31 +12547,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.7.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -11964,7 +12583,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.5",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -11972,7 +12592,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -12211,33 +12831,6 @@
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
-    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
       "version": "7.8.5",
       "dev": true,
@@ -12247,6 +12840,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-4.0.1.tgz",
+      "integrity": "sha512-3An5ISV5dq/kHfXdNyY5TUe2ONC3yXFSkLX2gu+W8xAhKhfvrRvkSAeKXCxZqZ0KJLX15ojBuLPyj+UikQMkOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -12331,6 +12938,25 @@
         }
       }
     },
+    "node_modules/eslint-plugin-promise": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "dev": true,
@@ -12402,6 +13028,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.1.tgz",
+      "integrity": "sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
+      "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^10.0.0 || ^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -12430,6 +13088,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -12446,28 +13117,30 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "9.1.2",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -12530,27 +13203,31 @@
       }
     },
     "node_modules/espree": {
-      "version": "11.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -13069,6 +13746,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/find-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-parent-dir": {
       "version": "0.3.1",
@@ -16541,6 +17225,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "dev": true,
@@ -17613,6 +18304,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-filter": {
       "version": "1.0.2",
@@ -19404,6 +20102,8 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19627,6 +20327,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "dev": true,
@@ -19724,6 +20434,19 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -20027,6 +20750,16 @@
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -22060,6 +22793,23 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "dev": true,
@@ -22673,6 +23423,48 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
+      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.3",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@wpsyntex/polylang-react-library": "^1.0.0"
   },
   "devDependencies": {
+    "@automattic/eslint-plugin-wpvip": "^1.3.0",
     "@playwright/test": "^1.58.2",
     "@wordpress/babel-preset-default": "^8.41.0",
     "@wordpress/base-styles": "^6.17.0",
@@ -44,6 +45,7 @@
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
+    "eslint": "^9.39.5",
     "glob": "^11.0.0",
     "mini-css-extract-plugin": "^2.10.1",
     "postcss": "^8.5.8",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "glob": "^11.0.0",
     "mini-css-extract-plugin": "^2.10.1",
     "postcss": "^8.5.8",
+    "prettier": "npm:wp-prettier@3.0.3",
     "rimraf": "^6.1.3",
     "sass": "^1.98.0",
     "sass-loader": "^16.0.7",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@wordpress/base-styles": "^6.17.0",
     "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
     "@wordpress/env": "^10.39.0",
+    "@wordpress/eslint-plugin": "^25.8.0",
     "@wordpress/scripts": "^32.6.0",
     "@wpsyntex/distribute": "^0.1.0",
     "@wpsyntex/e2e-test-utils": "^0.1.0",

--- a/tests/e2e/global.setup.mjs
+++ b/tests/e2e/global.setup.mjs
@@ -16,7 +16,7 @@ async function globalSetup( config ) {
 		{
 			cwd: process.cwd(),
 			stdio: 'inherit',
-		},
+		}
 	);
 }
 

--- a/tests/e2e/global.setup.mjs
+++ b/tests/e2e/global.setup.mjs
@@ -16,7 +16,7 @@ async function globalSetup( config ) {
 		{
 			cwd: process.cwd(),
 			stdio: 'inherit',
-		}
+		},
 	);
 }
 

--- a/tests/e2e/global.teardown.mjs
+++ b/tests/e2e/global.teardown.mjs
@@ -11,7 +11,7 @@ async function globalTeardown() {
 		{
 			cwd: process.cwd(),
 			stdio: 'ignore',
-		},
+		}
 	);
 }
 

--- a/tests/e2e/global.teardown.mjs
+++ b/tests/e2e/global.teardown.mjs
@@ -11,7 +11,7 @@ async function globalTeardown() {
 		{
 			cwd: process.cwd(),
 			stdio: 'ignore',
-		}
+		},
 	);
 }
 

--- a/tests/e2e/playwright.docker-browser.config.mjs
+++ b/tests/e2e/playwright.docker-browser.config.mjs
@@ -1,5 +1,5 @@
+import { devices } from '@playwright/test';
 import { getPlaywrightConfig } from '@wpsyntex/e2e-test-utils';
-import { devices } from '@playwright/test'; // eslint-disable-line import/no-extraneous-dependencies
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/tests/e2e/run-docker-browser.mjs
+++ b/tests/e2e/run-docker-browser.mjs
@@ -16,8 +16,8 @@
  */
 
 import { execSync } from 'child_process';
-import { fileURLToPath } from 'url';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath( import.meta.url );
 const __dirname = path.dirname( __filename );
@@ -54,7 +54,7 @@ const isContainerRunning = ( containerName ) => {
 	try {
 		const result = execSync(
 			`docker ps --filter "name=${ containerName }" --format "{{.Names}}"`,
-			{ encoding: 'utf-8', stdio: 'pipe' }
+			{ encoding: 'utf-8', stdio: 'pipe' },
 		);
 		return result.trim() === containerName;
 	} catch {
@@ -72,7 +72,7 @@ const containerExists = ( containerName ) => {
 	try {
 		const result = execSync(
 			`docker ps -a --filter "name=${ containerName }" --format "{{.Names}}"`,
-			{ encoding: 'utf-8', stdio: 'pipe' }
+			{ encoding: 'utf-8', stdio: 'pipe' },
 		);
 		return result.trim() === containerName;
 	} catch {
@@ -90,7 +90,7 @@ const getContainerImage = ( containerName ) => {
 	try {
 		const result = execSync(
 			`docker inspect --format='{{.Config.Image}}' ${ containerName }`,
-			{ encoding: 'utf-8', stdio: 'pipe' }
+			{ encoding: 'utf-8', stdio: 'pipe' },
 		);
 		return result.trim();
 	} catch {
@@ -148,7 +148,7 @@ const startPlaywrightServer = () => {
 				`--init --ipc=host --network host ` +
 				`${ PLAYWRIGHT_IMAGE } ` +
 				`/bin/sh -c "npx -y playwright@${ PLAYWRIGHT_VERSION } run-server --port ${ PLAYWRIGHT_SERVER_PORT } --host 0.0.0.0"`,
-			{ stdio: 'inherit' }
+			{ stdio: 'inherit' },
 		);
 		console.log( 'Playwright Server started successfully.' );
 		return true;
@@ -180,7 +180,7 @@ const isDockerRunning = () => {
 const main = () => {
 	if ( ! isDockerRunning() ) {
 		console.error(
-			'Docker is not running. Please start Docker and try again.'
+			'Docker is not running. Please start Docker and try again.',
 		);
 		process.exit( 1 );
 	}
@@ -203,7 +203,7 @@ const main = () => {
 			}
 		} else {
 			console.log(
-				`Container exists with different Playwright version (${ existingImage }). Removing...`
+				`Container exists with different Playwright version (${ existingImage }). Removing...`,
 			);
 			if ( ! removeContainer( PLAYWRIGHT_SERVER_NAME ) ) {
 				console.error( 'Failed to remove existing container.' );

--- a/tests/e2e/run-docker-browser.mjs
+++ b/tests/e2e/run-docker-browser.mjs
@@ -50,12 +50,12 @@ const PLAYWRIGHT_IMAGE = `mcr.microsoft.com/playwright:v${ PLAYWRIGHT_VERSION }-
  * @param {string} containerName - The name of the Docker container to check.
  * @return {boolean} True if the container is running, false otherwise.
  */
-const isContainerRunning = ( containerName ) => {
+const isContainerRunning = containerName => {
 	try {
-		const result = execSync(
-			`docker ps --filter "name=${ containerName }" --format "{{.Names}}"`,
-			{ encoding: 'utf-8', stdio: 'pipe' },
-		);
+		const result = execSync( `docker ps --filter "name=${ containerName }" --format "{{.Names}}"`, {
+			encoding: 'utf-8',
+			stdio: 'pipe',
+		} );
 		return result.trim() === containerName;
 	} catch {
 		return false;
@@ -68,11 +68,11 @@ const isContainerRunning = ( containerName ) => {
  * @param {string} containerName - The name of the Docker container to check.
  * @return {boolean} True if the container exists, false otherwise.
  */
-const containerExists = ( containerName ) => {
+const containerExists = containerName => {
 	try {
 		const result = execSync(
 			`docker ps -a --filter "name=${ containerName }" --format "{{.Names}}"`,
-			{ encoding: 'utf-8', stdio: 'pipe' },
+			{ encoding: 'utf-8', stdio: 'pipe' }
 		);
 		return result.trim() === containerName;
 	} catch {
@@ -86,12 +86,12 @@ const containerExists = ( containerName ) => {
  * @param {string} containerName - The name of the Docker container.
  * @return {string|null} The image name or null if not found.
  */
-const getContainerImage = ( containerName ) => {
+const getContainerImage = containerName => {
 	try {
-		const result = execSync(
-			`docker inspect --format='{{.Config.Image}}' ${ containerName }`,
-			{ encoding: 'utf-8', stdio: 'pipe' },
-		);
+		const result = execSync( `docker inspect --format='{{.Config.Image}}' ${ containerName }`, {
+			encoding: 'utf-8',
+			stdio: 'pipe',
+		} );
 		return result.trim();
 	} catch {
 		return null;
@@ -104,7 +104,7 @@ const getContainerImage = ( containerName ) => {
  * @param {string} containerName - The name of the Docker container to start.
  * @return {boolean} True if the container was started successfully, false otherwise.
  */
-const startExistingContainer = ( containerName ) => {
+const startExistingContainer = containerName => {
 	try {
 		console.log( `Starting existing container: ${ containerName }...` );
 		execSync( `docker start ${ containerName }`, { stdio: 'inherit' } );
@@ -122,7 +122,7 @@ const startExistingContainer = ( containerName ) => {
  * @param {string} containerName - The name of the Docker container to remove.
  * @return {boolean} True if the container was removed successfully, false otherwise.
  */
-const removeContainer = ( containerName ) => {
+const removeContainer = containerName => {
 	try {
 		console.log( `Removing existing container: ${ containerName }...` );
 		execSync( `docker rm -f ${ containerName }`, { stdio: 'inherit' } );
@@ -148,7 +148,7 @@ const startPlaywrightServer = () => {
 				`--init --ipc=host --network host ` +
 				`${ PLAYWRIGHT_IMAGE } ` +
 				`/bin/sh -c "npx -y playwright@${ PLAYWRIGHT_VERSION } run-server --port ${ PLAYWRIGHT_SERVER_PORT } --host 0.0.0.0"`,
-			{ stdio: 'inherit' },
+			{ stdio: 'inherit' }
 		);
 		console.log( 'Playwright Server started successfully.' );
 		return true;
@@ -179,9 +179,7 @@ const isDockerRunning = () => {
  */
 const main = () => {
 	if ( ! isDockerRunning() ) {
-		console.error(
-			'Docker is not running. Please start Docker and try again.',
-		);
+		console.error( 'Docker is not running. Please start Docker and try again.' );
 		process.exit( 1 );
 	}
 
@@ -203,7 +201,7 @@ const main = () => {
 			}
 		} else {
 			console.log(
-				`Container exists with different Playwright version (${ existingImage }). Removing...`,
+				`Container exists with different Playwright version (${ existingImage }). Removing...`
 			);
 			if ( ! removeContainer( PLAYWRIGHT_SERVER_NAME ) ) {
 				console.error( 'Failed to remove existing container.' );

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -119,7 +119,7 @@ test.describe.serial(
 			await setSwitcherLabels( page, 'Names' );
 			await page.getByRole( 'checkbox', { name: 'Display flags' } ).check();
 
-			const blockWithNamesAndFlags = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNamesAndFlags = await getNavigationLanguageSwitcherLocator( page );
 			const blockWithNamesAndFlagsScreenshot = await blockWithNamesAndFlags.screenshot();
 			expect( blockWithNamesAndFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-dropdown-with-names-and-flags.png',
@@ -131,7 +131,7 @@ test.describe.serial(
 			// Remove the language names and keep the flags.
 			await setSwitcherLabels( page, 'None' );
 
-			const blockWithFlags = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithFlags = await getNavigationLanguageSwitcherLocator( page );
 			const blockWithFlagsScreenshot = await blockWithFlags.screenshot();
 			expect( blockWithFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-dropdown-with-flags.png',
@@ -145,7 +145,7 @@ test.describe.serial(
 			await page.getByRole( 'checkbox', { name: 'Display flags' } ).uncheck();
 			await expect( page.getByRole( 'combobox', { name: 'Labels' } ) ).toHaveValue( 'names' );
 
-			const blockWithNames = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNames = await getNavigationLanguageSwitcherLocator( page );
 			const blockWithNamesScreenshot = await blockWithNames.screenshot();
 			expect( blockWithNamesScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-dropdown-with-names.png',
@@ -178,7 +178,7 @@ test.describe.serial(
 			await setSwitcherLabels( page, 'Names' );
 			await page.getByRole( 'checkbox', { name: 'Display flags' } ).check();
 
-			const blockWithNamesAndFlags = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNamesAndFlags = await getNavigationLanguageSwitcherLocator( page );
 			const blockWithNamesAndFlagsScreenshot = await blockWithNamesAndFlags.screenshot();
 			expect( blockWithNamesAndFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-list-with-names-and-flags.png',
@@ -190,7 +190,7 @@ test.describe.serial(
 			// Remove the language names and keep the flags.
 			await setSwitcherLabels( page, 'None' );
 
-			const blockWithFlags = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithFlags = await getNavigationLanguageSwitcherLocator( page );
 			const blockWithFlagsScreenshot = await blockWithFlags.screenshot();
 			expect( blockWithFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-list-with-flags.png',
@@ -204,7 +204,7 @@ test.describe.serial(
 			await page.getByRole( 'checkbox', { name: 'Display flags' } ).uncheck();
 			await expect( page.getByRole( 'combobox', { name: 'Labels' } ) ).toHaveValue( 'names' );
 
-			const blockWithNames = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNames = await getNavigationLanguageSwitcherLocator( page );
 			const blockWithNamesScreenshot = await blockWithNames.screenshot();
 			expect( blockWithNamesScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-list-with-names.png',
@@ -307,7 +307,7 @@ const selectNavigationLanguageSwitcherBlock = async page => {
  * @param {Page} page The page object.
  * @return {Locator} The locator of the Navigation Language Switcher block element.
  */
-const getNavigationLanguageSwitcherBlockLocator = page => {
+const getNavigationLanguageSwitcherLocator = page => {
 	return getEditorCanvas( page ).getByRole( 'document', {
 		name: 'Block: Navigation Language Switcher',
 	} );

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -70,7 +70,7 @@ test.describe.serial(
 			const navInserter = navigationBlock
 				.getByRole( 'button', { name: 'Add page' } )
 				.or(
-					navigationBlock.getByRole( 'button', { name: 'Add block' } ) // Fallback for WP 6.9
+					navigationBlock.getByRole( 'button', { name: 'Add block' } ), // Fallback for WP 6.9
 				);
 			await expect( navInserter ).toBeVisible();
 			await navInserter.click();
@@ -142,7 +142,7 @@ test.describe.serial(
 				'navigation-language-switcher-dropdown-with-names-and-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				}
+				},
 			);
 
 			// Remove the language names and keep the flags.
@@ -155,7 +155,7 @@ test.describe.serial(
 				'navigation-language-switcher-dropdown-with-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				}
+				},
 			);
 
 			// Remove the flags: labels must be shown before flags can be hidden.
@@ -164,7 +164,7 @@ test.describe.serial(
 				.getByRole( 'checkbox', { name: 'Display flags' } )
 				.uncheck();
 			await expect(
-				page.getByRole( 'combobox', { name: 'Labels' } )
+				page.getByRole( 'combobox', { name: 'Labels' } ),
 			).toHaveValue( 'names' );
 
 			const blockWithNames =
@@ -174,7 +174,7 @@ test.describe.serial(
 				'navigation-language-switcher-dropdown-with-names.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				}
+				},
 			);
 
 			// Save the changes for next tests.
@@ -211,7 +211,7 @@ test.describe.serial(
 				'navigation-language-switcher-list-with-names-and-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				}
+				},
 			);
 
 			// Remove the language names and keep the flags.
@@ -224,7 +224,7 @@ test.describe.serial(
 				'navigation-language-switcher-list-with-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				}
+				},
 			);
 
 			// Remove the flags: labels must be shown before flags can be hidden.
@@ -233,7 +233,7 @@ test.describe.serial(
 				.getByRole( 'checkbox', { name: 'Display flags' } )
 				.uncheck();
 			await expect(
-				page.getByRole( 'combobox', { name: 'Labels' } )
+				page.getByRole( 'combobox', { name: 'Labels' } ),
 			).toHaveValue( 'names' );
 
 			const blockWithNames =
@@ -243,7 +243,7 @@ test.describe.serial(
 				'navigation-language-switcher-list-with-names.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				}
+				},
 			);
 
 			// Save the changes for next tests.
@@ -283,7 +283,7 @@ test.describe.serial(
 					.getByRole( 'checkbox', {
 						name: 'Force link to front page',
 					} )
-					.isChecked()
+					.isChecked(),
 			).toBeTruthy();
 
 			// Edit the Navigation Language Switcher block settings to hides the current language.
@@ -295,7 +295,7 @@ test.describe.serial(
 					.getByRole( 'checkbox', {
 						name: 'Hide the current language',
 					} )
-					.isChecked()
+					.isChecked(),
 			).toBeTruthy();
 
 			// Edit the Navigation Language Switcher block settings to hide languages with no translation.
@@ -309,10 +309,10 @@ test.describe.serial(
 					.getByRole( 'checkbox', {
 						name: 'Hide languages with no translation',
 					} )
-					.isChecked()
+					.isChecked(),
 			).toBeTruthy();
 		} );
-	}
+	},
 );
 
 /**
@@ -368,7 +368,7 @@ const navigateToNavigationEditor = async ( admin, page, navigation ) => {
 	} );
 
 	await expect(
-		page.locator( 'iframe[name="editor-canvas"]' )
+		page.locator( 'iframe[name="editor-canvas"]' ),
 	).toBeVisible();
 };
 

--- a/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
+++ b/tests/e2e/specs/blocks/navigation-language-switcher.spec.js
@@ -54,11 +54,7 @@ test.describe.serial(
 		 *     - Check the navigation language switcher block is displayed in the editor.
 		 *     - Check the navigation language switcher block has the correct languages in a list.
 		 */
-		test( 'Block should be displayed in the editor', async ( {
-			admin,
-			page,
-			editor,
-		} ) => {
+		test( 'Block should be displayed in the editor', async ( { admin, page, editor } ) => {
 			await navigateToNavigationEditor( admin, page, navigation );
 
 			// Navigation editor: Add page (WP 7) or Add block appender (WP 6.9) → Link UI → Browse all.
@@ -67,18 +63,13 @@ test.describe.serial(
 			} );
 			await navigationBlock.click();
 
-			const navInserter = navigationBlock
-				.getByRole( 'button', { name: 'Add page' } )
-				.or(
-					navigationBlock.getByRole( 'button', { name: 'Add block' } ), // Fallback for WP 6.9
-				);
+			const navInserter = navigationBlock.getByRole( 'button', { name: 'Add page' } ).or(
+				navigationBlock.getByRole( 'button', { name: 'Add block' } ) // Fallback for WP 6.9
+			);
 			await expect( navInserter ).toBeVisible();
 			await navInserter.click();
 
-			await page
-				.getByRole( 'button', { name: 'Add block' } )
-				.first()
-				.click();
+			await page.getByRole( 'button', { name: 'Add block' } ).first().click();
 
 			// QuickInserter only lists a few blocks; Polylang's block is not among them.
 			const addBlockDialog = page.getByRole( 'dialog', {
@@ -95,12 +86,8 @@ test.describe.serial(
 			const blockLibrary = page.getByRole( 'region', {
 				name: 'Block Library',
 			} );
-			await blockLibrary
-				.getByRole( 'searchbox', { name: 'Search' } )
-				.fill( 'language' );
-			await blockLibrary
-				.getByRole( 'option', { name: 'Navigation Language Switcher' } )
-				.click();
+			await blockLibrary.getByRole( 'searchbox', { name: 'Search' } ).fill( 'language' );
+			await blockLibrary.getByRole( 'option', { name: 'Navigation Language Switcher' } ).click();
 
 			// Check the navigation language switcher block is present in the content.
 			await expect
@@ -130,51 +117,41 @@ test.describe.serial(
 			await selectNavigationLanguageSwitcherBlock( page );
 			await setSwitcherLayout( page, 'Dropdown' );
 			await setSwitcherLabels( page, 'Names' );
-			await page
-				.getByRole( 'checkbox', { name: 'Display flags' } )
-				.check();
+			await page.getByRole( 'checkbox', { name: 'Display flags' } ).check();
 
-			const blockWithNamesAndFlags =
-				await getNavigationLanguageSwitcherBlockLocator( page );
-			const blockWithNamesAndFlagsScreenshot =
-				await blockWithNamesAndFlags.screenshot();
+			const blockWithNamesAndFlags = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNamesAndFlagsScreenshot = await blockWithNamesAndFlags.screenshot();
 			expect( blockWithNamesAndFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-dropdown-with-names-and-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				},
+				}
 			);
 
 			// Remove the language names and keep the flags.
 			await setSwitcherLabels( page, 'None' );
 
-			const blockWithFlags =
-				await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithFlags = await getNavigationLanguageSwitcherBlockLocator( page );
 			const blockWithFlagsScreenshot = await blockWithFlags.screenshot();
 			expect( blockWithFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-dropdown-with-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				},
+				}
 			);
 
 			// Remove the flags: labels must be shown before flags can be hidden.
 			await setSwitcherLabels( page, 'Names' );
-			await page
-				.getByRole( 'checkbox', { name: 'Display flags' } )
-				.uncheck();
-			await expect(
-				page.getByRole( 'combobox', { name: 'Labels' } ),
-			).toHaveValue( 'names' );
+			await page.getByRole( 'checkbox', { name: 'Display flags' } ).uncheck();
+			await expect( page.getByRole( 'combobox', { name: 'Labels' } ) ).toHaveValue( 'names' );
 
-			const blockWithNames =
-				await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNames = await getNavigationLanguageSwitcherBlockLocator( page );
 			const blockWithNamesScreenshot = await blockWithNames.screenshot();
 			expect( blockWithNamesScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-dropdown-with-names.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				},
+				}
 			);
 
 			// Save the changes for next tests.
@@ -199,51 +176,41 @@ test.describe.serial(
 			await selectNavigationLanguageSwitcherBlock( page );
 			await setSwitcherLayout( page, 'Horizontal' );
 			await setSwitcherLabels( page, 'Names' );
-			await page
-				.getByRole( 'checkbox', { name: 'Display flags' } )
-				.check();
+			await page.getByRole( 'checkbox', { name: 'Display flags' } ).check();
 
-			const blockWithNamesAndFlags =
-				await getNavigationLanguageSwitcherBlockLocator( page );
-			const blockWithNamesAndFlagsScreenshot =
-				await blockWithNamesAndFlags.screenshot();
+			const blockWithNamesAndFlags = await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNamesAndFlagsScreenshot = await blockWithNamesAndFlags.screenshot();
 			expect( blockWithNamesAndFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-list-with-names-and-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				},
+				}
 			);
 
 			// Remove the language names and keep the flags.
 			await setSwitcherLabels( page, 'None' );
 
-			const blockWithFlags =
-				await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithFlags = await getNavigationLanguageSwitcherBlockLocator( page );
 			const blockWithFlagsScreenshot = await blockWithFlags.screenshot();
 			expect( blockWithFlagsScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-list-with-flags.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				},
+				}
 			);
 
 			// Remove the flags: labels must be shown before flags can be hidden.
 			await setSwitcherLabels( page, 'Names' );
-			await page
-				.getByRole( 'checkbox', { name: 'Display flags' } )
-				.uncheck();
-			await expect(
-				page.getByRole( 'combobox', { name: 'Labels' } ),
-			).toHaveValue( 'names' );
+			await page.getByRole( 'checkbox', { name: 'Display flags' } ).uncheck();
+			await expect( page.getByRole( 'combobox', { name: 'Labels' } ) ).toHaveValue( 'names' );
 
-			const blockWithNames =
-				await getNavigationLanguageSwitcherBlockLocator( page );
+			const blockWithNames = await getNavigationLanguageSwitcherBlockLocator( page );
 			const blockWithNamesScreenshot = await blockWithNames.screenshot();
 			expect( blockWithNamesScreenshot ).toMatchSnapshot(
 				'navigation-language-switcher-list-with-names.png',
 				{
 					maxDiffPixelRatio: 0.25,
-				},
+				}
 			);
 
 			// Save the changes for next tests.
@@ -267,35 +234,28 @@ test.describe.serial(
 		 *     - Ensure the hides languages with no translation setting is displayed correctly.
 		 *     - Ensure settings (forces link to front page, hides the current language, hides languages with no translation) are dispal correctly.
 		 */
-		test( 'Block advanced settings can be edited', async ( {
-			admin,
-			page,
-		} ) => {
+		test( 'Block advanced settings can be edited', async ( { admin, page } ) => {
 			await navigateToNavigationEditor( admin, page, navigation );
 
 			// Edit the Navigation Language Switcher block settings to forces link to front page.
 			await selectNavigationLanguageSwitcherBlock( page );
-			await page
-				.getByRole( 'checkbox', { name: 'Force link to front page' } )
-				.check();
+			await page.getByRole( 'checkbox', { name: 'Force link to front page' } ).check();
 			expect(
 				await page
 					.getByRole( 'checkbox', {
 						name: 'Force link to front page',
 					} )
-					.isChecked(),
+					.isChecked()
 			).toBeTruthy();
 
 			// Edit the Navigation Language Switcher block settings to hides the current language.
-			await page
-				.getByRole( 'checkbox', { name: 'Hide the current language' } )
-				.check();
+			await page.getByRole( 'checkbox', { name: 'Hide the current language' } ).check();
 			expect(
 				await page
 					.getByRole( 'checkbox', {
 						name: 'Hide the current language',
 					} )
-					.isChecked(),
+					.isChecked()
 			).toBeTruthy();
 
 			// Edit the Navigation Language Switcher block settings to hide languages with no translation.
@@ -309,10 +269,10 @@ test.describe.serial(
 					.getByRole( 'checkbox', {
 						name: 'Hide languages with no translation',
 					} )
-					.isChecked(),
+					.isChecked()
 			).toBeTruthy();
 		} );
-	},
+	}
 );
 
 /**
@@ -321,7 +281,7 @@ test.describe.serial(
  * @param {Page} page The page object.
  * @return {import('@playwright/test').FrameLocator} The canvas frame locator.
  */
-const getEditorCanvas = ( page ) => {
+const getEditorCanvas = page => {
 	return page.frameLocator( 'iframe[name="editor-canvas"]' );
 };
 
@@ -331,7 +291,7 @@ const getEditorCanvas = ( page ) => {
  * @param {Page} page The page object.
  * @return {Promise<Locator>} The locator of the Navigation Language Switcher block.
  */
-const selectNavigationLanguageSwitcherBlock = async ( page ) => {
+const selectNavigationLanguageSwitcherBlock = async page => {
 	return page
 		.locator( 'iframe[name="editor-canvas"]' )
 		.contentFrame()
@@ -347,7 +307,7 @@ const selectNavigationLanguageSwitcherBlock = async ( page ) => {
  * @param {Page} page The page object.
  * @return {Locator} The locator of the Navigation Language Switcher block element.
  */
-const getNavigationLanguageSwitcherBlockLocator = ( page ) => {
+const getNavigationLanguageSwitcherBlockLocator = page => {
 	return getEditorCanvas( page ).getByRole( 'document', {
 		name: 'Block: Navigation Language Switcher',
 	} );
@@ -367,9 +327,7 @@ const navigateToNavigationEditor = async ( admin, page, navigation ) => {
 		canvas: 'edit',
 	} );
 
-	await expect(
-		page.locator( 'iframe[name="editor-canvas"]' ),
-	).toBeVisible();
+	await expect( page.locator( 'iframe[name="editor-canvas"]' ) ).toBeVisible();
 };
 
 /**
@@ -377,10 +335,8 @@ const navigateToNavigationEditor = async ( admin, page, navigation ) => {
  *
  * @param {Page} page The page object.
  */
-const saveNavigationChanges = async ( page ) => {
-	await page
-		.getByRole( 'button', { name: /Submit for Review|Save/ } )
-		.click();
+const saveNavigationChanges = async page => {
+	await page.getByRole( 'button', { name: /Submit for Review|Save/ } ).click();
 };
 
 /**

--- a/tests/e2e/specs/browser-preferred-language.spec.js
+++ b/tests/e2e/specs/browser-preferred-language.spec.js
@@ -150,7 +150,7 @@ test.describe( 'Should detect browser preferred language', () => {
 
 		await setAcceptLanguageHeader(
 			context,
-			'zh-Hant-HK;q=1.0,zh-CN;q=0.9,en;q=0.8'
+			'zh-Hant-HK;q=1.0,zh-CN;q=0.9,en;q=0.8',
 		);
 
 		await page.goto( '/' );
@@ -168,13 +168,13 @@ test.describe( 'Should detect browser preferred language', () => {
 const expectLanguageCookie = async ( page, expectedLanguage ) => {
 	const cookies = await page.context().cookies();
 	const languageCookie = cookies.find(
-		( cookie ) => cookie.name === 'pll_language'
+		( cookie ) => cookie.name === 'pll_language',
 	);
 
 	expect( languageCookie, 'Language cookie should be set' ).toBeDefined();
 	expect(
 		languageCookie.value,
-		'Preferred language should be ' + expectedLanguage
+		'Preferred language should be ' + expectedLanguage,
 	).toBe( expectedLanguage );
 };
 

--- a/tests/e2e/specs/browser-preferred-language.spec.js
+++ b/tests/e2e/specs/browser-preferred-language.spec.js
@@ -41,11 +41,7 @@ test.describe( 'Should detect browser preferred language', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test( 'Should serve the best matching region', async ( {
-		page,
-		requestUtils,
-		context,
-	} ) => {
+	test( 'Should serve the best matching region', async ( { page, requestUtils, context } ) => {
 		await createLanguage( requestUtils, 'en_US' );
 		await createLanguage( requestUtils, 'en_GB', { slug: 'en-gb' } );
 
@@ -148,10 +144,7 @@ test.describe( 'Should detect browser preferred language', () => {
 			lang: 'en',
 		} );
 
-		await setAcceptLanguageHeader(
-			context,
-			'zh-Hant-HK;q=1.0,zh-CN;q=0.9,en;q=0.8',
-		);
+		await setAcceptLanguageHeader( context, 'zh-Hant-HK;q=1.0,zh-CN;q=0.9,en;q=0.8' );
 
 		await page.goto( '/' );
 
@@ -167,15 +160,12 @@ test.describe( 'Should detect browser preferred language', () => {
  */
 const expectLanguageCookie = async ( page, expectedLanguage ) => {
 	const cookies = await page.context().cookies();
-	const languageCookie = cookies.find(
-		( cookie ) => cookie.name === 'pll_language',
-	);
+	const languageCookie = cookies.find( cookie => cookie.name === 'pll_language' );
 
 	expect( languageCookie, 'Language cookie should be set' ).toBeDefined();
-	expect(
-		languageCookie.value,
-		'Preferred language should be ' + expectedLanguage,
-	).toBe( expectedLanguage );
+	expect( languageCookie.value, 'Preferred language should be ' + expectedLanguage ).toBe(
+		expectedLanguage
+	);
 };
 
 /**

--- a/tests/e2e/specs/posts/automatic-language-assignment-on-creation.spec.js
+++ b/tests/e2e/specs/posts/automatic-language-assignment-on-creation.spec.js
@@ -1,10 +1,6 @@
 // @ts-check
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
-import {
-	createLanguage,
-	deleteAllLanguages,
-	resetAllSettings,
-} from '@wpsyntex/e2e-test-utils';
+import { createLanguage, deleteAllLanguages, resetAllSettings } from '@wpsyntex/e2e-test-utils';
 
 /**
  * Covers content creation and automatic default language assignment.
@@ -34,14 +30,9 @@ test.describe( 'Content creation and automatic default language assignment', () 
 	 * Expected behavior:
 	 * Assert that the selected value contains 'en' (the default language).
 	 */
-	test( 'Check default language assignment on draft post', async ( {
-		page,
-		admin,
-	} ) => {
+	test( 'Check default language assignment on draft post', async ( { page, admin } ) => {
 		await admin.visitAdminPage( 'post-new.php' );
-		const selectedValue = await page
-			.getByRole( 'combobox', { name: /language/i } )
-			.inputValue();
+		const selectedValue = await page.getByRole( 'combobox', { name: /language/i } ).inputValue();
 
 		expect( selectedValue ).toContain( 'en' );
 	} );
@@ -66,13 +57,9 @@ test.describe( 'Content creation and automatic default language assignment', () 
 		editor,
 	} ) => {
 		await admin.createNewPost();
-		await editor.canvas
-			.getByRole( 'textbox', { name: /add title/i } )
-			.fill( 'Test Post Title' );
+		await editor.canvas.getByRole( 'textbox', { name: /add title/i } ).fill( 'Test Post Title' );
 		await editor.publishPost();
-		const selectedValue = await page
-			.getByRole( 'combobox', { name: /language/i } )
-			.inputValue();
+		const selectedValue = await page.getByRole( 'combobox', { name: /language/i } ).inputValue();
 
 		expect( selectedValue ).toContain( 'en' );
 	} );

--- a/tests/e2e/specs/settings/add-language-assign-content-without-languages.spec.js
+++ b/tests/e2e/specs/settings/add-language-assign-content-without-languages.spec.js
@@ -58,7 +58,7 @@ test.describe(
 
 			// Target the <span class="screen-reader-text">Default language</span>
 			await expect(
-				englishRow.getByText( 'Default language', { exact: true } )
+				englishRow.getByText( 'Default language', { exact: true } ),
 			).toBeVisible();
 		} );
 
@@ -96,10 +96,10 @@ test.describe(
 			// After clicking the "Assign" link, the previously created post should now be assigned to the default language (English en_US).
 			await admin.visitAdminPage( 'edit.php' );
 			const NoLanguagePostRow = page.locator(
-				`#post-${ noLanguagePost.id }`
+				`#post-${ noLanguagePost.id }`,
 			);
 			await expect(
-				NoLanguagePostRow.getByAltText( 'English' )
+				NoLanguagePostRow.getByAltText( 'English' ),
 			).toBeVisible();
 			await admin.visitAdminPage( 'admin.php', 'page=mlang' );
 		} );
@@ -145,5 +145,5 @@ test.describe(
 
 			await expect( postsCell ).toHaveText( '1', { timeout: 10_000 } );
 		} );
-	}
+	},
 );

--- a/tests/e2e/specs/settings/add-language-assign-content-without-languages.spec.js
+++ b/tests/e2e/specs/settings/add-language-assign-content-without-languages.spec.js
@@ -30,36 +30,21 @@ test.describe(
 		 * Behaviour expected:
 		 * - As this is the 1st language, it should be set as the default language.
 		 */
-		test( 'create English en_US as the default language', async ( {
-			page,
-			admin,
-		} ) => {
+		test( 'create English en_US as the default language', async ( { page, admin } ) => {
 			await admin.visitAdminPage( 'admin.php', 'page=mlang' );
 
-			await page
-				.getByRole( 'textbox', { name: 'Full name' } )
-				.fill( 'English' );
-			await page
-				.getByRole( 'textbox', { name: 'Locale' } )
-				.fill( 'en_US' );
-			await page
-				.getByRole( 'textbox', { name: 'Language code' } )
-				.fill( 'en' );
+			await page.getByRole( 'textbox', { name: 'Full name' } ).fill( 'English' );
+			await page.getByRole( 'textbox', { name: 'Locale' } ).fill( 'en_US' );
+			await page.getByRole( 'textbox', { name: 'Language code' } ).fill( 'en' );
 			await page.getByRole( 'radio', { name: 'left to right' } ).check();
 
 			// Submit the form to add the new language.
-			await page
-				.getByRole( 'button', { name: 'Add new language' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Add new language' } ).click();
 
-			const englishRow = page
-				.getByRole( 'row', { name: /English/ } )
-				.first();
+			const englishRow = page.getByRole( 'row', { name: /English/ } ).first();
 
 			// Target the <span class="screen-reader-text">Default language</span>
-			await expect(
-				englishRow.getByText( 'Default language', { exact: true } ),
-			).toBeVisible();
+			await expect( englishRow.getByText( 'Default language', { exact: true } ) ).toBeVisible();
 		} );
 
 		/**
@@ -95,12 +80,8 @@ test.describe(
 				.click();
 			// After clicking the "Assign" link, the previously created post should now be assigned to the default language (English en_US).
 			await admin.visitAdminPage( 'edit.php' );
-			const NoLanguagePostRow = page.locator(
-				`#post-${ noLanguagePost.id }`,
-			);
-			await expect(
-				NoLanguagePostRow.getByAltText( 'English' ),
-			).toBeVisible();
+			const NoLanguagePostRow = page.locator( `#post-${ noLanguagePost.id }` );
+			await expect( NoLanguagePostRow.getByAltText( 'English' ) ).toBeVisible();
 			await admin.visitAdminPage( 'admin.php', 'page=mlang' );
 		} );
 
@@ -116,11 +97,7 @@ test.describe(
 		 * - The post-count in the language table should be incremented.
 		 */
 
-		test( 'Check the post count', async ( {
-			page,
-			admin,
-			requestUtils,
-		} ) => {
+		test( 'Check the post count', async ( { page, admin, requestUtils } ) => {
 			// Create English en_US as the default language.
 			await createLanguage( requestUtils, 'en_US' );
 			// Create a post for English language.
@@ -134,9 +111,7 @@ test.describe(
 			// Visit the language settings page and click on the "Assign" link in the "Content without languages" section.
 			await admin.visitAdminPage( 'admin.php', 'page=mlang' );
 
-			const englishRow = page
-				.getByRole( 'row', { name: /English/ } )
-				.first();
+			const englishRow = page.getByRole( 'row', { name: /English/ } ).first();
 			// The "Posts" column cell contains a link with the post-count as its text.
 
 			const postsCell = englishRow.getByRole( 'cell' ).last();
@@ -145,5 +120,5 @@ test.describe(
 
 			await expect( postsCell ).toHaveText( '1', { timeout: 10_000 } );
 		} );
-	},
+	}
 );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -49,10 +49,10 @@ test.describe.serial( 'Strings translations', () => {
 				page,
 			} ) => {
 				await page.goto(
-					'wp-admin/admin.php?page=mlang_strings&paged=1'
+					'wp-admin/admin.php?page=mlang_strings&paged=1',
 				);
 				await expect(
-					page.getByRole( 'cell', { name: 'blogname' } )
+					page.getByRole( 'cell', { name: 'blogname' } ),
 				).toBeVisible();
 
 				const blognameRow = page
@@ -69,7 +69,7 @@ test.describe.serial( 'Strings translations', () => {
 				await expect(
 					page.getByRole( 'cell', {
 						name: 'polylang FR',
-					} )
+					} ),
 				).toBeVisible();
 			} );
 		} );
@@ -101,21 +101,21 @@ test.describe.serial( 'Strings translations', () => {
 				await admin.visitAdminPage(
 					'admin.php',
 					`page=mlang_strings&group=${ encodeURIComponent(
-						'Polylang E2E'
-					) }`
+						'Polylang E2E',
+					) }`,
 				);
 
 				await expect(
 					admin.page.getByRole( 'cell', {
 						name: 'Hello Polylang E2E',
 						exact: true,
-					} )
+					} ),
 				).toBeVisible();
 				await expect(
 					admin.page.getByRole( 'cell', {
 						name: 'e2e_custom_greeting',
 						exact: true,
-					} )
+					} ),
 				).toBeVisible();
 
 				const stringRow = admin.page
@@ -130,7 +130,7 @@ test.describe.serial( 'Strings translations', () => {
 					.click();
 
 				await expect( stringRow.getByLabel( 'Français' ) ).toHaveValue(
-					'Bonjour Polylang E2E FR'
+					'Bonjour Polylang E2E FR',
 				);
 			} );
 
@@ -152,8 +152,8 @@ test.describe.serial( 'Strings translations', () => {
 				await admin.visitAdminPage(
 					'admin.php',
 					`page=mlang_strings&group=${ encodeURIComponent(
-						'Polylang E2E'
-					) }`
+						'Polylang E2E',
+					) }`,
 				);
 
 				const multilineRow = admin.page
@@ -164,14 +164,14 @@ test.describe.serial( 'Strings translations', () => {
 				await expect(
 					multilineRow.getByRole( 'cell', {
 						name: 'e2e_custom_multiline',
-					} )
+					} ),
 				).toBeVisible();
 
 				const frenchField = multilineRow.getByLabel( 'Français' );
 
 				await expect( frenchField ).toHaveAttribute(
 					'name',
-					/translation\[fr\]/
+					/translation\[fr\]/,
 				);
 
 				await frenchField.fill( 'Ligne un\nLigne deux' );
@@ -186,7 +186,7 @@ test.describe.serial( 'Strings translations', () => {
 					.getByLabel( 'Français' );
 
 				await expect( frenchFieldAfterSave ).toHaveValue(
-					'Ligne un\nLigne deux'
+					'Ligne un\nLigne deux',
 				);
 			} );
 		} );
@@ -236,7 +236,7 @@ test.describe.serial( 'Strings translations', () => {
 					page
 						.locator( 'header' )
 						.locator( '.wp-block-site-title' )
-						.getByText( 'polylang FR', { exact: true } )
+						.getByText( 'polylang FR', { exact: true } ),
 				).toBeVisible();
 			} );
 		} );
@@ -259,7 +259,7 @@ test.describe.serial( 'Strings translations', () => {
 				await page.goto( frenchPostUrl );
 
 				await expect(
-					page.locator( '.pll-e2e-custom-string' )
+					page.locator( '.pll-e2e-custom-string' ),
 				).toHaveText( 'Bonjour Polylang E2E FR' );
 			} );
 
@@ -280,10 +280,10 @@ test.describe.serial( 'Strings translations', () => {
 				await page.goto( frenchPostUrl );
 
 				await expect(
-					page.locator( '.pll-e2e-custom-string-multiline' )
+					page.locator( '.pll-e2e-custom-string-multiline' ),
 				).toContainText( 'Ligne un' );
 				await expect(
-					page.locator( '.pll-e2e-custom-string-multiline' )
+					page.locator( '.pll-e2e-custom-string-multiline' ),
 				).toContainText( 'Ligne deux' );
 			} );
 		} );

--- a/tests/e2e/specs/strings-translations.spec.js
+++ b/tests/e2e/specs/strings-translations.spec.js
@@ -45,15 +45,9 @@ test.describe.serial( 'Strings translations', () => {
 			 *     - Click the "Save Changes" button.
 			 *     - Check that the "polylang FR" string is visible in the "Translations" screen.
 			 */
-			test( 'Blogname core string should be translatable', async ( {
-				page,
-			} ) => {
-				await page.goto(
-					'wp-admin/admin.php?page=mlang_strings&paged=1',
-				);
-				await expect(
-					page.getByRole( 'cell', { name: 'blogname' } ),
-				).toBeVisible();
+			test( 'Blogname core string should be translatable', async ( { page } ) => {
+				await page.goto( 'wp-admin/admin.php?page=mlang_strings&paged=1' );
+				await expect( page.getByRole( 'cell', { name: 'blogname' } ) ).toBeVisible();
 
 				const blognameRow = page
 					.getByRole( 'row', { name: 'Select polylang polylang' } )
@@ -62,14 +56,12 @@ test.describe.serial( 'Strings translations', () => {
 				await blognameRow.click();
 				await blognameRow.fill( 'polylang FR' );
 
-				await page
-					.getByRole( 'button', { name: 'Save Changes' } )
-					.click();
+				await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 
 				await expect(
 					page.getByRole( 'cell', {
 						name: 'polylang FR',
-					} ),
+					} )
 				).toBeVisible();
 			} );
 		} );
@@ -95,43 +87,31 @@ test.describe.serial( 'Strings translations', () => {
 			 *     - Check that the string and name cells show the expected values.
 			 *     - Fill the French translation and save (read on the frontend below).
 			 */
-			test( 'Custom string is listed in admin and can be translated', async ( {
-				admin,
-			} ) => {
+			test( 'Custom string is listed in admin and can be translated', async ( { admin } ) => {
 				await admin.visitAdminPage(
 					'admin.php',
-					`page=mlang_strings&group=${ encodeURIComponent(
-						'Polylang E2E',
-					) }`,
+					`page=mlang_strings&group=${ encodeURIComponent( 'Polylang E2E' ) }`
 				);
 
 				await expect(
 					admin.page.getByRole( 'cell', {
 						name: 'Hello Polylang E2E',
 						exact: true,
-					} ),
+					} )
 				).toBeVisible();
 				await expect(
 					admin.page.getByRole( 'cell', {
 						name: 'e2e_custom_greeting',
 						exact: true,
-					} ),
+					} )
 				).toBeVisible();
 
-				const stringRow = admin.page
-					.getByRole( 'row' )
-					.filter( { hasText: 'Hello Polylang E2E' } );
+				const stringRow = admin.page.getByRole( 'row' ).filter( { hasText: 'Hello Polylang E2E' } );
 
-				await stringRow
-					.getByLabel( 'Français' )
-					.fill( 'Bonjour Polylang E2E FR' );
-				await admin.page
-					.getByRole( 'button', { name: 'Save Changes' } )
-					.click();
+				await stringRow.getByLabel( 'Français' ).fill( 'Bonjour Polylang E2E FR' );
+				await admin.page.getByRole( 'button', { name: 'Save Changes' } ).click();
 
-				await expect( stringRow.getByLabel( 'Français' ) ).toHaveValue(
-					'Bonjour Polylang E2E FR',
-				);
+				await expect( stringRow.getByLabel( 'Français' ) ).toHaveValue( 'Bonjour Polylang E2E FR' );
 			} );
 
 			/**
@@ -151,9 +131,7 @@ test.describe.serial( 'Strings translations', () => {
 			} ) => {
 				await admin.visitAdminPage(
 					'admin.php',
-					`page=mlang_strings&group=${ encodeURIComponent(
-						'Polylang E2E',
-					) }`,
+					`page=mlang_strings&group=${ encodeURIComponent( 'Polylang E2E' ) }`
 				);
 
 				const multilineRow = admin.page
@@ -164,20 +142,15 @@ test.describe.serial( 'Strings translations', () => {
 				await expect(
 					multilineRow.getByRole( 'cell', {
 						name: 'e2e_custom_multiline',
-					} ),
+					} )
 				).toBeVisible();
 
 				const frenchField = multilineRow.getByLabel( 'Français' );
 
-				await expect( frenchField ).toHaveAttribute(
-					'name',
-					/translation\[fr\]/,
-				);
+				await expect( frenchField ).toHaveAttribute( 'name', /translation\[fr\]/ );
 
 				await frenchField.fill( 'Ligne un\nLigne deux' );
-				await admin.page
-					.getByRole( 'button', { name: 'Save Changes' } )
-					.click();
+				await admin.page.getByRole( 'button', { name: 'Save Changes' } ).click();
 
 				const frenchFieldAfterSave = admin.page
 					.getByRole( 'row' )
@@ -185,9 +158,7 @@ test.describe.serial( 'Strings translations', () => {
 					.filter( { hasText: 'Line two' } )
 					.getByLabel( 'Français' );
 
-				await expect( frenchFieldAfterSave ).toHaveValue(
-					'Ligne un\nLigne deux',
-				);
+				await expect( frenchFieldAfterSave ).toHaveValue( 'Ligne un\nLigne deux' );
 			} );
 		} );
 	} );
@@ -223,9 +194,7 @@ test.describe.serial( 'Strings translations', () => {
 			 *     - Check that the document title includes the French site title (WordPress appends site name on singular views).
 			 *     - Check that the header site title block shows "polylang FR" (block themes: `header` + `.wp-block-site-title`).
 			 */
-			test( 'Blogname French translation appears on the frontend', async ( {
-				page,
-			} ) => {
+			test( 'Blogname French translation appears on the frontend', async ( { page } ) => {
 				const response = await page.goto( frenchPostUrl );
 
 				expect( response.status() ).toBe( 200 );
@@ -236,7 +205,7 @@ test.describe.serial( 'Strings translations', () => {
 					page
 						.locator( 'header' )
 						.locator( '.wp-block-site-title' )
-						.getByText( 'polylang FR', { exact: true } ),
+						.getByText( 'polylang FR', { exact: true } )
 				).toBeVisible();
 			} );
 		} );
@@ -253,14 +222,12 @@ test.describe.serial( 'Strings translations', () => {
 			 *     - Open the French post on the frontend.
 			 *     - Check that the appended paragraph shows the French translation.
 			 */
-			test( 'French translation of custom string appears on the frontend', async ( {
-				page,
-			} ) => {
+			test( 'French translation of custom string appears on the frontend', async ( { page } ) => {
 				await page.goto( frenchPostUrl );
 
-				await expect(
-					page.locator( '.pll-e2e-custom-string' ),
-				).toHaveText( 'Bonjour Polylang E2E FR' );
+				await expect( page.locator( '.pll-e2e-custom-string' ) ).toHaveText(
+					'Bonjour Polylang E2E FR'
+				);
 			} );
 
 			/**
@@ -279,12 +246,12 @@ test.describe.serial( 'Strings translations', () => {
 			} ) => {
 				await page.goto( frenchPostUrl );
 
-				await expect(
-					page.locator( '.pll-e2e-custom-string-multiline' ),
-				).toContainText( 'Ligne un' );
-				await expect(
-					page.locator( '.pll-e2e-custom-string-multiline' ),
-				).toContainText( 'Ligne deux' );
+				await expect( page.locator( '.pll-e2e-custom-string-multiline' ) ).toContainText(
+					'Ligne un'
+				);
+				await expect( page.locator( '.pll-e2e-custom-string-multiline' ) ).toContainText(
+					'Ligne deux'
+				);
 			} );
 		} );
 	} );

--- a/tests/e2e/specs/term-list/term-quick-edit-language.spec.js
+++ b/tests/e2e/specs/term-list/term-quick-edit-language.spec.js
@@ -45,7 +45,7 @@ test.describe( 'Quick Edit language selection for terms', () => {
 		// Navigate to Categories admin page.
 		await admin.visitAdminPage(
 			'edit-tags.php',
-			'taxonomy=category&post_type=post'
+			'taxonomy=category&post_type=post',
 		);
 
 		// Create a French category via UI.
@@ -91,7 +91,7 @@ test.describe( 'Quick Edit language selection for terms', () => {
 		// Verify the displayed text.
 		const selectedOption = await page
 			.locator(
-				`#edit-${ termId } select[name="inline_lang_choice"] option:checked`
+				`#edit-${ termId } select[name="inline_lang_choice"] option:checked`,
 			)
 			.textContent();
 

--- a/tests/e2e/specs/term-list/term-quick-edit-language.spec.js
+++ b/tests/e2e/specs/term-list/term-quick-edit-language.spec.js
@@ -1,10 +1,6 @@
 // @ts-check
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
-import {
-	createLanguage,
-	deleteAllLanguages,
-	deleteAllTerms,
-} from '@wpsyntex/e2e-test-utils';
+import { createLanguage, deleteAllLanguages, deleteAllTerms } from '@wpsyntex/e2e-test-utils';
 
 /**
  * Tests Quick Edit language selection for terms.
@@ -43,24 +39,17 @@ test.describe( 'Quick Edit language selection for terms', () => {
 		requestUtils,
 	} ) => {
 		// Navigate to Categories admin page.
-		await admin.visitAdminPage(
-			'edit-tags.php',
-			'taxonomy=category&post_type=post',
-		);
+		await admin.visitAdminPage( 'edit-tags.php', 'taxonomy=category&post_type=post' );
 
 		// Create a French category via UI.
 		const categoryName = 'Test Catégorie FR';
 
 		await page.locator( '#tag-name' ).fill( categoryName );
-		await page
-			.locator( '#term_lang_choice' )
-			.selectOption( { label: 'Français' } );
+		await page.locator( '#term_lang_choice' ).selectOption( { label: 'Français' } );
 		await page.locator( '#submit' ).click();
 
 		// Wait for AJAX success message.
-		await page
-			.locator( '#ajax-response .notice-success' )
-			.waitFor( { state: 'visible' } );
+		await page.locator( '#ajax-response .notice-success' ).waitFor( { state: 'visible' } );
 
 		// Get the term ID from the API (after it was created via UI).
 		const terms = await requestUtils.rest( {
@@ -76,9 +65,7 @@ test.describe( 'Quick Edit language selection for terms', () => {
 		await categoryRow.locator( 'button.editinline' ).click();
 
 		// Wait for the specific inline edit form.
-		await page
-			.locator( `#edit-${ termId }` )
-			.waitFor( { state: 'visible' } );
+		await page.locator( `#edit-${ termId }` ).waitFor( { state: 'visible' } );
 
 		// Get the selected language value.
 		const selectedLanguage = await page
@@ -90,9 +77,7 @@ test.describe( 'Quick Edit language selection for terms', () => {
 
 		// Verify the displayed text.
 		const selectedOption = await page
-			.locator(
-				`#edit-${ termId } select[name="inline_lang_choice"] option:checked`,
-			)
+			.locator( `#edit-${ termId } select[name="inline_lang_choice"] option:checked` )
 			.textContent();
 
 		expect( selectedOption ).toBe( 'Français' );

--- a/tests/e2e/specs/widgets/language-switcher-widget.spec.js
+++ b/tests/e2e/specs/widgets/language-switcher-widget.spec.js
@@ -1,102 +1,88 @@
 // @ts-check
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
-import {
-	createLanguage,
-	deleteAllLanguages,
-	resetAllSettings,
-} from '@wpsyntex/e2e-test-utils';
+import { createLanguage, deleteAllLanguages, resetAllSettings } from '@wpsyntex/e2e-test-utils';
 
 /**
  * Covers language switcher block in the widget editor.
  */
-test.describe(
-	'Language Switcher block in Widget Editor',
-	{ tag: [ '@widget-editor' ] },
-	() => {
-		let initialTheme;
+test.describe( 'Language Switcher block in Widget Editor', { tag: [ '@widget-editor' ] }, () => {
+	let initialTheme;
 
-		/**
-		 * Before all tests:
-		 *     - Activate a theme with widget areas.
-		 *     - Create en_US and fr_FR languages.
-		 */
-		test.beforeAll( async ( { requestUtils } ) => {
-			const [ activeTheme ] = await requestUtils.rest( {
-				path: '/wp/v2/themes',
-				params: { status: 'active' },
-			} );
-			initialTheme = activeTheme.stylesheet;
-
-			// Activate a theme with widget areas.
-			await requestUtils.activateTheme( 'twentytwentyone' );
-
-			await createLanguage( requestUtils, 'en_US' );
-			await createLanguage( requestUtils, 'fr_FR' );
+	/**
+	 * Before all tests:
+	 *     - Activate a theme with widget areas.
+	 *     - Create en_US and fr_FR languages.
+	 */
+	test.beforeAll( async ( { requestUtils } ) => {
+		const [ activeTheme ] = await requestUtils.rest( {
+			path: '/wp/v2/themes',
+			params: { status: 'active' },
 		} );
+		initialTheme = activeTheme.stylesheet;
 
-		/**
-		 * Reset after all tests.
-		 */
-		test.afterAll( async ( { requestUtils } ) => {
-			await requestUtils.activateTheme( initialTheme );
-			await deleteAllLanguages( requestUtils );
-			await resetAllSettings( requestUtils );
+		// Activate a theme with widget areas.
+		await requestUtils.activateTheme( 'twentytwentyone' );
+
+		await createLanguage( requestUtils, 'en_US' );
+		await createLanguage( requestUtils, 'fr_FR' );
+	} );
+
+	/**
+	 * Reset after all tests.
+	 */
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( initialTheme );
+		await deleteAllLanguages( requestUtils );
+		await resetAllSettings( requestUtils );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.visitAdminPage( 'widgets.php' );
+	} );
+
+	/**
+	 * Ensures the language switcher block can be added in the widget editor without crashing and displays the languages.
+	 *
+	 * Prerequisites:
+	 *     - en_US and fr_FR languages exist.
+	 *     - A classic theme with widget areas is active (Twenty Twenty-One).
+	 *
+	 * Steps:
+	 *     - Go to "Appearance" > "Widgets".
+	 *     - Add a Language Switcher block.
+	 *     - Verify the block is displayed without the "block has encountered an error" message.
+	 *     - Verify the block preview lists English and French.
+	 */
+	test( 'Block can be added in a widget area and displays languages', async ( { page } ) => {
+		await page
+			.getByRole( 'toolbar', { name: 'Document tools' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
+
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
 		} );
+		await expect( blockLibrary ).toBeVisible();
 
-		test.beforeEach( async ( { admin } ) => {
-			await admin.visitAdminPage( 'widgets.php' );
+		await blockLibrary.getByRole( 'searchbox', { name: 'Search' } ).fill( 'Language Switcher' );
+		await blockLibrary
+			.getByRole( 'option', {
+				name: 'Language Switcher',
+				exact: true,
+			} )
+			.click();
+
+		// The block error message must not appear.
+		await expect(
+			page.getByText( 'This block has encountered an error and cannot be previewed.' )
+		).not.toBeVisible();
+
+		// The block must be visible and display both languages.
+		const block = page.getByRole( 'document', {
+			name: 'Block: Language Switcher',
 		} );
-
-		/**
-		 * Ensures the language switcher block can be added in the widget editor without crashing and displays the languages.
-		 *
-		 * Prerequisites:
-		 *     - en_US and fr_FR languages exist.
-		 *     - A classic theme with widget areas is active (Twenty Twenty-One).
-		 *
-		 * Steps:
-		 *     - Go to "Appearance" > "Widgets".
-		 *     - Add a Language Switcher block.
-		 *     - Verify the block is displayed without the "block has encountered an error" message.
-		 *     - Verify the block preview lists English and French.
-		 */
-		test( 'Block can be added in a widget area and displays languages', async ( {
-			page,
-		} ) => {
-			await page
-				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
-				.click();
-
-			const blockLibrary = page.getByRole( 'region', {
-				name: 'Block Library',
-			} );
-			await expect( blockLibrary ).toBeVisible();
-
-			await blockLibrary
-				.getByRole( 'searchbox', { name: 'Search' } )
-				.fill( 'Language Switcher' );
-			await blockLibrary
-				.getByRole( 'option', {
-					name: 'Language Switcher',
-					exact: true,
-				} )
-				.click();
-
-			// The block error message must not appear.
-			await expect(
-				page.getByText(
-					'This block has encountered an error and cannot be previewed.',
-				),
-			).not.toBeVisible();
-
-			// The block must be visible and display both languages.
-			const block = page.getByRole( 'document', {
-				name: 'Block: Language Switcher',
-			} );
-			await expect( block ).toBeVisible();
-			await expect( block.getByText( 'English' ) ).toBeVisible();
-			await expect( block.getByText( 'Français' ) ).toBeVisible();
-		} );
-	},
-);
+		await expect( block ).toBeVisible();
+		await expect( block.getByText( 'English' ) ).toBeVisible();
+		await expect( block.getByText( 'Français' ) ).toBeVisible();
+	} );
+} );

--- a/tests/e2e/specs/widgets/language-switcher-widget.spec.js
+++ b/tests/e2e/specs/widgets/language-switcher-widget.spec.js
@@ -86,8 +86,8 @@ test.describe(
 			// The block error message must not appear.
 			await expect(
 				page.getByText(
-					'This block has encountered an error and cannot be previewed.'
-				)
+					'This block has encountered an error and cannot be previewed.',
+				),
 			).not.toBeVisible();
 
 			// The block must be visible and display both languages.
@@ -98,5 +98,5 @@ test.describe(
 			await expect( block.getByText( 'English' ) ).toBeVisible();
 			await expect( block.getByText( 'Français' ) ).toBeVisible();
 		} );
-	}
+	},
 );


### PR DESCRIPTION
## What?
Switch JS linting to `@automattic/eslint-plugin-wpvip`, keep WordPress-specific `@wordpress/*` rules, enable Prettier (wp-prettier), and clear remaining errors on CI-linted paths.

## Why?
Align with Automattic VIP ESLint standards while retaining Gutenberg/i18n rules from `@wordpress/eslint-plugin`, and enforce consistent formatting via WordPress Prettier.

## How?
- Add `@automattic/eslint-plugin-wpvip`, `eslint`, and `@wordpress/eslint-plugin` as direct deps
- Compose VIP `javascript` + `formatting` + `react`, then layer WP `configs.custom` + `configs.i18n` (not full WP recommended)
- Enable Prettier last: declare `prettier` as `npm:wp-prettier@3.0.3`, add `.prettierrc.js` from VIP, and append `...AutomatticPlugin.configs.prettier`
- Leave `lint:js` unchanged; CI path filters stay the scope gate
- Auto-fix CI paths (`js/src/blocks`, `tests/e2e`), then apply the manual fixes below
- Allow `Automattic` in `.typos.toml`

### Manual fixes (not `--fix`)
- **`import/order`**: override VIP to `'newlines-between': 'always-and-inside-groups'` so WordPress `/** … dependencies */` import blocks stay valid
- **`switcher-controls.js`**: keep/restore `@wordpress/no-unsafe-wp-apis` disable on `__experimentalUnitControl`

## Test plan
- [x] `npm ci`
- [x] `npm run lint:js -- ./js/src/blocks ./tests/e2e` → 0 errors
- [x] `typos` passes
- [x] CI ESLint job still only runs on paths from `static-analysis.yml`