### PR TITLE
ci(dependabot): set GH_REPO for reviewer workflow

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Request review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh pr edit "${{ github.event.pull_request.number }}" --add-reviewer Hug0-Drelon
 
       - name: Dependabot metadata
@@ -28,5 +29,6 @@ jobs:
         if: steps.metadata.outputs.dependency-type == 'direct:production'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
         run: gh pr comment "${{ github.event.pull_request.number }}" --body "This Dependabot PR updates a production dependency (\`${DEP_NAMES}\`). Update the changelog for the next release before merging."


### PR DESCRIPTION
## What?
Set `GH_REPO` on the Dependabot reviewer `gh pr edit` and `gh pr comment` steps.

## Why?
The workflow does not check out the repo. `gh` infers the target from git remotes and fails with `fatal: not a git repository`.

## How?
Pass `GH_REPO: ${{ github.repository }}`. The CLI does not use Actions' `GITHUB_REPOSITORY` on its own.

## Test plan
- [ ] Next Dependabot PR: `request-review` job succeeds and requests `@Hug0-Drelon`
- [ ] Production bump also posts the changelog comment