### PR TITLE
build(deps): bump fast-uri to 3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10005,7 +10005,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/polylang/polylang/issues"
   },
   "overrides": {
+    "fast-uri": "3.1.6",
     "minimatch": "^9.0.9",
     "serialize-javascript": "^7.0.4"
   },


### PR DESCRIPTION
## What?
Pin transitive `fast-uri` to 3.1.6 via `package.json` overrides and update the lockfile.

## Why?
`fast-uri` is an indirect dev dependency (`copy-webpack-plugin` → `schema-utils` → `ajv`) flagged by Dependabot. It is not on the `allow` list in `dependabot.yml`, so no automated PR was opened.

There is no realistic exploit path in Polylang: `fast-uri` is only used at build time by `ajv` to resolve JSON Schema `$ref` URIs when validating webpack plugin options. It does not parse untrusted input, enforce host policies, or perform network requests. The shipped plugin does not include this dependency.

## How?
Add `"fast-uri": "3.1.6"` to `overrides`, following the same approach as `minimatch` and `serialize-javascript`.

## Test plan
- [x] `npm ci`
- [x] `npm run build`
- [x] `npm run lint:js`