### PR TITLE
chore(lint): run ESLint via npm script instead of wp-scripts

### DIFF
--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -5,18 +5,20 @@ on:
     branches: master
     paths:
       - '**.php'
-      - 'phpunit.xml'
+      - '**/phpunit.xml'
       - 'composer.json'
-      - '**.yml'
-      - '**.sh'
+      - 'composer.lock'
+      - 'tests/bin/**'
+      - '.github/workflows/integration-and-unit-tests.yml'
   pull_request:
     branches: master
     paths:
       - '**.php'
-      - 'phpunit.xml'
+      - '**/phpunit.xml'
       - 'composer.json'
-      - '**.yml'
-      - '**.sh'
+      - 'composer.lock'
+      - 'tests/bin/**'
+      - '.github/workflows/integration-and-unit-tests.yml'
   schedule:
     # Runs every Monday at 00:00.
     - cron:  '0 0 * * 1'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -51,6 +51,9 @@ jobs:
           js:
             - 'js/src/blocks/**/*.js'
             - 'tests/e2e/**/*.{js,mjs,cjs}'
+            - 'eslint.config.cjs'
+            - 'package.json'
+            - 'package-lock.json'
 
     - name: Run ESLint on blocks JS source files and e2e tests
       uses: polylang/actions/eslint@main

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "test:php:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 vendor/bin/phpunit'",
     "test:php:coverage": "npm run env:composer coverage",
     "test:php:coverage:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 composer coverage'",
-    "lint:js": "wp-scripts lint-js",
+    "lint:js": "eslint",
     "dist": "distribute"
   },
   "allowScripts": {


### PR DESCRIPTION
## What?
Point `lint:js` at the project's ESLint 9 binary (`eslint`) instead of `wp-scripts lint-js`. Tighten CI path filters so ESLint and PHPUnit run only when they are relevant.

## Why?
`wp-scripts lint-js` (from `@wordpress/scripts` 34) runs nested ESLint 10. `@automattic/eslint-plugin-wpvip` still requires ESLint 9 and uses `@babel/eslint-parser`, which crashes with `scopeManager.addGlobals is not a function`.

Upstream: https://github.com/Automattic/eslint-config-wpvip/issues/337

## How?
- `"lint:js": "eslint"` so extra args from CI (`npm run lint:js -- ./js/src/blocks ./tests/e2e`) still scope the run. `@wordpress/scripts` is kept for `npx wp-scripts lint-pkg-json` in CI.
- ESLint job (`static-analysis.yml`) also runs when `eslint.config.cjs`, `package.json`, or `package-lock.json` change.
- PHPUnit (`integration-and-unit-tests.yml`) no longer uses `**.yml` / `**.sh`. It runs on PHP sources, `**/phpunit.xml`, Composer files, `tests/bin/**`, and this workflow file.

## Test plan
- [ ] `npm run lint:js -- ./js/src/blocks ./tests/e2e` exits 0
- [ ] ESLint job runs on this PR (package.json / workflow change)
- [ ] After merge, ESLint-only PRs do not start PHPUnit