### PR TITLE
ci(workflows): cancel in-progress runs on PR updates

### DIFF
--- a/.github/workflows/consistent-versions.yml
+++ b/.github/workflows/consistent-versions.yml
@@ -2,6 +2,27 @@ name: Consistent versions
 
 on:
   push:
+    branches: master
+    paths: &consistent_versions_paths
+      - 'polylang.php'
+      - 'package.json'
+      - 'composer.json'
+      - 'readme.txt'
+      - 'phpcs.xml.dist'
+      - 'src/modules/Blocks/Language_Switcher/Standard/block.json'
+      - 'src/modules/Blocks/Language_Switcher/Navigation/block.json'
+      - '.github/consistent-versions.yaml'
+      - '.github/consistent-versions-tag.yaml'
+      - '.github/workflows/consistent-versions.yml'
+
+  pull_request:
+    branches: master
+    paths: *consistent_versions_paths
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/consistent-versions.yml
+++ b/.github/workflows/consistent-versions.yml
@@ -3,21 +3,9 @@ name: Consistent versions
 on:
   push:
     branches: master
-    paths: &consistent_versions_paths
-      - 'polylang.php'
-      - 'package.json'
-      - 'composer.json'
-      - 'readme.txt'
-      - 'phpcs.xml.dist'
-      - 'src/modules/Blocks/Language_Switcher/Standard/block.json'
-      - 'src/modules/Blocks/Language_Switcher/Navigation/block.json'
-      - '.github/consistent-versions.yaml'
-      - '.github/consistent-versions-tag.yaml'
-      - '.github/workflows/consistent-versions.yml'
 
   pull_request:
     branches: master
-    paths: *consistent_versions_paths
 
 # Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
 concurrency:

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened]
 
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -3,7 +3,7 @@ name: End To End Tests
 on:
   push:
     branches: master
-    paths:
+    paths: &e2e_paths
       - '**.php'
       - '!tests/**.php'
       - '**.js'
@@ -17,27 +17,19 @@ on:
       - '.github/workflows/end-to-end-tests.yml'
       - 'babel.config.js'
       - '.wp-env.json'
-
   pull_request:
     branches: master
-    paths:
-      - '**.php'
-      - '!tests/**.php'
-      - '**.js'
-      - '**.mjs'
-      - '**.cjs'
-      - '**.css'
-      - '**.scss'
-      - 'composer.json'
-      - 'package.json'
-      - 'webpack.config.js'
-      - '.github/workflows/end-to-end-tests.yml'
-      - 'babel.config.js'
-      - '.wp-env.json'
+    paths: *e2e_paths
   schedule:
     # Runs every Monday at 00:00.
     - cron:  '0 0 * * 1'
   workflow_dispatch:
+
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   testing:

--- a/.github/workflows/integration-and-unit-tests.yml
+++ b/.github/workflows/integration-and-unit-tests.yml
@@ -3,7 +3,7 @@ name: Integration and Unit Tests
 on:
   push:
     branches: master
-    paths:
+    paths: &phpunit_paths
       - '**.php'
       - '**/phpunit.xml'
       - 'composer.json'
@@ -12,17 +12,17 @@ on:
       - '.github/workflows/integration-and-unit-tests.yml'
   pull_request:
     branches: master
-    paths:
-      - '**.php'
-      - '**/phpunit.xml'
-      - 'composer.json'
-      - 'composer.lock'
-      - 'tests/bin/**'
-      - '.github/workflows/integration-and-unit-tests.yml'
+    paths: *phpunit_paths
   schedule:
     # Runs every Monday at 00:00.
     - cron:  '0 0 * * 1'
   workflow_dispatch:
+
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   testing:

--- a/.github/workflows/package-json-lint.yml
+++ b/.github/workflows/package-json-lint.yml
@@ -3,13 +3,18 @@ name: Package JSON Lint
 on:
   push:
     branches: master
-    paths:
+    paths: &package_json_paths
       - 'package.json'
   pull_request:
     branches: master
-    paths:
-      - 'package.json'
+    paths: *package_json_paths
   workflow_dispatch:
+
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   testing:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,6 +7,12 @@ on:
     branches: master
   workflow_dispatch:
 
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   testing:
     name: PHPCS and PHPStan

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,12 @@ on:
     branches: master
   workflow_dispatch:
 
+
+# Cancel superseded PR runs; master commits use unique SHAs so they still all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   testing:
     name: Spell Check with Typos


### PR DESCRIPTION
## What?
Add workflow concurrency to cancel superseded CI runs on PR updates.

## Why?
Reduce wasted GitHub Actions minutes when branches are pushed repeatedly (especially long-lived PRs).

## How?
- Standard block: group by PR number or commit SHA, `cancel-in-progress: true` (master commits stay isolated per SHA).
- `consistent-versions.yml`: switch from bare `on: push` to `pull_request` + `push` on `master` (no path filters — the check is fast and `.github/consistent-versions.yaml` stays the single source of truth).
- YAML anchors for duplicated `paths` lists where push and pull_request match (E2E, PHPUnit, etc.).

## Test plan
- [ ] Push to an open PR twice quickly: older runs cancel, latest completes.
- [ ] Push to `master`: all commits run to completion (no cancellation across SHAs).
- [ ] `consistent-versions` runs on PRs (including fork PRs).