### PR TITLE
Improve the switcher's "Open submenu" label

### DIFF
--- a/src/Switcher/Layout/Dropdown.php
+++ b/src/Switcher/Layout/Dropdown.php
@@ -106,7 +106,7 @@ class Dropdown extends Abstract_Layout {
 		$svg = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.5 4L6 8L10.5 4" stroke-width="1.5"></path></svg>';
 		return sprintf(
 			'<button aria-label="%1$s" class="pll-submenu-toggle">%2$s</button>',
-			esc_attr( __( 'Open languages submenu', 'polylang' ) ),
+			esc_attr( __( 'Open/Close languages submenu', 'polylang' ) ),
 			$svg
 		);
 	}


### PR DESCRIPTION
So it's also relevant when open.