### PR TITLE
Allow numeric types in `map_meta_cap` test

### DIFF
--- a/tests/phpunit/includes/map-meta-cap-trait.php
+++ b/tests/phpunit/includes/map-meta-cap-trait.php
@@ -25,7 +25,7 @@ trait PLL_UnitTest_Map_Meta_Cap_Trait {
 					return $caps;
 				}
 
-				static::assertIsInt( $args[0], 'map_meta_cap $args[0] must be an object ID.' );
+				static::assertIsNumeric( $args[0], 'map_meta_cap $args[0] must be an object ID.' );
 
 				return $caps;
 			},


### PR DESCRIPTION
When asserting the type of the 1st argument passed to the `map_meta_cap` filter, allow numeric values instead of integers only 🙄

Because https://github.com/polylang/polylang-wc/actions/runs/33395389572/job/99498566886?pr=1089

<img width="294" height="360" alt="Vous deviene fous" src="https://github.com/user-attachments/assets/ea33954a-6650-4f88-a421-4751492a64ba" />