### PR TITLE
Fix wrong canonical redirect

### DIFF
--- a/src/frontend/frontend-static-pages.php
+++ b/src/frontend/frontend-static-pages.php
@@ -131,36 +131,15 @@ class PLL_Frontend_Static_Pages extends PLL_Static_Pages {
 	}
 
 	/**
-	 * Manages redirections for the static front pages.
+	 * Prevents the canonical redirect if we are on a static front page.
 	 *
 	 * @since 1.8
 	 *
-	 * @param string|false $redirect_url The redirect URL.
+	 * @param string $redirect_url The redirect url.
 	 * @return string|false
 	 */
 	public function pll_check_canonical_url( $redirect_url ) {
-		global $wp_query;
-
-		if ( empty( $this->curlang->page_on_front ) ) {
-			return $redirect_url;
-		}
-
-		if ( $this->options['redirect_lang'] ) {
-			// Prevent the canonical redirect if we are on a static front page.
-			if ( empty( $redirect_url ) ) {
-				// Already prevented.
-				return $redirect_url;
-			}
-			return ! $this->options['force_lang'] && $wp_query->is_page( $this->curlang->page_on_front ) ? false : $redirect_url;
-		}
-
-		if ( 1 === $this->options['force_lang'] && ! $this->options['hide_default'] && $wp_query->is_home && ! $wp_query->is_posts_page ) {
-			// Redirect example.com/fr/ to example.com/fr/front-page/ if we're not hiding the page name, and not hiding
-			// the language slug for the default language.
-			return $this->curlang->get_home_url();
-		}
-
-		return $redirect_url;
+		return $this->options['redirect_lang'] && ! $this->options['force_lang'] && ! empty( $this->curlang->page_on_front ) && is_page( $this->curlang->page_on_front ) ? false : $redirect_url;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-canonical.php
+++ b/tests/phpunit/tests/test-canonical.php
@@ -13,8 +13,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	private static $tag_en;
 	private static $page_for_posts_en;
 	private static $page_for_posts_fr;
-	private static $page_on_front_en;
-	private static $page_on_front_fr;
 
 	/**
 	 * @param WP_UnitTest_Factory $factory
@@ -81,14 +79,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 		self::$model->post->set_language( self::$page_for_posts_fr, 'fr' );
 
 		self::$model->post->save_translations( self::$page_for_posts_en, array( 'en' => self::$page_for_posts_en, 'fr' => self::$page_for_posts_fr ) );
-
-		self::$page_on_front_en = $factory->post->create( array( 'post_title' => 'front', 'post_type' => 'page' ) );
-		self::$model->post->set_language( self::$page_on_front_en, 'en' );
-
-		self::$page_on_front_fr = $factory->post->create( array( 'post_title' => 'accueil', 'post_type' => 'page' ) );
-		self::$model->post->set_language( self::$page_on_front_fr, 'fr' );
-
-		self::$model->post->save_translations( self::$page_on_front_en, array( 'en' => self::$page_on_front_en, 'fr' => self::$page_on_front_fr ) );
 	}
 
 	public function init_for_sitemaps() {
@@ -105,19 +95,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-		wp_delete_post( self::$post_en, true );
-		wp_delete_post( self::$page_id, true );
-		wp_delete_post( self::$custom_post_id, true );
-		wp_delete_post( self::$not_rewritten_cpt_id, true );
-		wp_delete_post( self::$page_for_posts_en, true );
-		wp_delete_post( self::$page_for_posts_fr, true );
-		wp_delete_post( self::$page_on_front_en, true );
-		wp_delete_post( self::$page_on_front_fr, true );
-		wp_delete_term( self::$term_en, 'category' );
-		wp_delete_term( self::$second_term_en, 'category' );
-		wp_delete_term( self::$tag_en, 'post_tag' );
-		wp_delete_term( self::$custom_term_en, 'custom_tax' );
-
 		_unregister_post_type( 'pllcanonical' );
 		_unregister_post_type( 'cptnotrewrited' );
 		_unregister_taxonomy( 'custom_tax' );
@@ -539,7 +516,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 	 */
 	public function test_page_for_posts_with_name_and_language() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical(
@@ -553,7 +529,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_for_posts_should_match_page_for_post_option_when_language_is_incorrect() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/fr/posts/', '/en/posts/' );
@@ -561,7 +536,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_for_posts_should_match_page_for_post_option_posts_without_language() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/posts/', '/en/posts/' );
@@ -569,7 +543,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_for_posts_should_match_page_for_post_option_posts_from_plain_permalink() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '?page_id=' . self::$page_for_posts_en, '/en/posts/' );
@@ -577,7 +550,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_for_post_option_should_be_translated_when_language_is_incorrect() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/en/articles/', '/fr/articles/' );
@@ -585,7 +557,6 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_for_post_option_should_be_translated_when_no_language_is_set() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '/articles/', '/fr/articles/' );
@@ -593,43 +564,9 @@ class Canonical_Test extends PLL_Canonical_UnitTestCase {
 
 	public function test_page_for_post_option_should_be_translated_from_plain_permalink() {
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_fr );
 		update_option( 'page_for_posts', self::$page_for_posts_fr );
 		self::$model->clean_languages_cache(); // Clean the languages transient.
 		$this->assertCanonical( '?page_id=' . self::$page_for_posts_fr, '/fr/articles/' );
-	}
-
-	/**
-	 * Page on front.
-	 *
-	 * @ticket 3109
-	 * @see https://github.com/polylang/polylang-pro/issues/3109
-	 *
-	 * @testWith ["fr", "accueil"]
-	 *           ["en", "front"]
-	 *
-	 * @param string $lang_slug
-	 * @param string $page_slug
-	 * @return void
-	 */
-	public function test_root_redirect_to_page_on_front( string $lang_slug, string $page_slug ) {
-		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', self::$page_on_front_en );
-		update_option( 'page_for_posts', self::$page_for_posts_en );
-
-		$this->options['hide_default']  = false;
-		$this->options['rewrite']       = true;
-		$this->options['redirect_lang'] = false;
-
-		self::$model->clean_languages_cache(); // Clean the languages transient.
-
-		$this->assertCanonical(
-			"/$lang_slug/",
-			array(
-				'url' => "/$lang_slug/$page_slug/",
-				'qv'  => array( 'lang' => $lang_slug, 'pagename' => $page_slug, 'page' => '' ),
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1998

#1992 introduced a redirect in unwanted cases. This PR reverts 9f52ef0085dcc31e8b9b8aff87712dfcdb990e00.
We will take the time to work on a better fix for https://github.com/polylang/polylang-pro/issues/3109  