### PR TITLE
Raise min WP version for Jetpack tests

### DIFF
--- a/tests/phpunit/tests/plugins/test-jetpack.php
+++ b/tests/phpunit/tests/plugins/test-jetpack.php
@@ -7,7 +7,7 @@ class Jetpack_Test extends PLL_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::markTestSkippedIfFileNotExists( PLL_TEST_PLUGINS_DIR . 'jetpack/jetpack.php', 'This test requires the plugin Jetpack.' );
 
-		$min_wp_version = '6.7';
+		$min_wp_version = '6.9';
 
 		if ( version_compare( $GLOBALS['wp_version'], $min_wp_version, '<' ) ) {
 			self::markTestSkipped( "This test requires WordPress {$min_wp_version} or higher" );


### PR DESCRIPTION
Follow-up of https://github.com/polylang/.github/pull/9
Skip the Jetpack tests for WP < 6.9
See https://github.com/polylang/polylang/actions/runs/31097307949/job/92602287107