### PR TITLE
Add assertions to check isolated tests behave as intended

### DIFF
--- a/tests/phpunit/tests/plugins/test-model-maybe-create-language-terms.php
+++ b/tests/phpunit/tests/plugins/test-model-maybe-create-language-terms.php
@@ -12,6 +12,8 @@
 class Model_Maybe_Create_Language_Terms_Test extends PLL_UnitTestCase {
 
 	public function test_maybe_create_language_terms() {
+		$this->assertFalse( function_exists( 'PLL' ) );
+
 		// Translatable custom table.
 		require_once PLL_TEST_DATA_DIR . 'translatable.php';
 

--- a/tests/phpunit/tests/plugins/test-model-maybe-create-language-terms.php
+++ b/tests/phpunit/tests/plugins/test-model-maybe-create-language-terms.php
@@ -12,7 +12,7 @@
 class Model_Maybe_Create_Language_Terms_Test extends PLL_UnitTestCase {
 
 	public function test_maybe_create_language_terms() {
-		$this->assertFalse( function_exists( 'PLL' ) );
+		$this->assertFalse( function_exists( 'PLL' ), 'The test should run in a separate process' );
 
 		// Translatable custom table.
 		require_once PLL_TEST_DATA_DIR . 'translatable.php';

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -133,6 +133,8 @@ class Install_Test extends PLL_UnitTestCase {
 	 * This test must be executed before all uninstall tests.
 	 */
 	public function test_uninstall_without_removing_data() {
+		$this->assertFalse( defined( 'PLL_REMOVE_ALL_DATA' ) );
+
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );
 		}

--- a/tests/phpunit/tests/test-install.php
+++ b/tests/phpunit/tests/test-install.php
@@ -133,7 +133,7 @@ class Install_Test extends PLL_UnitTestCase {
 	 * This test must be executed before all uninstall tests.
 	 */
 	public function test_uninstall_without_removing_data() {
-		$this->assertFalse( defined( 'PLL_REMOVE_ALL_DATA' ) );
+		$this->assertFalse( defined( 'PLL_REMOVE_ALL_DATA' ), 'The test should run in a separate process' );
 
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );


### PR DESCRIPTION
We "isolated" 2 tests by running them in separate test suites before the other tests, in one case to make sure that the Polylang API is not loaded, in the other case to make sure that a constant is not set.  This PR asserts that the tests are executed in the correct conditions. 