### PR TITLE
fix(blocks): don't enqueue wp-editor in the widgets editor

### DIFF
--- a/js/src/blocks/hooks/use-current-language-with-editor-context.js
+++ b/js/src/blocks/hooks/use-current-language-with-editor-context.js
@@ -23,11 +23,11 @@ const findLanguageBySlug = ( languages, slug ) => {
 };
 
 /**
- * Wraps `useCurrentLanguage` from `@wpsyntex/polylang-react-library`.
+ * Resolves the current language in block editor contexts.
  *
- * The widgets editor does not load `@wordpress/editor`, so the library hook
- * cannot run there. In that context, fall back to the default language slug
- * injected by PHP (same as `useCurrentLanguage` when no post language exists).
+ * The widgets editor does not load `@wordpress/editor`, so the `core/editor`
+ * store may be unavailable. In that context, fall back to the current language
+ * slug injected by PHP (default language when none is set).
  *
  * @param {Array} languages The languages list.
  * @return {Object|null} The current language, `null` if not found.

--- a/js/src/blocks/hooks/use-current-language-with-editor-context.js
+++ b/js/src/blocks/hooks/use-current-language-with-editor-context.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Finds a language by slug.
+ *
+ * @param {Array}  languages The languages list.
+ * @param {string} slug      The language slug.
+ * @return {Object|null} The language, `null` if not found.
+ */
+const findLanguageBySlug = ( languages, slug ) => {
+	if ( ! languages || ! slug ) {
+		return null;
+	}
+
+	const currentLanguage = languages.find( ( language ) => {
+		return language.slug === slug;
+	} );
+
+	return currentLanguage ? currentLanguage : null;
+};
+
+/**
+ * Wraps `useCurrentLanguage` from `@wpsyntex/polylang-react-library`.
+ *
+ * The widgets editor does not load `@wordpress/editor`, so the library hook
+ * cannot run there. In that context, fall back to the default language slug
+ * injected by PHP (same as `useCurrentLanguage` when no post language exists).
+ *
+ * @param {Array} languages The languages list.
+ * @return {Object|null} The current language, `null` if not found.
+ */
+export const useCurrentLanguageWithEditorContext = ( languages ) => {
+	return useSelect(
+		( select ) => {
+			if ( ! languages ) {
+				return null;
+			}
+
+			if ( select( 'core/edit-widgets' ) ) {
+				return findLanguageBySlug(
+					languages,
+					pllEditorCurrentLanguageSlug // eslint-disable-line no-undef
+				);
+			}
+
+			const editorStore = select( 'core/editor' );
+
+			if ( ! editorStore ) {
+				return findLanguageBySlug(
+					languages,
+					pllEditorCurrentLanguageSlug // eslint-disable-line no-undef
+				);
+			}
+
+			const currentPost = editorStore.getCurrentPost();
+
+			if ( ! currentPost ) {
+				return null;
+			}
+
+			const currentLanguageSlug =
+				currentPost.lang ?? pllEditorCurrentLanguageSlug; // eslint-disable-line no-undef
+
+			return findLanguageBySlug( languages, currentLanguageSlug );
+		},
+		[ languages ]
+	);
+};

--- a/js/src/blocks/hooks/use-current-language-with-editor-context.js
+++ b/js/src/blocks/hooks/use-current-language-with-editor-context.js
@@ -39,13 +39,6 @@ export const useCurrentLanguageWithEditorContext = ( languages ) => {
 				return null;
 			}
 
-			if ( select( 'core/edit-widgets' ) ) {
-				return findLanguageBySlug(
-					languages,
-					pllEditorCurrentLanguageSlug // eslint-disable-line no-undef
-				);
-			}
-
 			const editorStore = select( 'core/editor' );
 
 			if ( ! editorStore ) {

--- a/js/src/blocks/hooks/use-memoized-flag.js
+++ b/js/src/blocks/hooks/use-memoized-flag.js
@@ -42,7 +42,6 @@ export const useMemoizedFlag = (
 					'--pll-flag-border-radius': flagBorderRadius,
 					'--pll-flag-width': flagWidth,
 				} }
-				/* eslint-disable-next-line prettier/prettier */
 				dangerouslySetInnerHTML={ {
 					__html: stripFlagDimensions( language.flag ),
 				} }

