### PR TITLE
Avoid mockery v1.6.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 		"automattic/vipwpcs": "*",
 		"phpcompatibility/phpcompatibility-wp": "^3",
 		"yoast/wp-test-utils": "^1.0.0",
+		"mockery/mockery": "!=1.6.13",
 		"rector/rector": "^2",
 		"wpsyntex/wp-phpunit": "dev-master",
 		"wpsyntex/object-cache-annihilator": "dev-master"


### PR DESCRIPTION
We require `yoast/wp-test-utils` which requires `brain/monkey` which in turn require `mockery/mockery`.
Problem: v1.6.13 introduced a bug in the doc of polyfills of `str_contains()`, `str_starts_with()` and ``str_end_with()`.
See : https://github.com/polylang/polylang/actions/runs/32054319062/job/95460840623
The fix is planned for v1.6.14. Waiting for this, I exclude v1.6.13 from our dependencies.