### PR TITLE
Remove a ReturnTypeWillChange annotation

### DIFF
--- a/src/translatable-objects.php
+++ b/src/translatable-objects.php
@@ -67,8 +67,7 @@ class PLL_Translatable_Objects implements IteratorAggregate {
 	 *
 	 * @phpstan-return ArrayIterator<string, PLL_Translatable_Object>
 	 */
-	#[\ReturnTypeWillChange]
-	public function getIterator() {
+	public function getIterator(): ArrayIterator {
 		return new ArrayIterator( $this->objects );
 	}
 


### PR DESCRIPTION
NB: There is a remaining annotation in `WP_Syntex\Polylang\Options\Options` that we cannot remove yet as `mixed` return type requires PHP 8.0.