--- a/js/src/blocks/language-switcher/rendered-switcher.js
+++ b/js/src/blocks/language-switcher/rendered-switcher.js
@@ -8,13 +8,13 @@ import { useContext } from '@wordpress/element';
  */
 import {
 	SubmenuIcon,
-	useCurrentLanguage,
 	useCuratedLanguages,
 } from '@wpsyntex/polylang-react-library';
 
 /**
  * Internal dependencies
  */
+import { useCurrentLanguageWithEditorContext } from '../hooks/use-current-language-with-editor-context';
 import { LanguagesContext } from '../languages-context';
 import { SwitcherLanguageLink } from '../components/switcher-language-link';
 import {
@@ -42,7 +42,7 @@ export const RenderedSwitcher = ( { attributes } ) => {
 		style,
 	} = attributes;
 	const { languages } = useContext( LanguagesContext );
-	const currentLanguage = useCurrentLanguage( languages );
+	const currentLanguage = useCurrentLanguageWithEditorContext( languages );
 	const curatedLanguages = useCuratedLanguages(
 		languages,
 		currentLanguage,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wpsyntex/polylang",
-  "version": "3.8.0",
+  "version": "3.9.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wpsyntex/polylang",
-      "version": "3.8.0",
+      "version": "3.9.0-dev",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@wpsyntex/polylang-react-library": "^1.0.0"
@@ -8183,7 +8183,6 @@
       "peerDependencies": {
         "@wordpress/api-fetch": ">=7.0.0",
         "@wordpress/data": ">=10.0.0",
-        "@wordpress/editor": ">=14.0.0",
         "@wordpress/element": ">=6.0.0",
         "@wordpress/primitives": ">=4.0.0",
         "lodash": ">=4.17.0",

--- a/package.json
+++ b/package.json
@@ -73,5 +73,12 @@
     "test:php:coverage:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 composer coverage'",
     "lint:js": "wp-scripts lint-js",
     "dist": "distribute"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "core-js": true,
+    "core-js-pure": true,
+    "fs-ext-extra-prebuilt": true,
+    "unrs-resolver": true
   }
 }

--- a/src/modules/Blocks/Language_Switcher/Abstract_Block.php
+++ b/src/modules/Blocks/Language_Switcher/Abstract_Block.php
@@ -128,7 +128,6 @@ abstract class Abstract_Block {
 				'wp-components',
 				'wp-element',
 				'wp-i18n',
-				'wp-editor',
 			),
 			POLYLANG_VERSION,
 			true


### PR DESCRIPTION
## What?
Stop enqueuing the deprecated `wp-editor` script with the language switcher block editor script, and resolve the current language in the widgets editor without `@wordpress/editor`.

## Why?
Fixes https://github.com/polylang/polylang-pro/issues/3060.

Visiting the block widgets editor triggers a PHP notice because `wp-editor` must not be loaded together with `wp-edit-widgets` or `wp-customize-widgets`. Removing `wp-editor` also avoids a JS error in the widgets screen (`storeNameOrDescriptor.name`), because `@wpsyntex/polylang-react-library`'s `useCurrentLanguage` relies on the `core/editor` store.

## How?
- Remove `wp-editor` from the `pll_blocks` script dependencies in `Abstract_Block.php`.
- Add `useCurrentLanguageWithEditorContext` for the language switcher block: use `core/editor` when available, otherwise fall back to `pllEditorCurrentLanguageSlug` (widgets editor).
- Sync `package-lock.json` after dependency updates (drops an unused `@wordpress/editor` peer dependency from `@wpsyntex/polylang-react-library`).
- Add `allowScripts` entries for npm install scripts and run `npm install`.
- Remove an obsolete Prettier ESLint disable in `useMemoizedFlag`.

## Test plan
- [x] Open **Appearance → Widgets** (block widgets editor) with Polylang active and confirm no `wp-editor` PHP notice is logged.
- [x] Add or edit a language switcher block in the widgets editor and confirm no JS error in the browser console.
- [x] Edit a language switcher block in the post editor and confirm block settings still work.
- [x] Run `npm install` and confirm no `allow-scripts` warnings.