### PR TITLE
fix(admin): hide language filter on Site Editor screen

### DIFF
--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -612,21 +612,9 @@ abstract class PLL_Admin_Base extends PLL_Base {
 	 * @return bool
 	 */
 	public function should_hide_admin_bar_menu(): bool {
-		global $pagenow, $typenow, $taxnow;
+		global $pagenow;
 
-		if ( in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
-			return ! empty( $typenow );
-		}
-
-		if ( 'site-editor.php' === $pagenow ) {
-			return true;
-		}
-
-		if ( 'term.php' === $pagenow ) {
-			return ! empty( $taxnow );
-		}
-
-		return false;
+		return in_array( $pagenow, array( 'post.php', 'post-new.php', 'site-editor.php', 'term.php' ), true );
 	}
 
 	/**

--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -618,6 +618,10 @@ abstract class PLL_Admin_Base extends PLL_Base {
 			return ! empty( $typenow );
 		}
 
+		if ( 'site-editor.php' === $pagenow ) {
+			return true;
+		}
+
 		if ( 'term.php' === $pagenow ) {
 			return ! empty( $taxnow );
 		}

--- a/src/admin/admin-base.php
+++ b/src/admin/admin-base.php
@@ -605,7 +605,7 @@ abstract class PLL_Admin_Base extends PLL_Base {
 
 	/**
 	 * Tells if the Polylang's admin bar menu should be hidden for the current page.
-	 * Conventionally, it should be hidden on edition pages.
+	 * Conventionally, it should be hidden on edition pages, term edit pages and Site Editor pages.
 	 *
 	 * @since 3.8
 	 *

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -76,28 +76,21 @@ class Admin_Test extends PLL_UnitTestCase {
 	}
 
 	/**
-	 * @testWith [ "post-new.php", "post-new.php?post_type=page", "page" ]
-	 *           [ "post.php", "post.php", "post" ]
-	 *           [ "site-editor.php", "site-editor.php", "" ]
-	 *           [ "term.php", "term.php", "category" ]
+	 * @testWith [ "post-new.php", "post-new.php?post_type=page" ]
+	 *           [ "post.php", "post.php" ]
+	 *           [ "site-editor.php", "site-editor.php" ]
+	 *           [ "term.php", "term.php" ]
 	 *
 	 * @param string $pagenow The page now.
 	 * @param string $url     The URL of the page.
-	 * @param string $typenow The type now.
 	 * @return void
 	 */
-	public function test_admin_bar_menu_should_hide( $pagenow, $url, $typenow ) {
+	public function test_admin_bar_menu_should_hide( $pagenow, $url ) {
 		global $wp_admin_bar;
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
 
 		$this->go_to( admin_url( $url ) );
 		$GLOBALS['pagenow'] = $pagenow;
-
-		if ( 'term.php' === $pagenow ) {
-			$GLOBALS['taxnow'] = $typenow;
-		} else {
-			$GLOBALS['typenow'] = $typenow;
-		}
 
 		$links_model = self::$model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );

--- a/tests/phpunit/tests/test-admin.php
+++ b/tests/phpunit/tests/test-admin.php
@@ -75,13 +75,29 @@ class Admin_Test extends PLL_UnitTestCase {
 		$this->assertSame( 'languages', $en->parent );
 	}
 
-	public function test_admin_bar_menu_should_hide() {
+	/**
+	 * @testWith [ "post-new.php", "post-new.php?post_type=page", "page" ]
+	 *           [ "post.php", "post.php", "post" ]
+	 *           [ "site-editor.php", "site-editor.php", "" ]
+	 *           [ "term.php", "term.php", "category" ]
+	 *
+	 * @param string $pagenow The page now.
+	 * @param string $url     The URL of the page.
+	 * @param string $typenow The type now.
+	 * @return void
+	 */
+	public function test_admin_bar_menu_should_hide( $pagenow, $url, $typenow ) {
 		global $wp_admin_bar;
 		add_filter( 'show_admin_bar', '__return_true' ); // Make sure to show admin bar.
 
-		$this->go_to( admin_url( 'post-new.php?post_type=page' ) );
-		$GLOBALS['pagenow'] = 'post-new.php';
-		$GLOBALS['typenow'] = 'page';
+		$this->go_to( admin_url( $url ) );
+		$GLOBALS['pagenow'] = $pagenow;
+
+		if ( 'term.php' === $pagenow ) {
+			$GLOBALS['taxnow'] = $typenow;
+		} else {
+			$GLOBALS['typenow'] = $typenow;
+		}
 
 		$links_model = self::$model->get_links_model();
 		$pll_admin = new PLL_Admin( $links_model );
@@ -91,7 +107,7 @@ class Admin_Test extends PLL_UnitTestCase {
 		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
 
 		$languages = $wp_admin_bar->get_node( 'languages' );
-		$this->assertEmpty( $languages, 'Languages admin bar menu should be hidden on post edit pages' );
+		$this->assertEmpty( $languages, "Languages admin bar menu should be hidden on $pagenow pages" );
 	}
 
 	public function test_remove_customize_submenu_with_block_base_theme() {


### PR DESCRIPTION
## What?
Hide the Polylang language filter in the admin bar on the Site Editor screen (`site-editor.php`).

## Why?
From WordPress 7.1, the admin bar is persistent in the Site Editor ([consistent navigation in WP 7.1](https://make.wordpress.org/core/2026/07/13/consistent-navigation-in-wordpress-7-1-with-persistent-toolbar/)). The language filter does not filter any content there and is misleading on Style and Templates screens.

Fixes polylang/polylang-pro#3080

## How?
Extend `PLL_Admin_Base::should_hide_admin_bar_menu()` to return `true` on `site-editor.php`, alongside existing post and term edit screens. Parameterize the PHPUnit test to cover post, term, and Site Editor pages.

## Test plan
- [ ] On a multilingual site, open the Site Editor and confirm the admin bar language filter is hidden
- [ ] Confirm the language filter still appears on list screens (e.g. Posts)
- [ ] Confirm the language filter is still hidden on post and term edit screens
- [x] Run `Admin_Test::test_admin_bar_menu_should_hide`