### PR TITLE
Assert `map_meta_cap` globally

### DIFF
--- a/tests/phpunit/includes/map-meta-cap-trait.php
+++ b/tests/phpunit/includes/map-meta-cap-trait.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Trait that makes sure that `user_can()` is used with a post ID as argument, and not a post object.
+ */
+trait PLL_UnitTest_Map_Meta_Cap_Trait {
+	/**
+	 * Inits an assertion that will make sure we always pass an integer to our calls to `user_can()`.
+	 *
+	 * @return void
+	 */
+	protected static function assert_map_meta_cap_args() {
+		add_filter(
+			'map_meta_cap',
+			function ( $caps, $cap, $user_id, $args ) {
+				if ( empty( $args[0] ) ) {
+					return $caps;
+				}
+				// https://github.com/WordPress/wordpress-develop/blob/c70675b7a1a04101065b0533f5c778bd92f4c69f/src/wp-includes/block-editor.php#L635
+				if ( 'edit_block_binding' === $cap && $args[0] instanceof WP_Block_Editor_Context ) {
+					return $caps;
+				}
+				// https://github.com/the-events-calendar/the-events-calendar/blob/8131277580621b35df981e0dd96b3c59505e7151/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php#L368
+				if ( 'read_private_posts' === $cap && 'tribe_events' === $args[0] ) {
+					return $caps;
+				}
+
+				static::assertIsInt( $args[0], 'map_meta_cap $args[0] must be an object ID.' );
+
+				return $caps;
+			},
+			PHP_INT_MIN,
+			4
+		);
+	}
+}

--- a/tests/phpunit/includes/testcase-multisites.php
+++ b/tests/phpunit/includes/testcase-multisites.php
@@ -8,7 +8,7 @@ use WP_Syntex\Polylang\Options\Registry as Options_Registry;
  * Test case offering a standardized way to test blogs in multisite.
  */
 abstract class PLL_Multisites_TestCase extends WP_UnitTestCase {
-	use PLL_File_Path_Helper_Trait;
+	use PLL_UnitTestCase_Trait;
 
 	/**
 	 * Blog in plain permalinks without Polylang.

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -73,6 +73,7 @@ trait PLL_UnitTestCase_Trait {
 	 * - Creates the deprecated `self::$model`.
 	 * - Removes some hooks.
 	 * - Tweaks `_doing_it_wrong()`.
+	 * - Asserts `map_meta_cap` filter arguments.
 	 * - Calls `self::pllSetUpBeforeClass()`.
 	 *
 	 * @param WP_UnitTest_Factory $factory WP_UnitTest_Factory object.

--- a/tests/phpunit/includes/testcase-trait.php
+++ b/tests/phpunit/includes/testcase-trait.php
@@ -12,6 +12,7 @@ use WP_Syntex\Polylang\Options\Options;
  * class properties here.
  */
 trait PLL_UnitTestCase_Trait {
+	use PLL_UnitTest_Map_Meta_Cap_Trait;
 	use PLL_File_Path_Helper_Trait;
 	use PLL_Doing_It_Wrong_Trait;
 	use PLL_Options_Trait;
@@ -90,6 +91,7 @@ trait PLL_UnitTestCase_Trait {
 		remove_action( 'admin_print_styles', 'print_emoji_styles' );
 
 		self::filter_doing_it_wrong_trigger_error();
+		self::assert_map_meta_cap_args();
 
 		/*
 		 * Ensure `$factory` is an instance of `PLL_UnitTest_Factory` otherwise testcases directly


### PR DESCRIPTION
This adds an assertion to the hook `map_meta_cap`, to make sure that if a 2nd argument is passed to `current_user_can()`, it's an integer (not an object, like a post). Some exceptions are handled in the assertion.

This seems to be the best way to monitor OUR use of `user_can()`: monitor every call to `user_can()` and exclude some 3rd parties.