### PR TITLE
Hide the legacy widget in the block widgets screen

### DIFF
--- a/src/Widgets/Languages.php
+++ b/src/Widgets/Languages.php
@@ -71,6 +71,20 @@ class Languages extends WP_Widget {
 		if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( Assets::class, 'enqueue_frontend_styles' ) );
 		}
+
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'filter_legacy_widgets' ) );
+	}
+
+	/**
+	 * Hides this legacy widget in the block widgets screen.
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $widget_ids An array of hidden widget ids.
+	 * @return array
+	 */
+	public function filter_legacy_widgets( $widget_ids ) {
+		return array_merge( $widget_ids, array( $this->id_base ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-widget-languages.php
+++ b/tests/phpunit/tests/test-widget-languages.php
@@ -182,6 +182,14 @@ class Widget_Languages_Test extends PLL_UnitTestCase {
 		$this->assertMatchesRegularExpression( "/id=[\"']{$prefix}-hide_if_no_translation[\"'][^>]* checked=[\"']checked[\"']/", $form );
 	}
 
+	public function test_legacy_widget_is_hidden() {
+		$this->init_frontend();
+		do_action( 'widgets_init' );
+
+		$settings = get_legacy_widget_block_editor_settings();
+		$this->assertContains( 'polylang', $settings['widgetTypesToHideFromLegacyWidgetBlock'] );
+	}
+
 	/**
 	 * Stores the widget's options into the database.
 	 *


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/3071.

## What

When displaying the block widgets screen, searching widgets with "lang" will display 2 widgets side-by-side: the classic one and the block one.
Polylang Pro hides the classic widget, so only the block widget remains.

## Why

Because reasons. And it's Friday.

## How

We decided to backport what is done in PLL Pro: hide the classic widget. We can't see value in keeping them both. Note: If a classic widget is already in use, it will still work, we just won't be able to add a new one.