### PR TITLE
fix(auto-translate): restore tax_query fallback when term has no translation

### DIFF
--- a/src/frontend/frontend-auto-translate.php
+++ b/src/frontend/frontend-auto-translate.php
@@ -266,11 +266,12 @@ class PLL_Frontend_Auto_Translate {
 			if ( isset( $q['taxonomy'], $q['terms'] ) && $this->model->is_translated_taxonomy( $q['taxonomy'] ) ) {
 				$arr = array();
 				$field = isset( $q['field'] ) && in_array( $q['field'], array( 'slug', 'name' ) ) ? $q['field'] : 'term_id';
-				foreach ( (array) $q['terms'] as $t ) {
-					$arr[] = $this->model->term->get_by( $field, $t, $this->curlang, $q['taxonomy'] );
+				foreach ( (array) $q['terms'] as $term ) {
+					$translated = $this->model->term->get_by( $field, $term, $this->curlang, $q['taxonomy'] );
+					$arr[]      = $translated ?: $term;
 				}
 
-				$tax_queries[ $key ]['terms'] = array_filter( $arr );
+				$tax_queries[ $key ]['terms'] = $arr;
 			} else {
 				// Nested queries.
 				$tax_queries[ $key ] = $this->translate_tax_query_recursive( $q );

--- a/tests/phpunit/tests/test-auto-translate.php
+++ b/tests/phpunit/tests/test-auto-translate.php
@@ -173,6 +173,36 @@ class Auto_Translate_Test extends PLL_UnitTestCase {
 		$this->assertEqualSets( array( $post_en, $post_fr ), wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
+	public function test_tax_query_fallback_when_term_has_no_translation() {
+		self::factory()->language->create( array( 'locale' => 'de_DE_formal' ) );
+
+		$terms = self::factory()->term->create_translated(
+			array( 'taxonomy' => 'trtax', 'name' => 'test', 'lang' => 'en' ),
+			array( 'taxonomy' => 'trtax', 'name' => 'essai', 'lang' => 'fr' )
+		);
+
+		$post_en = self::factory()->post->create( array( 'post_type' => 'trcpt', 'lang' => 'en' ) );
+		wp_set_post_terms( $post_en, array( 'test' ), 'trtax' );
+
+		PLL()->curlang = PLL()->model->get_language( 'de' );
+
+		$args = array(
+			'post_type' => 'trcpt',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'trtax',
+					'field'    => 'term_id',
+					'terms'    => array( $terms['en'] ),
+				),
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( array( $terms['en'] ), $query->tax_query->queries[0]['terms'] );
+		$this->assertEquals( array( get_post( $post_en ) ), $query->posts );
+	}
+
 	public function test_post() {
 		$posts = self::factory()->post->create_translated(
 			array( 'post_title' => 'test', 'lang' => 'en' ),


### PR DESCRIPTION
## What?
Restore the fallback to the original term in `translate_tax_query_recursive()` when no translation exists in the current language.

## Why?
A regression was introduced in #1891 when `get_translated_term_by()` was replaced by `PLL_Translated_Term::get_by()` combined with `array_filter()`. When a term has no translation in the current language, the `tax_query` terms array becomes empty and secondary queries return no results.

Polylang for WooCommerce surfaced this regression in CI: [PLLWC PHPUnit failure](https://github.com/polylang/polylang-wc/actions/runs/34387339432/job/102586827434#step:5:806) (`Filter_Blocks_Test::test_products_by_attribute_block`).

The regression was introduced in https://github.com/polylang/polylang/pull/1891/.

This restores the behavior that existed before #1891 and matches other auto-translate paths in the same class (`get_terms_args`, `category__in`, etc.) which already use `$translated ?: $original`.

## How?
- Keep the original term when `get_by()` returns an empty value.
- Stop filtering out falsy translated values from `tax_query` terms.
- Add a PHPUnit test covering a language without term translations.

## Test plan
- [x] `npm run env:composer -- cs -- src/frontend/frontend-auto-translate.php tests/phpunit/tests/test-auto-translate.php`
- [x] `npm run test:php -- --filter=Auto_Translate_Test`
- [x] CI green