### PR TITLE
chore(deps): drop @wordpress/scripts and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,7 @@
-# Same schedule and allow lists across Polylang plugins; Dependabot does not sync versions between repos.
+# Same schedule across Polylang plugins; Dependabot does not sync versions between repos.
+# allow — if a package does not match, Dependabot does not open a version PR or a security PR for it.
+# groups.build-tools — among packages that already passed allow, matching ones are collapsed into one PR instead of many.
+# open-pull-requests-limit: 3 — caps how many version-update PRs stay open (assignee and Monday 07:00 Europe/Paris are just process).
 version: 2
 updates:
   - package-ecosystem: npm
@@ -37,7 +40,9 @@ updates:
         patterns:
           - webpack
           - webpack-cli
-          - "*-loader"
+          - babel-loader
+          - css-loader
+          - sass-loader
           - sass
           - postcss
           - mini-css-extract-plugin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+# Same schedule and allow lists across Polylang plugins; Dependabot does not sync versions between repos.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    exclude-paths:
+      - tests/e2e/**
+    assignees:
+      - Hug0-Drelon
+    open-pull-requests-limit: 3
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Paris
+    allow:
+      - dependency-type: production
+      - dependency-name: webpack
+      - dependency-name: webpack-cli
+      - dependency-name: babel-loader
+      - dependency-name: "@wordpress/babel-preset-default"
+      - dependency-name: css-loader
+      - dependency-name: sass
+      - dependency-name: sass-loader
+      - dependency-name: postcss
+      - dependency-name: mini-css-extract-plugin
+      - dependency-name: css-minimizer-webpack-plugin
+      - dependency-name: terser-webpack-plugin
+      - dependency-name: clean-webpack-plugin
+      - dependency-name: copy-webpack-plugin
+      - dependency-name: "@wordpress/base-styles"
+      - dependency-name: "@wpsyntex/polylang-build-scripts"
+      - dependency-name: "@wpsyntex/distribute"
+      - dependency-name: glob
+      - dependency-name: rimraf
+    groups:
+      build-tools:
+        patterns:
+          - webpack
+          - webpack-cli
+          - "*-loader"
+          - sass
+          - postcss
+          - mini-css-extract-plugin
+          - css-minimizer-webpack-plugin
+          - terser-webpack-plugin
+          - clean-webpack-plugin
+          - copy-webpack-plugin
+          - "@wordpress/babel-preset-default"
+          - "@wordpress/base-styles"
+          - "@wpsyntex/polylang-build-scripts"
+          - "@wpsyntex/distribute"
+          - glob
+          - rimraf
+  - package-ecosystem: composer
+    directory: /
+    assignees:
+      - Hug0-Drelon
+    open-pull-requests-limit: 3
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Paris
+    allow:
+      - dependency-type: production

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,13 @@
 # Same schedule across Polylang plugins; Dependabot does not sync versions between repos.
 # allow — if a package does not match, Dependabot does not open a version PR or a security PR for it.
 # groups.build-tools — among packages that already passed allow, matching ones are collapsed into one PR instead of many.
-# open-pull-requests-limit: 3 — caps how many version-update PRs stay open (assignee and Monday 07:00 Europe/Paris are just process).
+# open-pull-requests-limit: 3 — caps how many version-update PRs stay open (Monday 07:00 Europe/Paris is just process).
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /
     exclude-paths:
       - tests/e2e/**
-    assignees:
-      - Hug0-Drelon
     open-pull-requests-limit: 3
     schedule:
       interval: weekly
@@ -57,8 +55,6 @@ updates:
           - rimraf
   - package-ecosystem: composer
     directory: /
-    assignees:
-      - Hug0-Drelon
     open-pull-requests-limit: 3
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,6 @@ updates:
       - dependency-name: copy-webpack-plugin
       - dependency-name: "@wordpress/base-styles"
       - dependency-name: "@wpsyntex/polylang-build-scripts"
-      - dependency-name: "@wpsyntex/distribute"
       - dependency-name: glob
       - dependency-name: rimraf
     groups:
@@ -49,7 +48,6 @@ updates:
           - "@wordpress/babel-preset-default"
           - "@wordpress/base-styles"
           - "@wpsyntex/polylang-build-scripts"
-          - "@wpsyntex/distribute"
           - glob
           - rimraf
   - package-ecosystem: composer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,12 @@
 # Same schedule across Polylang plugins; Dependabot does not sync versions between repos.
 # allow — if a package does not match, Dependabot does not open a version PR or a security PR for it.
 # groups.build-tools — among packages that already passed allow, matching ones are collapsed into one PR instead of many.
-# open-pull-requests-limit: 3 — caps how many version-update PRs stay open (Monday 07:00 Europe/Paris is just process).
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /
     exclude-paths:
       - tests/e2e/**
-    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: monday
@@ -55,7 +53,6 @@ updates:
           - rimraf
   - package-ecosystem: composer
     directory: /
-    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
-        run: gh pr comment "${{ github.event.pull_request.number }}" --body "This Dependabot PR updates a **production** dependency (\`${DEP_NAMES}\`)."
+        run: gh pr comment "${{ github.event.pull_request.number }}" --body "This Dependabot PR updates a production dependency (\`${DEP_NAMES}\`). Update the changelog for the next release before merging."

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -16,3 +17,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "${{ github.event.pull_request.number }}" --add-reviewer Hug0-Drelon
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on production updates
+        if: steps.metadata.outputs.dependency-type == 'direct:production'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: gh pr comment "${{ github.event.pull_request.number }}" --body "This Dependabot PR updates a **production** dependency (\`${DEP_NAMES}\`)."

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,7 +1,7 @@
 name: Request Dependabot review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened]
 
 permissions:

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,0 +1,18 @@
+name: Request Dependabot review
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit "${{ github.event.pull_request.number }}" --add-reviewer Hug0-Drelon

--- a/.github/workflows/package-json-lint.yml
+++ b/.github/workflows/package-json-lint.yml
@@ -30,4 +30,4 @@ jobs:
       run: npm ci
 
     - name: Run Package JSON Lint
-      run: npx wp-scripts lint-pkg-json
+      run: npm run lint:pkg-json

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -90,6 +90,19 @@ module.exports = [
 			},
 		},
 	},
+	{
+		files: [ 'tests/e2e/**' ],
+		rules: {
+			// Specs import root devDependencies; the nested stub is not an npm package.
+			'import/no-extraneous-dependencies': [
+				'error',
+				{
+					devDependencies: true,
+					packageDir: __dirname,
+				},
+			],
+		},
+	},
 	// Last: Prettier turns off conflicting stylistic ESLint rules.
 	...AutomatticPlugin.configs.prettier,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
         "@wordpress/env": "^10.39.0",
         "@wordpress/eslint-plugin": "^25.8.0",
-        "@wordpress/scripts": "^34.1.0",
+        "@wordpress/npm-package-json-lint-config": "^5.53.0",
         "@wpsyntex/distribute": "^0.1.0",
         "@wpsyntex/e2e-test-utils": "^0.1.0",
         "@wpsyntex/polylang-build-scripts": "^2.2.0",
@@ -31,6 +31,7 @@
         "eslint": "^9.39.5",
         "glob": "^11.0.0",
         "mini-css-extract-plugin": "^2.10.1",
+        "npm-package-json-lint": "^11.0.0",
         "postcss": "^8.5.8",
         "prettier": "npm:wp-prettier@3.0.3",
         "rimraf": "^6.1.3",
@@ -40,23 +41,6 @@
         "webpack": "^5.105.4",
         "webpack-cli": "^6.0.1"
       }
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@automattic/eslint-plugin-wpvip": {
       "version": "1.3.0",
@@ -660,61 +644,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-bigint": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.29.7",
       "dev": true,
@@ -743,148 +672,12 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-import-meta": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1503,34 +1296,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-constant-elements": {
-      "version": "7.29.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.29.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-react-jsx": {
       "version": "7.29.7",
       "dev": true,
@@ -1541,35 +1306,6 @@
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/plugin-syntax-jsx": "^7.29.7",
         "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.29.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.29.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1897,25 +1633,6 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/preset-react": {
-      "version": "7.29.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-transform-react-display-name": "^7.29.7",
-        "@babel/plugin-transform-react-jsx": "^7.29.7",
-        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
-        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/preset-typescript": {
       "version": "7.29.7",
       "dev": true,
@@ -1976,243 +1693,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@cacheable/memory": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cacheable/utils": "^2.5.0",
-        "@keyv/bigmap": "^1.3.1",
-        "hookified": "^1.15.1",
-        "keyv": "^5.6.0"
-      }
-    },
-    "node_modules/@cacheable/memory/node_modules/keyv": {
-      "version": "5.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
-    "node_modules/@cacheable/utils": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hashery": "^1.5.1",
-        "keyv": "^5.6.0"
-      }
-    },
-    "node_modules/@cacheable/utils/node_modules/keyv": {
-      "version": "5.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
     "node_modules/@colordx/core": {
       "version": "5.5.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.7",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/media-query-list-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
-      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "5.0.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      }
-    },
-    "node_modules/@discoveryjs/json-ext": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@dual-bundle/import-meta-resolve": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/JounQin"
-      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2977,232 +2461,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
-      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/core": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
-      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/pattern": "30.4.0",
-        "@jest/reporters": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "exit-x": "^0.2.2",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.4.1",
-        "jest-config": "30.4.2",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-resolve-dependencies": "30.4.2",
-        "jest-runner": "30.4.2",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract": {
-      "version": "30.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/jsdom": "^21.1.7",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "30.4.1",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@types/node": "*",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/globals": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
-      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/types": "30.4.1",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/pattern": {
       "version": "30.4.0",
       "dev": true,
@@ -3215,207 +2473,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/reporters": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
-      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "collect-v8-coverage": "^1.0.2",
-        "exit-x": "^0.2.2",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^5.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.2",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@jest/reporters/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -3424,95 +2481,6 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/snapshot-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
-      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/source-map": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
-      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "callsites": "^3.1.0",
-        "graceful-fs": "^4.2.11"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-result": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
-      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "collect-v8-coverage": "^1.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
-      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
-      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3586,457 +2554,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsonjoy.com/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/buffers": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
-      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/codegen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
-      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
-      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
-      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
-      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "@jsonjoy.com/fs-print": "4.68.1",
-        "@jsonjoy.com/fs-snapshot": "4.68.1",
-        "glob-to-regex.js": "^1.0.0",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
-      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
-      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
-      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "glob-to-regex.js": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
-      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
-      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "@jsonjoy.com/json-pack": "^17.65.0",
-        "@jsonjoy.com/util": "^17.65.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
-      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
-      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
-      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/base64": "17.67.0",
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0",
-        "@jsonjoy.com/json-pointer": "17.67.0",
-        "@jsonjoy.com/util": "17.67.0",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
-      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/util": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
-      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pack": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
-      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/base64": "^1.1.2",
-        "@jsonjoy.com/buffers": "^1.2.0",
-        "@jsonjoy.com/codegen": "^1.0.0",
-        "@jsonjoy.com/json-pointer": "^1.0.2",
-        "@jsonjoy.com/util": "^1.9.0",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pointer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
-      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/codegen": "^1.0.0",
-        "@jsonjoy.com/util": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/util": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
-      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^1.0.0",
-        "@jsonjoy.com/codegen": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@keyv/bigmap": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hashery": "^1.4.0",
-        "hookified": "^1.15.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "keyv": "^5.6.0"
-      }
-    },
-    "node_modules/@keyv/serialize": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "dev": true,
@@ -4047,13 +2564,6 @@
     },
     "node_modules/@kwsites/promise-deferred": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4085,19 +2595,6 @@
       "license": "MIT",
       "dependencies": {
         "eslint-scope": "5.1.1"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodable/entities": {
@@ -5471,175 +3968,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@peculiar/asn1-cms": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
-      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "@peculiar/asn1-x509-attr": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-csr": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
-      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
-      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
-      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-cms": "^2.8.0",
-        "@peculiar/asn1-pkcs8": "^2.8.0",
-        "@peculiar/asn1-rsa": "^2.8.0",
-        "@peculiar/asn1-schema": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
-      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
-      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-cms": "^2.8.0",
-        "@peculiar/asn1-pfx": "^2.8.0",
-        "@peculiar/asn1-pkcs8": "^2.8.0",
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "@peculiar/asn1-x509-attr": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
-      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
-      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-x509": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
-      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
-      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.8.0",
-        "@peculiar/asn1-x509": "^2.8.0",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
-      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/x509": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
-      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.0",
-        "@peculiar/asn1-csr": "^2.6.0",
-        "@peculiar/asn1-ecc": "^2.6.0",
-        "@peculiar/asn1-pkcs9": "^2.6.0",
-        "@peculiar/asn1-rsa": "^2.6.0",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "pvtsutils": "^1.3.6",
-        "reflect-metadata": "^0.2.2",
-        "tslib": "^2.8.1",
-        "tsyringe": "^4.10.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@php-wasm/cli-util": {
       "version": "3.1.48",
       "dev": true,
@@ -5929,58 +4257,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.17",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-html": "^0.0.9",
-        "core-js-pure": "^3.23.3",
-        "error-stack-parser": "^2.0.6",
-        "html-entities": "^2.1.0",
-        "loader-utils": "^2.0.4",
-        "schema-utils": "^4.2.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      },
-      "peerDependencies": {
-        "@types/webpack": "4.x || 5.x",
-        "react-refresh": ">=0.10.0 <1.0.0",
-        "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <5.0.0",
-        "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x || 5.x",
-        "webpack-hot-middleware": "2.x",
-        "webpack-plugin-serve": "0.x || 1.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/webpack": {
-          "optional": true
-        },
-        "sockjs-client": {
-          "optional": true
-        },
-        "type-fest": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        },
-        "webpack-hot-middleware": {
-          "optional": true
-        },
-        "webpack-plugin-serve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@prisma/instrumentation": {
       "version": "6.11.1",
       "dev": true,
@@ -6134,292 +4410,6 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
-      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@stylistic/stylelint-plugin": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.3.tgz",
-      "integrity": "sha512-85fsmzgsIVmyG3/GFrjuYj6Cz8rAM7IZiPiXCMiSMfoDOC1lOrzrXPDk24WqviAghnPqGpx8b0caK2PuewWGFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1",
-        "@csstools/media-query-list-parser": "^3.0.1",
-        "is-plain-object": "^5.0.0",
-        "postcss": "^8.4.41",
-        "postcss-selector-parser": "^6.1.2",
-        "postcss-value-parser": "^4.2.0",
-        "style-search": "^0.1.0"
-      },
-      "engines": {
-        "node": "^18.12 || >=20.9"
-      },
-      "peerDependencies": {
-        "stylelint": "^16.8.0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-plugin-transform-svg-component": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/babel-preset": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
-        "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
-        "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
-        "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
-        "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
-        "@svgr/babel-plugin-transform-svg-component": "8.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/core": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.21.3",
-        "@svgr/babel-preset": "8.1.0",
-        "camelcase": "^6.2.0",
-        "cosmiconfig": "^8.1.3",
-        "snake-case": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@svgr/hast-util-to-babel-ast": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.21.3",
-        "entities": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@svgr/plugin-jsx": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.21.3",
-        "@svgr/babel-preset": "8.1.0",
-        "@svgr/hast-util-to-babel-ast": "8.0.0",
-        "svg-parser": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@svgr/core": "*"
-      }
-    },
-    "node_modules/@svgr/plugin-svgo": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^8.1.3",
-        "deepmerge": "^4.3.1",
-        "svgo": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@svgr/core": "*"
-      }
-    },
-    "node_modules/@svgr/webpack": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.21.3",
-        "@babel/plugin-transform-react-constant-elements": "^7.21.3",
-        "@babel/preset-env": "^7.20.2",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.21.0",
-        "@svgr/core": "8.1.0",
-        "@svgr/plugin-jsx": "8.1.0",
-        "@svgr/plugin-svgo": "8.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "dev": true,
@@ -6494,72 +4484,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/bonjour": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
-      "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/btoa-lite": {
       "version": "1.0.2",
       "dev": true,
@@ -6584,54 +4508,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
-      "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express-serve-static-core": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
-      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -6646,23 +4526,6 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.17",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -6683,16 +4546,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jsdom": {
-      "version": "21.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -6721,13 +4574,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -6795,20 +4641,6 @@
         "@types/pg": "*"
       }
     },
-    "node_modules/@types/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "dev": true,
@@ -6817,93 +4649,13 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-index": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
-      "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/sockjs": {
-      "version": "0.3.36",
-      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
-      "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7750,23 +5502,6 @@
         }
       }
     },
-    "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.53.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.53.0.tgz",
-      "integrity": "sha512-u3ShLXmSTDmbTTe/2qEC2W4Gq5ygz5M7ahT4yOK8mkaefRE8/faX0RMHDCboaE5rApJM/sgvtufvEaLOsO4Q0g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "json2php": "^0.0.9"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
     "node_modules/@wordpress/deprecated": {
       "version": "4.53.0",
       "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.53.0.tgz",
@@ -8148,44 +5883,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/jest-console": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-9.1.0.tgz",
-      "integrity": "sha512-DvIDCckbQq3G4DZVktLmAQNGRsptkUSW5JeTbDAtr5L3ZtoV1fXYnryiDG9QP3ELgzIHcFX0Qa7TZmymb6SXxg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "jest-matcher-utils": "^30.4.1",
-        "jest-mock": "^30.4.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "jest": ">=30"
-      }
-    },
-    "node_modules/@wordpress/jest-preset-default": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-14.0.0.tgz",
-      "integrity": "sha512-ao/QFpjiVs56/WL7w/ZglLrIHmGPqiAKTNMakAZ/DQsjfEybaaHblzlpCHRCQ5qUGllYeUbQ7lsT9PrNLOe6zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/jest-console": "^9.1.0",
-        "babel-jest": "^30.4.1",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7",
-        "jest": ">=30"
-      }
-    },
     "node_modules/@wordpress/keycodes": {
       "version": "4.53.0",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.53.0.tgz",
@@ -8220,37 +5917,6 @@
       },
       "peerDependencies": {
         "npm-package-json-lint": ">=6.0.0"
-      }
-    },
-    "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.53.0.tgz",
-      "integrity": "sha512-YzZlwe7Mh0tmZAkv+sfza0bKl5qUBk19trwyUwZHPbkyRRsb5GBAC8mvvebpLp2wb01VQwp4X69gYpALxXRjMg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/base-styles": "^12.1.0",
-        "@wordpress/browserslist-config": "^6.53.0",
-        "autoprefixer": "^10.4.21",
-        "postcss-import": "^16.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/@wordpress/postcss-plugins-preset/node_modules/@wordpress/base-styles": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-12.1.0.tgz",
-      "integrity": "sha512-B8Ab7dU574B1lNtjnTolO340nnW+WeaztR4RFpoL6tyqWrvDU1hK6xcjQnuNtQYJc2ngH/MO/rZOVFaFa7HFxw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/prettier-config": {
@@ -8292,771 +5958,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/scripts": {
-      "version": "34.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-34.1.0.tgz",
-      "integrity": "sha512-eghybMctbwUuXzfWcJ25iNygCLT8oVwOKwgGuhxTTJGxD9j8xYmsu0KCqKDQ5UNnZoC0PKb4UikyEpwjmi2pWA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/core": "^7.25.7",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-        "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.53.0",
-        "@wordpress/browserslist-config": "^6.53.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.53.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.53.0",
-        "@wordpress/eslint-plugin": "^25.9.0",
-        "@wordpress/jest-preset-default": "^14.0.0",
-        "@wordpress/npm-package-json-lint-config": "^5.53.0",
-        "@wordpress/postcss-plugins-preset": "^5.53.0",
-        "@wordpress/prettier-config": "^4.53.0",
-        "@wordpress/stylelint-config": "^24.2.0",
-        "adm-zip": "^0.5.9",
-        "babel-jest": "^30.4.1",
-        "babel-loader": "^9.2.1",
-        "browserslist": "^4.28.4",
-        "chalk": "^4.1.1",
-        "check-node-version": "^4.1.0",
-        "copy-webpack-plugin": "^10.2.0",
-        "cross-spawn": "^7.0.6",
-        "css-loader": "^6.2.0",
-        "cssnano": "^6.0.1",
-        "dir-glob": "^3.0.1",
-        "eslint": "^10.0.0",
-        "fast-glob": "^3.2.7",
-        "jest": "^30.4.1",
-        "jest-environment-jsdom": "^30.4.1",
-        "jest-environment-node": "^30.4.1",
-        "json2php": "^0.0.9",
-        "markdownlint-cli": "^0.31.1",
-        "mini-css-extract-plugin": "^2.9.2",
-        "minimist": "^1.2.0",
-        "npm-package-json-lint": "^6.4.0",
-        "npm-packlist": "^3.0.0",
-        "postcss": "^8.4.38",
-        "postcss-loader": "^6.2.1",
-        "prettier": "npm:wp-prettier@^3.0.3",
-        "react-refresh": "^0.14.0",
-        "read-pkg-up": "^7.0.1",
-        "resolve-bin": "^1.0.1",
-        "rtlcss": "^4.3.0",
-        "sass": "^1.54.0",
-        "sass-loader": "^16.0.3",
-        "schema-utils": "^4.2.0",
-        "source-map-loader": "^3.0.0",
-        "stylelint": "^16.26.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.108.1",
-        "webpack-bundle-analyzer": "^4.9.1",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.2.1"
-      },
-      "bin": {
-        "wp-scripts": "bin/wp-scripts.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@playwright/test": ">=1",
-        "@wordpress/env": ">=10.0.0",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@playwright/test": {
-          "optional": true
-        },
-        "@wordpress/env": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
-        "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@eslint/config-helpers": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
-      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@webpack-cli/configtest": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@webpack-cli/info": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@webpack-cli/serve": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.53.0.tgz",
-      "integrity": "sha512-46wLx4MUEoXeWq+JtmFjFsQd0+m219bA1WUDW4vpMrNzO2qU87Rm+9LWudRQ5+niJvPiYyZruNAhscl5KRxbOQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "change-case": "^4.1.2",
-        "get-port": "^5.1.1",
-        "lighthouse": "^12.2.2",
-        "mime": "^3.0.0",
-        "web-vitals": "^4.2.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@playwright/test": ">=1",
-        "@types/node": "^20.17.10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/array-union": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/babel-loader": {
-      "version": "9.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-cache-dir": "^4.0.0",
-        "schema-utils": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.12.0",
-        "webpack": ">=5"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/clone-deep": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/commander": {
-      "version": "10.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/copy-webpack-plugin": {
-      "version": "10.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "^3.2.7",
-        "glob-parent": "^6.0.1",
-        "globby": "^12.0.2",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 12.20.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/css-loader": {
-      "version": "6.11.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
-        "postcss-modules-extract-imports": "^3.1.0",
-        "postcss-modules-local-by-default": "^4.0.5",
-        "postcss-modules-scope": "^3.2.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
-      "dev": true,
-      "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.7.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/eslint/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/find-cache-dir": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "common-path-prefix": "^3.0.0",
-        "pkg-dir": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/find-up": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/globby": {
-      "version": "12.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^3.0.1",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.7",
-        "ignore": "^5.1.9",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/ignore": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/scripts/node_modules/kind-of": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/locate-path": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/p-limit": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/p-locate": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/path-exists": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/pkg-dir": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/semver": {
-      "version": "7.8.5",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/slash": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/webpack-cli": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^2.1.1",
-        "@webpack-cli/info": "^2.0.2",
-        "@webpack-cli/serve": "^2.0.5",
-        "colorette": "^2.0.14",
-        "commander": "^10.0.1",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.7.3",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
-        "interpret": "^3.1.1",
-        "rechoir": "^0.8.0",
-        "webpack-merge": "^5.7.3"
-      },
-      "bin": {
-        "webpack-cli": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x"
-      },
-      "peerDependenciesMeta": {
-        "@webpack-cli/generators": {
-          "optional": true
-        },
-        "webpack-bundle-analyzer": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@wordpress/style-runtime": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.9.0.tgz",
@@ -9066,27 +5967,6 @@
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@wordpress/stylelint-config": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-24.2.0.tgz",
-      "integrity": "sha512-hRAcYVoGAAeh8abfkF5T7d6O2T7jQgf5jRP6HEWmQOqpOFkhenZaOFC6jdoX+t/PxXFUYFV3mzgjWqNa+b1jXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stylistic/stylelint-plugin": "^3.1.3",
-        "@wordpress/theme": "^1.2.0",
-        "stylelint-config-recommended": "^14.0.1",
-        "stylelint-config-recommended-scss": "^14.1.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.13.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "stylelint": "^16.8.2",
-        "stylelint-scss": "^6.4.0"
       }
     },
     "node_modules/@wordpress/theme": {
@@ -9367,11 +6247,6 @@
         "node": ">=16.5.0"
       }
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "dev": true,
@@ -9422,25 +6297,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "dev": true,
@@ -9474,14 +6330,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-errors": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": ">=5.0.0"
       }
     },
     "node_modules/ajv-formats": {
@@ -9533,30 +6381,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-html": {
-      "version": "0.0.9",
-      "dev": true,
-      "engines": [
-        "node >= 0.8.0"
-      ],
-      "license": "Apache-2.0",
-      "bin": {
-        "ansi-html": "bin/ansi-html"
-      }
-    },
-    "node_modules/ansi-html-community": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8.0"
-      ],
-      "license": "Apache-2.0",
-      "bin": {
-        "ansi-html": "bin/ansi-html"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
@@ -9577,20 +6401,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/anynum": {
@@ -9804,21 +6614,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/asn1js": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
-      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.5",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "dev": true,
@@ -9834,14 +6629,6 @@
       "version": "0.0.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -9863,43 +6650,6 @@
       "dependencies": {
         "stubborn-fs": "^2.0.0",
         "when-exit": "^2.1.4"
-      }
-    },
-    "node_modules/autoprefixer": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
-      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.6",
-        "caniuse-lite": "^1.0.30001806",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -9943,28 +6693,6 @@
         "react-native-b4a": {
           "optional": true
         }
-      }
-    },
-    "node_modules/babel-jest": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "30.4.1",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.4.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-loader": {
@@ -10030,39 +6758,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "workspaces": [
-        "test/babel-8"
-      ],
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-instrument": "^6.0.2",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
       "dev": true,
@@ -10097,50 +6792,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-import-attributes": "^7.24.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.4.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/balanced-match": {
@@ -10261,13 +6912,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/batch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "dev": true,
@@ -10279,19 +6923,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -10340,17 +6971,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bonjour-service": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
-      "integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "multicast-dns": "^7.2.5"
-      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -10413,16 +7033,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
     "node_modules/btoa-lite": {
       "version": "1.0.0",
       "dev": true,
@@ -10446,50 +7056,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/bytestreamjs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/cacheable": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cacheable/memory": "^2.2.0",
-        "@cacheable/utils": "^2.5.0",
-        "hookified": "^1.15.0",
-        "keyv": "^5.6.0",
-        "qified": "^0.10.1"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -10515,14 +7087,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/call-bind": {
@@ -10584,17 +7148,6 @@
       "dependencies": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/camelcase-keys": {
@@ -10703,51 +7256,10 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chardet": {
       "version": "2.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/check-node-version": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "chalk": "^3.0.0",
-        "map-values": "^1.0.1",
-        "minimist": "^1.2.0",
-        "object-filter": "^1.0.2",
-        "run-parallel": "^1.1.4",
-        "semver": "^6.3.0"
-      },
-      "bin": {
-        "check-node-version": "bin.js"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/check-node-version/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
@@ -10914,24 +7426,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/collect-v8-coverage": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
-      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -10945,11 +7439,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/colord": {
-      "version": "2.9.3",
       "dev": true,
       "license": "MIT"
     },
@@ -10985,74 +7474,10 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/compressible": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": ">= 1.43.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/compression": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
-      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "compressible": "~2.0.18",
-        "debug": "2.6.9",
-        "negotiator": "~0.6.4",
-        "on-headers": "~1.1.0",
-        "safe-buffer": "5.2.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/compression/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/compression/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/compression/node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -11083,16 +7508,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/connect-history-api-fallback": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
-      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/constant-case": {
@@ -11191,71 +7606,10 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.49.0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -11295,14 +7649,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
-      }
-    },
-    "node_modules/css-functions-list": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/css-loader": {
@@ -11960,79 +8306,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssnano": {
-      "version": "6.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-default": "^6.1.2",
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "6.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "css-declaration-sorter": "^7.2.0",
-        "cssnano-utils": "^4.0.2",
-        "postcss-calc": "^9.0.1",
-        "postcss-colormin": "^6.1.0",
-        "postcss-convert-values": "^6.1.0",
-        "postcss-discard-comments": "^6.0.2",
-        "postcss-discard-duplicates": "^6.0.3",
-        "postcss-discard-empty": "^6.0.3",
-        "postcss-discard-overridden": "^6.0.2",
-        "postcss-merge-longhand": "^6.0.5",
-        "postcss-merge-rules": "^6.1.1",
-        "postcss-minify-font-values": "^6.1.0",
-        "postcss-minify-gradients": "^6.0.3",
-        "postcss-minify-params": "^6.1.0",
-        "postcss-minify-selectors": "^6.0.4",
-        "postcss-normalize-charset": "^6.0.2",
-        "postcss-normalize-display-values": "^6.0.2",
-        "postcss-normalize-positions": "^6.0.2",
-        "postcss-normalize-repeat-style": "^6.0.2",
-        "postcss-normalize-string": "^6.0.2",
-        "postcss-normalize-timing-functions": "^6.0.2",
-        "postcss-normalize-unicode": "^6.1.0",
-        "postcss-normalize-url": "^6.0.2",
-        "postcss-normalize-whitespace": "^6.0.2",
-        "postcss-ordered-values": "^6.0.2",
-        "postcss-reduce-initial": "^6.1.0",
-        "postcss-reduce-transforms": "^6.0.2",
-        "postcss-svgo": "^6.0.3",
-        "postcss-unique-selectors": "^6.0.4"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/cssnano-utils": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
     "node_modules/csso": {
       "version": "5.0.5",
       "dev": true,
@@ -12063,18 +8336,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "dev": true,
@@ -12086,18 +8347,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/data-urls": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -12147,11 +8396,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/debounce": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -12230,71 +8474,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/dedent": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -12446,23 +8629,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1507524",
       "dev": true,
@@ -12482,19 +8648,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dns-packet": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
-      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/docker-compose": {
@@ -12617,11 +8770,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
@@ -12644,19 +8792,6 @@
       "version": "1.5.400",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/emittery": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -12770,14 +8905,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-stack-parser": {
-      "version": "2.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -13772,13 +9899,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "dev": true,
@@ -13793,78 +9913,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
-      }
-    },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/exit-x": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
-      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/express": {
@@ -14071,29 +10119,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/faye-websocket": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bser": "2.1.1"
-      }
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "dev": true,
@@ -14193,13 +10218,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/find-parent-dir": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.1.tgz",
-      "integrity": "sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "dev": true,
@@ -14236,27 +10254,6 @@
       "version": "3.4.4",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -14300,20 +10297,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fraction.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "dev": true,
@@ -14351,21 +10334,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -14452,16 +10420,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/get-port": {
       "version": "5.1.1",
       "dev": true,
@@ -14483,17 +10441,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -14594,23 +10541,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regex.js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
-      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
     "node_modules/globals": {
       "version": "16.5.0",
       "dev": true,
@@ -14679,11 +10609,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/globjoin": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "dev": true,
@@ -14723,27 +10648,6 @@
       "version": "4.2.11",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/gzip-size": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/handle-thing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -14822,17 +10726,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hashery": {
-      "version": "1.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^1.15.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "dev": true,
@@ -14866,11 +10759,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/hookified": {
-      "version": "1.15.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "dev": true,
@@ -14898,30 +10786,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
-      }
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "dev": true,
@@ -14937,33 +10801,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/html-tags": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -14992,28 +10833,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/http-parser-js": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
@@ -15024,31 +10843,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/http-proxy-middleware": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
-      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
       }
     },
     "node_modules/http2-wrapper": {
@@ -15073,26 +10867,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/hyperdyperid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.18"
       }
     },
     "node_modules/iconv-lite": {
@@ -15146,17 +10920,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ignore-walk": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/image-ssim": {
@@ -15307,14 +11070,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/irregular-plurals": {
-      "version": "3.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "dev": true,
@@ -15366,19 +11121,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -15529,16 +11271,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "dev": true,
@@ -15566,41 +11298,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -15631,19 +11328,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-network-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
-      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -15699,17 +11383,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "dev": true,
@@ -15717,11 +11390,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -15763,19 +11431,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -15821,17 +11476,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unsafe": {
@@ -15992,119 +11636,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "dev": true,
@@ -16135,544 +11666,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jest": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
-      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/types": "30.4.1",
-        "import-local": "^3.2.0",
-        "jest-cli": "30.4.2"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-changed-files": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
-      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "jest-util": "30.4.1",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-circus": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
-      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "co": "^4.6.0",
-        "dedent": "^1.6.0",
-        "is-generator-fn": "^2.1.0",
-        "jest-each": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "p-limit": "^3.1.0",
-        "pretty-format": "30.4.1",
-        "pure-rand": "^7.0.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-cli": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
-      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "exit-x": "^0.2.2",
-        "import-local": "^3.2.0",
-        "jest-config": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-config": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
-      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.4.0",
-        "@jest/test-sequencer": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-jest": "30.4.1",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "deepmerge": "^4.3.1",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.2",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-runner": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "parse-json": "^5.2.0",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "esbuild-register": ">=3.4.0",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "esbuild-register": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-config/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jest-config/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-config/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jest-config/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-config/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-config/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-docblock": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
-      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-each": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
-      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-environment-jsdom": {
-      "version": "30.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/environment-jsdom-abstract": "30.4.1",
-        "jsdom": "^26.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-environment-node": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-haste-map": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
-      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "picomatch": "^4.0.3",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-leak-detector": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
-      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jest-regex-util": {
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
@@ -16681,319 +11674,6 @@
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
-      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "slash": "^3.0.0",
-        "unrs-resolver": "^1.7.11"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve-dependencies": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
-      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-regex-util": "30.4.0",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runner": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
-      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/environment": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "emittery": "^0.13.1",
-        "exit-x": "^0.2.2",
-        "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-haste-map": "30.4.1",
-        "jest-leak-detector": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-resolve": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "jest-worker": "30.4.1",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
-      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/globals": "30.4.1",
-        "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "cjs-module-lexer": "^2.1.0",
-        "collect-v8-coverage": "^1.0.2",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-runtime/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jest-runtime/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
-      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@babel/generator": "^7.27.5",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1",
-        "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-preset-current-node-syntax": "^1.2.0",
-        "chalk": "^4.1.2",
-        "expect": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-diff": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1",
-        "semver": "^7.7.2",
-        "synckit": "^0.11.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest-util": {
@@ -17025,44 +11705,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-validate": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
-      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
-        "camelcase": "^6.3.0",
-        "chalk": "^4.1.2",
-        "leven": "^3.1.0",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-watcher": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
-      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "emittery": "^0.13.1",
-        "jest-util": "30.4.1",
-        "string-length": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-worker": {
@@ -17132,44 +11774,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/jsdom": {
-      "version": "26.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "dev": true,
@@ -17200,13 +11804,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json2php": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.9.tgz",
-      "integrity": "sha512-fQMYwvPsQt8hxRnCGyg1r2JVi6yL8Um0DIIawiKiMK9yhAAkcRNj5UsBWoaFvFzPpcWbgw9L6wzj+UMYA702Mw==",
-      "dev": true,
-      "license": "BSD"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -17308,19 +11905,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/known-css-properties": {
-      "version": "0.37.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "dev": true,
@@ -17337,33 +11921,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/launch-editor": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
-      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.4"
-      }
-    },
     "node_modules/legacy-javascript": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
       "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -17581,14 +12144,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "node_modules/loader-utils": {
       "version": "2.0.4",
       "dev": true,
@@ -17675,30 +12230,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/lookup-closest-locale": {
       "version": "6.2.0",
@@ -17754,16 +12289,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/makeerror": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tmpl": "1.0.5"
-      }
-    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "dev": true,
@@ -17774,144 +12299,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/map-values": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "Public Domain"
-    },
-    "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/markdownlint": {
-      "version": "0.25.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "markdown-it": "12.3.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/markdownlint-cli": {
-      "version": "0.31.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "~9.0.0",
-        "get-stdin": "~9.0.0",
-        "glob": "~7.2.0",
-        "ignore": "~5.2.0",
-        "js-yaml": "^4.1.0",
-        "jsonc-parser": "~3.0.0",
-        "markdownlint": "~0.25.1",
-        "markdownlint-rule-helpers": "~0.16.0",
-        "minimatch": "~3.0.5",
-        "run-con": "~1.2.10"
-      },
-      "bin": {
-        "markdownlint": "markdownlint.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/markdownlint-cli/node_modules/commander": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/ignore": {
-      "version": "5.2.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/markdownlint-rule-helpers": {
-      "version": "0.16.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/marky": {
       "version": "1.3.0",
@@ -17926,24 +12313,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mathml-tag-names": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/mdurl": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -17951,33 +12324,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/memfs": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
-      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.1",
-        "@jsonjoy.com/fs-fsa": "4.68.1",
-        "@jsonjoy.com/fs-node": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "@jsonjoy.com/fs-print": "4.68.1",
-        "@jsonjoy.com/fs-snapshot": "4.68.1",
-        "@jsonjoy.com/json-pack": "^1.11.0",
-        "@jsonjoy.com/util": "^1.9.0",
-        "glob-to-regex.js": "^1.0.1",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.0.3",
-        "tslib": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
       }
     },
     "node_modules/memize": {
@@ -18149,13 +12495,6 @@
       "peerDependencies": {
         "webpack": "^5.0.0"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -18338,32 +12677,10 @@
       "dev": true,
       "license": "Apache-2.0 WITH LLVM-exception"
     },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/multicast-dns": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
-      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dns-packet": "^5.2.2",
-        "thunky": "^1.0.2"
-      },
-      "bin": {
-        "multicast-dns": "cli.js"
-      }
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
@@ -18467,13 +12784,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-releases": {
       "version": "2.0.52",
       "dev": true,
@@ -18526,64 +12836,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/npm-package-json-lint": {
-      "version": "6.4.0",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-11.0.0.tgz",
+      "integrity": "sha512-XOFaxHM+TB9tK51Uj609kA1iA87cJe/VNCv/5INLCDbM///KpZpIai+t9LRRyOzvkd62j0JEWKSJeDUlzOSG6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
-        "ajv-errors": "^1.0.1",
-        "chalk": "^4.1.2",
-        "cosmiconfig": "^8.0.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "ignore": "^5.2.0",
-        "is-plain-obj": "^3.0.0",
-        "jsonc-parser": "^3.2.0",
-        "log-symbols": "^4.1.0",
-        "meow": "^9.0.0",
-        "plur": "^4.0.0",
-        "semver": "^7.3.8",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1",
-        "type-fest": "^3.2.0",
-        "validate-npm-package-name": "^5.0.0"
+        "chalk": "4.1.2",
+        "cosmiconfig": "10.0.0",
+        "debug": "4.4.3",
+        "globby": "11.1.0",
+        "ignore": "5.3.2",
+        "jsonc-parser": "3.3.1",
+        "meow": "9.0.0",
+        "minimatch": "10.2.6",
+        "semver": "7.8.5",
+        "strip-json-comments": "3.1.1",
+        "type-fest": "5.8.0",
+        "validate-npm-package-name": "8.0.0"
       },
       "bin": {
         "npmPkgJsonLint": "dist/cli.js"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       }
     },
-    "node_modules/npm-package-json-lint/node_modules/ajv": {
-      "version": "6.15.0",
+    "node_modules/npm-package-json-lint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/npm-package-json-lint/node_modules/array-union": {
       "version": "2.1.0",
@@ -18591,6 +12877,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npm-package-json-lint/node_modules/cosmiconfig": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-10.0.0.tgz",
+      "integrity": "sha512-RYs2EfrIoS16yh6j/MLgF753u5rROFFw3XGjcJXM4UQJm1iGXX7gKNyk4O/bCkyfi9Qfo+fVdd3FrnviZv830g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": "^22.18 || >= 24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/globby": {
@@ -18620,10 +12923,28 @@
         "node": ">= 4"
       }
     },
-    "node_modules/npm-package-json-lint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
+    "node_modules/npm-package-json-lint/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
-      "license": "MIT"
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
       "version": "7.8.5",
@@ -18637,63 +12958,19 @@
       }
     },
     "node_modules/npm-package-json-lint/node_modules/type-fest": {
-      "version": "3.13.1",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-packlist": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.6",
-        "ignore-walk": "^4.0.1",
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm-packlist/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nth-check": {
@@ -18707,11 +12984,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.24",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "dev": true,
@@ -18724,11 +12996,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
       "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/object-filter": {
-      "version": "1.0.2",
       "dev": true,
       "license": "MIT"
     },
@@ -18831,13 +13098,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/octokit": {
       "version": "3.1.2",
       "dev": true,
@@ -18865,16 +13125,6 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/on-headers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -18915,14 +13165,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -19126,24 +13368,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/p-retry": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
-      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.2",
-        "is-network-error": "^1.0.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "dev": true,
@@ -19245,28 +13469,6 @@
       "version": "1.0.11",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -19463,16 +13665,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "dev": true,
@@ -19482,24 +13674,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pkijs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
-      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@noble/hashes": "1.4.0",
-        "asn1js": "^3.0.6",
-        "bytestreamjs": "^2.0.1",
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/playwright": {
@@ -19542,20 +13716,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/plur": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "irregular-plurals": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "dev": true,
@@ -19589,269 +13749,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-calc": {
-      "version": "9.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.11",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.2"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-api": "^3.0.0",
-        "colord": "^2.9.3",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-import": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.2.0.tgz",
-      "integrity": "sha512-0mQUGlSp87Zl70K58RNwQAN1WS9plFE6KWGui9nyK6ninduMyjW/Khaoy/BpBoFTBh7ndAvAKrSKVbwy6vd/BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-loader": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.5",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.8.5",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/yaml": {
-      "version": "1.10.3",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-media-query-parser": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "6.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^6.1.1"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^4.0.2",
-        "postcss-selector-parser": "^6.0.16"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colord": "^2.9.3",
-        "cssnano-utils": "^4.0.2",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "cssnano-utils": "^4.0.2",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "6.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.16"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -19933,272 +13830,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/postcss-normalize-charset": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-utils": "^4.0.2",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-api": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-resolve-nested-selector": {
-      "version": "0.1.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-safe-parser": {
-      "version": "7.0.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-scss": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
-      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.29"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-svgo": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "svgo": "^3.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >= 18"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "6.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.16"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "dev": true,
@@ -20273,35 +13904,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -20400,59 +14002,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pure-rand": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
-      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/qified": {
-      "version": "0.10.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/qified/node_modules/hookified": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/qs": {
       "version": "6.15.3",
       "dev": true,
@@ -20540,50 +14089,6 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
-      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
-    "node_modules/read-cache/node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20711,13 +14216,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -20861,13 +14359,6 @@
         "node": ">=0.10.5"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -20905,16 +14396,6 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/resolve-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-1.0.1.tgz",
-      "integrity": "sha512-4G9C3udcDB1c9qaopB+9dygm2bMyF2LeJ2JHBIc24N7ob+UuSSwX3ID1hQwpDEQep9ZRNdhT//rgEd6xbWA/SA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-parent-dir": "~0.3.0"
-      }
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -20971,16 +14452,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "dev": true,
@@ -21030,63 +14501,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rtlcss": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.21",
-        "strip-json-comments": "^3.1.1"
-      },
-      "bin": {
-        "rtlcss": "bin/rtlcss.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-con": {
-      "version": "1.2.12",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~3.0.0",
-        "minimist": "^1.2.8",
-        "strip-json-comments": "~3.1.1"
-      },
-      "bin": {
-        "run-con": "cli.js"
-      }
-    },
-    "node_modules/run-con/node_modules/ini": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/run-parallel": {
@@ -21270,17 +14684,6 @@
         "node": ">=11.0.0"
       }
     },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "dev": true,
@@ -21297,27 +14700,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/selfsigned": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
-      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/x509": "^1.14.2",
-        "pkijs": "^3.3.3"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/semver": {
@@ -21391,83 +14773,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/serve-index": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
-      "integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "batch": "0.6.1",
-        "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.8.0",
-        "mime-types": "~2.1.35",
-        "parseurl": "~1.3.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-index/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/serve-index/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-index/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-index/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/serve-index/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/serve-static": {
@@ -21568,19 +14873,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
-      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shimmer": {
@@ -21726,41 +15018,12 @@
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
-    "node_modules/sirv": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/smart-buffer": {
@@ -21779,18 +15042,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/sockjs": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
-      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "faye-websocket": "^0.11.3",
-        "uuid": "^8.3.2",
-        "websocket-driver": "^0.7.4"
       }
     },
     "node_modules/socks": {
@@ -21819,68 +15070,8 @@
         "node": ">= 14"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.7.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-loader": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.5",
-        "iconv-lite": "^0.6.3",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/source-map-loader/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -21924,53 +15115,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/spdy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "handle-thing": "^2.0.0",
-        "http-deceiver": "^1.2.7",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/spdy-transport": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.2",
-        "readable-stream": "^3.0.6",
-        "wbuf": "^1.7.3"
-      }
-    },
-    "node_modules/spdy-transport/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/speedline-core": {
       "version": "1.4.3",
       "dev": true,
@@ -21996,30 +15140,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stackframe": {
-      "version": "1.3.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -22063,20 +15183,6 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -22240,26 +15346,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "dev": true,
@@ -22309,376 +15395,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/style-search": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/stylehacks": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.0",
-        "postcss-selector-parser": "^6.0.16"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/stylelint": {
-      "version": "16.26.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/stylelint"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/stylelint"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
-        "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/media-query-list-parser": "^4.0.3",
-        "@csstools/selector-specificity": "^5.0.0",
-        "@dual-bundle/import-meta-resolve": "^4.2.1",
-        "balanced-match": "^2.0.0",
-        "colord": "^2.9.3",
-        "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.3",
-        "css-tree": "^3.1.0",
-        "debug": "^4.4.3",
-        "fast-glob": "^3.3.3",
-        "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^11.1.1",
-        "global-modules": "^2.0.0",
-        "globby": "^11.1.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^3.3.1",
-        "ignore": "^7.0.5",
-        "imurmurhash": "^0.1.4",
-        "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.37.0",
-        "mathml-tag-names": "^2.1.3",
-        "meow": "^13.2.0",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.5.6",
-        "postcss-resolve-nested-selector": "^0.1.6",
-        "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.1.0",
-        "postcss-value-parser": "^4.2.0",
-        "resolve-from": "^5.0.0",
-        "string-width": "^4.2.3",
-        "supports-hyperlinks": "^3.2.0",
-        "svg-tags": "^1.0.0",
-        "table": "^6.9.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "bin": {
-        "stylelint": "bin/stylelint.mjs"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
-    "node_modules/stylelint-config-recommended": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
-      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/stylelint"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/stylelint"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "stylelint": "^16.1.0"
-      }
-    },
-    "node_modules/stylelint-config-recommended-scss": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
-      "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-scss": "^4.0.9",
-        "stylelint-config-recommended": "^14.0.1",
-        "stylelint-scss": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3",
-        "stylelint": "^16.6.1"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/stylelint-scss": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
-      "integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.1",
-        "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.37.0",
-        "mdn-data": "^2.25.0",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.6",
-        "postcss-selector-parser": "^7.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "stylelint": "^16.8.2"
-      }
-    },
-    "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
-      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
-      "version": "4.0.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/stylelint/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/stylelint/node_modules/array-union": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stylelint/node_modules/cosmiconfig": {
-      "version": "9.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "11.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^6.1.23"
-      }
-    },
-    "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.23",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cacheable": "^2.5.0",
-        "flatted": "^3.4.2",
-        "hookified": "^1.15.0"
-      }
-    },
-    "node_modules/stylelint/node_modules/global-modules": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/stylelint/node_modules/global-prefix": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/stylelint/node_modules/globby": {
-      "version": "11.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stylelint/node_modules/globby/node_modules/ignore": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/stylelint/node_modules/ini": {
-      "version": "1.3.8",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/stylelint/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/stylelint/node_modules/kind-of": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stylelint/node_modules/meow": {
-      "version": "13.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stylelint/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/stylelint/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -22688,21 +15404,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-hyperlinks": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -22715,69 +15416,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/svg-parser": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/svg-tags": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "node_modules/svgo": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0",
-        "sax": "^1.5.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/svgo/node_modules/css-tree": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/mdn-data": {
-      "version": "2.0.30",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.13",
@@ -22793,19 +15431,17 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/table": {
-      "version": "6.9.0",
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tannin": {
@@ -23014,43 +15650,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "dev": true,
@@ -23059,32 +15658,8 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/thingies": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
-      "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "^2"
-      }
-    },
     "node_modules/third-party-web": {
       "version": "0.27.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/thunky": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
     },
@@ -23114,17 +15689,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/tldts": {
-      "version": "6.1.86",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^6.1.86"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
     "node_modules/tldts-core": {
       "version": "7.4.10",
       "dev": true,
@@ -23137,11 +15701,6 @@
       "dependencies": {
         "tldts-core": "^7.4.10"
       }
-    },
-    "node_modules/tldts/node_modules/tldts-core": {
-      "version": "6.1.86",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.7",
@@ -23158,13 +15717,6 @@
       "dependencies": {
         "tmp": "^0.2.0"
       }
-    },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -23218,53 +15770,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tree-dump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
-      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/trim-newlines": {
@@ -23321,26 +15826,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tsyringe": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
-      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/tsyringe/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -23350,16 +15835,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -23486,11 +15961,6 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -23669,77 +16139,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-loader": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "mime-types": "^2.1.27",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "file-loader": "*",
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "file-loader": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/url-loader/node_modules/ajv": {
-      "version": "6.15.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/url-loader/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/url-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/url-loader/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/use-memo-one": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
@@ -23776,32 +16175,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
@@ -23821,11 +16194,13 @@
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "5.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-8.0.0.tgz",
+      "integrity": "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/vary": {
@@ -23878,27 +16253,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/walker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "makeerror": "1.0.12"
-      }
-    },
     "node_modules/wasm-feature-detect": {
       "version": "1.8.0",
       "dev": true,
@@ -23913,16 +16267,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/wcwidth": {
@@ -23942,14 +16286,6 @@
       "version": "0.4.1",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/webpack": {
       "version": "5.109.2",
@@ -23989,59 +16325,6 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-bundle-analyzer": {
-      "version": "4.10.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@discoveryjs/json-ext": "0.5.7",
-        "acorn": "^8.0.4",
-        "acorn-walk": "^8.0.0",
-        "commander": "^7.2.0",
-        "debounce": "^1.2.1",
-        "escape-string-regexp": "^4.0.0",
-        "gzip-size": "^6.0.0",
-        "html-escaper": "^2.0.2",
-        "opener": "^1.5.2",
-        "picocolors": "^1.0.0",
-        "sirv": "^2.0.3",
-        "ws": "^7.3.1"
-      },
-      "bin": {
-        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.13",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -24093,214 +16376,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
-      }
-    },
-    "node_modules/webpack-dev-middleware": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
-      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^4.43.1",
-        "mime-types": "^3.0.1",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/webpack-dev-server": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
-      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/bonjour": "^3.5.13",
-        "@types/connect-history-api-fallback": "^1.5.4",
-        "@types/express": "^4.17.25",
-        "@types/express-serve-static-core": "^4.17.21",
-        "@types/serve-index": "^1.9.4",
-        "@types/serve-static": "^1.15.5",
-        "@types/sockjs": "^0.3.36",
-        "@types/ws": "^8.5.10",
-        "ansi-html-community": "^0.0.8",
-        "bonjour-service": "^1.2.1",
-        "chokidar": "^3.6.0",
-        "colorette": "^2.0.10",
-        "compression": "^1.8.1",
-        "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.22.1",
-        "graceful-fs": "^4.2.6",
-        "http-proxy-middleware": "^2.0.9",
-        "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.14.1",
-        "open": "^10.0.3",
-        "p-retry": "^6.2.0",
-        "schema-utils": "^4.2.0",
-        "selfsigned": "^5.5.0",
-        "serve-index": "^1.9.1",
-        "sockjs": "^0.3.24",
-        "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^7.4.2",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "webpack-dev-server": "bin/webpack-dev-server.js"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        },
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
-      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/webpack-merge": {
@@ -24373,73 +16448,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/websocket-driver": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
-      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-parser-js": ">=0.5.1",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/websocket-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/when-exit": {
@@ -24595,20 +16603,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/ws": {
       "version": "8.21.0",
       "dev": true,
@@ -24629,38 +16623,6 @@
         }
       }
     },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wsl-utils/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/xdg-basedir": {
       "version": "5.1.0",
       "dev": true,
@@ -24670,14 +16632,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/xml-naming": {
@@ -24713,11 +16667,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
     "@wordpress/env": "^10.39.0",
     "@wordpress/eslint-plugin": "^25.8.0",
-    "@wordpress/scripts": "^34.1.0",
+    "@wordpress/npm-package-json-lint-config": "^5.53.0",
     "@wpsyntex/distribute": "^0.1.0",
     "@wpsyntex/e2e-test-utils": "^0.1.0",
     "@wpsyntex/polylang-build-scripts": "^2.2.0",
@@ -49,6 +49,7 @@
     "eslint": "^9.39.5",
     "glob": "^11.0.0",
     "mini-css-extract-plugin": "^2.10.1",
+    "npm-package-json-lint": "^11.0.0",
     "postcss": "^8.5.8",
     "prettier": "npm:wp-prettier@3.0.3",
     "rimraf": "^6.1.3",
@@ -76,6 +77,7 @@
     "test:php:coverage": "npm run env:composer coverage",
     "test:php:coverage:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/polylang bash -c 'WP_MULTISITE=1 composer coverage'",
     "lint:js": "eslint",
+    "lint:pkg-json": "npmPkgJsonLint ./package.json",
     "dist": "distribute"
   },
   "allowScripts": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,27 +1,4 @@
 {
-	"name": "@wpsyntex/polylang-e2e",
-	"version": "1.0.0",
-	"description": "E2E tests for Polylang",
-	"author": "WP Syntex",
-	"license": "GPL-3.0-or-later",
-	"keywords": [
-		"e2e",
-		"polylang",
-		"testing"
-	],
-	"homepage": "https://github.com/polylang/polylang#readme",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/polylang/polylang.git"
-	},
-	"bugs": {
-		"url": "https://github.com/polylang/polylang/issues"
-	},
-	"private": true,
-	"type": "module",
-	"dependencies": {
-		"@playwright/test": "^1.58.2",
-		"@wordpress/e2e-test-utils-playwright": "^1.41.0 <1.47.0",
-		"@wpsyntex/e2e-test-utils": "^0.1.0"
-	}
+  "private": true,
+  "type": "module"
 }


### PR DESCRIPTION
## What?
- Replace `tests/e2e/package.json` with an ESM stub and keep Playwright deps on the plugin root.
- Lint the root `package.json` with `npmPkgJsonLint` instead of `wp-scripts`.
- Remove `@wordpress/scripts`.
- Add Dependabot for npm (production + named build tools in this repo) and Composer (`require` only).
- Request a review on Dependabot PRs (`dependabot-reviewer.yml`) instead of assigning. Comment when the bump is a production dependency.

## Why?
`lint:js` already uses ESLint. The leftover `@wordpress/scripts` install is unused, noisy for Dependabot, and package-json lint should not recurse into the e2e stub. Dependabot no longer supports a `reviewers` key, so review requests are a workflow.

## How?
Standalone `npm-package-json-lint` + `@wordpress/npm-package-json-lint-config`, ESLint `packageDir` for e2e imports, weekly Dependabot (Monday 07:00 Europe/Paris). `pull_request_target` requests `@Hug0-Drelon` on `dependabot[bot]` PRs and uses `dependabot/fetch-metadata` (`direct:production`) for the production comment.

## Test plan
- [x] `npm ci` succeeds at the repo root
- [x] `npm run lint:pkg-json` lints only `./package.json`
- [x] `npm run lint:js -- tests/e2e` does not flag root Playwright/e2e-utils imports
- [x] `npm run build` succeeds
- [x] No `wp-scripts` / `@wordpress/scripts` in package.json or workflows
- [ ] After merge, a Dependabot PR requests review; a production bump also gets the comment