### PR TITLE
fix(blocks): don't enqueue wp-editor in the widgets editor

### DIFF
--- a/js/src/blocks/hooks/use-current-language-with-editor-context.js
+++ b/js/src/blocks/hooks/use-current-language-with-editor-context.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Finds a language by slug.
+ *
+ * @param {Array}  languages The languages list.
+ * @param {string} slug      The language slug.
+ * @return {Object|null} The language, `null` if not found.
+ */
+const findLanguageBySlug = ( languages, slug ) => {
+	if ( ! languages || ! slug ) {
+		return null;
+	}
+
+	const currentLanguage = languages.find( ( language ) => {
+		return language.slug === slug;
+	} );
+
+	return currentLanguage ? currentLanguage : null;
+};
+
+/**
+ * Resolves the current language in block editor contexts.
+ *
+ * The widgets editor does not load `@wordpress/editor`, so the `core/editor`
+ * store may be unavailable. In that context, fall back to the current language
+ * slug injected by PHP (default language when none is set).
+ *
+ * @param {Array} languages The languages list.
+ * @return {Object|null} The current language, `null` if not found.
+ */
+export const useCurrentLanguageWithEditorContext = ( languages ) => {
+	return useSelect(
+		( select ) => {
+			if ( ! languages ) {
+				return null;
+			}
+
+			const editorStore = select( 'core/editor' );
+
+			if ( ! editorStore ) {
+				return findLanguageBySlug(
+					languages,
+					pllEditorCurrentLanguageSlug // eslint-disable-line no-undef
+				);
+			}
+
+			const currentPost = editorStore.getCurrentPost();
+
+			if ( ! currentPost ) {
+				return null;
+			}
+
+			const currentLanguageSlug =
+				currentPost.lang ?? pllEditorCurrentLanguageSlug; // eslint-disable-line no-undef
+
+			return findLanguageBySlug( languages, currentLanguageSlug );
+		},
+		[ languages ]
+	);
+};

--- a/js/src/blocks/language-switcher/components/switcher-container.js
+++ b/js/src/blocks/language-switcher/components/switcher-container.js
@@ -6,9 +6,10 @@ import { useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useCurrentLanguageWithEditorContext } from '../../hooks/use-current-language-with-editor-context';
 import { LanguagesContext } from '../../languages-context';
 import { SwitcherUI } from './switcher-ui';
-import { useCurrentLanguage, useCuratedLanguages } from '@wpsyntex/polylang-react-library';
+import { useCuratedLanguages } from '@wpsyntex/polylang-react-library';
 
 /**
  * Switcher container component.
@@ -20,7 +21,7 @@ import { useCurrentLanguage, useCuratedLanguages } from '@wpsyntex/polylang-reac
 export const SwitcherContainer = ( { attributes } ) => {
 	const { dropdown, show_flags, show_names } = attributes;
 	const { languages } = useContext( LanguagesContext );
-	const currentLanguage = useCurrentLanguage( languages );
+	const currentLanguage = useCurrentLanguageWithEditorContext( languages );
 	const curatedLanguages = useCuratedLanguages(
 		languages,
 		currentLanguage,

--- a/package.json
+++ b/package.json
@@ -68,5 +68,12 @@
     "test:php:coverage": "npm run env:composer coverage",
     "test:php:coverage:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 composer coverage'",
     "lint:js": "wp-scripts lint-js"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "core-js": true,
+    "core-js-pure": true,
+    "fs-ext-extra-prebuilt": true,
+    "unrs-resolver": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
+    "glob": "^11.1.0",
     "mini-css-extract-plugin": "^2.10.1",
     "postcss": "^8.5.8",
     "rimraf": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -68,12 +68,5 @@
     "test:php:coverage": "npm run env:composer coverage",
     "test:php:coverage:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 composer coverage'",
     "lint:js": "wp-scripts lint-js"
-  },
-  "allowScripts": {
-    "@parcel/watcher": true,
-    "core-js": true,
-    "core-js-pure": true,
-    "fs-ext-extra-prebuilt": true,
-    "unrs-resolver": true
   }
 }

--- a/src/modules/Blocks/Language_Switcher/Abstract_Block.php
+++ b/src/modules/Blocks/Language_Switcher/Abstract_Block.php
@@ -151,7 +151,6 @@ abstract class Abstract_Block {
 				'wp-i18n',
 				'wp-server-side-render',
 				'lodash',
-				'wp-editor',
 			),
 			POLYLANG_VERSION,
 			true


### PR DESCRIPTION
## What?

Stop enqueuing the deprecated `wp-editor` script with the language switcher block editor script, and resolve the current language in the widgets editor without `@wordpress/editor`.

## Why?

Backport of #1966 for the 3.8.x branch.

Fixes https://github.com/polylang/polylang-pro/issues/3060.

Visiting the block widgets editor triggers a PHP notice because `wp-editor` must not be loaded together with `wp-edit-widgets` or `wp-customize-widgets`. Removing `wp-editor` also avoids a JS error in the widgets screen (`storeNameOrDescriptor.name`), because `@wpsyntex/polylang-react-library`'s `useCurrentLanguage` relies on the `core/editor` store.

## How?

* Remove `wp-editor` from the `pll_blocks` script dependencies in `Abstract_Block.php`.
* Add `useCurrentLanguageWithEditorContext` for the language switcher block: use `core/editor` when available, otherwise fall back to `pllEditorCurrentLanguageSlug` (widgets editor).
* Add `glob` as an explicit dev dependency (peer dependency of `@wpsyntex/polylang-build-scripts`).

## Test plan

- [x] Open **Appearance → Widgets** (block widgets editor) with Polylang active and confirm no `wp-editor` PHP notice is logged.
- [x] Add or edit a language switcher block in the widgets editor and confirm no JS error in the browser console.
- [x] Edit a language switcher block in the post editor and confirm block settings still work.
- [x] Run `npm install` and `npm run build` and confirm the build succeeds.