### PR TITLE
Isolate WP Importer tests

### DIFF
--- a/tests/phpunit/tests/plugins/test-wp-importer.php
+++ b/tests/phpunit/tests/plugins/test-wp-importer.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Run tests in a separate process to avoid a conflict with Jetpack 16.1 beta.
+ *
+ * @@runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class WP_Importer_Test extends PLL_UnitTestCase {
 	/**
 	 * @param WP_UnitTest_Factory $factory


### PR DESCRIPTION
Since Jetpack 16.1 beta, an error is reported in WordPress Importer test:
```
  Error: Class 'Rowbot\URL\URL' not found
  
  /home/runner/work/polylang/polylang/tmp/plugins/jetpack/vendor/wp-php-toolkit/data-liberation/URL/class-wpurl.php:46
  /home/runner/work/polylang/polylang/tmp/plugins/wordpress-importer/class-wp-import.php:197
  /home/runner/work/polylang/polylang/tmp/plugins/wordpress-importer/class-wp-import.php:105
  /home/runner/work/polylang/polylang/tests/phpunit/tests/plugins/test-wp-importer.php:90
  /home/runner/work/polylang/polylang/tests/phpunit/tests/plugins/test-wp-importer.php:110
  phpvfscomposer:///home/runner/work/polylang/polylang/vendor/phpunit/phpunit/phpunit:106
```
See https://github.com/polylang/polylang/actions/runs/30912742044/job/92003217121
This looks like a dependency conflict between the 2 plugins.

This PR runs WordPress Importer tests in a separate process to avoid running them in an environment where Jetpack is installed too.

The issue has been reported to the Jetpack team. See https://github.com/Automattic/jetpack/issues/51027