### PR TITLE
Add a context to i18n string `None`

### DIFF
--- a/js/src/blocks/components/switcher-controls.js
+++ b/js/src/blocks/components/switcher-controls.js
@@ -115,7 +115,7 @@ export const SwitcherControls = ( {
 
 	if ( show_flags ) {
 		labelOptions.push( {
-			label: __( 'None', 'polylang' ),
+			label: _x( 'None', 'Labels', 'polylang' ),
 			value: '',
 		} );
 	}
@@ -133,7 +133,7 @@ export const SwitcherControls = ( {
 
 	if ( show_flags ) {
 		toolbarLabelControls.push( {
-			title: __( 'None', 'polylang' ),
+			title: _x( 'None', 'Labels', 'polylang' ),
 			onClick: () => {
 				if ( ! show_flags ) {
 					createWarningNotice(

--- a/src/Switcher/Fields/Menu.php
+++ b/src/Switcher/Fields/Menu.php
@@ -51,7 +51,7 @@ class Menu extends Abstract_Fields {
 			'show_labels'            => array(
 				'label'   => __( 'Display labels:', 'polylang' ),
 				'choices' => array(
-					''      => __( 'None', 'polylang' ),
+					''      => _x( 'None', 'Labels', 'polylang' ),
 					'names' => __( 'Language names', 'polylang' ),
 					'codes' => __( 'Language codes', 'polylang' ),
 				),

--- a/src/Switcher/Fields/Widget.php
+++ b/src/Switcher/Fields/Widget.php
@@ -64,7 +64,7 @@ class Widget extends Abstract_Fields {
 			'show_labels'            => array(
 				'label'   => __( 'Display labels:', 'polylang' ),
 				'choices' => array(
-					''      => __( 'None', 'polylang' ),
+					''      => _x( 'None', 'Labels', 'polylang' ),
 					'names' => __( 'Language names', 'polylang' ),
 					'codes' => __( 'Language codes', 'polylang' ),
 				),


### PR DESCRIPTION
Missed opportunity from #1942.

## What

This adds a context to the i18n string `None` (`__()` vs `_x()`) when the string is used for "Display labels".

## Why

This word can be translated differently, depending on the context. For example, `Aucun`/`Aucune` in French.

> [!NOTE]
> There is a `__( 'None', 'polylang' )` [here](https://github.com/polylang/polylang/blob/9523fb71c016ef3176cfbb53aebceafc58c5ec14/src/admin/admin-filters-term.php#L485) but I don't think it should be contextualized.