### PR TITLE
ci(polylang): add consistent version checks

### DIFF
--- a/.github/consistent-versions-tag.yaml
+++ b/.github/consistent-versions-tag.yaml
@@ -1,0 +1,25 @@
+checks:
+  release-tag:
+    normalize:
+      - trim-v-prefix
+      - version
+    expected:
+      reader: env
+      variable: GITHUB_REF_NAME
+    values:
+      plugin-constant:
+        reader: php
+        file: ../polylang.php
+        path: $.constants.POLYLANG_VERSION
+      plugin-header:
+        reader: wordpress-plugin
+        file: ../polylang.php
+        path: $.Version
+      package-json:
+        reader: json
+        file: ../package.json
+        path: $.version
+      wordpress-readme:
+        reader: wordpress-readme
+        file: ../readme.txt
+        path: $['Stable tag']

--- a/.github/consistent-versions.yaml
+++ b/.github/consistent-versions.yaml
@@ -1,0 +1,78 @@
+checks:
+  release-version:
+    normalize: version
+    expected:
+      reader: php
+      file: ../polylang.php
+      path: $.constants.POLYLANG_VERSION
+    values:
+      plugin-header:
+        reader: wordpress-plugin
+        file: ../polylang.php
+        path: $.Version
+      package-json:
+        reader: json
+        file: ../package.json
+        path: $.version
+
+  block-json-version:
+    normalize: version
+    expected:
+      reader: php
+      file: ../polylang.php
+      path: $.constants.POLYLANG_VERSION
+    values:
+      standard-block:
+        reader: json
+        file: ../src/modules/Blocks/Language_Switcher/Standard/block.json
+        path: $.version
+      navigation-block:
+        reader: json
+        file: ../src/modules/Blocks/Language_Switcher/Navigation/block.json
+        path: $.version
+
+  minimum-php:
+    normalize: version
+    expected:
+      reader: php
+      file: ../polylang.php
+      path: $.constants.PLL_MIN_PHP_VERSION
+    values:
+      plugin-header:
+        reader: wordpress-plugin
+        file: ../polylang.php
+        path: $['Requires PHP']
+      wordpress-readme:
+        reader: wordpress-readme
+        file: ../readme.txt
+        path: $['Requires PHP']
+      composer:
+        reader: composer
+        file: ../composer.json
+        path: $.require.php
+        normalize: composer-minimum
+      phpcs:
+        reader: phpcs
+        file: ../phpcs.xml.dist
+        path: $.config.testVersion
+        normalize: composer-minimum
+
+  minimum-wordpress:
+    normalize: version
+    expected:
+      reader: php
+      file: ../polylang.php
+      path: $.constants.PLL_MIN_WP_VERSION
+    values:
+      plugin-header:
+        reader: wordpress-plugin
+        file: ../polylang.php
+        path: $['Requires at least']
+      wordpress-readme:
+        reader: wordpress-readme
+        file: ../readme.txt
+        path: $['Requires at least']
+      phpcs:
+        reader: phpcs
+        file: ../phpcs.xml.dist
+        path: $.config.minimum_supported_wp_version

--- a/.github/workflows/consistent-versions.yml
+++ b/.github/workflows/consistent-versions.yml
@@ -1,0 +1,20 @@
+name: Consistent versions
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    if: github.event.deleted == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: polylang/actions/consistent-versions@main
+        with:
+          config: .github/consistent-versions.yaml
+          tag-config: .github/consistent-versions-tag.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpsyntex/polylang",
-  "version": "3.9-dev",
+  "version": "3.9.0-dev",
   "description": "Adds multilingual capability to WordPress",
   "author": "WP Syntex",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpsyntex/polylang",
-  "version": "3.8.0",
+  "version": "3.9-dev",
   "description": "Adds multilingual capability to WordPress",
   "author": "WP Syntex",
   "license": "GPL-3.0-or-later",

--- a/src/modules/Blocks/Language_Switcher/Navigation/block.json
+++ b/src/modules/Blocks/Language_Switcher/Navigation/block.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.wp.org/trunk/block.json",
     "apiVersion": 3,
     "name": "polylang/navigation-language-switcher",
-    "version": "3.8",
+    "version": "3.9",
     "title": "Navigation Language Switcher",
     "category": "design",
 	"parent": [ "core/navigation" ],

--- a/src/modules/Blocks/Language_Switcher/Standard/block.json
+++ b/src/modules/Blocks/Language_Switcher/Standard/block.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.wp.org/trunk/block.json",
     "apiVersion": 3,
     "name": "polylang/language-switcher",
-    "version": "3.8",
+    "version": "3.9",
     "title": "Language Switcher",
     "category": "widgets",
     "description": "Language switcher to insert in content or as a widget.",


### PR DESCRIPTION
## What?
Add a **Consistent versions** CI workflow and config files under `.github/`.

## Why?
Version numbers are declared in many places (plugin header, PHP constant, readme, `package.json`, `composer.json`, PHPCS). They can drift apart silently; this automates the guard ([wpml-to-polylang#33](https://github.com/polylang/wpml-to-polylang/pull/33), [actions#23](https://github.com/polylang/actions/pull/23)).

## How?
- Workflow: `.github/workflows/consistent-versions.yml` → `polylang/actions/consistent-versions@main`
- Configs: `.github/consistent-versions.yaml`, `.github/consistent-versions-tag.yaml`
- Checks: release version, **block.json version**, min PHP, min WP; `package.json` via `json` reader
- SSOT: `POLYLANG_VERSION` / `PLL_MIN_*` constants

**Release version vs readme `Stable tag`**

On `master`, the plugin header and PHP constant use a `*-dev` suffix (e.g. `3.9-dev`) while `readme.txt` `Stable tag` intentionally reflects the **last shipped release** (e.g. `3.8.6`) until the next release is cut.

- **Daily check** (`.github/consistent-versions.yaml`): compares plugin header, PHP constant, and `package.json` only. Readme is excluded so CI stays green during development.
- **Tag check** (`.github/consistent-versions-tag.yaml`, runs on tag pushes only): compares the Git tag to plugin header, PHP constant, `package.json`, **and** readme `Stable tag`. This enforces full alignment at release time.

Also syncs `package.json` → `3.9.0-dev`, `block.json` → `3.9`.

**`package.json` dev version format**

The plugin header and PHP constant use WordPress-style dev versions (e.g. `3.9-dev`), but `package.json` must use valid npm semver (e.g. `3.9.0-dev`).

There is no practical override in `.npmpackagejsonlintrc.json`: `@wordpress/scripts` loads `package.json` via `normalize-package-data`, which rejects `3.9-dev` before npm-package-json-lint runs — and that breaks all wp-scripts commands (`build`, `lint:js`, etc.), not just package-json lint.

The consistent-versions check uses version normalization, so `3.9-dev` and `3.9.0-dev` are treated as equivalent.

## Test plan
- [x] **Consistent versions** workflow passes on push
- [ ] Tag check config is present (verified manually; runs only on tag pushes)